### PR TITLE
16-bit float reductions + updated softmax

### DIFF
--- a/bench/00_operators/reduction.cu
+++ b/bench/00_operators/reduction.cu
@@ -10,20 +10,17 @@ template <typename ValueType>
 void softmax(nvbench::state &state, nvbench::type_list<ValueType>)
 {
   // Get current parameters:
+  auto t4    = make_tensor<ValueType>({1,10845,8,16});
+  auto t4out    = make_tensor<ValueType>({1,10845,8,16});
+  t4.PrefetchDevice(0);
+  t4out.PrefetchDevice(0);
 
-
-auto t2    = make_tensor<ValueType>({86760, 16});
-auto t2out    = make_tensor<ValueType>({86760, 16});
-  t2.PrefetchDevice(0);
-  t2out.PrefetchDevice(0);
-
-  softmax(t2out, t2, {1});
+  softmax(t4out, t4, {3});
 
   state.exec( 
-    [&t2, &t2out](nvbench::launch &launch) {
-      matx::softmax(t2out, t2, (cudaStream_t)launch.get_stream());
+    [&t4, &t4out](nvbench::launch &launch) {
+      matx::softmax(t4out, t4, (cudaStream_t)launch.get_stream());
     });
-
 }
 NVBENCH_BENCH_TYPES(softmax, NVBENCH_TYPE_AXES(softmax_types));
 

--- a/include/matx/core/iterator.h
+++ b/include/matx/core/iterator.h
@@ -46,8 +46,8 @@ namespace matx {
 template <typename OperatorType>
 struct RandomOperatorIterator {
   using self_type = RandomOperatorIterator<OperatorType>;
-  using value_type = typename OperatorType::scalar_type;
-  using scalar_type = typename OperatorType::scalar_type;
+  using value_type = detail::convert_matx_type_t<typename OperatorType::scalar_type>;
+  using scalar_type = value_type;
   // using stride_type = std::conditional_t<is_tensor_view_v<OperatorType>, typename OperatorType::desc_type::stride_type,
   //                         index_t>;
   using stride_type = index_t;
@@ -67,12 +67,12 @@ struct RandomOperatorIterator {
   [[nodiscard]] __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ value_type operator*() const
   {
     if constexpr (OperatorType::Rank() == 0) {
-      return t_.operator()();
+      return static_cast<value_type>(t_.operator()());
     }
     else {
       auto arrs = detail::GetIdxFromAbs(t_, offset_);
       return detail::mapply([&](auto &&...args) {
-          return t_.operator()(args...);
+          return static_cast<value_type>(t_.operator()(args...));
         }, arrs);     
     }
   }  
@@ -145,8 +145,8 @@ struct RandomOperatorIterator {
 template <typename OperatorType>
 struct RandomOperatorOutputIterator {
   using self_type = RandomOperatorOutputIterator<OperatorType>;
-  using value_type = typename OperatorType::scalar_type;
-  using scalar_type = typename OperatorType::scalar_type;
+  using value_type = detail::convert_matx_type_t<typename OperatorType::scalar_type>;
+  using scalar_type = value_type;
   // using stride_type = std::conditional_t<is_tensor_view_v<OperatorType>, typename OperatorType::desc_type::stride_type,
   //                         index_t>;
   using stride_type = index_t;
@@ -161,13 +161,13 @@ struct RandomOperatorOutputIterator {
   [[nodiscard]] __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ reference operator*()
   {
     if constexpr (OperatorType::Rank() == 0) {
-      return t_.operator()();
+      return (reference)(t_.operator()());
     }
     else {
       auto arrs = detail::GetIdxFromAbs(t_, offset_);
 
       return std::apply([&](auto &&...args) -> reference {
-          return t_.operator()(args...);
+          return (reference)(t_.operator()(args...));
         }, arrs);    
     }
   }  

--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -161,14 +161,14 @@ namespace detail {
   template <typename Func, typename Tuple, size_t... S>
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) apply_impl(Func &&f, Tuple&& tuple, std::index_sequence<S...>)  {
     
-    if constexpr (is_std_tuple<std::remove_reference_t<Tuple>>::value || is_std_array<std::remove_reference_t<Tuple>>::value) {
+    if constexpr (is_std_tuple<remove_cvref_t<Tuple>>::value || is_std_array<remove_cvref_t<Tuple>>::value) {
       return cuda::std::invoke(std::forward<Func>(f), std::get<S>(std::forward<Tuple>(tuple))...);
     }
     else {
       return cuda::std::invoke(std::forward<Func>(f), cuda::std::get<S>(std::forward<Tuple>(tuple))...);
     }
 
-    if constexpr (!(is_std_tuple<std::remove_reference_t<Tuple>>::value || is_std_array<std::remove_reference_t<Tuple>>::value)) {
+    if constexpr (!(is_std_tuple<remove_cvref_t<Tuple>>::value || is_std_array<remove_cvref_t<Tuple>>::value)) {
             return cuda::std::invoke(std::forward<Func>(f), cuda::std::get<S>(std::forward<Tuple>(tuple))...);
     }
     else {
@@ -179,52 +179,52 @@ namespace detail {
   template <class Func, class Tuple>
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ constexpr decltype(auto) mapply(Func&& f, Tuple&& t)
   {
-    if constexpr (is_std_tuple<std::remove_reference_t<Tuple>>::value || is_std_array<std::remove_reference_t<Tuple>>::value) {
+    if constexpr (is_std_tuple<remove_cvref_t<Tuple>>::value || is_std_array<remove_cvref_t<Tuple>>::value) {
       return apply_impl(
           std::forward<Func>(f), std::forward<Tuple>(t),
-          std::make_index_sequence<std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+          std::make_index_sequence<std::tuple_size_v<remove_cvref_t<Tuple>>>{});
     }
     else {
       return apply_impl(
           std::forward<Func>(f), std::forward<Tuple>(t),
-          std::make_index_sequence<cuda::std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+          std::make_index_sequence<cuda::std::tuple_size_v<remove_cvref_t<Tuple>>>{});
     }
 
-    if constexpr (!(is_std_tuple<std::remove_reference_t<Tuple>>::value || is_std_array<std::remove_reference_t<Tuple>>::value)) {
+    if constexpr (!(is_std_tuple<remove_cvref_t<Tuple>>::value || is_std_array<remove_cvref_t<Tuple>>::value)) {
       return apply_impl(
           std::forward<Func>(f), std::forward<Tuple>(t),
-          std::make_index_sequence<cuda::std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+          std::make_index_sequence<cuda::std::tuple_size_v<remove_cvref_t<Tuple>>>{});
     }
     else {
       return apply_impl(
           std::forward<Func>(f), std::forward<Tuple>(t),
-          std::make_index_sequence<std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+          std::make_index_sequence<std::tuple_size_v<remove_cvref_t<Tuple>>>{});
     }
   }
 
   template <class Func, class Tuple>
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ constexpr decltype(auto) mapply_reverse(Func&& f, Tuple&& t)
   {
-    if constexpr (is_std_tuple<std::remove_reference_t<Tuple>>::value || is_std_array<std::remove_reference_t<Tuple>>::value) {
+    if constexpr (is_std_tuple<remove_cvref_t<Tuple>>::value || is_std_array<remove_cvref_t<Tuple>>::value) {
       return apply_impl(
           std::forward<Func>(f), std::forward<Tuple>(t),
-          make_index_sequence_rev<std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+          make_index_sequence_rev<std::tuple_size_v<remove_cvref_t<Tuple>>>{});
     }
     else {
       return apply_impl(
           std::forward<Func>(f), std::forward<Tuple>(t),
-          make_index_sequence_rev<cuda::std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+          make_index_sequence_rev<cuda::std::tuple_size_v<remove_cvref_t<Tuple>>>{});
     }
 
-    if constexpr (!(is_std_tuple<std::remove_reference_t<Tuple>>::value || is_std_array<std::remove_reference_t<Tuple>>::value)) {
+    if constexpr (!(is_std_tuple<remove_cvref_t<Tuple>>::value || is_std_array<remove_cvref_t<Tuple>>::value)) {
       return apply_impl(
           std::forward<Func>(f), std::forward<Tuple>(t),
-          make_index_sequence_rev<cuda::std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+          make_index_sequence_rev<cuda::std::tuple_size_v<remove_cvref_t<Tuple>>>{});
     }
     else {
       return apply_impl(
           std::forward<Func>(f), std::forward<Tuple>(t),
-          make_index_sequence_rev<std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+          make_index_sequence_rev<std::tuple_size_v<remove_cvref_t<Tuple>>>{});
     }
   }
 

--- a/include/matx/operators/index.h
+++ b/include/matx/operators/index.h
@@ -58,7 +58,7 @@ namespace matx
         template <typename... Is>
           __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
           {
-            std::array<index_t, int(sizeof...(Is))> inds{indices...};
+            std::array<index_t, sizeof...(Is)> inds{indices...};
             return inds[dim_];
           }
 

--- a/include/matx/operators/unary_operators.h
+++ b/include/matx/operators/unary_operators.h
@@ -65,6 +65,7 @@ namespace matx
     // dummy type to signal this is a matxop
     using matxop = bool;
     using scalar_type = typename Op::scalar_type;
+    using self_type = matxUnaryOp<I1, Op>;
 
     __MATX_INLINE__ const std::string str() const {
       return op_.str() + "(" + get_type_str(in1_) + ")";
@@ -78,7 +79,14 @@ namespace matx
       }
     }
 
-    template <typename... Is>
+    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ const auto operator()(const std::array<index_t, detail::get_rank<I1>()> &idx) const noexcept
+    {
+      return mapply([&](auto &&...args)  {
+          return this->operator()(args...);
+        }, idx);      
+    }  
+
+    template <typename... Is, std::enable_if_t<std::conjunction_v<std::is_integral<Is>...>, bool> = true>
     __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
     {
       auto i1 = get_value(in1_, indices...);

--- a/test/00_operators/ReductionTests.cu
+++ b/test/00_operators/ReductionTests.cu
@@ -92,7 +92,7 @@ TYPED_TEST_SUITE(ReductionTestsNumericNoHalf, MatXNumericNoHalfTypes);
 TYPED_TEST_SUITE(ReductionTestsComplexNonHalfTypes, MatXComplexNonHalfTypes);
 
 
-TYPED_TEST(ReductionTestsFloatNonComplexNonHalf, VarianceStd)
+TYPED_TEST(ReductionTestsFloatNonComplex, VarianceStd)
 {
   MATX_ENTER_HANDLER();
 
@@ -134,7 +134,7 @@ TYPED_TEST(ReductionTestsComplexNonHalfTypes, VarianceStdComplex)
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(ReductionTestsNumericNoHalf, Sum)
+TYPED_TEST(ReductionTestsNumeric, Sum)
 {
   MATX_ENTER_HANDLER();
 
@@ -161,10 +161,10 @@ TYPED_TEST(ReductionTestsNumericNoHalf, Sum)
   {
     tensor_t<TypeParam, 0> t0;
 
-    auto t4 = ones<TypeParam>({30, 40, 50, 60});
-    auto t3 = ones<TypeParam>({30, 40, 50});
-    auto t2 = ones<TypeParam>({30, 40});
-    auto t1 = ones<TypeParam>({30});
+    auto t4 = ones<TypeParam>({3, 4, 5, 6});
+    auto t3 = ones<TypeParam>({3, 4, 5});
+    auto t2 = ones<TypeParam>({3, 4});
+    auto t1 = ones<TypeParam>({3});
 
     sum(t0, t4, 0);
     cudaStreamSynchronize(0);
@@ -186,11 +186,11 @@ TYPED_TEST(ReductionTestsNumericNoHalf, Sum)
      ASSERT_TRUE(MatXUtils::MatXTypeCompare(t0(), (TypeParam)(t1.Size(0))));
   }
   {
-    tensor_t<TypeParam, 1> t1({30});
+    tensor_t<TypeParam, 1> t1({3});
 
-    auto t4 = ones<TypeParam>({30, 40, 50, 60});
-    auto t3 = ones<TypeParam>({30, 40, 50});
-    auto t2 = ones<TypeParam>({30, 40});
+    auto t4 = ones<TypeParam>({3, 4, 5, 6});
+    auto t3 = ones<TypeParam>({3, 4, 5});
+    auto t2 = ones<TypeParam>({3, 4});
 
     sum(t1, t4, 0);
 
@@ -214,18 +214,18 @@ TYPED_TEST(ReductionTestsNumericNoHalf, Sum)
     }
 
     // Test tensor input too
-    auto t2t = make_tensor<TypeParam>({30, 40});
-    (t2t = ones<TypeParam>({30, 40})).run();
+    auto t2t = make_tensor<TypeParam>({3, 4});
+    (t2t = ones<TypeParam>({3, 4})).run();
     sum(t1, t2t);
     for (index_t i = 0; i < t1.Size(0); i++) {
       ASSERT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (TypeParam)(t2t.Size(1))));
     }    
   }
   {
-    tensor_t<TypeParam, 2> t2({30, 40});
+    tensor_t<TypeParam, 2> t2({3, 4});
 
-    auto t4 = ones<TypeParam>({30, 40, 50, 60});
-    auto t3 = ones<TypeParam>({30, 40, 50});
+    auto t4 = ones<TypeParam>({3, 4, 5, 6});
+    auto t3 = ones<TypeParam>({3, 4, 5});
 
     sum(t2, t4, 0);
     cudaStreamSynchronize(0);
@@ -247,10 +247,10 @@ TYPED_TEST(ReductionTestsNumericNoHalf, Sum)
   }
   
   {
-    tensor_t<TypeParam, 2> t2a({30, 40});
-    tensor_t<TypeParam, 2> t2b({30, 40});
+    tensor_t<TypeParam, 2> t2a({3, 4});
+    tensor_t<TypeParam, 2> t2b({3, 4});
     
-    auto t4 = ones<TypeParam>({30, 40, 50, 60});
+    auto t4 = ones<TypeParam>({3, 4, 5, 6});
 
     sum(t2a, t4, 0);
     sum(t2b, t4, {2,3}, 0);
@@ -270,13 +270,13 @@ TYPED_TEST(ReductionTestsNumericNoHalf, Sum)
 
 // This works with half precision, but we need the proper test infrastructure to prevent compiling
 // half types for CCs that don't support it. Disable half on this test for now
-TYPED_TEST(ReductionTestsFloatNonComplexNonHalf, Softmax)
+TYPED_TEST(ReductionTestsFloatNonComplex, Softmax)
 {
   MATX_ENTER_HANDLER();
 
   auto pb = std::make_unique<detail::MatXPybind>();
   constexpr index_t size = 300;
-  pb->InitAndRunTVGenerator<TypeParam>("00_reductions", "softmax", "run", {8, size, size});
+  pb->InitAndRunTVGenerator<TypeParam>("00_reductions", "softmax", "run", {80, size, size});
 
   tensor_t<TypeParam, 1> t1({size});
   tensor_t<TypeParam, 1> t1_out({size});
@@ -286,8 +286,8 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalf, Softmax)
 
   MATX_TEST_ASSERT_COMPARE(pb, t1_out, "t1_sm", 0.01);
 
-  auto t3    = make_tensor<TypeParam>({8,size,size});
-  auto t3_out = make_tensor<TypeParam>({8,size,size});
+  auto t3    = make_tensor<TypeParam>({80,size,size});
+  auto t3_out = make_tensor<TypeParam>({80,size,size});
   pb->NumpyToTensorView(t3, "t3");
   softmax(t3_out, t3, {2});
   


### PR DESCRIPTION
- Added 16-bit support for several reduction types (both `__half` and `__nvbfloat16`
- Added unit tests for 16-bit reductions supported
- Added 16-bit support to `softmax`
- Added bias term on `softmax` to match Python's implementation