### PR TITLE
resample_poly optimizations and operator support

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ set(examples
     fft_conv 
     resample 
     mvdr_beamformer 
+    resample_poly_bench
     spectrogram 
     spectrogram_graph
     spherical_harmonics 

--- a/examples/channelize_poly_bench.cu
+++ b/examples/channelize_poly_bench.cu
@@ -94,11 +94,11 @@ void ChannelizePolyBench(matx::index_t channel_start, matx::index_t channel_stop
       cudaStreamSynchronize(stream);
 
       float elapsed_ms = 0.0f;
-      cudaEventRecord(start);
+      cudaEventRecord(start, stream);
       for (int k = 0; k < NUM_ITERATIONS; k++) {
         (output = channelize_poly(input, filter, num_channels, decimation_factor)).run(stream);
       }
-      cudaEventRecord(stop);
+      cudaEventRecord(stop, stream);
       cudaStreamSynchronize(stream);
       CUDA_CHECK_LAST_ERROR();
       cudaEventElapsedTime(&elapsed_ms, start, stop);

--- a/examples/resample_poly_bench.cu
+++ b/examples/resample_poly_bench.cu
@@ -1,0 +1,148 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "matx.h"
+#include <cassert>
+#include <cstdio>
+#include <cmath>
+#include <memory>
+#include <fstream>
+#include <istream>
+#include <cuda/std/complex>
+
+using namespace matx;
+
+// This example is used primarily for development purposes to benchmark the performance of the
+// polyphase resampler kernel(s). Typically, the parameters below (batch size, filter
+// length, input signal length, up/down factors) will be adjusted to a range of interest
+// and the benchmark will be run with and without the proposed kernel changes.
+
+constexpr int NUM_WARMUP_ITERATIONS = 2;
+
+// Number of iterations per timed test. Iteration times are averaged in the report.
+constexpr int NUM_ITERATIONS = 20;
+
+template <typename InType>
+void ResamplePolyBench()
+{
+  struct {
+    matx::index_t num_batches;
+    matx::index_t input_len;
+    matx::index_t up;
+    matx::index_t down;
+  } test_cases[] = {
+    { 1, 256, 384, 3125 },
+    { 1, 256, 4, 5 },
+    { 1, 256, 1, 4 },
+    { 1, 256, 1, 16 },
+    { 1, 3000, 384, 3125 },
+    { 1, 3000, 4, 5 },
+    { 1, 3000, 1, 4 },
+    { 1, 3000, 1, 16 },
+    { 1, 31000, 384, 3125 },
+    { 1, 31000, 4, 5 },
+    { 1, 31000, 1, 4 },
+    { 1, 31000, 1, 16 },
+    { 1, 256000, 384, 3125 },
+    { 1, 256000, 4, 5 },
+    { 1, 256000, 1, 4 },
+    { 1, 256000, 1, 16 },
+    { 42, 256000, 384, 3125 },
+    { 42, 256000, 4, 5 },
+    { 42, 256000, 1, 4 },
+    { 42, 256000, 1, 16 },
+    { 128, 256000, 384, 3125 },
+    { 128, 256000, 4, 5 },
+    { 128, 256000, 1, 4 },
+    { 128, 256000, 1, 16 },
+  };
+
+  cudaStream_t stream;
+  cudaStreamCreate(&stream);
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  for (size_t i = 0; i < sizeof(test_cases)/sizeof(test_cases[0]); i++) {
+      const matx::index_t num_batches = test_cases[i].num_batches;
+      const matx::index_t input_len = test_cases[i].input_len;
+      const matx::index_t up = test_cases[i].up;
+      const matx::index_t down = test_cases[i].down;
+      const matx::index_t half_len = 10 * std::max(up, down);
+      const matx::index_t filter_len = 2 * half_len + 1;
+      const matx::index_t filter_len_per_phase = (filter_len + up - 1) / up;
+
+      const index_t up_len = input_len * up;
+      const index_t output_len = up_len / down + ((up_len % down) ? 1 : 0);
+
+      auto input = matx::make_tensor<InType, 2>({num_batches, input_len});
+      auto filter = matx::make_tensor<InType, 1>({filter_len});
+      auto output = matx::make_tensor<InType, 2>({num_batches, output_len});
+
+      for (int k = 0; k < NUM_WARMUP_ITERATIONS; k++) {
+        (output = matx::resample_poly(input, filter, up, down)).run(stream);
+      }
+
+      cudaStreamSynchronize(stream);
+
+      float elapsed_ms = 0.0f;
+      cudaEventRecord(start);
+      for (int k = 0; k < NUM_ITERATIONS; k++) {
+        (output = matx::resample_poly(input, filter, up, down)).run(stream);
+      }
+      cudaEventRecord(stop);
+      cudaStreamSynchronize(stream);
+      CUDA_CHECK_LAST_ERROR();
+      cudaEventElapsedTime(&elapsed_ms, start, stop);
+
+      const double gflops = static_cast<double>(num_batches*(2*filter_len_per_phase-1)*output_len) / 1.0e9;
+      const double avg_elapsed_us = (static_cast<double>(elapsed_ms)/NUM_ITERATIONS)*1.0e3;
+      printf("Batches: %5lld  FilterLen: %5lld  InputLen: %7lld  OutputLen: %7lld  Up/Down: %4lld/%4lld Elapsed Usecs: %12.1f GFLOPS: %10.3f\n",
+        num_batches, filter_len, input_len, output_len, up, down, avg_elapsed_us, gflops/(avg_elapsed_us/1.0e6));
+  }
+
+  CUDA_CHECK_LAST_ERROR();
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+  cudaStreamDestroy(stream);
+}
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
+{
+  MATX_ENTER_HANDLER();
+
+  printf("Benchmarking float\n");
+  ResamplePolyBench<float>();
+
+  MATX_EXIT_HANDLER();
+}

--- a/examples/resample_poly_bench.cu
+++ b/examples/resample_poly_bench.cu
@@ -115,11 +115,11 @@ void ResamplePolyBench()
       cudaStreamSynchronize(stream);
 
       float elapsed_ms = 0.0f;
-      cudaEventRecord(start);
+      cudaEventRecord(start, stream);
       for (int k = 0; k < NUM_ITERATIONS; k++) {
         (output = matx::resample_poly(input, filter, up, down)).run(stream);
       }
-      cudaEventRecord(stop);
+      cudaEventRecord(stop, stream);
       cudaStreamSynchronize(stream);
       CUDA_CHECK_LAST_ERROR();
       cudaEventElapsedTime(&elapsed_ms, start, stop);

--- a/include/matx/transforms/resample_poly.h
+++ b/include/matx/transforms/resample_poly.h
@@ -137,9 +137,8 @@ inline void resample_poly_impl(OutType &out, const InType &in, const FilterType 
     MATX_ASSERT_STR(out.Size(i) == in.Size(i), matxInvalidDim, "resample_poly: input/output must have matched batch sizes");
   }
 
-  const index_t up_size = in.Size(RANK-1) * up;
-  const index_t outlen = up_size / down + ((up_size % down) ? 1 : 0);
-
+  [[maybe_unused]] const index_t up_size = in.Size(RANK-1) * up;
+  [[maybe_unused]] const index_t outlen = up_size / down + ((up_size % down) ? 1 : 0);
   MATX_ASSERT_STR(out.Size(RANK-1) == outlen, matxInvalidDim, "resample_poly: output size mismatch");
 
   const index_t g = gcd(up, down);

--- a/test/00_operators/ReductionTests.cu
+++ b/test/00_operators/ReductionTests.cu
@@ -623,8 +623,8 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, AllClose)
   auto B = make_tensor<TestType>({5, 5, 5});
   auto C = make_tensor<int>({});
 
-  (A = ones<TestType>(A.Shape())).run();
-  (B = ones<TestType>(B.Shape())).run();
+  (A = ones<TestType>(A.Shape())).run(exec);
+  (B = ones<TestType>(B.Shape())).run(exec);
   allclose(C, A, B, 1e-5, 1e-8, exec);
   // example-end allclose-test-1
   cudaStreamSynchronize(0);


### PR DESCRIPTION
Optimize resample_poly by using larger launch grids in cases with a small number of batches and/or a small upsampling factor. The new launch grids are particularly helpful for large signals without batches and low upsampling factors. Also add support for a wider range of operators via mapply.