### PR TITLE
implement QR for small batched matrices.

### DIFF
--- a/bench/00_transform/qr.cu
+++ b/bench/00_transform/qr.cu
@@ -1,0 +1,57 @@
+#include "matx.h"
+#include <nvbench/nvbench.cuh>
+#include "matx/core/nvtx.h"
+
+using namespace matx;
+
+using qr_types =
+    nvbench::type_list<float, double, cuda::std::complex<float>, cuda::std::complex<double>>;
+
+/* QR benchmarks */
+template <typename ValueType>
+void qr_batch(nvbench::state &state,
+                            nvbench::type_list<ValueType>)
+{
+  using AType = ValueType;
+  using SType = typename inner_op_type_t<AType>::type;
+
+  cudaStream_t stream = 0;
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream));
+
+  int batch = state.get_int64("batch");
+  int m = state.get_int64("rows");
+  int n = state.get_int64("cols");
+
+  auto A = make_tensor<AType>({batch, m, n});
+  auto Q = make_tensor<AType>({batch, m, m});
+  auto R = make_tensor<AType>({batch, m, n});
+
+  randomGenerator_t<AType> gen(A.TotalSize(),0);
+
+  auto random = gen.GetTensorView({batch, m, n}, NORMAL);
+  
+  A.PrefetchDevice(stream);
+  Q.PrefetchDevice(stream);
+  R.PrefetchDevice(stream);
+  
+  (A = random).run(stream);
+
+  // warm up
+  nvtxRangePushA("Warmup");
+  qr(Q, R, A, stream);
+
+  cudaDeviceSynchronize();
+  nvtxRangePop();
+
+  MATX_NVTX_START_RANGE( "Exec", matx_nvxtLogLevels::MATX_NVTX_LOG_ALL, 1 )
+  state.exec(
+   [&Q, &R, &A](nvbench::launch &launch) {
+      qr(Q, R, A, launch.get_stream()); });
+  MATX_NVTX_END_RANGE( 1 )
+
+}
+NVBENCH_BENCH_TYPES(qr_batch, NVBENCH_TYPE_AXES(qr_types))
+  .add_int64_axis("cols", {4, 16, 64})
+  .add_int64_axis("rows", {4})
+  .add_int64_axis("batch", {3000});
+

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -5,6 +5,7 @@ set (bench_sources
     00_transform/cub.cu
     00_transform/einsum.cu
     00_transform/svd_power.cu
+    00_transform/qr.cu
     00_operators/operators.cu
     00_operators/reduction.cu
     01_radar/SingleChanSimplePipeline.cu

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,7 @@ set(examples
     spectrogram_graph
     spherical_harmonics 
     svd_power
+    qr
     black_scholes)
 
 add_library(example_lib INTERFACE)

--- a/include/matx/transforms/qr.h
+++ b/include/matx/transforms/qr.h
@@ -1,0 +1,223 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx/core/error.h"
+#include "matx/core/nvtx.h"
+#include "matx/core/tensor.h"
+#include <cstdio>
+#include <numeric>
+
+namespace matx {
+
+/**
+ * Perform QR decomposition on a matrix using housholders reflections. If rank > 2 operations are batched.
+ *
+ * @tparam QType
+ *   Tensor or operator type for output of Q matrix or tensor output.
+ * @tparam RType
+ *   Tensor or operator type for output of R matrix
+ * @tparam AType
+ *   Tensor or operator type for output of A input tensors.
+ *
+ * @param Q
+ *   Q output tensor or operator.
+ * @param R
+ *   R output tensor or operator.
+ * @param A
+ *   Input tensor or operator for tensor A input.
+ * @param stream
+ *   CUDA stream
+ */
+template<typename QType, typename RType, typename AType>
+void qr(QType Q, RType R, AType A, cudaStream_t stream) {
+  MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+  static_assert(A.Rank() >= 2);
+  static_assert(Q.Rank() == A.Rank());
+  static_assert(R.Rank() == A.Rank());
+
+  MATX_ASSERT_STR(A.Rank() == Q.Rank(), matxInvalidDim, "qr: A and Q must have the same rank");
+  MATX_ASSERT_STR(A.Rank() == R.Rank(), matxInvalidDim, "qr: A and R must have the same rank");
+
+  using ATypeS = typename AType::scalar_type;
+  using NTypeS = typename inner_op_type_t<ATypeS>::type;
+  const int RANK = AType::Rank();
+
+  index_t m = A.Size(RANK-2);
+  index_t n = A.Size(RANK-1);
+  index_t k = std::min(m,n);
+  if(m<=n) k--;  // these matrices have one less update since the diagonal ends on the bottom of the matrix
+
+  // Create Identity matrix
+  auto E = eye<ATypeS>({m,m});
+
+  // Clone over batch Dims
+  auto ECShape = Q.Shape();
+  ECShape[RANK-1] = matxKeepDim;
+  ECShape[RANK-2] = matxKeepDim;
+
+  auto I = clone<RANK>(E, ECShape);
+
+  std::array<index_t, RANK-2> NShape;
+  for(int i = 0; i < RANK-2; i++) {
+    NShape[i] = A.Size(i);
+  }
+
+  std::array<index_t, RANK> VMShape;
+  for(int i = 0; i < RANK-1; i++) {
+    VMShape[i] = A.Size(i);
+  }
+  VMShape[RANK-1] = 1;
+
+  std::array<index_t, RANK> HShape;
+  for(int i = 0; i < RANK-2; i++) {
+    HShape[i] = A.Size(i);
+  }
+  HShape[RANK-2] = m;
+  HShape[RANK-1] = m;
+
+  auto N = make_tensor<NTypeS>(NShape, MATX_ASYNC_DEVICE_MEMORY, stream);
+  auto VM = make_tensor<ATypeS>(VMShape, MATX_ASYNC_DEVICE_MEMORY, stream);
+  auto H = make_tensor<ATypeS>(HShape, MATX_ASYNC_DEVICE_MEMORY, stream);
+  auto QN = make_tensor<ATypeS>(Q.Shape(), MATX_ASYNC_DEVICE_MEMORY, stream);
+  auto RN = make_tensor<ATypeS>(R.Shape(), MATX_ASYNC_DEVICE_MEMORY, stream);
+  
+  auto ci = N;  // alias
+
+  // Inititalize Q
+  (Q = I).run(stream);
+  (R = A).run(stream);
+
+  // setup slices
+  std::array<index_t, RANK> mSliceB, mSliceE;  // matrix slice starting at i,i
+  mSliceB.fill(0); mSliceE.fill(matxEnd);
+  
+  std::array<index_t, RANK> qSliceB, qSliceE;  // matrix slice starting at 0,i
+  qSliceB.fill(0); qSliceE.fill(matxEnd);
+
+  std::array<index_t, RANK> xSliceB, xSliceE;  // vector slice starting at i,i
+  xSliceB.fill(0); xSliceE.fill(matxEnd);
+  xSliceE[RANK-1] = matxDropDim; // drop last dim to make a vector
+  
+  std::array<index_t, RANK> vSliceB, vSliceE;  // vector slice starting at i,0?
+  vSliceB.fill(0); vSliceE.fill(matxEnd);
+  vSliceE[RANK-1] = matxDropDim; // drop last dim to make a vector
+
+  std::array<index_t, RANK> vmSliceB, vmSliceE;  // vector slice as a matrix starting at i
+  vmSliceB.fill(0); vmSliceE.fill(matxEnd);
+
+  // N cloned across x.
+  std::array<index_t, RANK-1> ncShape;
+  ncShape.fill(matxKeepDim);
+    
+  // clone  ci across hi
+  std::array<index_t, RANK> cicShape;
+  cicShape.fill(matxKeepDim);
+ 
+  for(int i = 0 ; i < k ; i++) {
+  
+    // update top left corner of slice
+    mSliceB[RANK-2] = i;
+    mSliceB[RANK-1] = i;
+
+    // update q slice
+    qSliceB[RANK-1] = i;
+  
+    // update v/vm slices to start at i
+    xSliceB[RANK-2] = i;
+    xSliceB[RANK-1] = i;
+    vmSliceB[RANK-2] = i;
+    vSliceB[RANK-2] = i;
+
+    // matrix slices
+    auto qi = slice<RANK>(Q, qSliceB, qSliceE);
+    auto qn = slice<RANK>(QN, qSliceB, qSliceE);
+    auto ri = slice<RANK>(R, mSliceB, mSliceE);
+    auto rn = slice<RANK>(RN, mSliceB, mSliceE);
+    auto hi = slice<RANK>(H, mSliceB, mSliceE);
+    auto vm = slice<RANK>(VM, vmSliceB, vmSliceE);
+    
+    // vector slices
+    auto v = slice<RANK-1>(VM, vSliceB, vSliceE);
+    auto x = slice<RANK-1>(R, xSliceB, xSliceE);
+    
+    //update clone shape
+    ncShape[RANK-2] = m-i;
+    auto nc = clone<RANK-1>(N,ncShape);
+    
+    // update cloned ci shape
+    cicShape[RANK-2] = m - i;
+    cicShape[RANK-1] = m - i;
+    auto cic = clone<RANK>(ci, cicShape);
+    
+    // create identity matrix and clone across full rank
+    auto Ei = eye<ATypeS>({m-i,m-i});
+    auto Ii = clone<RANK>(Ei, ECShape);
+
+    sum(N, norm(x), stream);
+    (N = sqrt(N)).run(stream);
+
+    // copy x into v and apply signed addition of nc
+    (IFELSE( (index(v.Rank()-1) == 0),
+             v = x + sign(x) * nc,
+             v = x)).run(stream);
+    
+    sum(ci, norm(v), stream);
+
+    (ci = NTypeS(2) / ci).run(stream);
+
+    matmul(hi, vm, conj(transpose(vm)), stream);
+
+    (hi = Ii - cic * hi).run(stream);
+
+    // update panel of r
+    matmul(rn, hi, ri, stream);
+    
+    // update panel of q
+    matmul(qn, qi, hi, stream); 
+    
+    // deep copy required (can't swap)
+    // copy current panels into output matrix
+    (ri = rn).run(stream);
+    (qi = qn).run(stream);
+    
+    // R & Q now contain latest
+  }
+  
+  // zero out lower triangular part of R
+  (IF(index(RANK-1) < index(RANK-2), R = 0)).run(stream);
+  
+}
+
+} // end namespace matx

--- a/include/matx/transforms/solver.h
+++ b/include/matx/transforms/solver.h
@@ -1280,7 +1280,7 @@ void det(OutputTensor &out, const InputTensor &a,
  *   CUDA stream
  */
 template <typename OutTensor, typename TauTensor, typename ATensor>
-void qr(OutTensor &out, TauTensor &tau,
+void cusolver_qr(OutTensor &out, TauTensor &tau,
         const ATensor &a, cudaStream_t stream = 0)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)

--- a/include/matx/transforms/transforms.h
+++ b/include/matx/transforms/transforms.h
@@ -45,6 +45,7 @@
 #include "matx/transforms/inverse.h"
 #include "matx/transforms/matmul.h"
 #include "matx/transforms/permute.h"
+#include "matx/transforms/qr.h"
 #include "matx/transforms/reduce.h"
 #include "matx/transforms/solver.h"
 #include "matx/transforms/transpose.h"

--- a/test/00_solver/QR2.cu
+++ b/test/00_solver/QR2.cu
@@ -1,0 +1,131 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "assert.h"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+#include "gtest/gtest.h"
+
+using namespace matx;
+
+template <typename TensorType>
+class QR2SolverTestNonHalfTypes : public ::testing::Test{
+};
+
+TYPED_TEST_SUITE(QR2SolverTestNonHalfTypes,
+                 MatXFloatNonHalfTypes);
+
+template <typename TypeParam, int RANK>
+void qr_test( const index_t (&AshapeA)[RANK]) {
+  using AType = TypeParam;
+  using SType = typename inner_op_type_t<AType>::type;
+  
+  cudaStream_t stream = 0;
+
+  std::array<index_t, RANK> Ashape = detail::to_array(AshapeA);
+  std::array<index_t, RANK> Qshape = Ashape;
+  std::array<index_t, RANK> Rshape = Ashape;
+
+  index_t m = Ashape[RANK-2];
+  index_t n = Ashape[RANK-1];
+
+  Qshape[RANK-2] = m;
+  Qshape[RANK-1] = m;
+
+  Rshape[RANK-2] = m;
+  Rshape[RANK-1] = n;
+
+  auto A = make_tensor<AType>(Ashape);
+  auto Q = make_tensor<AType>(Qshape);
+  auto R = make_tensor<AType>(Rshape);
+  
+  randomGenerator_t<AType> gen(A.TotalSize(),0);
+  auto random = gen.GetTensorView(Ashape, NORMAL);
+  (A = random).run(stream);
+  
+  A.PrefetchDevice(stream);
+  Q.PrefetchDevice(stream);
+  R.PrefetchDevice(stream);
+  
+  qr(Q, R, A, stream);
+
+  auto mdiffQTQ = make_tensor<SType>();
+  auto mdiffQR = make_tensor<SType>();
+
+  {
+    // QTQ == Identity
+    auto QTQ = make_tensor<AType>(Qshape);
+    matmul(QTQ, conj(transpose(Q)), Q, stream);
+    auto e = eye<SType>({m,m});
+
+    auto eShape = Qshape;
+    eShape[RANK-1] = matxKeepDim;
+    eShape[RANK-2] = matxKeepDim;
+    auto I = clone<RANK>(e, eShape);
+  
+    rmax(mdiffQTQ, abs(QTQ-I), stream);
+
+  }
+
+  {
+    // Q*R == A
+    auto QR = make_tensor<AType>(Ashape);
+    matmul(QR, Q, R, stream);
+    
+    rmax(mdiffQR, abs(A-QR), stream);
+  }
+
+  cudaDeviceSynchronize();
+
+  ASSERT_NEAR( mdiffQTQ(), SType(0), .00001);
+  ASSERT_NEAR( mdiffQR(), SType(0), .00001);
+}
+
+TYPED_TEST(QR2SolverTestNonHalfTypes, QR2)
+{
+  MATX_ENTER_HANDLER();
+  
+  qr_test<TypeParam>({4,4});
+  qr_test<TypeParam>({4,16});
+  qr_test<TypeParam>({16,4});
+
+  qr_test<TypeParam>({25,4,4});
+  qr_test<TypeParam>({25,4,16});
+  qr_test<TypeParam>({25,16,4});
+
+  qr_test<TypeParam>({5,5,4,4});
+  qr_test<TypeParam>({5,5,4,16});
+  qr_test<TypeParam>({5,5,16,4});
+  
+  MATX_EXIT_HANDLER();
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set (test_sources
     00_solver/Cholesky.cu
     00_solver/LU.cu
     00_solver/QR.cu
+    00_solver/QR2.cu
     00_solver/SVD.cu
     00_solver/Eigen.cu
     00_solver/Det.cu


### PR DESCRIPTION
Rename cusparse wrapper to cusparse_qr.
Cusolver API doesn't currently produce QR but instead R and the HH vectors.
