### PR TITLE
Added deriv/wrt operators.

### DIFF
--- a/include/matx_scalar_diffs.h
+++ b/include/matx_scalar_diffs.h
@@ -1,0 +1,173 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx_half.h"
+
+namespace matx {
+namespace detail {
+
+// This file defines derivatives for scalar operations
+namespace { 
+  using cuda::std::ceil;
+  using cuda::std::floor;
+  using cuda::std::round;
+  using cuda::std::sqrt;
+  using cuda::std::exp;
+  using cuda::std::log10;
+  using cuda::std::log2;
+  using cuda::std::log;
+  using cuda::std::abs;
+  using cuda::std::norm;
+  using cuda::std::sin;
+  using cuda::std::cos;
+  using cuda::std::tan;
+  using cuda::std::asin;
+  using cuda::std::acos;
+  using cuda::std::atan;
+  using cuda::std::sinh;
+  using cuda::std::cosh;
+  using cuda::std::tanh;
+  using cuda::std::asinh;
+  using cuda::std::acosh;
+  using cuda::std::atanh;
+  using cuda::std::pow;
+
+  // Helper function for no derivative
+  template <typename T>
+  static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__  auto none(T v) {
+    assert(false);
+    return v;
+  }
+  
+  template <typename T>
+  static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__  auto zero(T v) {
+    return 0;
+  }
+
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dsin(T x) { 
+    return cos(x); 
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dcos(T x) { 
+    return -sin(x); 
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dtan(T x) { 
+	  T c = cos(x); 
+    return T(1)/(c*c); 
+  }
+
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dasin(T x) { 
+    return T(1)/(T(1) - x*x); 
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dacos(T x) { 
+    return T(1)/(T(1) - x*x); 
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T datan(T x) { 
+    return T(1)/(T(1) + x*x); 
+  }
+
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dsinh(T x) { 
+    return (exp(x) + exp(-x))/T(2);
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dcosh(T x) { 
+    return (exp(x) + exp(-x))/T(2);  
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dtanh(T x) { 
+    T t = tanh(x); 
+    return T(1)-t*t; 
+  }
+
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dasinh(T x) { 
+    return T(1)/sqrt(x*x+T(1));
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dacosh(T x) { 
+    return T(1)/sqrt(x*x-T(1));
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T datanh(T x) { 
+    return T(1)/(1 - x*x);
+  }
+  
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dsqrt(T x) { 
+    return T(0.5)/sqrt(x); 
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dlog(T x) { 
+    return T(1)/x; 
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dlog2(T x) { 
+    return T(1)/(log(2)*x); 
+  }
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dlog10(T x) { 
+    return T(1)/(log(10)*x); 
+  }
+  
+  template <typename T> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T dabs(T x) { 
+    return x / abs(x);
+  }
+
+  template <typename T1, typename T2> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto dproduct(T1 v1, T2 v2, T1 d1, T2 d2) { 
+    // product rule
+    return v1*d2 + v2*d1;
+  }
+  
+  template <typename T1, typename T2> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto dquotient(T1 v1, T2 v2, T1 d1, T2 d2) { 
+    // quotient rule
+    return (d1*v2 - d2*v1)/(v2*v2);
+  }
+  
+  template <typename T1, typename T2> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto dadd([[maybe_unused]] T1 v1, [[maybe_unused]] T2 v2, T1 d1, T2 d2) { 
+    // sum rule
+    return d1 + d2;
+  }
+  
+  template <typename T1, typename T2> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto dsub([[maybe_unused]] T1 v1, [[maybe_unused]] T2 v2, T1 d1, T2 d2) { 
+    // difference rule
+    return d1 - d2;
+  }
+  
+  template <typename T1, typename T2> static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto dpow(T1 v1, T2 v2, [[maybe_unused]] T1 d1, [[maybe_unused]] T2 d2) {
+#if 0
+    if constexpr (std::is_same<float, T1>::value) {
+      printf("dpow: v1: %f, v2: %f, d1: %f, d2: %f\n", (float)v1, (float)v2, (float)d1, (float)d2);
+    }
+#endif
+    // derived from generalized power rule and chain rule
+    // https://www.youtube.com/watch?v=SUxcFxM65Ho
+    if(d2 != T2(0) )  // this branch arises when exponent is a constant
+      return pow(v1,v2) * ( v2 * d1 / v1 + d2 * log(v1));
+    else
+      return  pow(v1,v2) * ( v2 * d1 / v1);
+  }
+}  
+
+} // end namespace detail
+} // end namespace matx

--- a/test/00_diff/BasicDiffTests.cu
+++ b/test/00_diff/BasicDiffTests.cu
@@ -1,0 +1,205 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "assert.h"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+#include "gtest/gtest.h"
+
+using namespace matx;
+
+template <typename TensorType>
+class BasicDiffTestsFloat : public ::testing::Test {
+};
+
+TYPED_TEST_SUITE(BasicDiffTestsFloat, MatXFloatNonComplexTypes);
+
+TYPED_TEST(BasicDiffTestsFloat, Diffs)
+{
+  MATX_ENTER_HANDLER();
+
+  int scale = 1;
+  if constexpr (is_matx_half_v<TypeParam>) {
+    scale = 1000;
+  }
+  int size = 100;  
+  cudaStream_t stream = 0;
+
+  tensor_t<TypeParam, 1> t1i{{size}};
+  tensor_t<TypeParam, 1> t1o{{size}};
+  
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+    t1i(i) = TypeParam(i)/TypeParam(size)+TypeParam(1);
+  }
+  
+  // derivative of a constant
+  (t1o = deriv(t1i)).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     ASSERT_FLOAT_EQ(t1o(i), TypeParam(0));
+  }
+
+  // derivative d/dx(x) sampled at tensor t1i
+  (t1o = deriv(wrt(t1i))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     ASSERT_FLOAT_EQ(t1o(i), TypeParam(1));
+  }
+
+  (t1o = deriv(pow(wrt(t1i),TypeParam(2)))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     ASSERT_NEAR(t1o(i), TypeParam(2)*x, .001*scale);
+  }
+
+  (t1o = deriv(pow(TypeParam(2),wrt(t1i)))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     ASSERT_NEAR(t1o(i), log(TypeParam(2))*pow(TypeParam(2),x),.001*scale);
+  }
+
+  (t1o = deriv(pow(wrt(t1i),wrt(t1i)))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     ASSERT_FLOAT_EQ(t1o(i), (log(x)+TypeParam(1))*pow(x,x));
+  }
+  
+  (t1o = deriv(pow(sin(wrt(t1i)),TypeParam(2)))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     ASSERT_NEAR(t1o(i), TypeParam(2)*cos(x)*sin(x),.0001*scale);
+  }
+  
+  (t1o = deriv(pow(wrt(t1i),sin(wrt(t1i))))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     auto s = sin(x);
+     auto c = cos(x);
+     auto l = log(x);
+
+     ASSERT_NEAR(t1o(i), pow(x,sin(x)) * ( s/x + c*l ),.0001*scale);
+  }
+  
+  auto y = TypeParam(1) + sin(wrt(t1i)) - sin(wrt(t1i));
+  (t1o = deriv(pow(y,y))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     ASSERT_NEAR(t1o(i), TypeParam(0) ,.0001*scale);
+  }
+
+  (t1o = deriv(pow(sin(wrt(t1i))-sin(wrt(t1i))+TypeParam(1),sin(wrt(t1i))))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+    
+    auto x = t1i(i);
+    auto c = cos(x);
+    auto s = sin(x);
+    auto v = c*pow(s,s)*(log(s))+TypeParam(1);
+
+    ASSERT_NEAR(t1o(i), TypeParam(0),.0001*scale);
+  }
+
+  (t1o = deriv(sin(wrt(t1i)))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     ASSERT_FLOAT_EQ(t1o(i), cos(x));
+  }
+
+  (t1o = deriv(sin(sin(wrt(t1i))))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     ASSERT_NEAR(t1o(i), cos(x)*cos(sin(x)),.00001*scale);
+  }
+  (t1o = deriv(sin(wrt(t1i))+cos(wrt(t1i)))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     ASSERT_NEAR(t1o(i), cos(t1i(i))-sin(t1i(i)),.00001*scale);
+  }
+  (t1o = deriv(sin(wrt(t1i))-cos(wrt(t1i)))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     ASSERT_NEAR(t1o(i), cos(t1i(i))+sin(t1i(i)),.00001*scale);
+  }
+  
+  (t1o = deriv(sin(wrt(t1i))*cos(wrt(t1i)))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     ASSERT_NEAR(t1o(i), cos(t1i(i))*cos(t1i(i))-sin(t1i(i))*sin(t1i(i)), .00001*scale);
+  }
+
+  // Test disabled for half because the dynamic range is not sufficient to solve this in any meaningful way.
+  if(!is_matx_half_v<TypeParam> ) { 
+    (t1o = deriv(sin(wrt(t1i))/cos(wrt(t1i)))).run(stream);
+    cudaStreamSynchronize(stream);
+    for (index_t i = 0; i <t1i.Size(0); i++) {
+     ASSERT_NEAR(t1o(i), (sin(t1i(i))*sin(t1i(i))) / (cos(t1i(i))*cos(t1i(i))) + TypeParam(1), .001*scale);
+    }
+  }
+  
+  (t1o = deriv(sin(cos(wrt(t1i)))*cos(sin(wrt(t1i))))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     auto s = sin(x);
+     auto c = cos(x);
+     auto ss = sin(sin(x));
+     auto cc = cos(cos(x));
+     auto sc = sin(cos(x));
+     auto cs = cos(sin(x));
+
+     ASSERT_NEAR(t1o(i), -c*sc*ss - s*cc*cs, .00001*scale);
+  }
+  
+  (t1o = deriv(exp(sin(wrt(t1i))/sin(wrt(t1i))))).run(stream);
+  cudaStreamSynchronize(stream);
+  for (index_t i = 0; i <t1i.Size(0); i++) {
+     auto x = t1i(i);
+     auto s = sin(x);
+     auto c = cos(x);
+     auto s2 = s*s;
+     auto c2 = c*c;
+
+     ASSERT_NEAR(t1o(i), TypeParam(0), .0001*scale);
+  }
+  
+  MATX_EXIT_HANDLER();
+}
+

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -99,51 +99,51 @@ TYPED_TEST(OperatorTestsFloat, TrigFuncs)
   (tov0 = sin(tiv0)).run();
   return;
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_sin(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), sin(c)));
 
   (tov0 = cos(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_cos(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), cos(c)));
 
   (tov0 = tan(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_tan(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), tan(c)));
 
   (tov0 = asin(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_asin(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), asin(c)));
 
   (tov0 = acos(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_acos(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), acos(c)));
 
   (tov0 = atan(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_atan(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), atan(c)));
 
   (tov0 = sinh(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_sinh(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), sinh(c)));
 
   (tov0 = cosh(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_cosh(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), cosh(c)));
 
   (tov0 = tanh(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_tanh(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), tanh(c)));
 
   (tov0 = asinh(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_asinh(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), asinh(c)));
 
   (tov0 = acosh(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_acosh(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), acosh(c)));
 
   (tov0 = atanh(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_atanh(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), atanh(c)));
 
   MATX_EXIT_HANDLER();
 }
@@ -243,27 +243,27 @@ TYPED_TEST(OperatorTestsFloatNonComplex, OperatorFuncs)
 
   (tov0 = log10(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_log10(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), log10(c)));
 
   (tov0 = log(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_log(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), log(c)));
 
   (tov0 = log2(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_log2(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), log2(c)));
 
   (tov0 = floor(tiv0)).run();   
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_floor(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), floor(c)));
 
   (tov0 = ceil(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_ceil(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), ceil(c)));
 
   (tov0 = round(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_round(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), round(c)));
 
   MATX_EXIT_HANDLER();
 }
@@ -438,21 +438,21 @@ TYPED_TEST(OperatorTestsComplex, OperatorFuncs)
 
   (tov0 = exp(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_exp(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), exp(c)));
 
   (tov0 = conj(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_conj(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), conj(c)));
 
   // abs and norm take a complex and output a floating point value
   tensor_t<typename TypeParam::value_type, 0> tdd0;
   (tdd0 = norm(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tdd0(), detail::_internal_norm(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tdd0(), norm(c)));
 
   (tdd0 = abs(tiv0)).run();
   cudaStreamSynchronize(0);
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tdd0(), detail::_internal_abs(c)));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tdd0(), abs(c)));
 
   MATX_EXIT_HANDLER();
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set (test_sources
     00_solver/Det.cu
     00_operators/PythonEmbed.cu
     00_io/FileIOTests.cu
+    00_diff/BasicDiffTests.cu
     01_radar/MultiChannelRadarPipeline.cu
     01_radar/MVDRBeamformer.cu
     01_radar/ambgfun.cu


### PR DESCRIPTION
The deriv operator will return the first derviative with respect to "X" of the underlying
operation.

The derivative of a constant (or tensor) will return 0.

The wrt operator signifies where the variable "X" is in the operation.

Fundamentally this operator has the derivative return 1 instead of 0 at
this point.  So wrt(tensor) will return 1 instead of 0.

The operator passed into wrt then becomes the points at which the
derivative is sampled.

wrt can appear multiple times in an operator but cannot be nested and
should have the same sample points passed into it.

Examples:

// df/dx sin(x)*sin(y), sampled at x
auto op = deriv(sin(wrt(x)) * sin(y));

// df/dy sin(x)*sin(y), sampled at y
auto op = deriv(sin(x) * sin(wrt(y)));

// df/dx sin(x)*sin(x), sampled at x
auto op = deriv(sin(wrt(x)) * sin(wrt(x)));

Limiations:
       deriv cannot be nested.  Only the first derivative can be
       computed.
       wrt cannot be nested.
       Not all operations support derivatives.