### PR TITLE
Fixed conv2 filter size. Skip unit tests for HW without support for f…

### DIFF
--- a/include/matx.h
+++ b/include/matx.h
@@ -36,6 +36,7 @@
 #include "matx_half_complex.h"
 #include "matx_half.h"
 
+#include "matx_utils.h"
 #include "matx_error.h"
 #include "matx_tensor.h"
 #include "matx_random.h"

--- a/include/matx_allocator.h
+++ b/include/matx_allocator.h
@@ -220,6 +220,7 @@ inline void matxAlloc(void **ptr, size_t bytes,
                       cudaStream_t stream = 0)
 {
   [[maybe_unused]] cudaError_t err = cudaSuccess;
+
   switch (space) {
   case MATX_MANAGED_MEMORY:
     err = cudaMallocManaged(ptr, bytes);

--- a/include/matx_conv.h
+++ b/include/matx_conv.h
@@ -113,8 +113,8 @@ void matxDirectConv2DInternal(OutputType &o, InType &i,
   MATX_STATIC_ASSERT(OutputType::Rank() == InType::Rank(), matxInvalidDim);
   MATX_STATIC_ASSERT(FilterType::Rank() == 2, matxInvalidDim);
 
-  using strip_input_t = typename InType::scalar_type;
-  auto shmsize = sizeof(strip_input_t) * filter.Size(0) * filter.Size(1);
+  using filter_input_t = typename FilterType::scalar_type;
+  auto shmsize = sizeof(filter_input_t) * filter.Size(0) * filter.Size(1);
 
 #ifdef __CUDACC__  
   if constexpr (OutputType::Rank() == 1) {

--- a/include/matx_pybind.h
+++ b/include/matx_pybind.h
@@ -78,14 +78,11 @@ template <typename T> struct TestFailResult {
 };
 
 
-
 class MatXPybind {
 public:
   MatXPybind() { Init(); }
 
   void Init() { 
-    static pybind11::scoped_interpreter gil{};
-
     AddPath(std::string(MATX_ROOT) + GENERATORS_PATH); 
   }
 
@@ -437,6 +434,7 @@ public:
   }
 
 private:
+  inline static pybind11::scoped_interpreter gil = pybind11::scoped_interpreter{};
   pybind11::module_ mod;
   pybind11::object res_dict;
   pybind11::object sx_obj;

--- a/include/matx_type_utils.h
+++ b/include/matx_type_utils.h
@@ -212,6 +212,34 @@ template <> struct is_complex<matxBf16Complex> : std::true_type {
  */
 template <class T> inline constexpr bool is_complex_v = detail::is_complex<T>::value;
 
+
+namespace detail {
+template <typename T> struct is_bf16_type : std::false_type {};
+template <> struct is_bf16_type<matxBf16Complex> : std::true_type {};
+template <> struct is_bf16_type<matxBf16> : std::true_type {};
+}
+
+/**
+ * @brief Determine if a type is a BF16 type
+ * 
+ * @tparam T Type to test
+ */
+template <class T> inline constexpr bool is_bf16_type_v = detail::is_bf16_type<T>::value;
+
+namespace detail {
+template <typename T> struct is_fp16_type : std::false_type {};
+template <> struct is_fp16_type<matxBf16Complex> : std::true_type {};
+template <> struct is_fp16_type<matxBf16> : std::true_type {};
+}
+
+/**
+ * @brief Determine if a type is an FF16 type
+ * 
+ * @tparam T Type to test
+ */
+template <class T> inline constexpr bool is_fp16_type_v = detail::is_fp16_type<T>::value;
+
+
 namespace detail {
 template <typename T, typename = void>
 struct is_matx_shape : std::false_type {

--- a/test/00_transform/ConvCorr.cu
+++ b/test/00_transform/ConvCorr.cu
@@ -48,6 +48,7 @@ class CorrelationConvolutionTest : public ::testing::Test {
 protected:
   void SetUp() override
   {
+    CheckTestTypeSupport<T>();
     pb = std::make_unique<detail::MatXPybind>();
     pb->InitTVGenerator<T>("00_transforms", "conv_operators", {a_len, b_len});
 

--- a/test/00_transform/FFT.cu
+++ b/test/00_transform/FFT.cu
@@ -44,6 +44,8 @@ template <typename T> class FFTTest : public ::testing::Test {
 protected:
   void SetUp() override
   {
+    CheckTestTypeSupport<T>();
+
     pb = std::make_unique<detail::MatXPybind>();
 
     // Half precision needs a bit more tolerance when compared to fp32

--- a/test/00_transform/MatMul.cu
+++ b/test/00_transform/MatMul.cu
@@ -46,6 +46,8 @@ template <typename T> class MatMulTest : public ::testing::Test {
 protected:
   void SetUp() override
   {
+    CheckTestTypeSupport<T>();
+
     pb = std::make_unique<detail::MatXPybind>(); // Half precision needs a bit more
                                          // tolerance when compared to fp32
     if constexpr (is_complex_half_v<T> || is_matx_half_v<T>) {

--- a/test/include/utilities.h
+++ b/test/include/utilities.h
@@ -65,7 +65,7 @@ public:
    * @return Assertion result
    */
   template <typename T1, typename T2>
-  static ::testing::AssertionResult MatXTypeCompare(const T1 &a, const T2 &b,
+  static __MATX_INLINE__ ::testing::AssertionResult MatXTypeCompare(const T1 &a, const T2 &b,
                                                     double delta = 0.01)
   {
     if constexpr (matx::is_complex_v<T1>) {
@@ -97,4 +97,20 @@ public:
     return ::testing::AssertionSuccess();
   }
 };
+
+template <typename T>
+__MATX_INLINE__ void CheckTestTypeSupport() {
+  auto cc = detail::GetComputeCapabilityMajor();
+  if constexpr (is_bf16_type_v<T>) {
+    if (cc < AMPERE_CC) {
+      GTEST_SKIP();
+    }
+  }
+  else if constexpr (is_fp16_type_v<T>) {
+    if (cc < VOLTA_CC) {
+      GTEST_SKIP();
+    }
+  }
+}
+
 } // end namespace matx


### PR DESCRIPTION
- Fixed issue where conv2 test had an incorrect shm size. Bug only appeared on V100
- Added guards to prevent fp16/bf16 library code from running if card doesn't support it