### PR TITLE
Fixed cupy check for unit tests, default constructors, and file IO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ if (MATX_EN_FILEIO OR MATX_EN_VISUALIZATION OR MATX_EN_PYBIND11 OR MATX_BUILD_EX
     # Check for python libs
     include(cmake/CheckPythonLibs.cmake)
     check_python_libs("numpy")
+    check_optional_python_libs("cupy")
 
     # Required by pybind
     # https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-

--- a/cmake/CheckPythonLibs.cmake
+++ b/cmake/CheckPythonLibs.cmake
@@ -38,6 +38,24 @@ function(check_python_libs)
         if (NOT ${EXIT_CODE} EQUAL 0)
             message(FATAL_ERROR
                     "The ${pack} Python3 package is not installed. Please install it using the following command: \"pip3 install ${pack}\".")
+        else()
+            set(${pack}_PYTHON_PACKAGE 1 PARENT_SCOPE)
         endif()
     endforeach ()
 endfunction()
+
+function(check_optional_python_libs)
+    foreach (pack IN LISTS ARGN)
+        message(STATUS "checking python import module ${pack}")
+        set(CMD "import ${pack}")
+
+        execute_process(COMMAND ${Python3_EXECUTABLE} -c ${CMD} RESULT_VARIABLE EXIT_CODE OUTPUT_QUIET)
+        if (NOT ${EXIT_CODE} EQUAL 0)
+            message(STATUS
+                    "The optional python package ${pack} package is not installed. Some unit tests and functionality may not work")
+        else()
+            set(${pack}_PYTHON_PACKAGE 1 PARENT_SCOPE)
+        endif()
+    endforeach ()
+endfunction()
+

--- a/include/matx/core/iterator.h
+++ b/include/matx/core/iterator.h
@@ -57,8 +57,8 @@ struct RandomOperatorIterator {
   using iterator_category = std::random_access_iterator_tag;
   using difference_type = index_t;
 
-  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorIterator(const RandomOperatorIterator &) = default;
-  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorIterator(RandomOperatorIterator &&) = default;
+  __MATX_INLINE__ RandomOperatorIterator(const RandomOperatorIterator &) = default;
+  __MATX_INLINE__ RandomOperatorIterator(RandomOperatorIterator &&) = default;
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorIterator(const OperatorType &t) : t_(t), offset_(0) { }
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorIterator(OperatorType &&t) : t_(t), offset_(0) { }
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorIterator(const OperatorType &t, stride_type offset) : t_(t), offset_(offset) {}
@@ -184,8 +184,8 @@ struct RandomOperatorOutputIterator {
   using iterator_category = std::random_access_iterator_tag;
   using difference_type = index_t;
 
-  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorOutputIterator(RandomOperatorOutputIterator &&) = default;
-  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorOutputIterator(const RandomOperatorOutputIterator &) = default;
+  __MATX_INLINE__ RandomOperatorOutputIterator(RandomOperatorOutputIterator &&) = default;
+  __MATX_INLINE__ RandomOperatorOutputIterator(const RandomOperatorOutputIterator &) = default;
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorOutputIterator(OperatorType &&t) : t_(t), offset_(0) { }
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorOutputIterator(const OperatorType &t) : t_(t), offset_(0) { }
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorOutputIterator(const OperatorType &t, stride_type offset) : t_(t), offset_(offset) {}

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -80,12 +80,12 @@ class tensor_impl_t {
     // Type specifier for signaling this is a matx operation
     using matxop = bool;
 
-    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ tensor_impl_t(const tensor_impl_t &) = default;
-    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ tensor_impl_t(tensor_impl_t &&) = default;
-    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ tensor_impl_t& operator=(tensor_impl_t &&) = default;
+    __MATX_INLINE__ tensor_impl_t(const tensor_impl_t &) = default;
+    __MATX_INLINE__ tensor_impl_t(tensor_impl_t &&) = default;
+    __MATX_INLINE__ tensor_impl_t& operator=(tensor_impl_t &&) = default;
 
 
-    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__  ~tensor_impl_t() = default;
+    __MATX_INLINE__ ~tensor_impl_t() = default;
 
 
     const std::string str() const {

--- a/test/01_radar/ambgfun.cu
+++ b/test/01_radar/ambgfun.cu
@@ -57,7 +57,11 @@ protected:
   std::unique_ptr<detail::MatXPybind> pb;
 };
 
+#ifdef CUPY_INSTALLED
 TEST_F(RadarAmbiguityFunction, Cut2D)
+#else
+TEST_F(RadarAmbiguityFunction, DISABLED_Cut2D)
+#endif
 {
   MATX_ENTER_HANDLER();
 
@@ -71,7 +75,11 @@ TEST_F(RadarAmbiguityFunction, Cut2D)
   MATX_EXIT_HANDLER();
 }
 
+#ifdef CUPY_INSTALLED
 TEST_F(RadarAmbiguityFunction, CutDelay)
+#else
+TEST_F(RadarAmbiguityFunction, DISABLED_CutDelay)
+#endif
 {
   MATX_ENTER_HANDLER();
 
@@ -86,7 +94,11 @@ TEST_F(RadarAmbiguityFunction, CutDelay)
   MATX_EXIT_HANDLER();
 }
 
+#ifdef CUPY_INSTALLED
 TEST_F(RadarAmbiguityFunction, CutDoppler)
+#else
+TEST_F(RadarAmbiguityFunction, DISABLED_CutDoppler)
+#endif
 {
   MATX_ENTER_HANDLER();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,30 @@ set (test_sources
     main.cu
 )
 
+# Some of <00_io> tests need csv files and the binary 'test.mat' which all 
+# are located under 'CMAKE_SOURCE_DIR/test/00_io'. When calling the test
+# executable <matx_test> from its location in 'CMAKE_BINARY_DIR/test' the
+# search paths according <FileIOTests.cu> are 
+# '../test/00_io/small_csv_comma_nh.csv' and 
+# '../test/00_io/small_csv_complex_comma_nh.csv' respectively. Therefore
+# they must be copied to the correct location:
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/test/00_io)
+file(COPY_FILE
+	${CMAKE_SOURCE_DIR}/test/00_io/small_csv_comma_nh.csv
+	${CMAKE_BINARY_DIR}/test/00_io/small_csv_comma_nh.csv
+	ONLY_IF_DIFFERENT
+)
+file(COPY_FILE
+	${CMAKE_SOURCE_DIR}/test/00_io/small_csv_complex_comma_nh.csv
+	${CMAKE_BINARY_DIR}/test/00_io/small_csv_complex_comma_nh.csv
+	ONLY_IF_DIFFERENT
+)
+file(COPY_FILE
+	${CMAKE_SOURCE_DIR}/test/00_io/test.mat
+	${CMAKE_BINARY_DIR}/test/00_io/test.mat
+	ONLY_IF_DIFFERENT
+)
+
 # Find proprietary parameters
 file (GLOB_RECURSE proprietary_sources ../proprietary/*/tests/*.cu)
 foreach (ptest ${proprietary_sources})
@@ -49,6 +73,10 @@ add_executable(matx_test main.cu ${all_test_srcs})
 
 # Set all the flags/other properties
 set_property(TARGET matx_test PROPERTY ENABLE_EXPORTS 1)
+
+if (DEFINED cupy_PYTHON_PACKAGE)
+    target_compile_definitions(matx_test PRIVATE CUPY_INSTALLED)
+endif()
 
 if (MSVC)
     target_compile_options(matx_test  PRIVATE /W4 /WX)


### PR DESCRIPTION
Various fixes for CMake and default constructors for CUDA 12.3+. Thanks to @siegLoesch for the fixes on CMake