### PR TITLE
Fix calculation for pulses/channel/sec

### DIFF
--- a/examples/simple_radar_pipeline.cu
+++ b/examples/simple_radar_pipeline.cu
@@ -99,7 +99,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   float time_s = time_ms * .001f;
 
   printf("Pipeline rate: %f pulses/channel/sec\n",
-         static_cast<float>(iterations * numPulses) / time_s);
+         static_cast<float>(iterations * numChannels * numPulses) / time_s);
 
   cudaEventDestroy(start);
   cudaEventDestroy(stop);


### PR DESCRIPTION
Performance calculation isn't taking into account the number of channels in the test.