### PR TITLE
Fixing CUB sorting for 2D inputs

### DIFF
--- a/include/matx_reduce.h
+++ b/include/matx_reduce.h
@@ -1088,10 +1088,7 @@ void inline median(TensorType &dest,
 
   // If the rank is 0 we're finding the median of a vector
   if constexpr (RANK_IN == 1) {
-    detail::matxCubPlan_t<decltype(tmp_sort), TensorInType, detail::CUB_OP_RADIX_SORT> splan{
-        tmp_sort, in, {}, stream};
-
-    splan.ExecSort(tmp_sort, in, stream, SORT_DIR_ASC);
+    matx::sort(tmp_sort, in, SORT_DIR_ASC, stream);
 
     // Store median
     if (tmp_sort.Lsize() & 1) {
@@ -1110,9 +1107,7 @@ void inline median(TensorType &dest,
   else if (RANK_IN == 2) {
     MATX_ASSERT(dest.Size(0) == in.Size(0), matxInvalidSize);
 
-   detail::matxCubPlan_t<decltype(tmp_sort), TensorInType, detail::CUB_OP_RADIX_SORT> splan{
-        tmp_sort, in, {}, stream};
-    splan.ExecSort(tmp_sort, in, stream, SORT_DIR_ASC);
+    matx::sort(tmp_sort, in, SORT_DIR_ASC, stream);
 
     if (tmp_sort.Lsize() & 1) {
       auto sv = tmp_sort.template Slice<1>({0, tmp_sort.Lsize() / 2},

--- a/test/00_operators/ReductionTests.cu
+++ b/test/00_operators/ReductionTests.cu
@@ -168,6 +168,14 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalf, Sum)
     for (index_t i = 0; i < t1.Size(0); i++) {
       EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (TypeParam)(t2.Size(1))));
     }
+
+    // Test tensor input too
+    auto t2t = make_tensor<TypeParam>({30, 40});
+    (t2t = ones<TypeParam>({30, 40})).run();
+    sum(t1, t2t);
+    for (index_t i = 0; i < t1.Size(0); i++) {
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (TypeParam)(t2t.Size(1))));
+    }    
   }
 
   {


### PR DESCRIPTION
2D inputs for summing and sorting were broken due to memory allocation issues.

Fixed #134 