### PR TITLE
Implementing remap operator.

### DIFF
--- a/docs_input/api/tensorops.rst
+++ b/docs_input/api/tensorops.rst
@@ -93,3 +93,4 @@ Advanced Operators
 .. doxygenfunction:: hermitianT
 .. doxygenfunction:: r2cop
 .. doxygenfunction:: flatten
+.. doxygenfunction:: remap

--- a/include/matx_tensor.h
+++ b/include/matx_tensor.h
@@ -176,9 +176,9 @@ public:
   // Type specifier for reflection on class
   using type = T; ///< Type of traits
   using scalar_type = T; ///< Type of traits
-
   // Type specifier for signaling this is a matx operation or tensor view
   using matxop = bool; ///< Indicate this is a MatX operator
+  using matxoplvalue = bool; ///< Indicate this is a MatX operator that can be on the lhs of an equation
   using tensor_view = bool; ///< Indicate this is a MatX tensor view
   using storage_type = Storage; ///< Storage type trait
   using shape_type = typename Desc::shape_type;

--- a/include/matx_tensor_ops.h
+++ b/include/matx_tensor_ops.h
@@ -566,6 +566,120 @@ inline
   };
   }   
 
+/**
+ * Remaps elements an operator according to an index array/operator.
+ */
+  namespace detail {
+  template <int DIM, typename T, typename IdxType>
+  class RemapOp : public BaseOp<RemapOp<DIM, T, IdxType>>
+  {
+  private:
+    mutable typename base_type<T>::type op_;
+    typename base_type<IdxType>::type idx_;
+
+  public:
+    using matxop = bool;
+    using matxoplvalue = bool;
+
+    using scalar_type = typename T::scalar_type;
+    using shape_type = typename T::shape_type; 
+    using index_type = typename IdxType::scalar_type;
+    static_assert(std::is_integral<index_type>::value, "RemapOp: Type for index operator must be integral");
+    static_assert(IdxType::Rank() == 1, "RemapOp: Rank of index operator must be 1");
+    static_assert(DIM<T::Rank(), "RemapOp: DIM must be less than Rank of tensor");
+    __MATX_INLINE__ RemapOp(T op, IdxType idx) : op_(op), idx_(idx) {};
+
+    template <typename... Is>
+    __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices) const 
+    {
+      static_assert(sizeof...(Is)==Rank());
+      static_assert((std::is_convertible_v<Is, index_t> && ... ));
+
+      // convert variadic type to tupple so we can read/update
+      std::array<index_t, Rank()> ind{indices...};
+      // get current index for dim
+      auto i = ind[DIM];
+      // remap current index for dim
+      ind[DIM] = idx_(i);
+      //return op_(ind);
+      return mapply(op_, ind);
+    }
+
+    static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
+    {
+      return T::Rank();
+    }
+    constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
+    {
+      if(dim == DIM)
+        return idx_.Size(0);
+      else 
+        return op_.Size(dim);
+    }
+    
+    template<typename R> 
+    inline auto operator=(const R &rhs) {
+      return set(*this, rhs);
+    }
+  };
+  }
+
+/**
+ * @brief Operator to logically remap elements of an operator based on an index array/operator.
+ *
+ * The rank of the output tensor is equal to the rank of the input tensor.
+ * The rank of the index tensor must be 1.  
+ *
+ * The size of the output tensor is the same as the input tensor except in the applied dimenions.
+ * In the applied dimension the size of the output tensor is equal to the size of the index tensor.
+ * 
+ * This operator can appear as an rvalue or lvalue. 
+ *
+ * @tparam DIM Dimension to apply the remap 
+ * @tparam T Input operator/tensor type
+ * @tparam Ind Input index Operator type
+ * @param t Input operator
+ * @param idx Index operator/tensor
+ * @return Value in t from each location in idx
+ */
+template <int DIM, typename Op, typename Ind>
+auto __MATX_INLINE__ remap(Op t, Ind idx)
+{
+  return detail::RemapOp<DIM, Op, Ind>(t, idx);
+};   
+
+/**
+ * @brief Operator to logically remap elements of an operator based on an index array/operator.
+ *
+ * The rank of the output tensor is equal to the rank of the input tensor.
+ * The rank of the index tensor must be 1.  
+ * The number of DIMS and the number of Inds provided must be the same.
+ *
+ * The size of the output tensor is the same as the input tensor except in the applied dimenions.
+ * In the applied dimension the size of the output tensor is equal to the size of the index tensor.
+ * 
+ * This operator can appear as an rvalue or lvalue. 
+ *
+ * @tparam DIM Dimension to apply the remap 
+ * @tparam DIMS... list of multiple dimensions to remap along
+ * @tparam T Input operator/tensor type
+ * @tparam Ind Input index Operator type
+ * @tparam Inds... list of multiple index operators to remap along
+ * @param t Input operator
+ * @param idx Index operator/tensor
+ * @return Value in t from each location in idx
+ */
+template <int DIM, int... DIMS, typename Op, typename Ind, typename... Inds>
+auto __MATX_INLINE__ remap(Op t, Ind idx, Inds... inds)
+{
+  static_assert(sizeof...(DIMS) == sizeof...(Inds), "remap number of DIMs must match number of index arrays");
+
+  // recursively call remap on remaining bits
+  auto op = remap<DIMS...>(t, inds...);
+
+  // construct remap op
+  return detail::RemapOp<DIM, decltype(op) , Ind>(op, idx);
+};   
 
 /**
  * @brief Helper function to select values from a predicate operator

--- a/include/matx_type_utils.h
+++ b/include/matx_type_utils.h
@@ -91,6 +91,26 @@ template <typename T> constexpr bool is_matx_op()
 }
 
 namespace detail {
+template <typename T, typename = void>
+struct is_matx_op_lvalue_impl : std::false_type {
+};
+
+template <typename T>
+struct is_matx_op_lvalue_impl<T, std::void_t<typename T::matxoplvalue>> : std::true_type {
+};
+}
+
+/**
+ * @brief Determine if a type is a left hand side operator
+ * 
+ * @tparam T Type to test
+ */
+template <typename T> constexpr bool is_matx_op_lvalue()
+{
+  return detail::is_matx_op_lvalue_impl<T>::value;
+}
+
+namespace detail {
 template <typename T, typename = void> struct is_tensor_view : std::false_type {
 };
 


### PR DESCRIPTION
This operator takes an operator/tensor
and an index array and logically gathers elements from that index array.
This allows the user to logically select/broadcast elements from a
dimension of the tensor.  This operator could then be stored in a memory
backed tensor to create a linear ordering of an operator to pass into a
library backed routine like matmul or fft.