### PR TITLE
Removing __host__ and __device__ qualifiers for host compilers

### DIFF
--- a/include/kernels/matx_conv_kernels.cuh
+++ b/include/kernels/matx_conv_kernels.cuh
@@ -26,6 +26,7 @@ typedef enum {
   MATX_C_METHOD_AUTO,
 } matxConvCorrMethod_t;
 
+
 template <typename OutType, typename InType, typename FilterType>
 __global__ void Conv1D(OutType d_out, InType d_in, FilterType d_filter,
                        index_t signal_len, index_t filter_len,
@@ -283,5 +284,6 @@ __global__ void Conv2D(OutType d_out, InType d_in, FilterType d_filter,
     }
   }
 }
+    
 
 }; // namespace matx

--- a/include/kernels/matx_filter_kernels.cuh
+++ b/include/kernels/matx_filter_kernels.cuh
@@ -38,6 +38,7 @@ typedef enum {
 // Chunk ID assignment used for atomic incrementing between blocks
 static __device__ uint32_t cid_assign[MAX_BATCHES] = {0};
 
+
 template <uint32_t num_recursive, uint32_t num_non_recursive, typename OutType,
           typename InType, typename FilterType>
 __global__ __launch_bounds__(BLOCK_SIZE_RECURSIVE, 1) void RecursiveFilter(
@@ -608,5 +609,6 @@ __global__ __launch_bounds__(BLOCK_SIZE_RECURSIVE, 1) void RecursiveFilter(
 
   return;
 }
+
 
 }; // namespace matx

--- a/include/kernels/matx_utility_kernels.cuh
+++ b/include/kernels/matx_utility_kernels.cuh
@@ -48,4 +48,5 @@ __global__ void PrintKernel(tensor_t<T, RANK> v, const index_t i,
   v.InternalPrint(i, j, k, l);
 }
 
+
 } // namespace matx

--- a/include/kernels/matx_utility_kernels.cuh
+++ b/include/kernels/matx_utility_kernels.cuh
@@ -15,38 +15,38 @@ template <typename T, int RANK> class tensor_t;
 
 namespace matx {
 
-template <typename T, int RANK>
-__global__ void PrintKernel(tensor_t<T, RANK> v)
+template <typename T, int RANK, typename ... Args>
+__global__ void PrintKernel(tensor_t<T, RANK> v, Args ...dims)
 {
-  v.InternalPrint();
+  v.InternalPrint(dims...);
 }
 
-template <typename T, int RANK>
-__global__ void PrintKernel(tensor_t<T, RANK> v, index_t k)
-{
-  v.InternalPrint(k);
-}
+// template <typename T, int RANK>
+// __global__ void PrintKernel(tensor_t<T, RANK> v, index_t k)
+// {
+//   v.InternalPrint(k);
+// }
 
-template <typename T, int RANK>
-__global__ void PrintKernel(tensor_t<T, RANK> v, const index_t k,
-                            const index_t l)
-{
-  v.InternalPrint(k, l);
-}
+// template <typename T, int RANK>
+// __global__ void PrintKernel(tensor_t<T, RANK> v, const index_t k,
+//                             const index_t l)
+// {
+//   v.InternalPrint(k, l);
+// }
 
-template <typename T, int RANK>
-__global__ void PrintKernel(tensor_t<T, RANK> v, const index_t j,
-                            const index_t k, const index_t l)
-{
-  v.InternalPrint(j, k, l);
-}
+// template <typename T, int RANK>
+// __global__ void PrintKernel(tensor_t<T, RANK> v, const index_t j,
+//                             const index_t k, const index_t l)
+// {
+//   v.InternalPrint(j, k, l);
+// }
 
-template <typename T, int RANK>
-__global__ void PrintKernel(tensor_t<T, RANK> v, const index_t i,
-                            const index_t j, const index_t k, const index_t l)
-{
-  v.InternalPrint(i, j, k, l);
-}
+// template <typename T, int RANK>
+// __global__ void PrintKernel(tensor_t<T, RANK> v, const index_t i,
+//                             const index_t j, const index_t k, const index_t l)
+// {
+//   v.InternalPrint(i, j, k, l);
+// }
 
 
 } // namespace matx

--- a/include/matx_defines.h
+++ b/include/matx_defines.h
@@ -31,30 +31,33 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
-#include <cuda/std/ccomplex>
-#include "matx_defines.h"
-#include "matx_half_complex.h"
-#include "matx_half.h"
 
-#include "matx_error.h"
-#include "matx_tensor.h"
-#include "matx_random.h"
-#include "matx_tensor_generators.h"
-#include "matx_tensor_ops.h"
-#include "matx_exec_kernel.h"
-#include "matx_fft.h"
-#include "matx_conv.h"
-#include "matx_corr.h"
-#include "matx_matmul.h"
-#include "matx_reduce.h"
-#include "matx_inverse.h"
-#include "matx_solver.h"
-#include "matx_cov.h"
-#include "matx_cub.h"
+// This file is intended to contain simple defines that don't rely on any other headers. It must be
+// useable on both host and device compilers
+
+namespace matx {
+
+#ifdef INDEX_64_BIT
+    using index_t = long long int;
+#endif
+
+#ifdef INDEX_32_BIT
+    using index_t = int32_t;
+#endif
+
+#if ((defined(INDEX_64_BIT) && defined(INDEX_32_BIT)) ||                       \
+     (!defined(INDEX_64_BIT) && !defined(INDEX_32_BIT)))
+static_assert(false, "Must choose either 64-bit or 32-bit index mode");
+#endif
+
+#ifdef __CUDA_CC__
+    #define __MATX_HOST__ __host__
+    #define __MATX_DEVICE__ __device__
+#else
+    #define __MATX_HOST__  __host__
+    #define __MATX_DEVICE__ __device__
+#endif
 
 
-using fcomplex = cuda::std::complex<float>;
-using dcomplex = cuda::std::complex<double>;
 
-#define TEST_VECTOR_PATH "generated/"
-
+}

--- a/include/matx_half.h
+++ b/include/matx_half.h
@@ -34,6 +34,7 @@
 
 #include "cuda_bf16.h"
 #include "cuda_fp16.h"
+#include "matx_defines.h"
 #include <type_traits>
 
 namespace matx {
@@ -47,33 +48,33 @@ namespace matx {
 template <typename T> struct alignas(sizeof(T)) matxHalf {
   using value_type = T;
 
-  __host__ __device__ __forceinline__ matxHalf() : x(0.0f) {}
-  __host__ __device__ __forceinline__ matxHalf(const matxHalf<T> &x_) noexcept
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf() : x(0.0f) {}
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf(const matxHalf<T> &x_) noexcept
       : x(x_.x)
   {
   }
 
   template <typename T2>
-  __host__ __device__ __forceinline__ matxHalf(const T2 &x_) noexcept
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf(const T2 &x_) noexcept
       : x(static_cast<float>(x_))
   {
   }
   __forceinline__ ~matxHalf() = default;
 
-  __host__ __device__ __forceinline__ operator float() const
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ operator float() const
   {
     return static_cast<float>(x);
   }
-  __host__ __device__ __forceinline__ operator double() const
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ operator double() const
   {
     return static_cast<double>(x);
   }
-  // __host__ __device__ __forceinline__ operator const float() const { return
+  // __MATX_HOST__ __MATX_DEVICE__ __forceinline__ operator const float() const { return
   // static_cast<float>(x); }
-  // __host__ __device__ __forceinline__ operator const double() const { return
+  // __MATX_HOST__ __MATX_DEVICE__ __forceinline__ operator const double() const { return
   // static_cast<float>(x); }
 
-  __host__ __device__ __forceinline__ matxHalf<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> &
   operator=(const matxHalf<T> &rhs)
   {
     x = rhs.x;
@@ -81,14 +82,14 @@ template <typename T> struct alignas(sizeof(T)) matxHalf {
   }
 
   template <typename T2>
-  __host__ __device__ __forceinline__ matxHalf<T> &operator=(const T2 &rhs)
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> &operator=(const T2 &rhs)
   {
     x = static_cast<float>(rhs);
     return *this;
   }
 
   template <typename X>
-  __host__ __device__ __forceinline__ matxHalf<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> &
   operator+=(const matxHalf<X> &rhs)
   {
     *this = *this + rhs;
@@ -96,7 +97,7 @@ template <typename T> struct alignas(sizeof(T)) matxHalf {
   }
 
   template <typename X>
-  __host__ __device__ __forceinline__ matxHalf<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> &
   operator-=(const matxHalf<X> &rhs)
   {
     *this = *this - rhs;
@@ -104,7 +105,7 @@ template <typename T> struct alignas(sizeof(T)) matxHalf {
   }
 
   template <typename X>
-  __host__ __device__ __forceinline__ matxHalf<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> &
   operator*=(const matxHalf<X> &rhs)
   {
     *this = *this * rhs;
@@ -112,14 +113,14 @@ template <typename T> struct alignas(sizeof(T)) matxHalf {
   }
 
   template <typename X>
-  __host__ __device__ __forceinline__ matxHalf<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> &
   operator/=(const matxHalf<X> &rhs)
   {
     *this = *this / rhs;
     return *this;
   }
 
-  __host__ __device__ __forceinline__ matxHalf<T> &operator+=(float f) const
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> &operator+=(float f) const
   {
 #ifdef __CUDA_ARCH__
     return {x + f};
@@ -128,7 +129,7 @@ template <typename T> struct alignas(sizeof(T)) matxHalf {
 #endif
   }
 
-  __host__ __device__ __forceinline__ matxHalf<T> &operator-=(float f) const
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> &operator-=(float f) const
   {
 #ifdef __CUDA_ARCH__
     return {x + f};
@@ -141,7 +142,7 @@ template <typename T> struct alignas(sizeof(T)) matxHalf {
 };
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator+(const matxHalf<T> &lhs, const T &rhs)
 {
   matxHalf<T> tmp{rhs};
@@ -149,7 +150,7 @@ operator+(const matxHalf<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator+(const T &lhs, const matxHalf<T> &rhs)
 {
   matxHalf<T> tmp{lhs};
@@ -157,7 +158,7 @@ operator+(const T &lhs, const matxHalf<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator-(const matxHalf<T> &lhs, const T &rhs)
 {
   matxHalf<T> tmp{rhs};
@@ -165,7 +166,7 @@ operator-(const matxHalf<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator-(const T &lhs, const matxHalf<T> &rhs)
 {
   matxHalf<T> tmp{lhs};
@@ -173,7 +174,7 @@ operator-(const T &lhs, const matxHalf<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator*(const matxHalf<T> &lhs, const T &rhs)
 {
   matxHalf<T> tmp{rhs};
@@ -181,7 +182,7 @@ operator*(const matxHalf<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator*(const T &lhs, const matxHalf<T> &rhs)
 {
   matxHalf<T> tmp{lhs};
@@ -189,7 +190,7 @@ operator*(const T &lhs, const matxHalf<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator/(const matxHalf<T> &lhs, const T &rhs)
 {
   matxHalf<T> tmp{rhs};
@@ -197,7 +198,7 @@ operator/(const matxHalf<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator/(const T &lhs, const matxHalf<T> &rhs)
 {
   matxHalf<T> tmp{lhs};
@@ -205,13 +206,13 @@ operator/(const T &lhs, const matxHalf<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T> operator-(const matxHalf<T> &l)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> operator-(const matxHalf<T> &l)
 {
   return {-l.x};
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator==(const matxHalf<T> &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator==(const matxHalf<T> &lhs,
                                                     const matxHalf<T> &rhs)
 {
 #ifdef __CUDA_ARCH__
@@ -222,7 +223,7 @@ __host__ __device__ __forceinline__ bool operator==(const matxHalf<T> &lhs,
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator==(const matxHalf<T> &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator==(const matxHalf<T> &lhs,
                                                     const T &rhs)
 {
   matxHalf<T> tmp{rhs};
@@ -230,7 +231,7 @@ __host__ __device__ __forceinline__ bool operator==(const matxHalf<T> &lhs,
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator==(const T &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator==(const T &lhs,
                                                     const matxHalf<T> &rhs)
 {
   matxHalf<T> tmp{lhs};
@@ -238,14 +239,14 @@ __host__ __device__ __forceinline__ bool operator==(const T &lhs,
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator!=(const matxHalf<T> &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator!=(const matxHalf<T> &lhs,
                                                     const matxHalf<T> &rhs)
 {
   return !(lhs == rhs);
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator!=(const matxHalf<T> &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator!=(const matxHalf<T> &lhs,
                                                     const T &rhs)
 {
   matxHalf<T> tmp{rhs};
@@ -253,7 +254,7 @@ __host__ __device__ __forceinline__ bool operator!=(const matxHalf<T> &lhs,
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator!=(const T &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator!=(const T &lhs,
                                                     const matxHalf<T> &rhs)
 {
   matxHalf<T> tmp{lhs};
@@ -261,7 +262,7 @@ __host__ __device__ __forceinline__ bool operator!=(const T &lhs,
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator>(const matxHalf<T> &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator>(const matxHalf<T> &lhs,
                                                    const matxHalf<T> &rhs)
 {
 #ifdef __CUDA_ARCH__
@@ -272,7 +273,7 @@ __host__ __device__ __forceinline__ bool operator>(const matxHalf<T> &lhs,
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator<(const matxHalf<T> &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator<(const matxHalf<T> &lhs,
                                                    const matxHalf<T> &rhs)
 {
 #ifdef __CUDA_ARCH__
@@ -283,21 +284,21 @@ __host__ __device__ __forceinline__ bool operator<(const matxHalf<T> &lhs,
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator<=(const matxHalf<T> &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator<=(const matxHalf<T> &lhs,
                                                     const matxHalf<T> &rhs)
 {
   return lhs < rhs || lhs == rhs;
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool operator>=(const matxHalf<T> &lhs,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool operator>=(const matxHalf<T> &lhs,
                                                     const matxHalf<T> &rhs)
 {
   return lhs > rhs || lhs == rhs;
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator+(const matxHalf<T> &lhs, const matxHalf<T> &rhs)
 {
 #ifdef __CUDA_ARCH__
@@ -308,7 +309,7 @@ operator+(const matxHalf<T> &lhs, const matxHalf<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator-(const matxHalf<T> &lhs, const matxHalf<T> &rhs)
 {
 #ifdef __CUDA_ARCH__
@@ -319,7 +320,7 @@ operator-(const matxHalf<T> &lhs, const matxHalf<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator*(const matxHalf<T> &lhs, const matxHalf<T> &rhs)
 {
 #ifdef __CUDA_ARCH__
@@ -330,7 +331,7 @@ operator*(const matxHalf<T> &lhs, const matxHalf<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalf<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T>
 operator/(const matxHalf<T> &lhs, const matxHalf<T> &rhs)
 {
 #ifdef __CUDA_ARCH__
@@ -341,7 +342,7 @@ operator/(const matxHalf<T> &lhs, const matxHalf<T> &rhs)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> abs(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> abs(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return __habs(x.x);
@@ -351,7 +352,7 @@ __host__ __device__ __forceinline__ matxHalf<T> abs(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 abs(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -362,7 +363,7 @@ abs(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> log(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> log(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hlog(x.x);
@@ -372,7 +373,7 @@ __host__ __device__ __forceinline__ matxHalf<T> log(const matxHalf<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> sqrt(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> sqrt(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hsqrt(x.x);
@@ -382,7 +383,7 @@ __host__ __device__ __forceinline__ matxHalf<T> sqrt(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 sqrt(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -393,7 +394,7 @@ sqrt(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ int isinf(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ int isinf(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return __hisinf(x.x);
@@ -403,7 +404,7 @@ __host__ __device__ __forceinline__ int isinf(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ int isinf(const matxHalf<__nv_bfloat16> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ int isinf(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
   return __hisinf(x.x);
@@ -413,7 +414,7 @@ __host__ __device__ __forceinline__ int isinf(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 log(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -424,7 +425,7 @@ log(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> log10(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> log10(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hlog10(x.x);
@@ -434,7 +435,7 @@ __host__ __device__ __forceinline__ matxHalf<T> log10(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 log10(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -445,7 +446,7 @@ log10(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> log2(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> log2(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hlog2(x.x);
@@ -455,7 +456,7 @@ __host__ __device__ __forceinline__ matxHalf<T> log2(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 log2(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -466,7 +467,7 @@ log2(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> exp(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> exp(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hexp(x.x);
@@ -476,7 +477,7 @@ __host__ __device__ __forceinline__ matxHalf<T> exp(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 exp(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -488,7 +489,7 @@ exp(const matxHalf<__nv_bfloat16> &x)
 
 // Trig functions
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> pow(const matxHalf<T> &x,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> pow(const matxHalf<T> &x,
                                                     const matxHalf<T> &y)
 {
   auto tmp = cuda::std::pow(static_cast<float>(x.x), static_cast<float>(y.x));
@@ -496,7 +497,7 @@ __host__ __device__ __forceinline__ matxHalf<T> pow(const matxHalf<T> &x,
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> pow(const matxHalf<T> &x,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> pow(const matxHalf<T> &x,
                                                     const T &y)
 {
   auto tmp = cuda::std::pow(static_cast<float>(x.x), static_cast<float>(y));
@@ -504,7 +505,7 @@ __host__ __device__ __forceinline__ matxHalf<T> pow(const matxHalf<T> &x,
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> pow(const T &x,
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> pow(const T &x,
                                                     const matxHalf<T> &y)
 {
   auto tmp = cuda::std::pow(x, static_cast<float>(y.x));
@@ -512,7 +513,7 @@ __host__ __device__ __forceinline__ matxHalf<T> pow(const T &x,
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> floor(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> floor(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hfloor(x.x);
@@ -522,7 +523,7 @@ __host__ __device__ __forceinline__ matxHalf<T> floor(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 floor(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -533,7 +534,7 @@ floor(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> ceil(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> ceil(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hceil(x.x);
@@ -543,7 +544,7 @@ __host__ __device__ __forceinline__ matxHalf<T> ceil(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 ceil(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -554,7 +555,7 @@ ceil(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> round(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> round(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hrint(x.x);
@@ -564,7 +565,7 @@ __host__ __device__ __forceinline__ matxHalf<T> round(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 round(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -575,7 +576,7 @@ round(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> sin(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> sin(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hsin(x.x);
@@ -585,7 +586,7 @@ __host__ __device__ __forceinline__ matxHalf<T> sin(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 sin(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -596,7 +597,7 @@ sin(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> cos(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> cos(const matxHalf<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return hcos(x.x);
@@ -606,7 +607,7 @@ __host__ __device__ __forceinline__ matxHalf<T> cos(const matxHalf<T> &x)
 }
 
 template <>
-__host__ __device__ __forceinline__ matxHalf<__nv_bfloat16>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<__nv_bfloat16>
 cos(const matxHalf<__nv_bfloat16> &x)
 {
 #if __CUDA_ARCH__ >= 800
@@ -617,61 +618,61 @@ cos(const matxHalf<__nv_bfloat16> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> tan(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> tan(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::tan(static_cast<float>(x.x)));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> asin(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> asin(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::asin(static_cast<float>(x.x)));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> acos(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> acos(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::acos(static_cast<float>(x.x)));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> atan(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> atan(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::atan(static_cast<float>(x.x)));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> asinh(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> asinh(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::asinh(static_cast<float>(x.x)));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> acosh(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> acosh(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::acosh(static_cast<float>(x.x)));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> atanh(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> atanh(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::atanh(static_cast<float>(x.x)));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> sinh(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> sinh(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::sinh(static_cast<float>(x.x)));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> cosh(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> cosh(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::cosh(static_cast<float>(x.x)));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalf<T> tanh(const matxHalf<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalf<T> tanh(const matxHalf<T> &x)
 {
   return static_cast<T>(cuda::std::tanh(static_cast<float>(x.x)));
 }

--- a/include/matx_half_complex.h
+++ b/include/matx_half_complex.h
@@ -37,6 +37,7 @@
 #include "matx_half.h"
 #include <complex>
 #include <cuda/std/complex>
+#include <cuda/std/cmath>
 #include <type_traits>
 
 namespace matx {
@@ -50,22 +51,22 @@ namespace matx {
 template <typename T> struct alignas(sizeof(T) * 2) matxHalfComplex {
   using value_type = T;
 
-  __host__ __device__ __forceinline__ matxHalfComplex() : x(0.0f), y(0.0f) {}
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex() : x(0.0f), y(0.0f) {}
 
-  __host__ __device__ __forceinline__
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__
   matxHalfComplex(const cuda::std::complex<float> &x_) noexcept
       : x(x_.real()), y(x_.imag())
   {
   }
 
   template <typename T2>
-  __host__ __device__ __forceinline__ matxHalfComplex(const T2 &x_) noexcept
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex(const T2 &x_) noexcept
       : x(static_cast<float>(x_)), y(0.0f)
   {
   }
 
   template <typename T2, typename T3>
-  __host__ __device__ __forceinline__ matxHalfComplex(const T2 &x_,
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex(const T2 &x_,
                                                       const T3 &y_) noexcept
       : x(static_cast<float>(x_)), y(static_cast<float>(y_))
   {
@@ -73,33 +74,33 @@ template <typename T> struct alignas(sizeof(T) * 2) matxHalfComplex {
 
   __forceinline__ ~matxHalfComplex() = default;
 
-  __host__ __device__ __forceinline__ operator cuComplex()
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ operator cuComplex()
   {
     return make_cuFloatComplex(x, y);
   }
 
-  __host__ __device__ __forceinline__ operator cuda::std::complex<float>()
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ operator cuda::std::complex<float>()
   {
     return {x, y};
   }
 
-  __host__ __device__ __forceinline__ operator cuda::std::complex<double>()
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ operator cuda::std::complex<double>()
   {
     return {x, y};
   }
 
-  __host__ __device__ __forceinline__ operator std::complex<float>()
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ operator std::complex<float>()
   {
     return {x, y};
   }
 
-  __host__ __device__ __forceinline__ operator std::complex<double>()
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ operator std::complex<double>()
   {
     return {x, y};
   }
 
   template <typename X>
-  __host__ __device__ __forceinline__ matxHalfComplex<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T> &
   operator=(const matxHalfComplex<X> &rhs)
   {
     x = rhs.x;
@@ -108,7 +109,7 @@ template <typename T> struct alignas(sizeof(T) * 2) matxHalfComplex {
   }
 
   template <typename X>
-  __host__ __device__ __forceinline__ matxHalfComplex<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T> &
   operator+=(const matxHalfComplex<X> &rhs)
   {
     *this = *this + rhs;
@@ -116,7 +117,7 @@ template <typename T> struct alignas(sizeof(T) * 2) matxHalfComplex {
   }
 
   template <typename X>
-  __host__ __device__ __forceinline__ matxHalfComplex<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T> &
   operator-=(const matxHalfComplex<X> &rhs)
   {
     *this = *this - rhs;
@@ -124,7 +125,7 @@ template <typename T> struct alignas(sizeof(T) * 2) matxHalfComplex {
   }
 
   template <typename X>
-  __host__ __device__ __forceinline__ matxHalfComplex<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T> &
   operator*=(const matxHalfComplex<X> &rhs)
   {
     *this = *this * rhs;
@@ -132,36 +133,36 @@ template <typename T> struct alignas(sizeof(T) * 2) matxHalfComplex {
   }
 
   template <typename X>
-  __host__ __device__ __forceinline__ matxHalfComplex<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T> &
   operator/=(const matxHalfComplex<X> &rhs)
   {
     *this = *this / rhs;
     return *this;
   }
 
-  __host__ __device__ __forceinline__ matxHalfComplex<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T> &
   operator+=(float f) const
   {
     return {x + f, y + f};
   }
 
-  __host__ __device__ __forceinline__ matxHalfComplex<T> &
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T> &
   operator-=(float f) const
   {
     return {x + f, y + f};
   }
 
-  __host__ __device__ __forceinline__ void real(T r) { x = r; }
-  __host__ __device__ __forceinline__ void imag(T i) { y = i; }
-  __host__ __device__ __forceinline__ constexpr T real() const { return x; }
-  __host__ __device__ __forceinline__ constexpr T imag() const { return y; }
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ void real(T r) { x = r; }
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ void imag(T i) { y = i; }
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ constexpr T real() const { return x; }
+  __MATX_HOST__ __MATX_DEVICE__ __forceinline__ constexpr T imag() const { return y; }
 
   T x;
   T y;
 };
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator+(const matxHalfComplex<T> &lhs, const T &rhs)
 {
   matxHalfComplex<T> tmp{rhs};
@@ -169,7 +170,7 @@ operator+(const matxHalfComplex<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator+(const T &lhs, const matxHalfComplex<T> &rhs)
 {
   matxHalfComplex<T> tmp{lhs};
@@ -177,7 +178,7 @@ operator+(const T &lhs, const matxHalfComplex<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator-(const matxHalfComplex<T> &lhs, const T &rhs)
 {
   matxHalfComplex<T> tmp{rhs};
@@ -185,7 +186,7 @@ operator-(const matxHalfComplex<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator-(const T &lhs, const matxHalfComplex<T> &rhs)
 {
   matxHalfComplex<T> tmp{lhs};
@@ -193,7 +194,7 @@ operator-(const T &lhs, const matxHalfComplex<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator*(const matxHalfComplex<T> &lhs, const T &rhs)
 {
   matxHalfComplex<T> tmp{rhs};
@@ -201,7 +202,7 @@ operator*(const matxHalfComplex<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator*(const T &lhs, const matxHalfComplex<T> &rhs)
 {
   matxHalfComplex<T> tmp{lhs};
@@ -209,7 +210,7 @@ operator*(const T &lhs, const matxHalfComplex<T> &rhs)
 }
 
 template <typename T1, typename T2>
-__host__ __device__ __forceinline__ matxHalfComplex<T2>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T2>
 operator*(const T1 &lhs, const matxHalfComplex<T2> &rhs)
 {
   matxHalfComplex<T2> tmp{lhs};
@@ -217,7 +218,7 @@ operator*(const T1 &lhs, const matxHalfComplex<T2> &rhs)
 }
 
 template <typename T1, typename T2>
-__host__ __device__ __forceinline__ matxHalfComplex<T1>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T1>
 operator*(const matxHalfComplex<T1> &lhs, const T2 &rhs)
 {
   matxHalfComplex<T1> tmp{rhs};
@@ -225,7 +226,7 @@ operator*(const matxHalfComplex<T1> &lhs, const T2 &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator/(const matxHalfComplex<T> &lhs, const T &rhs)
 {
   matxHalfComplex<T> tmp{rhs};
@@ -233,7 +234,7 @@ operator/(const matxHalfComplex<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator/(const T &lhs, const matxHalfComplex<T> &rhs)
 {
   matxHalfComplex<T> tmp{lhs};
@@ -241,21 +242,21 @@ operator/(const T &lhs, const matxHalfComplex<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator-(const matxHalfComplex<T> &l)
 {
   return {-l.x, -l.y};
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool
 operator==(const matxHalfComplex<T> &lhs, const matxHalfComplex<T> &rhs)
 {
   return lhs.x == rhs.x && lhs.y == rhs.y;
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool
 operator==(const matxHalfComplex<T> &lhs, const T &rhs)
 {
   matxHalfComplex<T> tmp{rhs};
@@ -263,7 +264,7 @@ operator==(const matxHalfComplex<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool
 operator==(const T &lhs, const matxHalfComplex<T> &rhs)
 {
   matxHalfComplex<T> tmp{lhs};
@@ -271,14 +272,14 @@ operator==(const T &lhs, const matxHalfComplex<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool
 operator!=(const matxHalfComplex<T> &lhs, const matxHalfComplex<T> &rhs)
 {
   return !(lhs == rhs);
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool
 operator!=(const matxHalfComplex<T> &lhs, const T &rhs)
 {
   matxHalfComplex<T> tmp{rhs};
@@ -286,7 +287,7 @@ operator!=(const matxHalfComplex<T> &lhs, const T &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ bool
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool
 operator!=(const T &lhs, const matxHalfComplex<T> &rhs)
 {
   matxHalfComplex<T> tmp{lhs};
@@ -307,28 +308,28 @@ bool operator<=(const matxHalfComplex<T> &lhs,
                 const matxHalfComplex<T> &rhs) = delete;
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator+(const matxHalfComplex<T> &lhs, const matxHalfComplex<T> &rhs)
 {
   return {lhs.x + rhs.x, lhs.y + rhs.y};
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator-(const matxHalfComplex<T> &lhs, const matxHalfComplex<T> &rhs)
 {
   return {lhs.x - rhs.x, lhs.y - rhs.y};
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator*(const matxHalfComplex<T> &lhs, const matxHalfComplex<T> &rhs)
 {
   return {lhs.x * rhs.x - lhs.y * rhs.y, lhs.x * rhs.y + lhs.y * rhs.x};
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 operator/(const matxHalfComplex<T> &lhs, const matxHalfComplex<T> &rhs)
 {
 #ifdef __CUDA_ARCH__
@@ -356,14 +357,14 @@ operator/(const matxHalfComplex<T> &lhs, const matxHalfComplex<T> &rhs)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 conj(const matxHalfComplex<T> &x)
 {
   return {x.real(), -static_cast<float>(x.imag())};
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ T abs(const matxHalfComplex<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ T abs(const matxHalfComplex<T> &x)
 {
 #ifdef __CUDA_ARCH__
   return sqrt(x.real() * x.real() + x.imag() * x.imag());
@@ -374,28 +375,28 @@ __host__ __device__ __forceinline__ T abs(const matxHalfComplex<T> &x)
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ T arg(const matxHalfComplex<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ T arg(const matxHalfComplex<T> &x)
 {
   return static_cast<T>(cuda::std::atan2(static_cast<float>(x.real()),
                                          static_cast<float>(x.imag())));
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ T atan2(const matxHalfComplex<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ T atan2(const matxHalfComplex<T> &x)
 {
   return static_cast<T>(cuda::std::atan2(static_cast<float>(x.imag()),
                                          static_cast<float>(x.real())));
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ T atan2(const T &x, const T &y)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ T atan2(const T &x, const T &y)
 {
   return static_cast<T>(
       cuda::std::atan2(static_cast<float>(y), static_cast<float>(x)));
 }
 
 template <typename T>
-__host__ __device__ __forceinline__ T norm(const matxHalfComplex<T> &x)
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ T norm(const matxHalfComplex<T> &x)
 {
   if (isinf(x.real()))
     return static_cast<T>(cuda::std::abs(static_cast<float>(x.real())));
@@ -406,21 +407,21 @@ __host__ __device__ __forceinline__ T norm(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 log(const matxHalfComplex<T> &x)
 {
   return {log(abs(x)), arg(x)};
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 log10(const matxHalfComplex<T> &x)
 {
   return log(x) / log(static_cast<T>(10.0f));
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 exp(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -430,7 +431,7 @@ exp(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 pow(const matxHalfComplex<T> &x, const matxHalfComplex<T> &y)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -442,7 +443,7 @@ pow(const matxHalfComplex<T> &x, const matxHalfComplex<T> &y)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 pow(const matxHalfComplex<T> &x, const T &y)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -452,7 +453,7 @@ pow(const matxHalfComplex<T> &x, const T &y)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 pow(const T &x, const matxHalfComplex<T> &y)
 {
   cuda::std::complex<float> tmp{static_cast<float>(y.real()),
@@ -463,28 +464,28 @@ pow(const T &x, const matxHalfComplex<T> &y)
 
 // Trig functions
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 sin(const matxHalfComplex<T> &x)
 {
   return sinh(matxHalfComplex<T>{-static_cast<float>(x.imag()), x.real()});
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 cos(const matxHalfComplex<T> &x)
 {
   return cosh(matxHalfComplex<T>{-static_cast<float>(x.imag()), x.real()});
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 tan(const matxHalfComplex<T> &x)
 {
   return tanh(matxHalfComplex<T>{-static_cast<float>(x.imag()), x.real()});
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 asinh(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -494,7 +495,7 @@ asinh(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 acosh(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -504,7 +505,7 @@ acosh(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 atanh(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -514,7 +515,7 @@ atanh(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 asin(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -524,7 +525,7 @@ asin(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 acos(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -534,7 +535,7 @@ acos(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 atan(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -544,7 +545,7 @@ atan(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 sinh(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -554,7 +555,7 @@ sinh(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 cosh(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),
@@ -564,7 +565,7 @@ cosh(const matxHalfComplex<T> &x)
 }
 
 template <class T>
-__host__ __device__ __forceinline__ matxHalfComplex<T>
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ matxHalfComplex<T>
 tanh(const matxHalfComplex<T> &x)
 {
   cuda::std::complex<float> tmp{static_cast<float>(x.real()),

--- a/include/matx_radar.h
+++ b/include/matx_radar.h
@@ -62,7 +62,7 @@ public:
   {
   }
 
-  __device__ inline void operator()(index_t idy, index_t idx)
+  __MATX_DEVICE__ inline void operator()(index_t idy, index_t idx)
   {
 
     index_t xcol = idx - (xnorm_.Size(xnorm_.Rank() - 1) - 1) + idy;
@@ -77,12 +77,12 @@ public:
     }
   }
 
-  __host__ __device__ inline index_t Size(uint32_t i) const
+  __MATX_HOST__ __MATX_DEVICE__ inline index_t Size(uint32_t i) const
   {
     return out_.Size(i);
   }
 
-  static inline constexpr __host__ __device__ int32_t Rank()
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
   {
     return O::Rank();
   }
@@ -102,7 +102,7 @@ public:
       : out_(out), x_(x), fs_(fs), cut_(cut), nfreq_(nfreq)
   {
   }
-  __device__ inline void operator()(index_t idx)
+  __MATX_DEVICE__ inline void operator()(index_t idx)
   {
 
     out_(idx) =
@@ -112,11 +112,11 @@ public:
         x_(idx);
   }
 
-  __host__ __device__ inline index_t Size(uint32_t i) const
+  __MATX_HOST__ __MATX_DEVICE__ inline index_t Size(uint32_t i) const
   {
     return out_.Size(i);
   }
-  static inline constexpr __host__ __device__ int32_t Rank()
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
   {
     return O::Rank();
   }
@@ -134,7 +134,7 @@ public:
       : out_(out), x_(x), fs_(fs), cut_(cut)
   {
   }
-  __device__ inline void operator()(index_t idx)
+  __MATX_DEVICE__ inline void operator()(index_t idx)
   {
 
     out_(idx) = exp(cuda::std::complex<float>{
@@ -142,11 +142,11 @@ public:
                 x_(idx);
   }
 
-  __host__ __device__ inline index_t Size(uint32_t i) const
+  __MATX_HOST__ __MATX_DEVICE__ inline index_t Size(uint32_t i) const
   {
     return out_.Size(i);
   }
-  static inline constexpr __host__ __device__ int32_t Rank()
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
   {
     return O::Rank();
   }

--- a/include/matx_random.h
+++ b/include/matx_random.h
@@ -55,7 +55,7 @@ __global__ void curand_setup_kernel(Gen *states, uint64_t seed, index_t size)
 };
 
 template <typename Gen>
-__inline__ __device__ void get_random(float &val, Gen *state,
+__inline__ __MATX_DEVICE__ void get_random(float &val, Gen *state,
                                       Distribution_t dist)
 {
   if (dist == UNIFORM) {
@@ -67,7 +67,7 @@ __inline__ __device__ void get_random(float &val, Gen *state,
 };
 
 template <typename Gen>
-__inline__ __device__ void get_random(double &val, Gen *state,
+__inline__ __MATX_DEVICE__ void get_random(double &val, Gen *state,
                                       Distribution_t dist)
 {
   if (dist == UNIFORM) {
@@ -79,7 +79,7 @@ __inline__ __device__ void get_random(double &val, Gen *state,
 };
 
 template <typename Gen>
-__inline__ __device__ void get_random(cuda::std::complex<float> &val,
+__inline__ __MATX_DEVICE__ void get_random(cuda::std::complex<float> &val,
                                       Gen *state, Distribution_t dist)
 {
   if (dist == UNIFORM) {
@@ -94,7 +94,7 @@ __inline__ __device__ void get_random(cuda::std::complex<float> &val,
 };
 
 template <typename Gen>
-__inline__ __device__ void get_random(cuda::std::complex<double> &val,
+__inline__ __MATX_DEVICE__ void get_random(cuda::std::complex<double> &val,
                                       Gen *state, Distribution_t dist)
 {
   if (dist == UNIFORM) {
@@ -235,11 +235,11 @@ public:
   /**
    * Retrieve a value from a rank-0 random view
    */
-  __device__ T operator()()
+  __MATX_DEVICE__ T operator()()
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 0, bool> = true>
-  inline __device__ T operator()()
+  inline __MATX_DEVICE__ T operator()()
   {
 #endif
     T val;
@@ -254,11 +254,11 @@ public:
    * @param i
    *   First index
    */
-  __device__ T operator()(index_t i)
+  __MATX_DEVICE__ T operator()(index_t i)
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 1, bool> = true>
-  inline __device__ T operator()(index_t i)
+  inline __MATX_DEVICE__ T operator()(index_t i)
   {
 #endif
     T val;
@@ -275,11 +275,11 @@ public:
    * @param j
    *   Second index
    */
-  __device__ T operator()(index_t i, index_t j)
+  __MATX_DEVICE__ T operator()(index_t i, index_t j)
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 2, bool> = true>
-  inline __device__ T operator()(index_t i, index_t j)
+  inline __MATX_DEVICE__ T operator()(index_t i, index_t j)
   {
 #endif
     T val;
@@ -298,11 +298,11 @@ public:
    * @param k
    *   Third index
    */
-  __device__ T operator()(index_t i, index_t j, index_t k)
+  __MATX_DEVICE__ T operator()(index_t i, index_t j, index_t k)
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 3, bool> = true>
-  inline __device__ T operator()(index_t i, index_t j, index_t k)
+  inline __MATX_DEVICE__ T operator()(index_t i, index_t j, index_t k)
   {
 #endif
     T val;
@@ -324,11 +324,11 @@ public:
    * @param l
    *   Fourth index
    */
-  __device__ T operator()(index_t i, index_t j, index_t k, index_t l)
+  __MATX_DEVICE__ T operator()(index_t i, index_t j, index_t k, index_t l)
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 4, bool> = true>
-  inline __device__ T operator()(index_t i, index_t j, index_t k, index_t l)
+  inline __MATX_DEVICE__ T operator()(index_t i, index_t j, index_t k, index_t l)
   {
 #endif
     T val;
@@ -339,9 +339,9 @@ public:
     return alpha_ * val + beta_;
   };
 
-  static inline constexpr __host__ __device__ int32_t Rank() { return RANK; }
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return RANK; }
 
-  index_t inline __host__ __device__ Size(int dim) const
+  index_t inline __MATX_HOST__ __MATX_DEVICE__ Size(int dim) const
   {
     return shape_.Size(dim);
   }

--- a/include/matx_reduce.h
+++ b/include/matx_reduce.h
@@ -54,7 +54,7 @@
  * @returns
  *   Value shuffled*
  */
-__device__ inline auto __shfl_down_sync(unsigned mask,
+__MATX_DEVICE__ inline auto __shfl_down_sync(unsigned mask,
                                         cuda::std::complex<float> var,
                                         unsigned int delta)
 {
@@ -78,7 +78,7 @@ __device__ inline auto __shfl_down_sync(unsigned mask,
  * @returns
  *   Value shuffled
  */
-__device__ inline auto __shfl_down_sync(unsigned mask,
+__MATX_DEVICE__ inline auto __shfl_down_sync(unsigned mask,
                                         cuda::std::complex<double> var,
                                         unsigned int delta)
 {
@@ -97,7 +97,7 @@ __device__ inline auto __shfl_down_sync(unsigned mask,
  * @param val
  *   Value to compare against
  */
-__device__ inline void atomicMin(float *addr, float val)
+__MATX_DEVICE__ inline void atomicMin(float *addr, float val)
 {
   unsigned int *address_as_uint = (unsigned int *)addr;
   unsigned int old = *address_as_uint, assumed;
@@ -120,7 +120,7 @@ __device__ inline void atomicMin(float *addr, float val)
  * @param val
  *   Value to compare against
  */
-__device__ inline void atomicMax(float *addr, float val)
+__MATX_DEVICE__ inline void atomicMax(float *addr, float val)
 {
   unsigned int *address_as_uint = (unsigned int *)addr;
   unsigned int old = *address_as_uint, assumed;
@@ -143,7 +143,7 @@ __device__ inline void atomicMax(float *addr, float val)
  * @param val
  *   Value to compare against
  */
-__device__ inline void atomicAny(float *addr, float val)
+__MATX_DEVICE__ inline void atomicAny(float *addr, float val)
 {
   // We don't actually need an atomic operation here since we only write to the
   // location if any thread has the correct value.
@@ -163,7 +163,7 @@ __device__ inline void atomicAny(float *addr, float val)
  * @param val
  *   Value to compare against
  */
-template <typename T> __device__ T atomicMul(T *address, T val)
+template <typename T> __MATX_DEVICE__ T atomicMul(T *address, T val)
 {
   T old = *address, assumed;
 
@@ -195,7 +195,7 @@ template <typename T> __device__ T atomicMul(T *address, T val)
  * @param val
  *   Value to compare against
  */
-template <> __device__ inline float atomicMul(float *address, float val)
+template <> __MATX_DEVICE__ inline float atomicMul(float *address, float val)
 {
   unsigned int *address_as_uint = (unsigned int *)address;
   unsigned int old = *address_as_uint, assumed;
@@ -222,7 +222,7 @@ template <> __device__ inline float atomicMul(float *address, float val)
  * @param val
  *   Value to compare against
  */
-__device__ inline void atomicAll(float *addr, float val)
+__MATX_DEVICE__ inline void atomicAll(float *addr, float val)
 {
   unsigned int *address_as_uint = (unsigned int *)addr;
   unsigned int old = *address_as_uint, assumed;
@@ -245,7 +245,7 @@ __device__ inline void atomicAll(float *addr, float val)
  * @param val
  *   Value to compare against
  */
-template <> __device__ inline double atomicMul(double *address, double val)
+template <> __MATX_DEVICE__ inline double atomicMul(double *address, double val)
 {
   unsigned long long int *address_as_ull = (unsigned long long int *)address;
   unsigned long long int old = *address_as_ull, assumed;
@@ -272,7 +272,7 @@ template <> __device__ inline double atomicMul(double *address, double val)
  * @param val
  *   Value to compare against
  */
-__device__ inline void atomicMin(double *addr, double val)
+__MATX_DEVICE__ inline void atomicMin(double *addr, double val)
 {
   unsigned long long int *address_as_ull = (unsigned long long int *)addr;
   unsigned long long int old = *address_as_ull, assumed;
@@ -295,7 +295,7 @@ __device__ inline void atomicMin(double *addr, double val)
  * @param val
  *   Value to compare against
  */
-__device__ inline void atomicMax(double *addr, double val)
+__MATX_DEVICE__ inline void atomicMax(double *addr, double val)
 {
   unsigned long long int *address_as_ull = (unsigned long long int *)addr;
   unsigned long long int old = *address_as_ull, assumed;
@@ -319,7 +319,7 @@ __device__ inline void atomicMax(double *addr, double val)
  * @param val
  *   Value to compare against
  */
-__device__ inline void atomicAny(double *addr, double val)
+__MATX_DEVICE__ inline void atomicAny(double *addr, double val)
 {
   // We don't actually need an atomic operation here since we only write to the
   // location if any thread has the correct value.
@@ -338,7 +338,7 @@ __device__ inline void atomicAny(double *addr, double val)
  * @param val
  *   Value to compare against
  */
-__device__ inline void atomicAll(double *addr, float val)
+__MATX_DEVICE__ inline void atomicAll(double *addr, float val)
 {
   unsigned long long int *address_as_ull = (unsigned long long int *)addr;
   unsigned long long int old = *address_as_ull, assumed;
@@ -363,7 +363,7 @@ __device__ inline void atomicAll(double *addr, float val)
  * @param val
  *   Value to add
  */
-__device__ inline void atomicAdd(cuda::std::complex<float> *addr,
+__MATX_DEVICE__ inline void atomicAdd(cuda::std::complex<float> *addr,
                                  cuda::std::complex<float> val)
 {
   float *addrf = reinterpret_cast<float *>(addr);
@@ -383,7 +383,7 @@ __device__ inline void atomicAdd(cuda::std::complex<float> *addr,
  * @param val
  *   Value to add
  */
-__device__ inline void atomicAdd(cuda::std::complex<double> *addr,
+__MATX_DEVICE__ inline void atomicAdd(cuda::std::complex<double> *addr,
                                  cuda::std::complex<double> val)
 {
   double *addrp = reinterpret_cast<double *>(addr);
@@ -392,46 +392,46 @@ __device__ inline void atomicAdd(cuda::std::complex<double> *addr,
 }
 
 namespace matx {
-template <typename T> constexpr inline __host__ __device__ T maxVal();
-template <typename T> constexpr inline __host__ __device__ T minVal();
+template <typename T> constexpr inline __MATX_HOST__ __MATX_DEVICE__ T maxVal();
+template <typename T> constexpr inline __MATX_HOST__ __MATX_DEVICE__ T minVal();
 
 /* Returns the max value of an int32_t at compile time */
-template <> constexpr inline __host__ __device__ int32_t maxVal<int32_t>()
+template <> constexpr inline __MATX_HOST__ __MATX_DEVICE__ int32_t maxVal<int32_t>()
 {
   return INT_MAX;
 }
 /* Returns the min value of an int32_t at compile time */
-template <> constexpr inline __host__ __device__ int32_t minVal<int32_t>()
+template <> constexpr inline __MATX_HOST__ __MATX_DEVICE__ int32_t minVal<int32_t>()
 {
   return INT_MIN;
 }
 /* Returns the max value of a uint32_t at compile time */
-template <> constexpr inline __host__ __device__ uint32_t maxVal<uint32_t>()
+template <> constexpr inline __MATX_HOST__ __MATX_DEVICE__ uint32_t maxVal<uint32_t>()
 {
   return UINT_MAX;
 }
 /* Returns the min value of a uint32_t at compile time */
-template <> constexpr inline __host__ __device__ uint32_t minVal<uint32_t>()
+template <> constexpr inline __MATX_HOST__ __MATX_DEVICE__ uint32_t minVal<uint32_t>()
 {
   return 0;
 }
 /* Returns the max value of a float at compile time */
-template <> constexpr inline __host__ __device__ float maxVal<float>()
+template <> constexpr inline __MATX_HOST__ __MATX_DEVICE__ float maxVal<float>()
 {
   return FLT_MAX;
 }
 /* Returns the min value of a float at compile time */
-template <> constexpr inline __host__ __device__ float minVal<float>()
+template <> constexpr inline __MATX_HOST__ __MATX_DEVICE__ float minVal<float>()
 {
   return -FLT_MAX;
 }
 /* Returns the max value of a double at compile time */
-template <> constexpr inline __host__ __device__ double maxVal<double>()
+template <> constexpr inline __MATX_HOST__ __MATX_DEVICE__ double maxVal<double>()
 {
   return DBL_MAX;
 }
 /* Returns the min value of a double at compile time */
-template <> constexpr inline __host__ __device__ double minVal<double>()
+template <> constexpr inline __MATX_HOST__ __MATX_DEVICE__ double minVal<double>()
 {
   return -DBL_MAX;
 }
@@ -445,9 +445,9 @@ template <> constexpr inline __host__ __device__ double minVal<double>()
 template <typename T> class reduceOpSum {
 public:
   using matx_reduce = bool;
-  __host__ __device__ inline T Reduce(T v1, T v2) { return v1 + v2; }
-  __host__ __device__ inline T Init() { return T(0); }
-  __device__ inline void atomicReduce(T *addr, T val) { atomicAdd(addr, val); }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Reduce(T v1, T v2) { return v1 + v2; }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Init() { return T(0); }
+  __MATX_DEVICE__ inline void atomicReduce(T *addr, T val) { atomicAdd(addr, val); }
 };
 
 /**
@@ -459,9 +459,9 @@ public:
 template <typename T> class reduceOpProd {
 public:
   using matx_reduce = bool;
-  __host__ __device__ inline T Reduce(T v1, T v2) { return v1 * v2; }
-  __host__ __device__ inline T Init() { return T(1); }
-  __device__ inline void atomicReduce(T *addr, T val) { atomicMul(addr, val); }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Reduce(T v1, T v2) { return v1 * v2; }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Init() { return T(1); }
+  __MATX_DEVICE__ inline void atomicReduce(T *addr, T val) { atomicMul(addr, val); }
 };
 
 /**
@@ -474,9 +474,9 @@ public:
 template <typename T> class reduceOpMax {
 public:
   using matx_reduce = bool;
-  __host__ __device__ inline T Reduce(T v1, T v2) { return v1 > v2 ? v1 : v2; }
-  __host__ __device__ inline T Init() { return minVal<T>(); }
-  __device__ inline void atomicReduce(T *addr, T val) { atomicMax(addr, val); }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Reduce(T v1, T v2) { return v1 > v2 ? v1 : v2; }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Init() { return minVal<T>(); }
+  __MATX_DEVICE__ inline void atomicReduce(T *addr, T val) { atomicMax(addr, val); }
 };
 
 /**
@@ -488,12 +488,12 @@ public:
 template <typename T> class reduceOpAny {
 public:
   using matx_reduce = bool;
-  __host__ __device__ inline T Reduce(T v1, T v2)
+  __MATX_HOST__ __MATX_DEVICE__ inline T Reduce(T v1, T v2)
   {
     return (v1 != 0) || (v2 != 0);
   }
-  __host__ __device__ inline T Init() { return (T)(0); }
-  __device__ inline void atomicReduce(T *addr, T val) { atomicAny(addr, val); }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Init() { return (T)(0); }
+  __MATX_DEVICE__ inline void atomicReduce(T *addr, T val) { atomicAny(addr, val); }
 };
 
 /**
@@ -505,12 +505,12 @@ public:
 template <typename T> class reduceOpAll {
 public:
   using matx_reduce = bool;
-  __host__ __device__ inline T Reduce(T v1, T v2)
+  __MATX_HOST__ __MATX_DEVICE__ inline T Reduce(T v1, T v2)
   {
     return (v1 != 0) && (v2 != 0);
   }
-  __host__ __device__ inline T Init() { return (T)(1); }
-  __device__ inline void atomicReduce(T *addr, T val) { atomicAll(addr, val); }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Init() { return (T)(1); }
+  __MATX_DEVICE__ inline void atomicReduce(T *addr, T val) { atomicAll(addr, val); }
 };
 
 /**
@@ -523,9 +523,9 @@ public:
 template <typename T> class reduceOpMin {
 public:
   using matx_reduce = bool;
-  __host__ __device__ inline T Reduce(T v1, T v2) { return v1 < v2 ? v1 : v2; }
-  __host__ __device__ inline T Init() { return maxVal<T>(); }
-  __device__ inline void atomicReduce(T *addr, T val) { atomicMin(addr, val); }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Reduce(T v1, T v2) { return v1 < v2 ? v1 : v2; }
+  __MATX_HOST__ __MATX_DEVICE__ inline T Init() { return maxVal<T>(); }
+  __MATX_DEVICE__ inline void atomicReduce(T *addr, T val) { atomicMin(addr, val); }
 };
 
 #if 0
@@ -533,19 +533,19 @@ public:
     class reduceOpSumMax {
       public:
         using matx_reduce = bool;
-        __host__ __device__ inline T Reduce(T v1, T v2) {
+        __MATX_HOST__ __MATX_DEVICE__ inline T Reduce(T v1, T v2) {
           T val;
           val.x = reduceOpSum<decltype(T::x)>().Reduce(v1,v2);
           val.y = reduceOpMax<decltype(T::y)>().Reduce(v1,v2); 
           return val;
         }
-        __host__ __device__ inline T Init() {
+        __MATX_HOST__ __MATX_DEVICE__ inline T Init() {
           T val;
           val.x = reduceOpSum<decltype(T::x)>().Init();
           val.y = reduceOpMax<decltype(T::y)>().Init();
           return val;
         }
-        __device__ inline void atomicReduce(T *addr, T val) {
+        __MATX_DEVICE__ inline void atomicReduce(T *addr, T val) {
           reduceOpSum<decltype(T::x)>().atomicReduce(&(addr->x), val.x);
           reduceOpMax<decltype(T::y)>().atomicReduce(&(addr->y), val.y);
         }
@@ -553,7 +553,7 @@ public:
 #endif
 
 template <typename T, typename Op>
-__device__ inline T warpReduceOp(T val, Op op, uint32_t size)
+__MATX_DEVICE__ inline T warpReduceOp(T val, Op op, uint32_t size)
 {
   // breaking this out so common case is faster without branches
   if (size > 16) {

--- a/include/matx_scalar_ops.h
+++ b/include/matx_scalar_ops.h
@@ -43,7 +43,7 @@ namespace matx {
 // constexpr if
 #define MATX_UNARY_OP_GEN(FUNC, OPNAME)                                        \
   template <typename T>                                                        \
-  static inline __host__ __device__ auto _internal_##FUNC(T v1)                \
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto _internal_##FUNC(T v1)                \
   {                                                                            \
     if constexpr (is_matx_type_v<T>) {                                         \
       return FUNC(v1);                                                         \
@@ -59,7 +59,7 @@ namespace matx {
     }                                                                          \
   }                                                                            \
   template <typename T> struct OPNAME##F {                                     \
-    static inline __host__ __device__ auto op(T v1)                            \
+    static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T v1)                            \
     {                                                                          \
       return _internal_##FUNC(v1);                                             \
     }                                                                          \
@@ -68,7 +68,7 @@ namespace matx {
 
 #define MATX_BINARY_OP_GEN(FUNC, OPNAME)                                       \
   template <typename T1, typename T2>                                          \
-  static inline __host__ __device__ auto _internal_##FUNC(T1 v1, T2 v2)        \
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto _internal_##FUNC(T1 v1, T2 v2)        \
   {                                                                            \
     if constexpr (is_matx_type_v<T1> || is_matx_type_v<T2>) {                  \
       return FUNC(v1, v2);                                                     \
@@ -84,7 +84,7 @@ namespace matx {
     }                                                                          \
   }                                                                            \
   template <typename T> struct OPNAME##F {                                     \
-    static inline __host__ __device__ auto op(T1 v1, T2 v2)                    \
+    static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2)                    \
     {                                                                          \
       return _internal_##FUNC(v1, v2);                                         \
     }                                                                          \
@@ -94,21 +94,21 @@ namespace matx {
 
 template <typename T1, typename F> class UnOp {
 public:
-  static inline __host__ __device__ auto op(const T1 &v1) { return F::op(v1); }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(const T1 &v1) { return F::op(v1); }
 
-  inline __device__ auto operator()(const T1 &v1) { return op(v1); }
+  inline __MATX_DEVICE__ auto operator()(const T1 &v1) { return op(v1); }
 
   using scalar_type = std::invoke_result_t<decltype(op), T1>;
 };
 
 template <typename T1, typename T2, typename F> class BinOp {
 public:
-  static inline __host__ __device__ auto op(const T1 &v1, const T2 &v2)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(const T1 &v1, const T2 &v2)
   {
     return F::op(v1, v2);
   }
 
-  inline __device__ auto operator()(const T1 &v1, const T2 &v2)
+  inline __MATX_DEVICE__ auto operator()(const T1 &v1, const T2 &v2)
   {
     return op(v1, v2);
   }
@@ -118,13 +118,13 @@ public:
 
 template <typename T1, typename T2, typename T3, typename F> class TerOp {
 public:
-  static inline __host__ __device__ auto op(const T1 &v1, const T2 &v2,
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(const T1 &v1, const T2 &v2,
                                             const T3 &v3)
   {
     return F::op(v1, v2, v3);
   }
 
-  inline __device__ auto operator()(const T1 &v1, const T2 &v2, const T3 &v3)
+  inline __MATX_DEVICE__ auto operator()(const T1 &v1, const T2 &v2, const T3 &v3)
   {
     return op(v1, v2, v3);
   }
@@ -141,11 +141,11 @@ MATX_UNARY_OP_GEN(exp, Exp);
 template <typename T> struct ExpjF {
   template <typename T2 = T,
             std::enable_if_t<std::is_floating_point_v<T2>, bool> = true>
-  inline __host__ __device__ ExpjF()
+  inline __MATX_HOST__ __MATX_DEVICE__ ExpjF()
   {
   }
 
-  static inline __host__ __device__ auto op(T v1)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T v1)
   {
     return cuda::std::complex<T>{cuda::std::cos(v1), cuda::std::sin(v1)};
   }
@@ -153,7 +153,7 @@ template <typename T> struct ExpjF {
 template <typename T> using ExpjOp = UnOp<T, ExpjF<T>>;
 
 template <typename T>
-static inline __host__ __device__ auto _internal_conj(T v1)
+static inline __MATX_HOST__ __MATX_DEVICE__ auto _internal_conj(T v1)
 {
   if constexpr (is_cuda_complex_v<T>) {
     return cuda::std::conj(v1);
@@ -169,7 +169,7 @@ static inline __host__ __device__ auto _internal_conj(T v1)
   }
 }
 template <typename T> struct ConjF {
-  static inline __host__ __device__ auto op(T v1)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T v1)
   {
     if constexpr (is_complex_v<T>) {
       return _internal_conj(v1);
@@ -189,7 +189,7 @@ MATX_UNARY_OP_GEN(norm, Norm);
 
 // Trigonometric functions
 // MATX_UNARY_OP_GEN(sin, Sin);
-template <typename T> static inline __host__ __device__ auto _internal_sin(T v1)
+template <typename T> static inline __MATX_HOST__ __MATX_DEVICE__ auto _internal_sin(T v1)
 {
   if constexpr (is_matx_type_v<T>) {
     return sin(v1);
@@ -205,7 +205,7 @@ template <typename T> static inline __host__ __device__ auto _internal_sin(T v1)
   }
 }
 template <typename T> struct SinF {
-  static inline __host__ __device__ auto op(T v1) { return _internal_sin(v1); }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T v1) { return _internal_sin(v1); }
 };
 template <typename T> using SinOp = UnOp<T, SinF<T>>;
 
@@ -221,17 +221,17 @@ MATX_UNARY_OP_GEN(asinh, Asinh);
 MATX_UNARY_OP_GEN(acosh, Acosh);
 MATX_UNARY_OP_GEN(atanh, Atanh);
 
-template <typename T> static inline __host__ __device__ auto _internal_normcdf(T v1)
+template <typename T> static inline __MATX_HOST__ __MATX_DEVICE__ auto _internal_normcdf(T v1)
 {
   return normcdf(v1);
 }
 template <typename T> struct NormCdfF {
-  static inline __host__ __device__ auto op(T v1) { return _internal_normcdf(v1); }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T v1) { return _internal_normcdf(v1); }
 };
 template <typename T> using NormCdfOp = UnOp<T, NormCdfF<T>>;
 
 template <typename T>
-static inline __host__ __device__ auto _internal_angle(T v1)
+static inline __MATX_HOST__ __MATX_DEVICE__ auto _internal_angle(T v1)
 {
   if constexpr (is_cuda_complex_v<T>) {
     return cuda::std::atan2(v1.imag(), v1.real());
@@ -248,7 +248,7 @@ static inline __host__ __device__ auto _internal_angle(T v1)
 }
 template <typename T, std::enable_if_t<is_complex_v<T>, bool> = true>
 struct Angle {
-  static inline __host__ __device__ auto op(T v1)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T v1)
   {
     return _internal_angle(v1);
   }
@@ -256,12 +256,12 @@ struct Angle {
 template <typename T> using AngleOp = UnOp<T, Angle<T>>;
 
 // template<typename T> struct SubNegF {
-//   static inline __host__  __device__ auto op(T v1) { return -v1; }};
+//   static inline __MATX_HOST__  __MATX_DEVICE__ auto op(T v1) { return -v1; }};
 // template<typename T> using SubNegOp = UnOp<T,SubNegF<T> >;
 
 // Binary Operators
 template <typename T1, typename T2> struct AddF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2)
   {
     if constexpr (is_complex_v<T1> && std::is_arithmetic_v<T2>) {
       if constexpr (is_complex_half_v<T1>) {
@@ -298,7 +298,7 @@ template <typename T1, typename T2> struct AddF {
 template <typename T1, typename T2> using AddOp = BinOp<T1, T2, AddF<T1, T2>>;
 
 template <typename T1, typename T2> struct SubF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2)
   {
     if constexpr (is_complex_v<T1> && std::is_arithmetic_v<T2>) {
       if constexpr (is_complex_half_v<T1>) {
@@ -335,7 +335,7 @@ template <typename T1, typename T2> struct SubF {
 template <typename T1, typename T2> using SubOp = BinOp<T1, T2, SubF<T1, T2>>;
 
 template <typename T1, typename T2> struct MulF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2)
   {
     if constexpr (is_complex_v<T1> && std::is_arithmetic_v<T2>) {
       if constexpr (is_complex_half_v<T1>) {
@@ -372,7 +372,7 @@ template <typename T1, typename T2> struct MulF {
 template <typename T1, typename T2> using MulOp = BinOp<T1, T2, MulF<T1, T2>>;
 
 template <typename T1, typename T2> struct DivF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2)
   {
     if constexpr (is_complex_v<T1> && std::is_arithmetic_v<T2>) {
       if constexpr (is_complex_half_v<T1>) {
@@ -409,14 +409,14 @@ template <typename T1, typename T2> struct DivF {
 template <typename T1, typename T2> using DivOp = BinOp<T1, T2, DivF<T1, T2>>;
 
 template <typename T1, typename T2> struct ModF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 % v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 % v2; }
 };
 template <typename T1, typename T2> using ModOp = BinOp<T1, T2, ModF<T1, T2>>;
 
 // MATX_BINARY_OP_GEN(pow, Pow);
 
 template <typename T1, typename T2>
-static inline __host__ __device__ auto _internal_pow(T1 v1, T2 v2)
+static inline __MATX_HOST__ __MATX_DEVICE__ auto _internal_pow(T1 v1, T2 v2)
 {
   if constexpr (is_matx_type_v<T1>) {
     return pow(v1, v2);
@@ -433,7 +433,7 @@ static inline __host__ __device__ auto _internal_pow(T1 v1, T2 v2)
 }
 
 template <typename T1, typename T2> struct PowF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2)
   {
     return _internal_pow(v1, v2);
   }
@@ -441,7 +441,7 @@ template <typename T1, typename T2> struct PowF {
 template <typename T1, typename T2> using PowOp = BinOp<T1, T2, PowF<T1, T2>>;
 
 template <typename T1, typename T2> struct MaxF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2)
   {
     return max(v1, v2);
   }
@@ -449,7 +449,7 @@ template <typename T1, typename T2> struct MaxF {
 template <typename T1, typename T2> using MaxOp = BinOp<T1, T2, MaxF<T1, T2>>;
 
 template <typename T1, typename T2> struct MinF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2)
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2)
   {
     return min(v1, v2);
   }
@@ -458,62 +458,62 @@ template <typename T1, typename T2> using MinOp = BinOp<T1, T2, MinF<T1, T2>>;
 
 // Logical Operators
 template <typename T1, typename T2> struct LTF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 < v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 < v2; }
 };
 template <typename T1, typename T2> using LTOp = BinOp<T1, T2, LTF<T1, T2>>;
 
 template <typename T1, typename T2> struct GTF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 > v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 > v2; }
 };
 template <typename T1, typename T2> using GTOp = BinOp<T1, T2, GTF<T1, T2>>;
 
 template <typename T1, typename T2> struct LTEF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 <= v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 <= v2; }
 };
 template <typename T1, typename T2> using LTEOp = BinOp<T1, T2, LTEF<T1, T2>>;
 
 template <typename T1, typename T2> struct GTEF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 >= v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 >= v2; }
 };
 template <typename T1, typename T2> using GTEOp = BinOp<T1, T2, GTEF<T1, T2>>;
 
 template <typename T1, typename T2> struct EQF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 == v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 == v2; }
 };
 template <typename T1, typename T2> using EQOp = BinOp<T1, T2, EQF<T1, T2>>;
 
 template <typename T1, typename T2> struct NEF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 != v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 != v2; }
 };
 template <typename T1, typename T2> using NEOp = BinOp<T1, T2, NEF<T1, T2>>;
 
 template <typename T1, typename T2> struct AndAndF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 && v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 && v2; }
 };
 template <typename T1, typename T2> using AndAndOp = BinOp<T1, T2, AndAndF<T1, T2>>;
 
 template <typename T1, typename T2> struct OrOrF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 || v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 || v2; }
 };
 template <typename T1, typename T2> using OrOrOp = BinOp<T1, T2, OrOrF<T1, T2>>;
 
 template <typename T1> struct NotF {
-  static inline __host__ __device__ auto op(T1 v1) { return !v1; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1) { return !v1; }
 };
 template <typename T1> using NotOp = UnOp<T1, NotF<T1>>;
 
 template <typename T1, typename T2> struct AndF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 & v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 & v2; }
 };
 template <typename T1, typename T2> using AndOp = BinOp<T1, T2, AndF<T1, T2>>;
 
 template <typename T1, typename T2> struct OrF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 | v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 | v2; }
 };
 template <typename T1, typename T2> using OrOp = BinOp<T1, T2, OrF<T1, T2>>;
 
 template <typename T1, typename T2> struct XorF {
-  static inline __host__ __device__ auto op(T1 v1, T2 v2) { return v1 ^ v2; }
+  static inline __MATX_HOST__ __MATX_DEVICE__ auto op(T1 v1, T2 v2) { return v1 ^ v2; }
 };
 template <typename T1, typename T2> using XorOp = BinOp<T1, T2, XorF<T1, T2>>;
 

--- a/include/matx_shape.h
+++ b/include/matx_shape.h
@@ -86,7 +86,7 @@ public:
    * @returns Number of elements in dimension
    *
    */
-  inline __host__ __device__ index_t Size([[maybe_unused]] uint32_t dim) const
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Size([[maybe_unused]] uint32_t dim) const
       noexcept
   {
     if constexpr (Rank() > 0)
@@ -138,14 +138,14 @@ public:
    * @returns Rank of the tensor
    *
    */
-  static inline constexpr __host__ __device__ int32_t Rank() { return RANK; }
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return RANK; }
 
 private:
   std::array<index_t, RANK> n_;
 };
 
 template <int RANK1, int RANK2>
-__host__ __device__ __forceinline__ bool
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool
 operator==(const tensorShape_t<RANK1> &lhs, const tensorShape_t<RANK2> &rhs)
 {
   if constexpr (RANK1 != RANK2) {
@@ -162,7 +162,7 @@ operator==(const tensorShape_t<RANK1> &lhs, const tensorShape_t<RANK2> &rhs)
 }
 
 template <int RANK1, int RANK2>
-__host__ __device__ __forceinline__ bool
+__MATX_HOST__ __MATX_DEVICE__ __forceinline__ bool
 operator!=(const tensorShape_t<RANK1> &lhs, const tensorShape_t<RANK2> &rhs)
 {
   return !(lhs == rhs);

--- a/include/matx_signal.h
+++ b/include/matx_signal.h
@@ -54,19 +54,19 @@ private:
 public:
   dctOp(O out, I in, index_t N) : out_(out), in_(in), N_(N) {}
 
-  __device__ inline void operator()(index_t idx)
+  __MATX_DEVICE__ inline void operator()(index_t idx)
   {
     out_(idx) =
         in_(idx).real() * 2.0f * cuda::std::cos(-1 * M_PI * idx / (2.0 * N_)) -
         in_(idx).imag() * 2.0f * cuda::std::sin(-1 * M_PI * idx / (2.0 * N_));
   }
 
-  __host__ __device__ inline index_t Size(uint32_t i) const
+  __MATX_HOST__ __MATX_DEVICE__ inline index_t Size(uint32_t i) const
   {
     return out_.Size(i);
   }
 
-  static inline constexpr __host__ __device__ int32_t Rank()
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
   {
     return O::Rank();
   }

--- a/include/matx_tensor.h
+++ b/include/matx_tensor.h
@@ -125,7 +125,7 @@ public:
 
   set &operator=(const set &) = delete;
 
-  __device__ inline auto operator()() noexcept
+  __MATX_DEVICE__ inline auto operator()() noexcept
   {
     if constexpr (is_matx_half_v<T> &&
                   std::is_integral_v<decltype(get_value(op_))>) {
@@ -138,7 +138,7 @@ public:
     return out_();
   }
 
-  __device__ inline auto operator()(index_t i) noexcept
+  __MATX_DEVICE__ inline auto operator()(index_t i) noexcept
   {
     if constexpr (is_matx_half_v<T> &&
                   std::is_integral_v<decltype(get_value(op_, i))>) {
@@ -151,7 +151,7 @@ public:
     return out_(i);
   }
 
-  __device__ inline auto operator()(index_t i, index_t j) noexcept
+  __MATX_DEVICE__ inline auto operator()(index_t i, index_t j) noexcept
   {
     if constexpr (is_matx_half_v<T> &&
                   std::is_integral_v<decltype(get_value(op_, i, j))>) {
@@ -164,7 +164,7 @@ public:
     return out_(i, j);
   }
 
-  __device__ inline auto operator()(index_t i, index_t j, index_t k) noexcept
+  __MATX_DEVICE__ inline auto operator()(index_t i, index_t j, index_t k) noexcept
   {
     if constexpr (is_matx_half_v<T> &&
                   std::is_integral_v<decltype(get_value(op_, i, j, k))>) {
@@ -177,7 +177,7 @@ public:
     return out_(i, j, k);
   }
 
-  __device__ inline auto operator()(index_t i, index_t j, index_t k,
+  __MATX_DEVICE__ inline auto operator()(index_t i, index_t j, index_t k,
                                     index_t l) noexcept
   {
     if constexpr (is_matx_half_v<T> &&
@@ -197,7 +197,7 @@ public:
    * @return
    *   Rank of the operator
    */
-  static inline constexpr __host__ __device__ int32_t Rank() { return RANK; }
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return RANK; }
 
   /**
    * Get the rank of the operator along a single dimension
@@ -208,7 +208,7 @@ public:
    *   Size of dimension
    */
   template <int M = RANK, std::enable_if_t<M >= 1, bool> = true>
-  inline __host__ __device__ index_t Size(uint32_t dim) const
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
   {
     return size_[dim];
   }
@@ -241,7 +241,7 @@ public:
   template <int M = RANK, std::enable_if_t<M != 0, bool> = true>
   tensor_t() = delete;
 
-  __host__ __device__ tensor_t<T, RANK>(tensor_t<T, RANK> const &rhs) noexcept
+  __MATX_HOST__ __MATX_DEVICE__ tensor_t<T, RANK>(tensor_t<T, RANK> const &rhs) noexcept
       : data_(rhs.data_), ldata_(rhs.ldata_), shape_(rhs.shape_), s_(rhs.s_),
         refcnt_(rhs.refcnt_)
   {
@@ -252,7 +252,7 @@ public:
 #endif
   }
 
-  __host__ __device__ tensor_t<T, RANK>(tensor_t<T, RANK> const &&rhs) noexcept
+  __MATX_HOST__ __MATX_DEVICE__ tensor_t<T, RANK>(tensor_t<T, RANK> const &&rhs) noexcept
       : data_(rhs.data_), ldata_(rhs.ldata_), shape_(std::move(rhs.shape_)),
         s_(rhs.s_), refcnt_(rhs.refcnt_)
   {
@@ -267,7 +267,7 @@ public:
    * @param rhs
    *   Tensor to copy from
    */
-  __host__ __device__ void Shallow(const tensor_t<T, RANK> &rhs) noexcept
+  __MATX_HOST__ __MATX_DEVICE__ void Shallow(const tensor_t<T, RANK> &rhs) noexcept
   {
     data_ = rhs.data_;
     ldata_ = rhs.ldata_;
@@ -279,7 +279,7 @@ public:
     }
   }
 
-  inline __host__ __device__ ~tensor_t()
+  inline __MATX_HOST__ __MATX_DEVICE__ ~tensor_t()
   {
 #ifndef __CUDA_ARCH__
     Free();
@@ -510,7 +510,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator=(const tensor_t<T, RANK> &op)
   {
     return set(*this, op);
   }
@@ -525,7 +525,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator=(const T2 &op)
   {
     return set(*this, op);
   }
@@ -540,7 +540,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator+=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator+=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this + op);
   }
@@ -556,7 +556,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator+=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator+=(const T2 &op)
   {
     return set(*this, *this + op);
   }
@@ -571,7 +571,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator-=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator-=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this - op);
   }
@@ -587,7 +587,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator-=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator-=(const T2 &op)
   {
     return set(*this, *this - op);
   }
@@ -602,7 +602,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator*=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator*=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this * op);
   }
@@ -618,7 +618,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator*=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator*=(const T2 &op)
   {
     return set(*this, *this * op);
   }
@@ -633,7 +633,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator/=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator/=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this / op);
   }
@@ -649,7 +649,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator/=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator/=(const T2 &op)
   {
     return set(*this, *this / op);
   }
@@ -664,7 +664,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator<<=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator<<=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this << op);
   }
@@ -680,7 +680,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator<<=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator<<=(const T2 &op)
   {
     return set(*this, *this << op);
   }
@@ -695,7 +695,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator>>=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator>>=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this >> op);
   }
@@ -711,7 +711,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator>>=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator>>=(const T2 &op)
   {
     return set(*this, *this >> op);
   }
@@ -726,7 +726,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator|=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator|=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this | op);
   }
@@ -742,7 +742,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator|=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator|=(const T2 &op)
   {
     return set(*this, *this | op);
   }
@@ -757,7 +757,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator&=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator&=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this & op);
   }
@@ -773,7 +773,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator&=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator&=(const T2 &op)
   {
     return set(*this, *this & op);
   }
@@ -788,7 +788,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator^=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator^=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this ^ op);
   }
@@ -804,7 +804,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator^=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator^=(const T2 &op)
   {
     return set(*this, *this ^ op);
   }
@@ -819,7 +819,7 @@ public:
    * @returns set object containing the destination view and source object
    *
    */
-  [[nodiscard]] inline __host__ auto operator%=(const tensor_t<T, RANK> &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator%=(const tensor_t<T, RANK> &op)
   {
     return set(*this, *this % op);
   }
@@ -835,7 +835,7 @@ public:
    *
    */
   template <typename T2>
-  [[nodiscard]] inline __host__ auto operator%=(const T2 &op)
+  [[nodiscard]] inline __MATX_HOST__ auto operator%=(const T2 &op)
   {
     return set(*this, *this % op);
   }
@@ -1119,7 +1119,7 @@ public:
    * @returns Underlying data pointer of type T
    *
    */
-  __host__ __device__ inline T *Data() const noexcept { return ldata_; }
+  __MATX_HOST__ __MATX_DEVICE__ inline T *Data() const noexcept { return ldata_; }
 
   /**
    * Set the underlying data pointer from the view
@@ -1134,7 +1134,7 @@ public:
    *   Optional reference count for new memory or nullptr if not tracked
    *
    */
-  __host__ inline void
+  __MATX_HOST__ inline void
   SetData(T *const data, cuda::std::atomic<uint32_t> *refcnt = nullptr) noexcept
   {
     SetData(data, data, refcnt);
@@ -1155,7 +1155,7 @@ public:
    *   Optional reference count for new memory or nullptr if not tracked
    *
    */
-  __host__ inline void
+  __MATX_HOST__ inline void
   SetData(T *const data, T *const ldata,
           cuda::std::atomic<uint32_t> *refcnt = nullptr) noexcept
   {
@@ -1176,7 +1176,7 @@ public:
    * @returns Rank of the tensor
    *
    */
-  static inline constexpr __host__ __device__ int32_t Rank() { return RANK; }
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return RANK; }
 
   /**
    * Get the reference count
@@ -1184,7 +1184,7 @@ public:
    * @returns Reference count or 0 if not tracked
    *
    */
-  inline __host__ index_t GetRefCount() const noexcept
+  inline __MATX_HOST__ index_t GetRefCount() const noexcept
   {
     if (refcnt_ == nullptr) {
       return 0;
@@ -1202,7 +1202,7 @@ public:
    * @returns Number of elements in dimension
    *
    */
-  inline __host__ __device__ index_t Size(uint32_t dim) const noexcept
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const noexcept
   {
     return shape_.Size(dim);
   }
@@ -1213,7 +1213,7 @@ public:
    * @return
    *    The size of the dimension
    */
-  inline __host__ __device__ index_t Lsize() const noexcept
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Lsize() const noexcept
   {
     return shape_.Size(Rank() - 1);
   }
@@ -1224,7 +1224,7 @@ public:
    * @return
    *    The size of the dimension
    */
-  inline __host__ __device__ bool IsLinear() const noexcept
+  inline __MATX_HOST__ __MATX_DEVICE__ bool IsLinear() const noexcept
   {
     index_t ttl = 1;
     for (int i = RANK - 1; i >= 0; i--) {
@@ -1252,7 +1252,7 @@ public:
   {
 #else
   template <int M = RANK, std::enable_if_t<M >= 1, bool> = true>
-  inline __host__ __device__ index_t Stride(uint32_t dim) const
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Stride(uint32_t dim) const
   {
 #endif
     return s_[dim];
@@ -1274,11 +1274,11 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ const T &operator()() const noexcept
+  __MATX_HOST__ __MATX_DEVICE__ const T &operator()() const noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 0, bool> = true>
-  inline __host__ __device__ const T &operator()() const noexcept
+  inline __MATX_HOST__ __MATX_DEVICE__ const T &operator()() const noexcept
   {
 #endif
     return *ldata_;
@@ -1291,11 +1291,11 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ T &operator()() noexcept
+  __MATX_HOST__ __MATX_DEVICE__ T &operator()() noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 0, bool> = true>
-  inline __host__ __device__ T &operator()() noexcept
+  inline __MATX_HOST__ __MATX_DEVICE__ T &operator()() noexcept
   {
 #endif
     return *ldata_;
@@ -1311,11 +1311,11 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ const T &operator()(index_t id0) const noexcept
+  __MATX_HOST__ __MATX_DEVICE__ const T &operator()(index_t id0) const noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 1, bool> = true>
-  inline __host__ __device__ const T &operator()(index_t id0) const noexcept
+  inline __MATX_HOST__ __MATX_DEVICE__ const T &operator()(index_t id0) const noexcept
   {
 #endif
     return *(ldata_ + s_[0] * id0);
@@ -1331,11 +1331,11 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ T &operator()(index_t id0) noexcept
+  __MATX_HOST__ __MATX_DEVICE__ T &operator()(index_t id0) noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 1, bool> = true>
-  inline __host__ __device__ T &operator()(index_t id0) noexcept
+  inline __MATX_HOST__ __MATX_DEVICE__ T &operator()(index_t id0) noexcept
   {
 #endif
     return *(ldata_ + s_[0] * id0);
@@ -1354,12 +1354,12 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ const T &operator()(index_t id0,
+  __MATX_HOST__ __MATX_DEVICE__ const T &operator()(index_t id0,
                                           index_t id1) const noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 2, bool> = true>
-  inline __host__ __device__ const T &operator()(index_t id0,
+  inline __MATX_HOST__ __MATX_DEVICE__ const T &operator()(index_t id0,
                                                  index_t id1) const noexcept
   {
 #endif
@@ -1379,11 +1379,11 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ T &operator()(index_t id0, index_t id1) noexcept
+  __MATX_HOST__ __MATX_DEVICE__ T &operator()(index_t id0, index_t id1) noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 2, bool> = true>
-  inline __host__ __device__ T &operator()(index_t id0, index_t id1) noexcept
+  inline __MATX_HOST__ __MATX_DEVICE__ T &operator()(index_t id0, index_t id1) noexcept
   {
 #endif
     return *(ldata_ + s_[0] * id0 + s_[1] * id1);
@@ -1405,12 +1405,12 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ const T &operator()(index_t id0, index_t id1,
+  __MATX_HOST__ __MATX_DEVICE__ const T &operator()(index_t id0, index_t id1,
                                           index_t id2) const noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 3, bool> = true>
-  inline __host__ __device__ const T &operator()(index_t id0, index_t id1,
+  inline __MATX_HOST__ __MATX_DEVICE__ const T &operator()(index_t id0, index_t id1,
                                                  index_t id2) const noexcept
   {
 #endif
@@ -1433,12 +1433,12 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ T &operator()(index_t id0, index_t id1,
+  __MATX_HOST__ __MATX_DEVICE__ T &operator()(index_t id0, index_t id1,
                                     index_t id2) noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 3, bool> = true>
-  inline __host__ __device__ T &operator()(index_t id0, index_t id1,
+  inline __MATX_HOST__ __MATX_DEVICE__ T &operator()(index_t id0, index_t id1,
                                            index_t id2) noexcept
   {
 #endif
@@ -1464,12 +1464,12 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ const T &operator()(index_t id0, index_t id1, index_t id2,
+  __MATX_HOST__ __MATX_DEVICE__ const T &operator()(index_t id0, index_t id1, index_t id2,
                                           index_t id3) const noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 4, bool> = true>
-  inline __host__ __device__ const T &
+  inline __MATX_HOST__ __MATX_DEVICE__ const T &
   operator()(index_t id0, index_t id1, index_t id2, index_t id3) const noexcept
   {
 #endif
@@ -1495,12 +1495,12 @@ public:
    *
    */
 #ifdef DOXYGEN_ONLY
-  __host__ __device__ T &operator()(index_t id0, index_t id1, index_t id2,
+  __MATX_HOST__ __MATX_DEVICE__ T &operator()(index_t id0, index_t id1, index_t id2,
                                     index_t id3) noexcept
   {
 #else
   template <int M = RANK, std::enable_if_t<M == 4, bool> = true>
-  inline __host__ __device__ T &operator()(index_t id0, index_t id1,
+  inline __MATX_HOST__ __MATX_DEVICE__ T &operator()(index_t id0, index_t id1,
                                            index_t id2, index_t id3) noexcept
   {
 #endif
@@ -1643,7 +1643,7 @@ public:
    *
    */
   template <int M = RANK, std::enable_if_t<M == 0, bool> = true>
-  inline __host__ void SetVals(T const &val) noexcept
+  inline __MATX_HOST__ void SetVals(T const &val) noexcept
   {
     this->operator()() = val;
   }
@@ -1660,7 +1660,7 @@ public:
   template <int M = RANK, std::enable_if_t<(!is_cuda_complex_v<T> && M == 1) ||
                                                (is_cuda_complex_v<T> && M == 0),
                                            bool> = true>
-  inline __host__ void SetVals(const std::initializer_list<T> &vals) noexcept
+  inline __MATX_HOST__ void SetVals(const std::initializer_list<T> &vals) noexcept
   {
     for (size_t i = 0; i < vals.size(); i++) {
       if constexpr (is_cuda_complex_v<T>) {
@@ -1686,7 +1686,7 @@ public:
   template <int M = RANK, std::enable_if_t<(!is_cuda_complex_v<T> && M == 2) ||
                                                (is_cuda_complex_v<T> && M == 1),
                                            bool> = true>
-  inline __host__ void
+  inline __MATX_HOST__ void
   SetVals(const std::initializer_list<const std::initializer_list<T>>
               &vals) noexcept
   {
@@ -1719,7 +1719,7 @@ public:
   template <int M = RANK, std::enable_if_t<(!is_cuda_complex_v<T> && M == 3) ||
                                                (is_cuda_complex_v<T> && M == 2),
                                            bool> = true>
-  inline __host__ void
+  inline __MATX_HOST__ void
   SetVals(const std::initializer_list<
           const std::initializer_list<const std::initializer_list<T>>>
               vals) noexcept
@@ -1756,7 +1756,7 @@ public:
   template <int M = RANK, std::enable_if_t<(!is_cuda_complex_v<T> && M == 4) ||
                                                (is_cuda_complex_v<T> && M == 3),
                                            bool> = true>
-  inline __host__ void
+  inline __MATX_HOST__ void
   SetVals(const std::initializer_list<const std::initializer_list<
               const std::initializer_list<const std::initializer_list<T>>>>
               &vals) noexcept
@@ -1801,7 +1801,7 @@ public:
    */
   template <int M = RANK,
             std::enable_if_t<is_cuda_complex_v<T> && M == 4, bool> = true>
-  inline __host__ void
+  inline __MATX_HOST__ void
   SetVals(const std::initializer_list<
           const std::initializer_list<const std::initializer_list<
               const std::initializer_list<const std::initializer_list<T>>>>>
@@ -1982,7 +1982,7 @@ public:
    *
    * @param val
    */
-  inline __host__ __device__ void PrintVal(const T &val) const noexcept
+  inline __MATX_HOST__ __MATX_DEVICE__ void PrintVal(const T &val) const noexcept
   {
     if constexpr (is_complex_v<T>) {
       printf("%.4f%+.4fj ", static_cast<float>(val.real()),
@@ -2030,7 +2030,7 @@ public:
   void InternalPrint() const noexcept
 #else
   template <int N = RANK, std::enable_if_t<N == 0, bool> = true>
-  __host__ __device__ void InternalPrint() const noexcept
+  __MATX_HOST__ __MATX_DEVICE__ void InternalPrint() const noexcept
 #endif
   {
     PrintVal(this->operator()());
@@ -2050,7 +2050,7 @@ public:
   void InternalPrint(const index_t k = 0) const noexcept
 #else
   template <int N = RANK, std::enable_if_t<N == 1, bool> = true>
-  __host__ __device__ void InternalPrint(const index_t k = 0) const noexcept
+  __MATX_HOST__ __MATX_DEVICE__ void InternalPrint(const index_t k = 0) const noexcept
 #endif
   {
     for (index_t _k = 0; _k < ((k == 0) ? Size(0) : k); _k++) {
@@ -2077,7 +2077,7 @@ public:
   void InternalPrint(const index_t k = 0, const index_t l = 0) const noexcept
 #else
   template <int N = RANK, std::enable_if_t<N == 2, bool> = true>
-  __host__ __device__ void InternalPrint(const index_t k = 0,
+  __MATX_HOST__ __MATX_DEVICE__ void InternalPrint(const index_t k = 0,
                                          const index_t l = 0) const noexcept
 #endif
   {
@@ -2115,7 +2115,7 @@ public:
                      const index_t l = 0) const noexcept
 #else
   template <int N = RANK, std::enable_if_t<N == 3, bool> = true>
-  __host__ __device__ void InternalPrint(const index_t j = 0,
+  __MATX_HOST__ __MATX_DEVICE__ void InternalPrint(const index_t j = 0,
                                          const index_t k = 0,
                                          const index_t l = 0) const noexcept
 #endif
@@ -2161,7 +2161,7 @@ public:
                      const index_t k = 0, const index_t l = 0) const
 #else
   template <int N = RANK, std::enable_if_t<N == 4, bool> = true>
-  __host__ __device__ void
+  __MATX_HOST__ __MATX_DEVICE__ void
   InternalPrint(const index_t i = 0, const index_t j = 0, const index_t k = 0,
                 const index_t l = 0) const noexcept
 #endif

--- a/include/matx_tensor.h
+++ b/include/matx_tensor.h
@@ -2021,363 +2021,108 @@ public:
   }
 
   /**
-   * Print a rank=0 tensor
+   * Print a tensor
    *
-   * Type-agnostic function to print a rank=0 tensor to stdout
+   * Type-agnostic function to print a tensor to stdout
    *
    */
-#ifdef DOXYGEN_ONLY
-  void InternalPrint() const noexcept
-#else
-  template <int N = RANK, std::enable_if_t<N == 0, bool> = true>
-  __MATX_HOST__ __MATX_DEVICE__ void InternalPrint() const noexcept
-#endif
+  template <typename ... Args>
+  __MATX_HOST__ __MATX_DEVICE__ void InternalPrint(Args ...dims) const noexcept
   {
-    PrintVal(this->operator()());
-    printf("\n");
-  }
+    MATX_STATIC_ASSERT(RANK == sizeof...(Args), "Number of dimensions to print must match tensor rank");
 
-  /**
-   * Print a rank=1 tensor
-   *
-   * Type-agnostic function to print a rank=1 tensor to stdout
-   *
-   * @param k
-   *   Ending index of first dimension. Use 0 to print all values
-   *   in dimension.
-   */
-#ifdef DOXYGEN_ONLY
-  void InternalPrint(const index_t k = 0) const noexcept
-#else
-  template <int N = RANK, std::enable_if_t<N == 1, bool> = true>
-  __MATX_HOST__ __MATX_DEVICE__ void InternalPrint(const index_t k = 0) const noexcept
-#endif
-  {
-    for (index_t _k = 0; _k < ((k == 0) ? Size(0) : k); _k++) {
-      printf("%06lld: ", _k);
-      PrintVal(this->operator()(_k));
+    if constexpr (sizeof...(Args) == 0) {
+      PrintVal(this->operator()());
       printf("\n");
     }
-  }
-
-  /**
-   * Print a rank=2 tensor
-   *
-   * Type-agnostic function to print a rank=2 tensor to stdout
-   *
-   * @param k
-   *   Ending index of first dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param l
-   *   Ending index of second dimension. Use 0 to print all values
-   *   in dimension.
-   */
-#ifdef DOXYGEN_ONLY
-  void InternalPrint(const index_t k = 0, const index_t l = 0) const noexcept
-#else
-  template <int N = RANK, std::enable_if_t<N == 2, bool> = true>
-  __MATX_HOST__ __MATX_DEVICE__ void InternalPrint(const index_t k = 0,
-                                         const index_t l = 0) const noexcept
-#endif
-  {
-    for (index_t _k = 0; _k < ((k == 0) ? Size(0) : k); _k++) {
-      for (index_t _l = 0; _l < ((l == 0) ? Size(1) : l); _l++) {
-        if (_l == 0)
-          printf("%06lld: ", _k);
-
-        PrintVal(this->operator()(_k, _l));
+    else if constexpr (sizeof...(Args) == 1) {
+      auto& k = pp_get<0>(dims...);
+      for (index_t _k = 0; _k < ((k == 0) ? Size(0) : k); _k++) {
+        printf("%06lld: ", _k);
+        PrintVal(this->operator()(_k));
+        printf("\n");
       }
-      printf("\n");
     }
-  }
-
-  /**
-   * Print a rank=3 tensor
-   *
-   * Type-agnostic function to print a rank=3 tensor to stdout
-   *
-   * @param j
-   *   Ending index of first dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param k
-   *   Ending index of second dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param l
-   *   Ending index of third dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   */
-#ifdef DOXYGEN_ONLY
-  void InternalPrint(const index_t j = 0, const index_t k = 0,
-                     const index_t l = 0) const noexcept
-#else
-  template <int N = RANK, std::enable_if_t<N == 3, bool> = true>
-  __MATX_HOST__ __MATX_DEVICE__ void InternalPrint(const index_t j = 0,
-                                         const index_t k = 0,
-                                         const index_t l = 0) const noexcept
-#endif
-  {
-    for (index_t _j = 0; _j < ((j == 0) ? Size(0) : j); _j++) {
-      printf("[%06lld,:,:]\n", _j);
-      for (index_t _k = 0; _k < ((k == 0) ? Size(1) : k); _k++) {
-        for (index_t _l = 0; _l < ((l == 0) ? Size(2) : l); _l++) {
+    else if constexpr (sizeof...(Args) == 2) {
+      auto& k = pp_get<0>(dims...);
+      auto& l = pp_get<1>(dims...);
+      for (index_t _k = 0; _k < ((k == 0) ? Size(0) : k); _k++) {
+        for (index_t _l = 0; _l < ((l == 0) ? Size(1) : l); _l++) {
           if (_l == 0)
             printf("%06lld: ", _k);
 
-          PrintVal(this->operator()(_j, _k, _l));
+          PrintVal(this->operator()(_k, _l));
         }
         printf("\n");
       }
-      printf("\n");
     }
-  }
-
-  /**
-   * Print a rank=4 tensor
-   *
-   * Type-agnostic function to print a rank=4 tensor to stdout
-   *
-   * @param i
-   *   Ending index of first dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param j
-   *   Ending index of second dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param k
-   *   Ending index of third dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param l
-   *   Ending index of fourth dimension. Use 0 to print all values
-   *   in dimension.
-   */
-#ifdef DOXYGEN_ONLY
-  void InternalPrint(const index_t i = 0, const index_t j = 0,
-                     const index_t k = 0, const index_t l = 0) const
-#else
-  template <int N = RANK, std::enable_if_t<N == 4, bool> = true>
-  __MATX_HOST__ __MATX_DEVICE__ void
-  InternalPrint(const index_t i = 0, const index_t j = 0, const index_t k = 0,
-                const index_t l = 0) const noexcept
-#endif
-  {
-    for (index_t _i = 0; _i < ((i == 0) ? Size(0) : i); _i++) {
-      for (index_t _j = 0; _j < ((j == 0) ? Size(1) : j); _j++) {
-        printf("[%06lld,%06lld,:,:]\n", _i, _j);
-        for (index_t _k = 0; _k < ((k == 0) ? Size(2) : k); _k++) {
-          for (index_t _l = 0; _l < ((l == 0) ? Size(3) : l); _l++) {
+    else if constexpr (sizeof...(Args) == 3) {
+      auto& j = pp_get<0>(dims...);
+      auto& k = pp_get<1>(dims...);
+      auto& l = pp_get<2>(dims...);
+      for (index_t _j = 0; _j < ((j == 0) ? Size(0) : j); _j++) {
+        printf("[%06lld,:,:]\n", _j);
+        for (index_t _k = 0; _k < ((k == 0) ? Size(1) : k); _k++) {
+          for (index_t _l = 0; _l < ((l == 0) ? Size(2) : l); _l++) {
             if (_l == 0)
               printf("%06lld: ", _k);
 
-            PrintVal(this->operator()(_i, _j, _k, _l));
+            PrintVal(this->operator()(_j, _k, _l));
           }
           printf("\n");
         }
         printf("\n");
+      }      
+    }
+    else if constexpr (sizeof...(Args) == 4) {
+      auto& i = pp_get<0>(dims...);
+      auto& j = pp_get<1>(dims...);
+      auto& k = pp_get<2>(dims...);
+      auto& l = pp_get<3>(dims...); 
+      for (index_t _i = 0; _i < ((i == 0) ? Size(0) : i); _i++) {
+        for (index_t _j = 0; _j < ((j == 0) ? Size(1) : j); _j++) {
+          printf("[%06lld,%06lld,:,:]\n", _i, _j);
+          for (index_t _k = 0; _k < ((k == 0) ? Size(2) : k); _k++) {
+            for (index_t _l = 0; _l < ((l == 0) ? Size(3) : l); _l++) {
+              if (_l == 0)
+                printf("%06lld: ", _k);
+
+              PrintVal(this->operator()(_i, _j, _k, _l));
+            }
+            printf("\n");
+          }
+          printf("\n");
+        }
       }
     }
-  }
+  }  
 
   /**
-   * Print a rank=0 tensor
+   * Print a tensor
    *
-   * Type-agnostic function to print a rank=0 tensor to stdout
+   * Type-agnostic function to print a tensor to stdout
    *
    */
-#ifdef DOXYGEN_ONLY
-  void Print() const
-#else
-  template <int N = RANK, std::enable_if_t<N == 0, bool> = true>
-  inline void Print() const
-#endif
+  template <typename ... Args>
+  inline void Print(Args ...dims) const
   {
     auto kind = GetPointerKind(data_);
     cudaDeviceSynchronize();
     if (HostPrintable(kind)) {
-      InternalPrint();
+      InternalPrint(dims...);
     }
     else if (DevicePrintable(kind)) {
       if (PRINT_ON_DEVICE) {
-        PrintKernel<<<1, 1>>>(*this);
+        PrintKernel<<<1, 1>>>(*this, dims...);
       }
       else {
         tensor_t<T, RANK> tmpv(this->shape_, (const index_t(&)[RANK])this->s_);
         cudaMemcpy(tmpv.Data(), this->Data(), tmpv.Bytes(),
                    cudaMemcpyDeviceToHost);
-        tmpv.Print();
+        tmpv.Print(dims...);
       }
     }
-  }
-
-  /**
-   * Print a rank=1 tensor
-   *
-   * Type-agnostic function to print a rank=1 tensor to stdout
-   *
-   * @param k
-   *   Ending index of first dimension. Use 0 to print all values
-   *   in dimension.
-   */
-#ifdef DOXYGEN_ONLY
-  void Print(index_t k = 0) const noexcept
-#else
-  template <int N = RANK, std::enable_if_t<N == 1, bool> = true>
-  inline void Print(index_t k = 0) const noexcept
-#endif
-  {
-    auto kind = GetPointerKind(data_);
-    cudaDeviceSynchronize();
-    if (HostPrintable(kind)) {
-      InternalPrint(k);
-    }
-    else if (DevicePrintable(kind)) {
-      if (PRINT_ON_DEVICE) {
-        PrintKernel<<<1, 1>>>(*this, k);
-      }
-      else {
-        tensor_t<T, RANK> tmpv(this->shape_, (const index_t(&)[RANK])this->s_);
-        cudaMemcpy(tmpv.Data(), this->Data(), tmpv.Bytes(),
-                   cudaMemcpyDeviceToHost);
-        tmpv.Print(k);
-      }
-    }
-  }
-
-  /**
-   * Print a rank=2 tensor
-   *
-   * Type-agnostic function to print a rank=2 tensor to stdout
-   *
-   * @param k
-   *   Ending index of first dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param l
-   *   Ending index of second dimension. Use 0 to print all values
-   *   in dimension.
-   */
-#ifdef DOXYGEN_ONLY
-  void Print(const index_t k = 0, const index_t l = 0) const noexcept
-#else
-  template <int N = RANK, std::enable_if_t<N == 2, bool> = true>
-  inline void Print(const index_t k = 0, const index_t l = 0) const noexcept
-#endif
-  {
-    auto kind = GetPointerKind(data_);
-    cudaDeviceSynchronize();
-    if (HostPrintable(kind)) {
-      InternalPrint(k, l);
-    }
-    else if (DevicePrintable(kind)) {
-      if (PRINT_ON_DEVICE) {
-        PrintKernel<<<1, 1>>>(*this, k, l);
-      }
-      else {
-        tensor_t<T, RANK> tmpv(this->shape_, (const index_t(&)[RANK])this->s_);
-        cudaMemcpy(tmpv.Data(), this->Data(), tmpv.Bytes(),
-                   cudaMemcpyDeviceToHost);
-        tmpv.Print(k, l);
-      }
-    }
-  }
-
-  /**
-   * Print a rank=3 tensor
-   *
-   * Type-agnostic function to print a rank=3 tensor to stdout
-   *
-   * @param j
-   *   Ending index of first dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param k
-   *   Ending index of second dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param l
-   *   Ending index of third dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   */
-#ifdef DOXYGEN_ONLY
-  void Print(const index_t j = 0, const index_t k = 0,
-             const index_t l = 0) const noexcept
-#else
-  template <int N = RANK, std::enable_if_t<N == 3, bool> = true>
-  inline void Print(const index_t j = 0, const index_t k = 0,
-                    const index_t l = 0) const noexcept
-#endif
-  {
-    auto kind = GetPointerKind(data_);
-    cudaDeviceSynchronize();
-    if (HostPrintable(kind)) {
-      InternalPrint(j, k, l);
-    }
-    else if (DevicePrintable(kind)) {
-      if (PRINT_ON_DEVICE) {
-        PrintKernel<<<1, 1>>>(*this, j, k, l);
-      }
-      else {
-        tensor_t<T, RANK> tmpv(this->shape_, (const index_t(&)[RANK])this->s_);
-        cudaMemcpy(tmpv.Data(), this->Data(), tmpv.Bytes(),
-                   cudaMemcpyDeviceToHost);
-        tmpv.Print(j, k, l);
-      }
-    }
-  }
-
-  /**
-   * Print a rank=4 tensor
-   *
-   * Type-agnostic function to print a rank=4 tensor to stdout
-   *
-   * @param i
-   *   Ending index of first dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param j
-   *   Ending index of second dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param k
-   *   Ending index of third dimension. Use 0 to print all values
-   *   in dimension.
-   *
-   * @param l
-   *   Ending index of fourth dimension. Use 0 to print all values
-   *   in dimension.
-   */
-#ifdef DOXYGEN_ONLY
-  void Print(const index_t i = 0, const index_t j = 0, const index_t k = 0,
-             const index_t l = 0) const noexcept
-#else
-  template <int N = RANK, std::enable_if_t<N == 4, bool> = true>
-  inline void Print(const index_t i = 0, const index_t j = 0,
-                    const index_t k = 0, const index_t l = 0) const noexcept
-#endif
-  {
-    auto kind = GetPointerKind(data_);
-    cudaDeviceSynchronize();
-    if (HostPrintable(kind)) {
-      InternalPrint(i, j, k, l);
-    }
-    else if (DevicePrintable(kind)) {
-      if (PRINT_ON_DEVICE) {
-        PrintKernel<<<1, 1>>>(*this, i, j, k, l);
-      }
-      else {
-        tensor_t<T, RANK> tmpv(this->shape_, (const index_t(&)[RANK])this->s_);
-        cudaMemcpy(tmpv.Data(), this->Data(), tmpv.Bytes(),
-                   cudaMemcpyDeviceToHost);
-        tmpv.Print(i, j, k, l);
-      }
-    }
-  }
+  }  
 
 private:
   /**

--- a/include/matx_tensor_generators.h
+++ b/include/matx_tensor_generators.h
@@ -51,20 +51,20 @@ public:
 
   ConstVal(tensorShape_t<RANK> s, T val) : s_(s), v_(val){};
 
-  inline __device__ T operator()() { return v_; };
-  inline __device__ T operator()(index_t) { return v_; };
-  inline __device__ T operator()(index_t, index_t) { return v_; };
-  inline __device__ T operator()(index_t, index_t, index_t) { return v_; };
-  inline __device__ T operator()(index_t, index_t, index_t, index_t)
+  inline __MATX_DEVICE__ T operator()() { return v_; };
+  inline __MATX_DEVICE__ T operator()(index_t) { return v_; };
+  inline __MATX_DEVICE__ T operator()(index_t, index_t) { return v_; };
+  inline __MATX_DEVICE__ T operator()(index_t, index_t, index_t) { return v_; };
+  inline __MATX_DEVICE__ T operator()(index_t, index_t, index_t, index_t)
   {
     return v_;
   };
 
-  inline __host__ __device__ index_t Size(uint32_t dim) const
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
   {
     return s_.Size(dim);
   }
-  static inline constexpr __host__ __device__ int32_t Rank() { return RANK; }
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return RANK; }
 };
 
 /**
@@ -126,29 +126,29 @@ public:
 
   Diag(tensorShape_t<RANK> s, T val) : s_(s), val_(val){};
 
-  inline __device__ T operator()() { return T(val_); };
-  inline __device__ T operator()(index_t i)
+  inline __MATX_DEVICE__ T operator()() { return T(val_); };
+  inline __MATX_DEVICE__ T operator()(index_t i)
   {
     if (i == 0)
       return val_;
     else
       return T(0.0f);
   };
-  inline __device__ T operator()(index_t i, index_t j)
+  inline __MATX_DEVICE__ T operator()(index_t i, index_t j)
   {
     if (i == j)
       return T(val_);
     else
       return T(0.0f);
   };
-  inline __device__ T operator()(index_t i, index_t j, index_t k)
+  inline __MATX_DEVICE__ T operator()(index_t i, index_t j, index_t k)
   {
     if (i == j && i == k)
       return T(val_);
     else
       return T(0.0f);
   };
-  inline __device__ T operator()(index_t i, index_t j, index_t k, index_t l)
+  inline __MATX_DEVICE__ T operator()(index_t i, index_t j, index_t k, index_t l)
   {
     if (i == j && k == l && i == k)
       return T(val_);
@@ -156,11 +156,11 @@ public:
       return T(0.0f);
   };
 
-  inline __host__ __device__ index_t Size(uint32_t dim) const
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
   {
     return s_.Size(dim);
   }
-  static inline constexpr __host__ __device__ int32_t Rank() { return RANK; }
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return RANK; }
 };
 
 /**
@@ -215,8 +215,8 @@ public:
   using scalar_type = typename Generator1D::scalar_type;
 
   matxGenerator1D_t(tensorShape_t<RANK> s, Generator1D f) : f_(f), s_(s) {}
-  inline __device__ auto operator()(int i) { return f_(i); };
-  inline __device__ auto operator()(int i, int j)
+  inline __MATX_DEVICE__ auto operator()(int i) { return f_(i); };
+  inline __MATX_DEVICE__ auto operator()(int i, int j)
   {
     if constexpr (Dim == 0) {
       return f_(i);
@@ -227,7 +227,7 @@ public:
     // BUG WAR
     return scalar_type(0);
   };
-  inline __device__ auto operator()(int i, int j, int k)
+  inline __MATX_DEVICE__ auto operator()(int i, int j, int k)
   {
     if constexpr (Dim == 0) {
       return f_(i);
@@ -241,7 +241,7 @@ public:
     // BUG WAR
     return scalar_type(0);
   };
-  inline __device__ auto operator()(int i, int j, int k, int l)
+  inline __MATX_DEVICE__ auto operator()(int i, int j, int k, int l)
   {
     if constexpr (Dim == 0) {
       return f_(i);
@@ -259,11 +259,11 @@ public:
     return scalar_type(0);
   };
 
-  inline __host__ __device__ index_t Size(uint32_t dim) const
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
   {
     return s_.Size(dim);
   }
-  static inline constexpr __host__ __device__ int32_t Rank() { return RANK; }
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return RANK; }
 
 private:
   Generator1D f_;
@@ -277,9 +277,9 @@ private:
 public:
   using scalar_type = T;
 
-  inline __host__ __device__ Hamming(index_t size) : size_(size){};
+  inline __MATX_HOST__ __MATX_DEVICE__ Hamming(index_t size) : size_(size){};
 
-  inline __host__ __device__ T operator()(index_t i)
+  inline __MATX_HOST__ __MATX_DEVICE__ T operator()(index_t i)
   {
     return T(.54) - T(.46) * cuda::std::cos(T(2 * M_PI) * T(i) / T(size_ - 1));
   }
@@ -361,9 +361,9 @@ private:
 
 public:
   using scalar_type = T;
-  inline __host__ __device__ Hanning(index_t size) : size_(size){};
+  inline __MATX_HOST__ __MATX_DEVICE__ Hanning(index_t size) : size_(size){};
 
-  inline __host__ __device__ T operator()(index_t i)
+  inline __MATX_HOST__ __MATX_DEVICE__ T operator()(index_t i)
   {
     return T(0.5) * (1 - cuda::std::cos(T(2 * M_PI) * T(i) / T(size_ - 1)));
   }
@@ -444,9 +444,9 @@ private:
 
 public:
   using scalar_type = T;
-  inline __host__ __device__ Blackman(index_t size) : size_(size){};
+  inline __MATX_HOST__ __MATX_DEVICE__ Blackman(index_t size) : size_(size){};
 
-  inline __host__ __device__ T operator()(index_t i)
+  inline __MATX_HOST__ __MATX_DEVICE__ T operator()(index_t i)
   {
     return T(0.42) +
            ((T)0.5 *
@@ -529,9 +529,9 @@ private:
 
 public:
   using scalar_type = T;
-  inline __host__ __device__ Bartlett(index_t size) : size_(size){};
+  inline __MATX_HOST__ __MATX_DEVICE__ Bartlett(index_t size) : size_(size){};
 
-  inline __host__ __device__ T operator()(index_t i)
+  inline __MATX_HOST__ __MATX_DEVICE__ T operator()(index_t i)
   {
     return (T(2) / (T(size_) - 1)) *
            (((T(size_) - 1) / T(2)) -
@@ -618,7 +618,7 @@ public:
 
   Range(T first, T step) : first_(first), step_(step) {}
 
-  __device__ inline T operator()(index_t idx)
+  __MATX_DEVICE__ inline T operator()(index_t idx)
   {
     if constexpr (is_matx_half_v<T>) {
       return first_ + T(static_cast<T>((float)idx) * step_);
@@ -828,7 +828,7 @@ public:
 #endif
   }
 
-  __device__ inline T operator()(index_t idx) { return range_(idx); }
+  __MATX_DEVICE__ inline T operator()(index_t idx) { return range_(idx); }
 };
 
 /// @name Linspace
@@ -926,7 +926,7 @@ public:
 #endif
   }
 
-  __device__ inline T operator()(index_t idx)
+  __MATX_DEVICE__ inline T operator()(index_t idx)
   {
     if constexpr (is_matx_half_v<T>) {
       return static_cast<T>(
@@ -1025,16 +1025,16 @@ public:
 
   Meshgrid_X(std::array<T, 3> x, std::array<T, 3> y) : x_(x), y_(y) {}
 
-  inline __device__ T operator()(index_t i, index_t j)
+  inline __MATX_DEVICE__ T operator()(index_t i, index_t j)
   {
     return x_[0] + j * (x_[1] - x_[0]) / (x_[2] - 1);
   }
 
-  inline __host__ __device__ index_t Size(uint32_t dim) const
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
   {
     return (dim == 0) ? y_[2] : x_[2];
   }
-  static inline constexpr __host__ __device__ int32_t Rank() { return 2; }
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return 2; }
 };
 
 template <typename T> class Meshgrid_Y {
@@ -1049,16 +1049,16 @@ public:
 
   Meshgrid_Y(std::array<T, 3> x, std::array<T, 3> y) : x_(x), y_(y) {}
 
-  inline __device__ T operator()(index_t i, index_t j)
+  inline __MATX_DEVICE__ T operator()(index_t i, index_t j)
   {
     return y_[0] + i * (y_[1] - y_[0]) / (y_[2] - 1);
   };
 
-  inline __host__ __device__ index_t Size(uint32_t dim) const
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
   {
     return (dim == 0) ? y_[2] : x_[2];
   }
-  static inline constexpr __host__ __device__ int32_t Rank() { return 2; }
+  static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return 2; }
 };
 /**
  * Creates an mesh grid X matrix

--- a/include/matx_tensor_ops.h
+++ b/include/matx_tensor_ops.h
@@ -69,7 +69,7 @@ namespace matx
   inline
       typename std::enable_if_t<!std::is_same_v<T, S> && std::is_arithmetic_v<S>,
                                 cuda::std::complex<T>>
-          __host__ __device__ operator*(const cuda::std::complex<T> &c, S n)
+          __MATX_HOST__ __MATX_DEVICE__ operator*(const cuda::std::complex<T> &c, S n)
   {
     return c * T(n);
   }
@@ -78,7 +78,7 @@ namespace matx
   inline
       typename std::enable_if_t<!std::is_same_v<T, S> && std::is_arithmetic_v<S>,
                                 cuda::std::complex<T>>
-          __host__ __device__ operator*(S n, const cuda::std::complex<T> &c)
+          __MATX_HOST__ __MATX_DEVICE__ operator*(S n, const cuda::std::complex<T> &c)
   {
     return T(n) * c;
   }  
@@ -220,22 +220,22 @@ namespace matx
     using scalar_type = void;
 
     // Rank=0 accessor
-    inline __device__ auto operator()() {}
+    inline __MATX_DEVICE__ auto operator()() {}
     // Rank=1 accessor
-    inline __device__ auto operator()(index_t i) {}
+    inline __MATX_DEVICE__ auto operator()(index_t i) {}
     // Rank=2 accessor
-    inline __device__ auto operator()(index_t i, index_t j) {}
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j) {}
     // Rank=3 accessor
-    inline __device__ auto operator()(index_t i, index_t j, index_t k) {}
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k) {}
     // Rank=4 accessor
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
     }
 
     // Rank of chain. Purely for type annotations and has no meaning
-    static inline constexpr __host__ __device__ int32_t Rank() { return -2; }
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return -2; }
     // Size of dimension. Purely for type annotations and has no meaning
-    index_t inline __host__ __device__ Size(int) const { return 0; }
+    index_t inline __MATX_HOST__ __MATX_DEVICE__ Size(int) const { return 0; }
   };
 
   /**
@@ -268,42 +268,42 @@ namespace matx
       }
     }
 
-    inline __device__ auto operator()()
+    inline __MATX_DEVICE__ auto operator()()
     {
       get_value(op_);
       args_.operator()();
     }
 
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       get_value(op_, i);
       args_.operator()(i);
     }
 
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       get_value(op_, i, j);
       args_.operator()(i, j);
     }
 
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       get_value(op_, i, j, k);
       args_.operator()(i, j, k);
     }
 
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       get_value(op_, i, j, k, l);
       args_.operator()(i, j, k, l);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank() noexcept
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() noexcept
     {
       return std::max({T1::Rank(), ARGS::Rank()...});
     }
 
-    index_t inline __host__ __device__ Size(int dim) const noexcept
+    index_t inline __MATX_HOST__ __MATX_DEVICE__ Size(int dim) const noexcept
     {
       return size_[dim];
     }
@@ -356,38 +356,38 @@ namespace matx
       }
     }
 
-    __device__ inline auto operator()()
+    __MATX_DEVICE__ inline auto operator()()
     {
       if (get_value(cond_))
       {
         get_value(op_);
       }
     }
-    __device__ inline auto operator()(index_t i)
+    __MATX_DEVICE__ inline auto operator()(index_t i)
     {
       if (get_value(cond_, i))
         get_value(op_, i);
     }
-    __device__ inline auto operator()(index_t i, index_t j)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j)
     {
       if (get_value(cond_, i, j))
         get_value(op_, i, j);
     }
-    __device__ inline auto operator()(index_t i, index_t j, index_t k)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j, index_t k)
     {
       if (get_value(cond_, i, j, k))
         get_value(op_, i, j, k);
     }
-    __device__ inline auto operator()(index_t i, index_t j, index_t k, index_t l)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       if (get_value(cond_, i, j, k, l))
         get_value(op_, i, j, k, l);
     }
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return MAX(get_rank<T1>(), get_rank<T2>());
     }
-    index_t inline __host__ __device__ Size(int dim) const
+    index_t inline __MATX_HOST__ __MATX_DEVICE__ Size(int dim) const
     {
       return size_[dim];
     }
@@ -442,35 +442,35 @@ namespace matx
       }
     }
 
-    __device__ inline auto operator()()
+    __MATX_DEVICE__ inline auto operator()()
     {
       if (get_value(cond_))
         get_value(op1_);
       else
         get_value(op2_);
     }
-    __device__ inline auto operator()(index_t i)
+    __MATX_DEVICE__ inline auto operator()(index_t i)
     {
       if (get_value(cond_, i))
         get_value(op1_, i);
       else
         get_value(op2_, i);
     }
-    __device__ inline auto operator()(index_t i, index_t j)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j)
     {
       if (get_value(cond_, i, j))
         get_value(op1_, i, j);
       else
         get_value(op2_, i, j);
     }
-    __device__ inline auto operator()(index_t i, index_t j, index_t k)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j, index_t k)
     {
       if (get_value(cond_, i, j, k))
         get_value(op1_, i, j, k);
       else
         get_value(op2_, i, j, k);
     }
-    __device__ inline auto operator()(index_t i, index_t j, index_t k, index_t l)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       if (get_value(cond_, i, j, k, l))
         get_value(op1_, i, j, k, l);
@@ -478,12 +478,12 @@ namespace matx
         get_value(op2_, i, j, k, l);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return MAX(get_rank<C1>(), get_rank<T1>(), get_rank<T2>());
     }
 
-    index_t inline __host__ __device__ Size(int dim) const
+    index_t inline __MATX_HOST__ __MATX_DEVICE__ Size(int dim) const
     {
       return size_[dim];
     }
@@ -508,14 +508,14 @@ namespace matx
     using scalar_type = typename T1::scalar_type;
 
     inline ReverseOp(T1 op) : op_(op){};
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       if constexpr (DIM == 0)
         i = Size(0) - i - 1;
       return op_(i);
     }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       if constexpr (DIM == 0)
         i = Size(0) - i - 1;
@@ -523,7 +523,7 @@ namespace matx
         j = Size(1) - j - 1;
       return op_(i, j);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       if constexpr (DIM == 0)
         i = Size(0) - i - 1;
@@ -533,7 +533,7 @@ namespace matx
         k = Size(2) - k - 1;
       return op_(i, j, k);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       if constexpr (DIM == 0)
         i = Size(0) - i - 1;
@@ -546,11 +546,11 @@ namespace matx
       return op_(i, j, k, l);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op_.Size(dim);
     }
@@ -652,26 +652,26 @@ namespace matx
 
     inline HermitianTransOp(T1 op) : op_(op) {}
 
-    inline __device__ auto operator()() { return conj(op_()); }
-    inline __device__ auto operator()(index_t i) { return conj(op_(i)); }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()() { return conj(op_()); }
+    inline __MATX_DEVICE__ auto operator()(index_t i) { return conj(op_(i)); }
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       return conj(op_(j, i));
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       return conj(op_(k, j, i));
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       return conj(op_(l, k, j, i));
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op_.Size(Rank() - dim - 1);
     }
@@ -707,41 +707,41 @@ namespace matx
     inline DiagOp(T1 op) : op_(op) {}
 
     template <int M = RANK, std::enable_if_t<M == 1, bool> = true>
-    inline __device__ auto operator()()
+    inline __MATX_DEVICE__ auto operator()()
     {
       return op_(0);
     }
 
     template <int M = RANK, std::enable_if_t<M == 2, bool> = true>
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       return op_(i, i);
     }
     template <int M = RANK, std::enable_if_t<M == 3, bool> = true>
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       return op_(i, j, j);
     }
     template <int M = RANK, std::enable_if_t<M == 4, bool> = true>
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       return op_(i, j, k, k);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return RANK - 1;
     }
 
     template <int M = RANK, std::enable_if_t<M == 2, bool> = true>
-    inline __host__ __device__ index_t Size([[maybe_unused]] uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size([[maybe_unused]] uint32_t dim) const
     {
       return std::min(op_.Size((uint32_t)(RANK - 1)),
                       op_.Size((uint32_t)(RANK - 2)));
     }
 
     template <int M = RANK, std::enable_if_t<M == 3, bool> = true>
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return dim == 0 ? op_.Size(dim)
                       : std::min(op_.Size((uint32_t)(RANK - 1)),
@@ -749,7 +749,7 @@ namespace matx
     }
 
     template <int M = RANK, std::enable_if_t<M == 4, bool> = true>
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return (dim <= 1) ? op_.Size(dim)
                         : std::min(op_.Size((uint32_t)(RANK - 1)),
@@ -789,27 +789,27 @@ namespace matx
     {
     }
 
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       return op2_(i % op2_.Size(0), j % op2_.Size(1)) *
              op1_(i / op2_.Size(0), j / op2_.Size(1));
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       return op2_(i, j % op2_.Size(1), k % op2_.Size(2)) *
              op1_(i, j / op2_.Size(1), k / op2_.Size(2));
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       return op2_(i, j, k % op2_.Size(2), l % op2_.Size(3)) *
              op1_(i, j, k / op2_.Size(2), l / op2_.Size(3));
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op1_.Size(dim) * op2_.Size(dim);
     }
@@ -884,27 +884,27 @@ namespace matx
       }
     }
 
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i) { return op_(i % op_.Size(0)); }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i) { return op_(i % op_.Size(0)); }
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       return op_(i % op_.Size(0), j % op_.Size(1));
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       return op_(i % op_.Size(0), j % op_.Size(1), k % op_.Size(2));
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       return op_(i % op_.Size(0), j % op_.Size(1), k % op_.Size(2),
                  l % op_.Size(3));
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op_.Size(dim) * reps_[dim];
     }
@@ -985,23 +985,23 @@ namespace matx
 
     inline SelfOp(T1 op) : op_(op) {}
 
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i) { return op_(i); }
-    inline __device__ auto operator()(index_t i, index_t j) { return op_(i, j); }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i) { return op_(i); }
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j) { return op_(i, j); }
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       return op_(i, j, k);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       return op_(i, j, k, l);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op_.Size(dim);
     }
@@ -1065,14 +1065,14 @@ namespace matx
       }
     }
 
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       if constexpr (DIM == 0)
         i = (base_ + i) % Size(0);
       return op_(i);
     }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       if constexpr (DIM == 0)
         i = (base_ + i) % Size(0);
@@ -1080,7 +1080,7 @@ namespace matx
         j = (base_ + j) % Size(1);
       return op_(i, j);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       if constexpr (DIM == 0)
         i = (base_ + i) % Size(0);
@@ -1090,7 +1090,7 @@ namespace matx
         k = (base_ + k) % Size(2);
       return op_(i, j, k);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       if constexpr (DIM == 0)
         i = (base_ + i) % Size(0);
@@ -1103,11 +1103,11 @@ namespace matx
       return op_(i, j, k, l);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op_.Size(dim);
     }
@@ -1200,26 +1200,26 @@ namespace matx
     using scalar_type = typename T1::scalar_type;
 
     inline FFTShift1DOp(T1 op) : op_(op){};
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       i = (i + (Size(0) + 1) / 2) % Size(0);
       return op_(i);
     }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       i = i;
       j = (j + (Size(1) + 1) / 2) % Size(1);
       return op_(i, j);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       i = i;
       j = j;
       k = (k + (Size(2) + 1) / 2) % Size(2);
       return op_(i, j, k);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       i = i;
       j = j;
@@ -1228,11 +1228,11 @@ namespace matx
       return op_(i, j, k, l);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op_.Size(dim);
     }
@@ -1267,26 +1267,26 @@ namespace matx
     using scalar_type = typename T1::scalar_type;
 
     inline FFTShift2DOp(T1 op) : op_(op){};
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       i = (i + (Size(0) + 1) / 2) % Size(0);
       return op_(i);
     }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       i = (i + (Size(0) + 1) / 2) % Size(0);
       j = (j + (Size(1) + 1) / 2) % Size(1);
       return op_(i, j);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       i = i;
       j = (j + (Size(1) + 1) / 2) % Size(1);
       k = (k + (Size(2) + 1) / 2) % Size(2);
       return op_(i, j, k);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       i = i;
       j = j;
@@ -1295,11 +1295,11 @@ namespace matx
       return op_(i, j, k, l);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op_.Size(dim);
     }
@@ -1335,26 +1335,26 @@ namespace matx
     using scalar_type = typename T1::scalar_type;
 
     inline IFFTShift1DOp(T1 op) : op_(op){};
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       i = (i + Size(0) / 2) % Size(0);
       return op_(i);
     }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       i = i;
       j = (j + Size(1) / 2) % Size(1);
       return op_(i, j);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       i = i;
       j = j;
       k = (k + Size(2) / 2) % Size(2);
       return op_(i, j, k);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       i = i;
       j = j;
@@ -1363,11 +1363,11 @@ namespace matx
       return op_(i, j, k, l);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op_.Size(dim);
     }
@@ -1403,26 +1403,26 @@ namespace matx
     using scalar_type = typename T1::scalar_type;
 
     inline IFFTShift2DOp(T1 op) : op_(op){};
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       i = (i + Size(0) / 2) % Size(0);
       return op_(i);
     }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       i = (i + Size(0) / 2) % Size(0);
       j = (j + Size(1) / 2) % Size(1);
       return op_(i, j);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       i = i;
       j = (j + Size(1) / 2) % Size(1);
       k = (k + Size(2) / 2) % Size(2);
       return op_(i, j, k);
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       i = i;
       j = j;
@@ -1431,11 +1431,11 @@ namespace matx
       return op_(i, j, k, l);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       return op_.Size(dim);
     }
@@ -1484,38 +1484,38 @@ namespace matx
       }
     }
 
-    __device__ inline auto operator()()
+    __MATX_DEVICE__ inline auto operator()()
     {
       auto i1 = get_value(in1_);
       return op_(i1);
     }
-    __device__ inline auto operator()(index_t i)
+    __MATX_DEVICE__ inline auto operator()(index_t i)
     {
       auto i1 = get_value(in1_, i);
       return op_(i1);
     }
-    __device__ inline auto operator()(index_t i, index_t j)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j)
     {
       auto i1 = get_value(in1_, i, j);
       return op_(i1);
     }
-    __device__ inline auto operator()(index_t i, index_t j, index_t k)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j, index_t k)
     {
       auto i1 = get_value(in1_, i, j, k);
       return op_(i1);
     }
-    __device__ inline auto operator()(index_t i, uint32_t j, index_t k, index_t l)
+    __MATX_DEVICE__ inline auto operator()(index_t i, uint32_t j, index_t k, index_t l)
     {
       auto i1 = get_value(in1_, i, j, k, l);
       return op_(i1);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<I1>();
     }
 
-    index_t inline __host__ __device__ Size(int dim) const
+    index_t inline __MATX_HOST__ __MATX_DEVICE__ Size(int dim) const
     {
       return size_[dim];
     }
@@ -1533,8 +1533,8 @@ namespace matx
     using scalar_type = typename T1::scalar_type;
 
     inline ComplexPlanarOp(T1 op) : op_(op){};
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       if (i >= op_.Size(0))
       {
@@ -1542,7 +1542,7 @@ namespace matx
       }
       return op_(i).real();
     }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       if (i >= op_.Size(0))
       {
@@ -1550,7 +1550,7 @@ namespace matx
       }
       return op_(i, j).real();
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       if (j >= op_.Size(1))
       {
@@ -1558,7 +1558,7 @@ namespace matx
       }
       return op_(i, j, k).real();
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       if (k >= op_.Size(2))
       {
@@ -1567,11 +1567,11 @@ namespace matx
       return op_(i, j, k, l).real();
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       if constexpr (Rank() <= 1)
       {
@@ -1623,29 +1623,29 @@ namespace matx
                                             cuda::std::complex<scalar_type>>;
 
     inline ComplexInterleavedOp(T1 op) : op_(op){};
-    inline __device__ auto operator()() { return op_(); }
-    inline __device__ auto operator()(index_t i)
+    inline __MATX_DEVICE__ auto operator()() { return op_(); }
+    inline __MATX_DEVICE__ auto operator()(index_t i)
     {
       return complex_type{op_(i), op_(op_.Size(0) / 2 + i)};
     }
-    inline __device__ auto operator()(index_t i, index_t j)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j)
     {
       return complex_type{op_(i, j), op_(op_.Size(0) / 2 + i, j)};
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k)
     {
       return {op_(i, j, k), op_(i, j + op_.Size(1) / 2, k)};
     }
-    inline __device__ auto operator()(index_t i, index_t j, index_t k, index_t l)
+    inline __MATX_DEVICE__ auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       return {op_(i, j, k, l), op_(i, j, k + op_.Size(2) / 2, l)};
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return get_rank<T1>();
     }
-    inline __host__ __device__ index_t Size(uint32_t dim) const
+    inline __MATX_HOST__ __MATX_DEVICE__ index_t Size(uint32_t dim) const
     {
       if constexpr (Rank() <= 1)
       {
@@ -1710,35 +1710,35 @@ namespace matx
       }
     }
 
-    __device__ inline auto operator()()
+    __MATX_DEVICE__ inline auto operator()()
     {
       // Rank 0
       auto i1 = get_value(in1_);
       auto i2 = get_value(in2_);
       return op_(i1, i2);
     }
-    __device__ inline auto operator()(index_t i)
+    __MATX_DEVICE__ inline auto operator()(index_t i)
     {
       // Rank 1
       auto i1 = get_value(in1_, i);
       auto i2 = get_value(in2_, i);
       return op_(i1, i2);
     }
-    __device__ inline auto operator()(index_t i, index_t j)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j)
     {
       // Rank 2
       auto i1 = get_value(in1_, i, j);
       auto i2 = get_value(in2_, i, j);
       return op_(i1, i2);
     }
-    __device__ inline auto operator()(index_t i, index_t j, index_t k)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j, index_t k)
     {
       // Rank 3
       auto i1 = get_value(in1_, i, j, k);
       auto i2 = get_value(in2_, i, j, k);
       return op_(i1, i2);
     }
-    __device__ inline auto operator()(index_t i, index_t j, index_t k, index_t l)
+    __MATX_DEVICE__ inline auto operator()(index_t i, index_t j, index_t k, index_t l)
     {
       // Rank 4
       auto i1 = get_value(in1_, i, j, k, l);
@@ -1746,12 +1746,12 @@ namespace matx
       return op_(i1, i2);
     }
 
-    static inline constexpr __host__ __device__ int32_t Rank()
+    static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
     {
       return MAX(get_rank<I1>(), get_rank<I2>());
     }
 
-    index_t inline __host__ __device__ Size(int dim) const
+    index_t inline __MATX_HOST__ __MATX_DEVICE__ Size(int dim) const
     {
       return size_[dim];
     }
@@ -1759,7 +1759,7 @@ namespace matx
 
 // Returns an address of a pointer of type T aligned to new address
 template <typename T>
-constexpr inline __host__ __device__ T *AlignAddr(uint8_t *addr)
+constexpr inline __MATX_HOST__ __MATX_DEVICE__ T *AlignAddr(uint8_t *addr)
 {
   if (((uint64_t)addr % std::alignment_of_v<T>) != 0) {
     return reinterpret_cast<T *>(

--- a/include/matx_tensor_utils.h
+++ b/include/matx_tensor_utils.h
@@ -36,20 +36,20 @@ namespace matx
 {
 
   template <typename T>
-  inline constexpr __host__ __device__ T MAX(T a)
+  inline constexpr __MATX_HOST__ __MATX_DEVICE__ T MAX(T a)
   {
     return a;
   }
 
   template <typename T, typename... Args>
-  inline constexpr __host__ __device__ T MAX(T a, Args... args)
+  inline constexpr __MATX_HOST__ __MATX_DEVICE__ T MAX(T a, Args... args)
   {
     auto v = MAX(args...);
     return (a >= v) ? a : v;
   }
 
   template <class T, class M = T>
-  inline constexpr __host__ __device__ int32_t get_rank()
+  inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t get_rank()
   {
     if constexpr (is_matx_op<M>())
       return T::Rank();
@@ -64,7 +64,7 @@ namespace matx
   }
 
   template <class T, class M = T>
-  inline __host__ __device__ index_t get_size([[maybe_unused]] T a,
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t get_size([[maybe_unused]] T a,
                                               [[maybe_unused]] uint32_t dim)
   {
     if constexpr (is_matx_op<M>())
@@ -80,7 +80,7 @@ namespace matx
   }
 
   template <int RANK, class T, class M = T>
-  inline __host__ __device__ index_t
+  inline __MATX_HOST__ __MATX_DEVICE__ index_t
   get_expanded_size([[maybe_unused]] T a, [[maybe_unused]] uint32_t dim)
   {
     index_t size = 0;
@@ -112,7 +112,7 @@ namespace matx
   // We also have to do this recursively to get around bug
   // We also have to invert logic and repeat to get around bug
   template <class T, class M = T>
-  inline __device__ auto get_matx_value(T i, index_t idx)
+  inline __MATX_DEVICE__ auto get_matx_value(T i, index_t idx)
   {
     if constexpr (T::Rank() == 1)
     {
@@ -135,7 +135,7 @@ namespace matx
   }
 
   template <class T, class M = T>
-  inline __device__ auto get_matx_value(T i, index_t idy, index_t idx)
+  inline __MATX_DEVICE__ auto get_matx_value(T i, index_t idy, index_t idx)
   {
     if constexpr (T::Rank() == 2)
     {
@@ -158,7 +158,7 @@ namespace matx
   }
 
   template <class T, class M = T>
-  inline __device__ auto get_matx_value(T i, index_t idz, index_t idy,
+  inline __MATX_DEVICE__ auto get_matx_value(T i, index_t idz, index_t idy,
                                         index_t idx)
   {
     if constexpr (T::Rank() == 3)
@@ -182,7 +182,7 @@ namespace matx
   }
 
   template <class T, class M = T>
-  inline __device__ auto get_matx_value(T i, index_t idw, index_t idz,
+  inline __MATX_DEVICE__ auto get_matx_value(T i, index_t idw, index_t idz,
                                         index_t idy, index_t idx)
   {
     if constexpr (T::Rank() == 4)
@@ -206,7 +206,7 @@ namespace matx
   }
 
   template <class T, class M = T>
-  inline __device__ auto get_value(T i)
+  inline __MATX_DEVICE__ auto get_value(T i)
   {
     if constexpr (is_matx_op<M>())
     {
@@ -229,7 +229,7 @@ namespace matx
   }
 
   template <class T, class M = T>
-  inline __device__ auto get_value(T i, index_t idx)
+  inline __MATX_DEVICE__ auto get_value(T i, index_t idx)
   {
     if constexpr (is_matx_op<M>())
     {
@@ -252,7 +252,7 @@ namespace matx
   }
 
   template <class T, class M = T>
-  inline __device__ auto get_value(T i, index_t idy, index_t idx)
+  inline __MATX_DEVICE__ auto get_value(T i, index_t idy, index_t idx)
   {
     if constexpr (is_matx_op<M>())
     {
@@ -275,7 +275,7 @@ namespace matx
   }
 
   template <class T, class M = T>
-  inline __device__ auto get_value(T i, index_t idz, index_t idy, index_t idx)
+  inline __MATX_DEVICE__ auto get_value(T i, index_t idz, index_t idy, index_t idx)
   {
     if constexpr (is_matx_op<M>())
     {
@@ -298,7 +298,7 @@ namespace matx
   }
 
   template <class T, class M = T>
-  inline __device__ auto get_value(T i, index_t idw, index_t idz, index_t idy,
+  inline __MATX_DEVICE__ auto get_value(T i, index_t idw, index_t idz, index_t idy,
                                    index_t idx)
   {
     if constexpr (is_matx_op<M>())

--- a/include/matx_type_utils.h
+++ b/include/matx_type_utils.h
@@ -46,19 +46,6 @@
 
 namespace matx {
 
-#ifdef INDEX_64_BIT
-using index_t = long long int;
-#endif
-
-#ifdef INDEX_32_BIT
-using index_t = int32_t;
-#endif
-
-#if ((defined(INDEX_64_BIT) && defined(INDEX_32_BIT)) ||                       \
-     (!defined(INDEX_64_BIT) && !defined(INDEX_32_BIT)))
-static_assert(false, "Must choose either 64-bit or 32-bit index mode");
-#endif
-
 template <typename T, typename = void>
 struct is_matx_op_impl : std::false_type {
 };

--- a/include/matx_type_utils.h
+++ b/include/matx_type_utils.h
@@ -191,6 +191,12 @@ struct extract_scalar_type_impl<T, std::void_t<typename T::scalar_type>> {
 template <typename T>
 using extract_scalar_type_t = typename extract_scalar_type_impl<T>::scalar_type;
 
+// Get the n-th element from a parameter pack
+template <int I, class... Ts>
+__MATX_DEVICE__ __MATX_HOST__ decltype(auto) pp_get(Ts&&... ts) {
+  return std::get<I>(std::forward_as_tuple(ts...));
+}
+
 
 
 // Supported MatX data types. This enum helps translate types into integers for


### PR DESCRIPTION
Host compilers don't recognize __host__/__device__ annotations. This change conditionally adds them in if coming from nvcc.