### PR TITLE
Allow 0-stride dimensions for cublas input/output

### DIFF
--- a/include/matx/transforms/matmul.h
+++ b/include/matx/transforms/matmul.h
@@ -1023,8 +1023,9 @@ __MATX_INLINE__ auto getCublasSupportedTensor( const Op &in, cudaStream_t stream
     
       // either RANK-1 or RANK-2 stride must equal one in cublasLt
       (in.Stride(RANK-1) != 1 && in.Stride(RANK-2) != 1) || 
-      // cloned matrices not supported in cublas
-      (in.Stride(RANK-1) == 0 || in.Stride(RANK-2) == 0)
+      // cublas allows 0 strides, but verify that the corresponding size is 1
+      (in.Stride(RANK-1) == 0 && in.Size(RANK-1) != 1) ||
+      (in.Stride(RANK-2) == 0 && in.Size(RANK-2) != 1)
       ) {
       supported = false;
     }

--- a/test/00_transform/MatMul.cu
+++ b/test/00_transform/MatMul.cu
@@ -578,8 +578,8 @@ TYPED_TEST(MatMulTestFloatTypes, MediumMatVec)
   this->pb->NumpyToTensorView(a, "a");
   this->pb->NumpyToTensorView(b, "b");
 
-  auto cs = c.template Slice<1>({0,0}, {matxEnd, matxDropDim});
-  auto bs = b.template Slice<1>({0,0}, {matxEnd, matxDropDim});
+  auto cs = slice<1>(c, {0,0}, {matxEnd, matxDropDim});
+  auto bs = slice<1>(b, {0,0}, {matxEnd, matxDropDim});
   matvec<decltype(cs), decltype(a), decltype(bs), PROVIDER_TYPE_CUBLASLT>(cs, a, bs);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, c, "c", this->thresh);
@@ -613,8 +613,8 @@ TYPED_TEST(MatMulTestFloatTypes, MediumMatVecBatch)
   this->pb->NumpyToTensorView(a, "a");
   this->pb->NumpyToTensorView(b, "b");
 
-  auto cs = c.template Slice<2>({0,0,0}, {matxEnd, matxEnd, matxDropDim});
-  auto bs = b.template Slice<2>({0,0,0}, {matxEnd, matxEnd, matxDropDim});
+  auto cs = slice<2>(c, {0,0,0}, {matxEnd, matxEnd, matxDropDim});
+  auto bs = slice<2>(b, {0,0,0}, {matxEnd, matxEnd, matxDropDim});
   matvec<decltype(cs), decltype(a), decltype(bs), PROVIDER_TYPE_CUBLASLT>(cs, a, bs);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, c, "c", this->thresh);
@@ -649,8 +649,8 @@ TYPED_TEST(MatMulTestFloatTypes, MatVecRowVector)
   this->pb->NumpyToTensorView(a, "a");
   this->pb->NumpyToTensorView(b, "b");
 
-  auto cs = c.template Slice<2>({0,0,0}, {matxEnd, matxEnd, matxDropDim});
-  auto bs = b.template Slice<2>({0,0,0}, {matxEnd, matxEnd, matxDropDim});
+  auto cs = slice<2>(c, {0,0,0}, {matxEnd, matxEnd, matxDropDim});
+  auto bs = slice<2>(b, {0,0,0}, {matxEnd, matxEnd, matxDropDim});
   matvec<decltype(cs), decltype(a), decltype(bs), PROVIDER_TYPE_CUBLASLT>(cs, a, bs);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, c, "c", this->thresh);


### PR DESCRIPTION
Currently, if a tensor contains 0-stride dimensions in one of the last two dimensions, then that tensor will not be used directly as input/output to cublas matmul and a copy will be made transparently. This generates copies during matvec operations because matvec clones a tensor and delegates to matmul, which then copies the tensor because the clone creates a 0-stride dimension. This change allows 0-stride dimensions if the dimension size is 1 (and thus no index will stride in that dimension) and thus eliminates allocations/frees and copies when calling matvec.