### PR TITLE
Fix broken notebook link in Quick Start Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ cd build/test
 ## Quick Start Guide
 We provide a variety of training materials and examples to quickly learn the MatX API.
 - A [quick start guide](docs_input/quickstart.rst) can be found in the docs directory or from the [main documentation site](https://nvidia.github.io/MatX/quickstart.html). The MatX quick start guide is modeled after [NumPy's](https://numpy.org/doc/stable/user/quickstart.html) and demonstrates how to manipulate and create tensors.
-- A set of MatX [notebooks](docs/notebooks) can be found in the docs directory. These four notebooks walk through the major MatX features and allow the developer to practice writing MatX code with guided examples and questions.
+- A set of MatX [notebooks](docs_input/notebooks) can be found in the docs directory. These four notebooks walk through the major MatX features and allow the developer to practice writing MatX code with guided examples and questions.
 - Finally, for new MatX developers, browsing the [example applications](examples) can provide familarity with the API and best practices.
 
 ## Release History


### PR DESCRIPTION
"A set of MatX notebooks" now directs users to the correct folder.