### PR TITLE
Update reverse/shift APIs

### DIFF
--- a/docs_input/api/tensorops.rst
+++ b/docs_input/api/tensorops.rst
@@ -77,10 +77,7 @@ Advanced Operators
 .. doxygenclass:: matx::IF 
 .. doxygenclass:: matx::IFELSE
 .. doxygenfunction:: reverse
-.. doxygenfunction:: shift0
-.. doxygenfunction:: shift1
-.. doxygenfunction:: shift2
-.. doxygenfunction:: shift3
+.. doxygenfunction:: shift
 .. doxygenfunction:: fftshift1D
 .. doxygenfunction:: fftshift2D    
 .. doxygenfunction:: repmat(T1 t, index_t reps)    

--- a/docs_input/api/tensorops.rst
+++ b/docs_input/api/tensorops.rst
@@ -76,10 +76,7 @@ Advanced Operators
 
 .. doxygenclass:: matx::IF 
 .. doxygenclass:: matx::IFELSE
-.. doxygenfunction:: reverseX
-.. doxygenfunction:: reverseY
-.. doxygenfunction:: reverseZ
-.. doxygenfunction:: reverseW
+.. doxygenfunction:: reverse
 .. doxygenfunction:: shift0
 .. doxygenfunction:: shift1
 .. doxygenfunction:: shift2

--- a/include/matx_corr.h
+++ b/include/matx_corr.h
@@ -67,7 +67,7 @@ void corr(OutputTensor &o, const In1Type &i1, const In2Type &i2,
   MATX_ASSERT_STR(method == MATX_C_METHOD_DIRECT, matxNotSupported,
                "Only direct correlation method supported at this time");
 
-  auto i2r = reverseX(conj(i2));
+  auto i2r = reverse<In2Type::Rank()-1>(conj(i2));
   conv1d(o, i1, i2r, mode, stream);
 }
 

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -1971,7 +1971,7 @@ TYPED_TEST(OperatorTestsNumeric, Reverse)
   }
 
   {
-    (t2r = reverseY(t2)).run();
+    (t2r = reverse<0>(t2)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -1983,7 +1983,7 @@ TYPED_TEST(OperatorTestsNumeric, Reverse)
   }
 
   {
-    (t2r = reverseX(t2)).run();
+    (t2r = reverse<1>(t2)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -1995,7 +1995,7 @@ TYPED_TEST(OperatorTestsNumeric, Reverse)
   }
 
   {
-    (t2r = reverseX(reverseY(t2))).run();
+    (t2r = reverse<0,1>(t2)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -1841,7 +1841,7 @@ TYPED_TEST(OperatorTestsNumeric, Shift)
   }
 
   {
-    (t2s = shift0(t2, 5)).run();
+    (t2s = shift<0>(t2, 5)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -1853,7 +1853,7 @@ TYPED_TEST(OperatorTestsNumeric, Shift)
   }
 
   {
-    (t2s = shift1(t2, 5)).run();
+    (t2s = shift<1>(t2, 5)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -1865,7 +1865,7 @@ TYPED_TEST(OperatorTestsNumeric, Shift)
   }
 
   {
-    (t2s = shift0(shift1(t2, 5), 6)).run();
+    (t2s = shift<1,0>(t2, 5, 6)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -1904,7 +1904,7 @@ TYPED_TEST(OperatorTestsNumeric, Shift)
 
   // Negative shifts
   {
-    (t2s = shift0(t2, -5)).run();
+    (t2s = shift<0>(t2, -5)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -1916,7 +1916,7 @@ TYPED_TEST(OperatorTestsNumeric, Shift)
   }
 
   {
-    (t2s = shift1(t2, -5)).run();
+    (t2s = shift<1>(t2, -5)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -1929,7 +1929,7 @@ TYPED_TEST(OperatorTestsNumeric, Shift)
 
   // Large shifts
   {
-    (t2s = shift0(t2, t2.Size(0) * 4)).run();
+    (t2s = shift<0>(t2, t2.Size(0) * 4)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -1942,8 +1942,8 @@ TYPED_TEST(OperatorTestsNumeric, Shift)
   {
     // Shift 4 times the size back, minus one. This should be equivalent to
     // simply shifting by -1
-    (t2s = shift0(t2, -t2.Size(0) * 4 - 1)).run();
-    (t2s2 = shift0(t2, -1)).run();
+    (t2s = shift<0>(t2, -t2.Size(0) * 4 - 1)).run();
+    (t2s2 = shift<0>(t2, -1)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {


### PR DESCRIPTION
reverse/shift APIs now take a template parameter for the dims instead of having them in the function name.  They also can take multiple DIMs.  This is consistent with the remap APIs.  Fixes #206 