### PR TITLE
Fix a few issues highlighted by linters/clang

### DIFF
--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -1167,7 +1167,8 @@ public:
 
   __MATX_INLINE__ __MATX_HOST__ bool IsManagedPointer() {
     bool managed;
-    MATX_ASSERT(cuPointerGetAttribute(&managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)Data()) == CUDA_SUCCESS, matxNotSupported);
+    const CUresult retval = cuPointerGetAttribute(&managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)Data());
+    MATX_ASSERT(retval == CUDA_SUCCESS, matxNotSupported);
     return managed;
   }
 

--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -38,7 +38,7 @@
 #include "matx/core/nvtx.h"
 #include "matx/core/dlpack.h"
 #include "matx/core/make_tensor.h"
-
+#include "matx/kernels/utility.cuh"
 
 namespace matx
 {

--- a/include/matx/executors/device.h
+++ b/include/matx/executors/device.h
@@ -84,41 +84,41 @@ namespace matx
           MATX_STATIC_ASSERT((sizeof(op) + sizeof(index_t) * Op::Rank()) <= CUDA_MAX_VAL_PARAM, 
               "Parameter buffer to device is limited to 4096B. Please break up your operator statement into multiple executions to limit the size of the parameters");
 
-          if constexpr (op.Rank() == 0) {
+          if constexpr (Op::Rank() == 0) {
             threads = 1;
             blocks = 1;
             detail::matxOpT0Kernel<<<blocks, threads, 0, stream_>>>(op);
           }
           else {
-            std::array<index_t, op.Rank()> sizes;
-            for (int i = 0; i < op.Rank(); i++) {
+            std::array<index_t, Op::Rank()> sizes;
+            for (int i = 0; i < Op::Rank(); i++) {
               sizes[i] = op.Size(i);
             }        
 
-            bool stride = detail::get_grid_dims<op.Rank()>(blocks, threads, sizes, 256);
+            bool stride = detail::get_grid_dims<Op::Rank()>(blocks, threads, sizes, 256);
 
-            if constexpr (op.Rank() == 1) {
+            if constexpr (Op::Rank() == 1) {
               if(stride) {
                 detail::matxOpT1StrideKernel<<<blocks, threads, 0, stream_>>>(op, sizes[0]);
               } else {
                 detail::matxOpT1Kernel<<<blocks, threads, 0, stream_>>>(op, sizes[0]);
               }
             }
-            else if constexpr (op.Rank() == 2) {
+            else if constexpr (Op::Rank() == 2) {
               if(stride) {
                 detail::matxOpT2StrideKernel<<<blocks, threads, 0, stream_>>>(op, sizes[0], sizes[1]);
               } else {
                 detail::matxOpT2Kernel<<<blocks, threads, 0, stream_>>>(op, sizes[0], sizes[1]);
               }
             }
-            else if constexpr (op.Rank() == 3) {
+            else if constexpr (Op::Rank() == 3) {
               if(stride) {
                 detail::matxOpT3StrideKernel<<<blocks, threads, 0, stream_>>>(op, sizes[0], sizes[1], sizes[2]);
               } else {
                 detail::matxOpT3Kernel<<<blocks, threads, 0, stream_>>>(op, sizes[0], sizes[1], sizes[2]);
               }
             }
-            else if constexpr (op.Rank() == 4) {
+            else if constexpr (Op::Rank() == 4) {
               if(stride) {
                 detail::matxOpT4StrideKernel<<<blocks, threads, 0, stream_>>>(op, sizes[0], sizes[1], sizes[2], sizes[3]);
               } else {
@@ -131,7 +131,7 @@ namespace matx
             } 
           }
 #else
-          MATX_THROW(matxNotSupported, "Cannot execute device function from host compiler");    
+          #error "Cannot execute device function from host compiler"
 #endif    
         }
 

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -618,6 +618,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, SliceOp)
   (t2 = linspace<1>(t2.Shape(), (inner_type)0, (inner_type)10)).run(exec);
   (t3 = linspace<2>(t3.Shape(), (inner_type)0, (inner_type)10)).run(exec);
   (t4 = linspace<3>(t4.Shape(), (inner_type)0, (inner_type)10)).run(exec);
+  cudaStreamSynchronize(0);
 
   auto t2t = slice(t2, {1, 2}, {3, 5});
   auto t3t = slice(t3, {1, 2, 3}, {3, 5, 7});
@@ -673,6 +674,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, SliceAndReduceOp)
   tensor_t<TestType, 3> t3t{{30, 20, 10}};
   (t2t = linspace<1>(t2t.Shape(), (inner_type)0, (inner_type)10)).run(exec);
   (t3t = linspace<2>(t3t.Shape(), (inner_type)0, (inner_type)10)).run(exec);
+  cudaStreamSynchronize(0);
 
   {
     index_t j = 0;


### PR DESCRIPTION
Attempting to build some code with newer versions of Clang highlighted a few issues, including a throw from a noexcept method, an assertion removing a function call in release builds, and some runtime rank-checks used in constexpr expressions.