### PR TITLE
Removing inheritance from std::iterator

### DIFF
--- a/include/matx/core/iterator.h
+++ b/include/matx/core/iterator.h
@@ -54,7 +54,7 @@ struct RandomOperatorIterator {
   using pointer = value_type*;
   using reference = value_type&;
   using iterator_category = std::random_access_iterator_tag;
-  using difference_type = typename std::iterator<iterator_category, value_type>::difference_type;
+  using difference_type = index_t;
 
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorIterator(const OperatorType &t) : t_(t), offset_(0) { }
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorIterator(const OperatorType &t, stride_type offset) : t_(t), offset_(offset) {}
@@ -153,7 +153,7 @@ struct RandomOperatorOutputIterator {
   using pointer = value_type*;
   using reference = value_type&;
   using iterator_category = std::random_access_iterator_tag;
-  using difference_type = typename std::iterator<iterator_category, value_type>::difference_type;
+  using difference_type = index_t;
 
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorOutputIterator(const OperatorType &t) : t_(t), offset_(0) { }
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorOutputIterator(const OperatorType &t, stride_type offset) : t_(t), offset_(offset) {}

--- a/include/matx/transforms/cub.h
+++ b/include/matx/transforms/cub.h
@@ -120,7 +120,7 @@ struct BeginOffset {
   using pointer = value_type*;
   using reference = value_type;
   using iterator_category = std::random_access_iterator_tag;
-  using difference_type = typename std::iterator<iterator_category, value_type>::difference_type;
+  using difference_type = index_t;
 
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ BeginOffset(const OperatorType &t) : size_(t.Size(t.Rank() - 1)), offset_(0) { }
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ BeginOffset(const OperatorType &t, stride_type offset) : size_(t.Size(t.Rank() - 1)), offset_(offset) {}
@@ -179,7 +179,7 @@ struct EndOffset {
   using pointer = value_type*;
   using reference = value_type;
   using iterator_category = std::random_access_iterator_tag;
-  using difference_type = typename std::iterator<iterator_category, value_type>::difference_type;
+  using difference_type = index_t;
 
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ EndOffset(const OperatorType &t) : size_(t.Size(t.Rank() - 1)), offset_(0) { }
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ EndOffset(const OperatorType &t, stride_type offset) : size_(t.Size(t.Rank() - 1)), offset_(offset) {}


### PR DESCRIPTION
Fixes g++12 warning/error