### PR TITLE
Allow Print() for user-defined memory

### DIFF
--- a/include/matx_allocator.h
+++ b/include/matx_allocator.h
@@ -166,25 +166,6 @@ inline matxMemorySpace_t GetPointerKind(void *ptr)
     return iter->second.kind;
   }
 
-  // If we haven't found the pointer it's likely that this is a View that has a
-  // modified data pointer starting past the base. Instead, look through all
-  // pointers and find the one that's closest to this one.
-  void *tmp = nullptr;
-  intptr_t mindist = std::numeric_limits<int64_t>::max();
-  for (auto const &[k, v] : allocationMap) {
-    auto diff = (intptr_t)ptr - (intptr_t)k;
-    if (diff < mindist) {
-      tmp = k;
-      mindist = diff;
-    }
-  }
-
-  MATX_ASSERT(tmp != nullptr, matxInvalidParameter);
-
-  iter = allocationMap.find(tmp);
-  if (iter != allocationMap.end()) {
-    return iter->second.kind;
-  }
 
   return MATX_INVALID_MEMORY;
 }

--- a/include/matx_storage.h
+++ b/include/matx_storage.h
@@ -212,7 +212,7 @@ namespace matx
     size_t size_;
     std::shared_ptr<T> data_;
 
-    void ConfigureShared(T *ptr, size_t size) {
+    void ConfigureShared(T *ptr, [[maybe_unused]] size_t size) {
       if constexpr (std::is_same_v<O, non_owning>) {
         data_ = std::shared_ptr<T>(ptr, [](auto){});
       }

--- a/include/matx_tensor.h
+++ b/include/matx_tensor.h
@@ -1620,11 +1620,12 @@ public:
   void Print(Args... dims) const {
 #ifdef __CUDACC__    
     auto kind = GetPointerKind(this->ldata_);
+
     cudaDeviceSynchronize();
     if (HostPrintable(kind)) {
       InternalPrint(dims...);
     }
-    else if (DevicePrintable(kind)) {
+    else if (DevicePrintable(kind) || kind == MATX_INVALID_MEMORY) {
       if constexpr (PRINT_ON_DEVICE) {
         PrintKernel<<<1, 1>>>(*this, dims...);
       }


### PR DESCRIPTION
closes #121 

This is a partial fix for printing user-defined pointers. It's partial because another issue (#110) would maintain the user pointers across allocations, which it doesn't do right now. This will also only work for device pointers provided by a user (not host only). There is currently no way to identify what type of pointer this is, but since we're primarily a GPU library, this is a good temporary tradeoff. Note that it's important to also make sure you make the pointer `non_owning`  type as to not have MatX free the memory on destruction: 

```
    cudaMalloc(&ptr, 100*4);
    auto c = make_tensor<float, 1, non_owning>((float*)ptr, {100});
```