### PR TITLE
Download RAPIDS.cmake only if it does not exist.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,11 @@ endif()
 # In an upcoming CMake it will have the capability to auto-detect GPU architectures. For now, rapids-cmake has a utility
 # function to do it, so we grab that as a dependency. The user can optionally override GPU_ARCH to specify
 # their own
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
-     ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
+         ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+    include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+endif()
 
 include(rapids-cmake)
 include(rapids-cpm)


### PR DESCRIPTION
There's a bug where downstream repositories using a newer version of `RAPIDS.cmake` will have it overridden by MatX on subsequent builds. This prevents MatX from downloading `RAPIDS.cmake` if it already exists.