### PR TITLE
Change sign of shift to match python/matlab.

### DIFF
--- a/include/matx_tensor_ops.h
+++ b/include/matx_tensor_ops.h
@@ -1682,7 +1682,8 @@ auto __MATX_INLINE__ reverse(Op t)
   auto self(T1 t) { return detail::SelfOp<T1, T1::Rank()>(t); };
 
   /**
- * Shifts the indexing of an operator or View by a given amount
+ * Shifts the indexing of an operator to move the array forward or backward by the
+ * shift amount. 
  *
  * ShiftOp allows adjusting the relative view of a tensor to start at a
  * new offset. This may be useful to cut off part of a tensor that is
@@ -1713,7 +1714,7 @@ auto __MATX_INLINE__ reverse(Op t)
     __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
     {
       auto tup = cuda::std::make_tuple(indices...);
-      auto shift = get_value(shift_, indices...);
+      auto shift = -get_value(shift_, indices...);
 
 
       shift = (shift + cuda::std::get<DIM>(tup)) % Size(DIM);

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -2180,7 +2180,7 @@ TYPED_TEST(OperatorTestsNumeric, ShiftOp)
   tensor_t<TypeParam, 2> t2s({count0, count1});
   tensor_t<TypeParam, 2> t2s2({count0, count1});
   tensor_t<int, 0> t0;
-  t0() = 5;
+  t0() = -5;
 
   for (index_t i = 0; i < count0; i++) {
     for (index_t j = 0; j < count1; j++) {
@@ -2189,7 +2189,7 @@ TYPED_TEST(OperatorTestsNumeric, ShiftOp)
   }
 
   {
-    (t2s = shift<0>(t2, 5)).run();
+    (t2s = shift<0>(t2, -5)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -2213,7 +2213,7 @@ TYPED_TEST(OperatorTestsNumeric, ShiftOp)
   }
 
   {
-    (t2s = shift<1>(t2, 5)).run();
+    (t2s = shift<1>(t2, -5)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -2225,7 +2225,7 @@ TYPED_TEST(OperatorTestsNumeric, ShiftOp)
   }
 
   {
-    (t2s = shift<1,0>(t2, 5, 6)).run();
+    (t2s = shift<1,0>(t2, -5, -6)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -2262,9 +2262,9 @@ TYPED_TEST(OperatorTestsNumeric, ShiftOp)
     }
   }
 
-  // Negative shifts
+  // Right shifts
   {
-    (t2s = shift<0>(t2, -5)).run();
+    (t2s = shift<0>(t2, 5)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -2276,7 +2276,7 @@ TYPED_TEST(OperatorTestsNumeric, ShiftOp)
   }
 
   {
-    (t2s = shift<1>(t2, -5)).run();
+    (t2s = shift<1>(t2, 5)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {
@@ -2289,7 +2289,7 @@ TYPED_TEST(OperatorTestsNumeric, ShiftOp)
 
   // Large shifts
   {
-    (t2s = shift<0>(t2, t2.Size(0) * 4)).run();
+    (t2s = shift<0>(t2, -t2.Size(0) * 4)).run();
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count0; i++) {


### PR DESCRIPTION
This is a breaking change.  For consistency it is best to update this
sooner rather than later.