### PR TITLE
Added a Print() to print the whole tensor

### DIFF
--- a/include/matx_tensor.h
+++ b/include/matx_tensor.h
@@ -1553,9 +1553,11 @@ public:
    * @tparam Args Integral argument types
    * @param dims Number of values to print for each dimension
    */
-  template <typename ... Args, std::enable_if_t<((std::is_integral_v<Args>) && ...), bool> = true>
-  void Print(Args ...dims) const
-  {
+  template <typename... Args,
+            std::enable_if_t<((std::is_integral_v<Args>)&&...) &&
+                                 (RANK == 0 || sizeof...(Args) > 0),
+                             bool> = true>
+  void Print(Args... dims) const {
 #ifdef __CUDACC__    
     auto kind = GetPointerKind(this->ldata_);
     cudaDeviceSynchronize();
@@ -1577,9 +1579,26 @@ public:
     }
 #else
     InternalPrint(dims...);
-#endif    
-  }      
+#endif
+  }
 
+  /**
+   * @brief Print a tensor's all values to stdout
+   *
+   * This form of `Print()` is an alias of `Print(0)`, `Print(0, 0)`,
+   * `Print(0, 0, 0)` and `Print(0, 0, 0, 0)` for 1D, 2D, 3D and 4D tensor
+   * respectively. It passes the proper number of zeros to `Print(...)`
+   * automatically according to the rank of this tensor. The user only have to
+   * invoke `.Print()` to print the whole tensor, instead of passing zeros
+   * manually.
+   */
+  template <typename... Args,
+            std::enable_if_t<(RANK > 0 && sizeof...(Args) == 0), bool> = true>
+  void Print(Args... dims) const {
+    std::array<int, RANK> arr = {0};
+    auto tp = std::tuple_cat(arr);
+    std::apply([&](auto &&...args) { this->Print(args...); }, tp);
+  }
 
   /**
    * @brief Print a tensor's values to stdout using start/end parameters


### PR DESCRIPTION
Before, we have to call `.Print(0)`, `.Print(0, 0)`, `.Print(0, 0, 0)` or `.Print(0, 0, 0, 0)` to print the whole tensor (except 0-D tensors), which is not friendly. In addition, the [01_introduction.ipynb](https://github.com/NVIDIA/MatX/blob/main/docs_input/notebooks/01_introduction.ipynb) says that we could call `.Print()` on tensors to print the whole tensor.

So I added an alias to `.Print(0)`, `.Print(0, 0)`, `.Print(0, 0, 0)` or `.Print(0, 0, 0, 0)` by introducing an overloaded template function`Print(Args... dims)` that will be instantiated only when the arguments are empty and the rank of the tensor is greater than 0. This alias function actually constructs the `0, 0, ..., 0` arguments list and passes it to the original `Print(Args... dims)`.

The new interface has been tested on 0-D, 1-D, 2-D, 3-D and 4-D tensors.