### PR TITLE
Add rank0 tensor remap support

### DIFF
--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -58,7 +58,7 @@ namespace matx
         using shape_type = typename T::shape_type; 
         using index_type = typename IdxType::scalar_type;
         static_assert(std::is_integral<index_type>::value, "RemapOp: Type for index operator must be integral");
-        static_assert(IdxType::Rank() <= 1, "RemapOp: Rank of index operator must be 1");
+        static_assert(IdxType::Rank() <= 1, "RemapOp: Rank of index operator must be 0 or 1");
         static_assert(DIM<T::Rank(), "RemapOp: DIM must be less than Rank of tensor");
 
         __MATX_INLINE__ std::string str() const { return "remap(" + op_.str() + ")"; }

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -1168,6 +1168,85 @@ TYPED_TEST(OperatorTestsNumericAllExecs, RemapOp)
   MATX_EXIT_HANDLER();
 }
 
+TYPED_TEST(OperatorTestsNumericAllExecs, RemapRankZero)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto sync = [&exec]() constexpr {
+    if constexpr (std::is_same_v<ExecType,cudaExecutor>) {
+      cudaDeviceSynchronize();
+    }
+  };
+
+  const int N = 16;
+
+  // 1D source tensor cases
+  {
+    auto from = make_tensor<int>({N});
+    (from = range<0>({N}, 0, 1)).run(exec);
+    sync();
+    auto ind = make_tensor<int>();
+    auto r = remap<0>(from, ind);
+    auto to = make_tensor<int>({1});
+
+    ind() = N/2;
+    (to = r).run(exec);
+    sync();
+
+    ASSERT_EQ(to(0), N/2);
+
+    ind() = N/4;
+    (to = r).run(exec);
+    sync();
+
+    ASSERT_EQ(to(0), N/4);
+  }
+
+  // 2D source tensor cases
+  {
+    auto from = make_tensor<int>({N,N});
+    (from = ones(from.Shape())).run(exec);
+    sync();
+
+    auto i0 = make_tensor<int>();
+    auto i1 = make_tensor<int>();
+    auto r0 = remap<0>(from, i0);
+    auto r1 = remap<1>(from, i0);
+
+    auto to0 = make_tensor<int>({1,N});
+    auto to1 = make_tensor<int>({N,1});
+
+    i0() = N/2;
+    from(N/2,0) = 2;
+    from(0,N/2) = 3;
+    (to0 = r0).run(exec);
+    (to1 = r1).run(exec);
+    sync();
+
+    ASSERT_EQ(to0(0,0), 2);
+    ASSERT_EQ(to0(0,1), 1);
+    ASSERT_EQ(to1(0,0), 3);
+    ASSERT_EQ(to1(1,0), 1);
+
+    i0() = N/3;
+    i1() = 2*(N/3);
+    from(N/3, 2*(N/3)) = 11;
+
+    // Select a single entry from the 2D input tensor
+    auto entry = make_tensor<int>({1,1});
+    (entry = remap<0,1>(from, i0, i1)).run(exec);
+    sync();
+
+    ASSERT_EQ(entry(0,0), 11);
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
 TYPED_TEST(OperatorTestsComplexTypesAllExecs, RealImagOp)
 {
   MATX_ENTER_HANDLER();


### PR DESCRIPTION
Add remap() support for 0-rank index tensors

This update treats 0-rank index tensors as if they were rank-1 index tensors of size 1.