### PR TITLE
Typo fix

### DIFF
--- a/include/matx_tensor.h
+++ b/include/matx_tensor.h
@@ -1326,7 +1326,7 @@ public:
                l < (((vals.begin() + i)->begin() + j)->begin() + k)->size();
                l++) {
             for (size_t m = 0;
-                 m < ((((vals.begin() + i)->begin() + j)->begin + k)->begin + l)
+                 m < ((((vals.begin() + i)->begin() + j)->begin() + k)->begin() + l)
                          ->size();
                  m++) {
               typename T::value_type real =

--- a/include/matx_tensor.h
+++ b/include/matx_tensor.h
@@ -1323,7 +1323,7 @@ public:
       for (size_t j = 0; j < (vals.begin() + i)->size(); j++) {
         for (size_t k = 0; k < ((vals.begin() + i)->begin() + j)->size(); k++) {
           for (size_t l = 0;
-               l < (((vals.begin() + i)->begin() + j)->begin + k)->size();
+               l < (((vals.begin() + i)->begin() + j)->begin() + k)->size();
                l++) {
             for (size_t m = 0;
                  m < ((((vals.begin() + i)->begin() + j)->begin + k)->begin + l)


### PR DESCRIPTION
This is to fix the typo causing compilation failure with the following error:

`error: a pointer to a bound function may only be used to call the function`

This error also means that this particular function is not unit tested.
