### PR TITLE
Fix use of deprecated constructor.

### DIFF
--- a/examples/spectrogram_graph.cu
+++ b/examples/spectrogram_graph.cu
@@ -84,7 +84,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   tensor_t<float, 1> carrier({N});
   tensor_t<float, 1> noise({N});
   tensor_t<float, 1> x({N});
-  auto freqs = make_tensor<float, 1>(half_win);
+  auto freqs = make_tensor<float>({half_win[0]});
   tensor_t<complex, 2> fftStackedMatrix(
       {(N - noverlap) / nstep, nfft / 2 + 1});
   tensor_t<float, 1> s_time({(N - noverlap) / nstep});


### PR DESCRIPTION
Make sure example spectrogram_graph builds fine under flag `-Werror`