### PR TITLE
Fixes for clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,13 @@ target_include_directories(matx INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOU
 target_compile_features(matx INTERFACE cxx_std_17 $<BUILD_INTERFACE:cuda_std_17>)
 target_compile_options(matx INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    if (CMAKE_COMPILER_VERSION VERSION_LESS 14)
+        target_compile_options(matx INTERFACE -fPIE)
+    endif()
+    target_compile_options(matx INTERFACE -std=c++17 $<$<COMPILE_LANGUAGE:CUDA>:-ccbin=${CMAKE_CXX_COMPILER}>)
+endif()
+
 # 11.2 and above required for async allocation
 if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.4)
     message(FATAL_ERROR "MatX requires CUDA 11.4 or higher. Please update before using.")
@@ -109,22 +116,30 @@ if (NOT CMAKE_BUILD_TYPE OR ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 endif()
 
 # Set preferred compiler warning flags
-set(WARN_FLAGS  -Wall
-                -Wextra
-                -Wcast-align
-                -Wunused
-                -Wconversion
-                -Wno-unknown-pragmas
-                -Wnon-virtual-dtor
-                -Wshadow)
-
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(WARN_FLAGS ${WARN_FLAGS}
-        -Wmisleading-indentation
-        -Wduplicated-cond
-        -Wduplicated-branches
-        -Wlogical-op
-        -Wnull-dereference)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(WARN_FLAGS
+        -Wno-unknown-warning-option
+        -Wno-inconsistent-missing-override
+        -Wno-c++20-extensions
+        -Wno-deprecated-declarations)
+else ()
+    set(WARN_FLAGS
+        -Wall
+        -Wextra
+        -Wcast-align
+        -Wunused
+        -Wconversion
+        -Wno-unknown-pragmas
+        -Wnon-virtual-dtor
+        -Wshadow)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set(WARN_FLAGS ${WARN_FLAGS}
+            -Wmisleading-indentation
+            -Wduplicated-cond
+            -Wduplicated-branches
+            -Wlogical-op
+            -Wnull-dereference)
+    endif()
 endif()
 
 set(WARN_FLAGS ${WARN_FLAGS} $<$<COMPILE_LANGUAGE:CUDA>:-Werror all-warnings>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,30 +116,33 @@ if (NOT CMAKE_BUILD_TYPE OR ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 endif()
 
 # Set preferred compiler warning flags
+set(WARN_FLAGS
+    -Wall
+    -Wcast-align
+    -Wunused
+    -Wno-unknown-pragmas
+    -Wnon-virtual-dtor
+    -Wshadow)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(WARN_FLAGS ${WARN_FLAGS}
+        -Wmisleading-indentation
+        -Wduplicated-cond
+        -Wduplicated-branches
+        -Wlogical-op
+        -Wnull-dereference)
+endif()
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(WARN_FLAGS
-        -Wno-unknown-warning-option
-        -Wno-inconsistent-missing-override
+    set(WARN_FLAGS ${WARN_FLAGS}
+        -Wmisleading-indentation
+        -Wnull-dereference
         -Wno-c++20-extensions
-        -Wno-deprecated-declarations)
-else ()
-    set(WARN_FLAGS
-        -Wall
+        -Wno-unused-lambda-capture)
+else()
+    set(WARN_FLAGS ${WARN_FLAGS}
         -Wextra
-        -Wcast-align
-        -Wunused
-        -Wconversion
-        -Wno-unknown-pragmas
-        -Wnon-virtual-dtor
-        -Wshadow)
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        set(WARN_FLAGS ${WARN_FLAGS}
-            -Wmisleading-indentation
-            -Wduplicated-cond
-            -Wduplicated-branches
-            -Wlogical-op
-            -Wnull-dereference)
-    endif()
+        -Wconversion)
 endif()
 
 set(WARN_FLAGS ${WARN_FLAGS} $<$<COMPILE_LANGUAGE:CUDA>:-Werror all-warnings>)

--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -1389,9 +1389,9 @@ public:
                l < (((vals.begin() + i)->begin() + j)->begin() + k)->size();
                l++) {
             for (size_t m = 0;
-                 m < ((((vals.begin() + i)->begin() + j)->begin() + k)->begin() + l)
+                 (m+1) < ((((vals.begin() + i)->begin() + j)->begin() + k)->begin() + l)
                          ->size();
-                 m++) {
+                 m+=2) {
               typename T::value_type real =
                   (((((vals.begin() + i)->begin() + j)->begin() + k)->begin() +
                     l)
@@ -1405,7 +1405,6 @@ public:
                    m + 1)
                       ->real();
               this->operator()(i, j, k, l) = {real, imag};
-              m++;
             }
           }
         }

--- a/include/matx/core/tensor_desc.h
+++ b/include/matx/core/tensor_desc.h
@@ -312,7 +312,9 @@ public:
         and clone(). It appears there's no valid code path that would cause this to be unitialized,
         so we're ignoring the warning in this one spot. */
     #pragma GCC diagnostic push
+    #ifndef __clang__
     #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+    #endif
     return *(stride_.begin() + dim); 
     #pragma GCC diagnostic pop
   }

--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -59,7 +59,7 @@ namespace matx
     }
     else {
       index_t total = 1;
-      for (int i = 0; i < op.Rank(); i++) {
+      for (int i = 0; i < Op::Rank(); i++) {
         total *= op.Size(i);
       }
 
@@ -81,7 +81,7 @@ namespace matx
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
     index_t maxSize = op.Size(0);
 
-    for (int i = 1; i < op.Rank(); i++)
+    for (int i = 1; i < Op::Rank(); i++)
     {
       maxSize = std::max(op.Size(i), maxSize);
     }
@@ -102,7 +102,7 @@ namespace detail {
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto GetIdxFromAbs(const Op &op, index_t abs) {
     using l_stride_type = index_t;
     using l_shape_type = index_t;
-    constexpr int RANK = op.Rank();
+    constexpr int RANK = Op::Rank();
 
     std::array<l_shape_type, RANK> indices;
 
@@ -138,7 +138,7 @@ namespace detail {
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto BlockToIdx(const Op &op, index_t abs, int nb_dims) {
     using l_stride_type = index_t;
     using l_shape_type = index_t;
-    constexpr int RANK = op.Rank();
+    constexpr int RANK = Op::Rank();
     std::array<l_shape_type, RANK> indices{0};
 
     for (int idx = 0; idx < RANK - nb_dims; idx++) {
@@ -601,8 +601,8 @@ namespace detail {
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
-    MATX_STATIC_ASSERT(op.Rank() == sizeof...(Args), "Number of dimensions to print must match tensor rank");
-    MATX_STATIC_ASSERT(op.Rank() <= 4, "Printing is only supported on tensors of rank 4 or lower currently");
+    MATX_STATIC_ASSERT(Op::Rank() == sizeof...(Args), "Number of dimensions to print must match tensor rank");
+    MATX_STATIC_ASSERT(Op::Rank() <= 4, "Printing is only supported on tensors of rank 4 or lower currently");
 
     if constexpr (sizeof...(Args) == 0) {
       PrintVal(op.operator()());
@@ -838,12 +838,12 @@ void print(const Op &op, Args... dims)
   // print tensor size info first
   std::string type = (is_tensor_view_v<Op>) ? "Tensor" : "Operator";
 
-  printf("%s{%s} Rank: %d, Sizes:[", type.c_str(), detail::GetTensorType<typename Op::scalar_type>().c_str(), op.Rank());
+  printf("%s{%s} Rank: %d, Sizes:[", type.c_str(), detail::GetTensorType<typename Op::scalar_type>().c_str(), Op::Rank());
 
-  for (index_t dimIdx = 0; dimIdx < (op.Rank() ); dimIdx++ )
+  for (index_t dimIdx = 0; dimIdx < (Op::Rank() ); dimIdx++ )
   {
     printf("%" INDEX_T_FMT, op.Size(static_cast<int>(dimIdx)) );
-    if( dimIdx < (op.Rank() - 1) )
+    if( dimIdx < (Op::Rank() - 1) )
       printf(", ");
   }
 
@@ -852,10 +852,10 @@ void print(const Op &op, Args... dims)
     printf("], Strides:[");
     if constexpr (Op::Rank() > 0)
     {
-      for (index_t dimIdx = 0; dimIdx < (op.Rank() ); dimIdx++ )
+      for (index_t dimIdx = 0; dimIdx < (Op::Rank() ); dimIdx++ )
       {
         printf("%" INDEX_T_FMT, op.Stride(static_cast<int>(dimIdx)) );
-        if( dimIdx < (op.Rank() - 1) )
+        if( dimIdx < (Op::Rank() - 1) )
         {
           printf(",");
         }

--- a/include/matx/generators/random.h
+++ b/include/matx/generators/random.h
@@ -545,6 +545,10 @@ public:
             curandGenerateNormalDouble(gen_, &val[1], 1, beta_, alpha_);
           }
         }
+        else {
+          val = 0;
+          MATX_ASSERT_STR(false, matxInvalidParameter, "Unsupported distribution");
+        }
 #endif
 
         return val;

--- a/include/matx/operators/pwelch.h
+++ b/include/matx/operators/pwelch.h
@@ -65,7 +65,7 @@ namespace matx
         __MATX_INLINE__ PWelchOp(const OpX &x, index_t nperseg, index_t noverlap, index_t nfft) :
               x_(x), nperseg_(nperseg), noverlap_(noverlap), nfft_(nfft) {
 
-          MATX_STATIC_ASSERT_STR(x.Rank() == 1, matxInvalidDim, "pwelch:  Only input rank of 1 is supported presently");
+          MATX_STATIC_ASSERT_STR(OpX::Rank() == 1, matxInvalidDim, "pwelch:  Only input rank of 1 is supported presently");
           for (int r = 0; r < x.Rank(); r++) {
             out_dims_[r] = x_.Size(r);
           }

--- a/include/matx/operators/repmat.h
+++ b/include/matx/operators/repmat.h
@@ -183,7 +183,7 @@ namespace matx
    *   New operator with repeated data
    */
   template <typename T1>
-    auto __MATX_INLINE__ repmat(T1 t, const index_t (&reps)[])
+    auto __MATX_INLINE__ repmat(const T1 &t, const index_t (&reps)[T1::Rank()])
     {
       return detail::RepMatOp<T1, T1::Rank()>(t, reps);
     };
@@ -202,7 +202,8 @@ namespace matx
    *   New operator with repeated data
    */
   template <typename T1>
-    auto __MATX_INLINE__ repmat(T1 t, const index_t *reps)
+    auto __MATX_INLINE__ repmat(const T1 &t,
+      const std::array<index_t, T1::Rank()> &reps)
     {
       return detail::RepMatOp<T1, T1::Rank()>(t, reps);
     };

--- a/include/matx/transforms/conv.h
+++ b/include/matx/transforms/conv.h
@@ -308,7 +308,7 @@ inline void conv1d_impl(OutputType o, const In1Type &i1, const In2Type &i2,
     // clone i2
     auto ci2 = clone<LRank>(i2, shape);
 
-    static_assert(i1.Rank() == ci2.Rank());
+    static_assert(In1Type::Rank() == decltype(ci2)::Rank());
 
     conv1d_impl_internal(o, i1, ci2, mode, method, stream);
 

--- a/include/matx/transforms/cub.h
+++ b/include/matx/transforms/cub.h
@@ -1713,7 +1713,7 @@ template <typename SelectType, typename CountTensor, typename OutputTensor, type
 void find_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperator &a, SelectType sel, cudaExecutor exec = 0)
 {
 #ifdef __CUDACC__
-  static_assert(num_found.Rank() == 0, "Num found output tensor rank must be 0");
+  static_assert(CountTensor::Rank() == 0, "Num found output tensor rank must be 0");
 
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
   auto cparams = detail::SelectParams_t<SelectType, CountTensor>{sel, num_found};  
@@ -1785,7 +1785,7 @@ void find_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperator 
 template <typename SelectType, typename CountTensor, typename OutputTensor, typename InputOperator>
 void find_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperator &a, SelectType sel, [[maybe_unused]] SingleThreadHostExecutor exec)
 {
-  static_assert(num_found.Rank() == 0, "Num found output tensor rank must be 0");
+  static_assert(CountTensor::Rank() == 0, "Num found output tensor rank must be 0");
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
   if (a.Size(a.Rank() - 1) == 0) {
@@ -1836,7 +1836,7 @@ template <typename SelectType, typename CountTensor, typename OutputTensor, type
 void find_idx_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperator &a, SelectType sel, cudaExecutor exec = 0)
 {
 #ifdef __CUDACC__
-  static_assert(num_found.Rank() == 0, "Num found output tensor rank must be 0");
+  static_assert(CountTensor::Rank() == 0, "Num found output tensor rank must be 0");
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
   cudaStream_t stream = exec.getStream();
@@ -1906,7 +1906,7 @@ void find_idx_impl(OutputTensor &a_out, CountTensor &num_found, const InputOpera
 template <typename SelectType, typename CountTensor, typename OutputTensor, typename InputOperator>
 void find_idx_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperator &a, SelectType sel, [[maybe_unused]] SingleThreadHostExecutor exec)
 {
-  static_assert(num_found.Rank() == 0, "Num found output tensor rank must be 0");
+  static_assert(CountTensor::Rank() == 0, "Num found output tensor rank must be 0");
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
   if (a.Size(a.Rank() - 1) == 0) {
@@ -1951,7 +1951,7 @@ template <typename CountTensor, typename OutputTensor, typename InputOperator>
 void unique_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperator &a,  cudaExecutor exec = 0)
 {
 #ifdef __CUDACC__
-  static_assert(num_found.Rank() == 0, "Num found output tensor rank must be 0");
+  static_assert(CountTensor::Rank() == 0, "Num found output tensor rank must be 0");
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
   cudaStream_t stream = exec.getStream();
@@ -2024,7 +2024,7 @@ template <typename CountTensor, typename OutputTensor, typename InputOperator>
 void unique_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperator &a, [[maybe_unused]] SingleThreadHostExecutor exec)
 {
 #ifdef __CUDACC__
-  static_assert(num_found.Rank() == 0, "Num found output tensor rank must be 0");
+  static_assert(CountTensor::Rank() == 0, "Num found output tensor rank must be 0");
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
   
   if (a.Size(a.Rank() - 1) == 0) {

--- a/include/matx/transforms/reduce.h
+++ b/include/matx/transforms/reduce.h
@@ -1378,12 +1378,12 @@ void __MATX_INLINE__ reduce(OutType dest, [[maybe_unused]] TensorIndexType idest
     }
   }
   dim3 blocks, threads;
-  std::array<index_t, in.Rank()> sizes;
-  for (int i = 0; i < in.Rank(); i++) {
+  std::array<index_t, InType::Rank()> sizes;
+  for (int i = 0; i < InType::Rank(); i++) {
     sizes[i] = in.Size(i);
   }
 
-  detail::get_grid_dims<in.Rank()>(blocks, threads, sizes);
+  detail::get_grid_dims<InType::Rank()>(blocks, threads, sizes);
 
   if (init) {
     (dest = static_cast<promote_half_t<T>>(op.Init())).run(stream);
@@ -1630,7 +1630,7 @@ void __MATX_INLINE__ softmax_impl(OutType dest, const InType &in, PermDims dims,
   auto perm = detail::getPermuteDims<InType::Rank()>(dims);
 
   // Create the shape of the summed tensor based on the permutation params
-  std::array<index_t, in.Rank() - (int)dims.size()> red_shape{};
+  std::array<index_t, InType::Rank() - (int)dims.size()> red_shape{};
   #pragma unroll
   for (int r = 0; r < in.Rank() - (int)dims.size(); r++) {
     red_shape[r] = in.Size(perm[r]);

--- a/include/matx/transforms/svd.h
+++ b/include/matx/transforms/svd.h
@@ -78,9 +78,9 @@ template<typename UType, typename SType, typename VTType, typename AType, typena
 void svdpi_impl(UType &U, SType &S, VTType &VT, AType &A, X0Type &x0, int iterations,  cudaStream_t stream, index_t k=-1) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
-  static_assert(U.Rank() == A.Rank());
-  static_assert(VT.Rank() == A.Rank());
-  static_assert(S.Rank() == A.Rank()-1);
+  static_assert(UType::Rank() == AType::Rank());
+  static_assert(VTType::Rank() == AType::Rank());
+  static_assert(SType::Rank() == AType::Rank()-1);
 
   using ATypeS = typename AType::scalar_type;
   using STypeS = typename SType::scalar_type;
@@ -152,7 +152,7 @@ void svdpi_impl(UType &U, SType &S, VTType &VT, AType &A, X0Type &x0, int iterat
   // for each singular value
   for(int i = 0; i < k; i++) {
 
-    std::array<index_t, S.Rank()> sShapeB, sShapeE;
+    std::array<index_t, SType::Rank()> sShapeB, sShapeE;
 
     sShapeB.fill(0);
     sShapeE.fill(matxEnd);
@@ -335,9 +335,9 @@ template<typename UType, typename SType, typename VTType, typename AType>
 void svdbpi_impl(UType &U, SType &S, VTType &VT, AType &A, int iterations,  cudaStream_t stream) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
-  static_assert(U.Rank() == A.Rank());
-  static_assert(VT.Rank() == A.Rank());
-  static_assert(S.Rank() == A.Rank()-1);
+  static_assert(UType::Rank() == AType::Rank());
+  static_assert(VTType::Rank() == AType::Rank());
+  static_assert(SType::Rank() == AType::Rank()-1);
 
   using ATypeS = typename AType::scalar_type;
   using STypeS = typename SType::scalar_type;

--- a/test/00_io/FileIOTests.cu
+++ b/test/00_io/FileIOTests.cu
@@ -46,7 +46,7 @@ protected:
     pb->InitAndRunTVGenerator<T>("00_file_io", "csv", "run", {});
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   const std::string small_csv = "../test/00_io/small_csv_comma_nh.csv";

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -3100,7 +3100,8 @@ TYPED_TEST(OperatorTestsAllExecs, RepMat)
   // Now a rectangular repmat
   tensor_t<TestType, 2> t2r({count0 * same_reps, count1 * same_reps * 2});
 
-  auto rrepop = repmat(t2, {same_reps, same_reps * 2});
+  index_t rreps[] = {same_reps, same_reps * 2};
+  auto rrepop = repmat(t2, static_cast<const index_t*>(rreps));
   ASSERT_TRUE(rrepop.Size(0) == same_reps * t2.Size(0));
   ASSERT_TRUE(rrepop.Size(1) == same_reps * 2 * t2.Size(1));
 

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -3100,8 +3100,7 @@ TYPED_TEST(OperatorTestsAllExecs, RepMat)
   // Now a rectangular repmat
   tensor_t<TestType, 2> t2r({count0 * same_reps, count1 * same_reps * 2});
 
-  index_t rreps[] = {same_reps, same_reps * 2};
-  auto rrepop = repmat(t2, static_cast<const index_t*>(rreps));
+  auto rrepop = repmat(t2, {same_reps, same_reps * 2});
   ASSERT_TRUE(rrepop.Size(0) == same_reps * t2.Size(0));
   ASSERT_TRUE(rrepop.Size(1) == same_reps * 2 * t2.Size(1));
 

--- a/test/00_solver/Cholesky.cu
+++ b/test/00_solver/Cholesky.cu
@@ -49,7 +49,7 @@ protected:
     pb->NumpyToTensorView(Lv, "L");
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   tensor_t<T, 2> Bv{{dim_size, dim_size}};

--- a/test/00_solver/Det.cu
+++ b/test/00_solver/Det.cu
@@ -49,7 +49,7 @@ protected:
     pb->NumpyToTensorView(Av, "A");
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   tensor_t<T, 2> Av{{m, m}};

--- a/test/00_solver/Eigen.cu
+++ b/test/00_solver/Eigen.cu
@@ -48,7 +48,7 @@ protected:
     pb->NumpyToTensorView(Bv, "B");
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   tensor_t<T, 2> Bv{{dim_size, dim_size}};

--- a/test/00_solver/Inverse.cu
+++ b/test/00_solver/Inverse.cu
@@ -46,7 +46,7 @@ protected:
 
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
 };

--- a/test/00_solver/LU.cu
+++ b/test/00_solver/LU.cu
@@ -51,7 +51,7 @@ protected:
     pb->NumpyToTensorView(Uv, "U");
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   tensor_t<T, 2> Av{{m, n}};

--- a/test/00_solver/QR.cu
+++ b/test/00_solver/QR.cu
@@ -52,7 +52,7 @@ protected:
     pb->NumpyToTensorView(Rv, "R");
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   tensor_t<T, 2> Av{{m, n}};

--- a/test/00_solver/SVD.cu
+++ b/test/00_solver/SVD.cu
@@ -48,7 +48,7 @@ protected:
     pb->InitAndRunTVGenerator<T>("00_solver", "svd", "run", {m, n});
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
 };

--- a/test/00_tensor/EinsumTests.cu
+++ b/test/00_tensor/EinsumTests.cu
@@ -46,7 +46,7 @@ protected:
     pb = std::make_unique<detail::MatXPybind>();
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   float thresh = 0.01f;

--- a/test/00_transform/ChannelizePoly.cu
+++ b/test/00_transform/ChannelizePoly.cu
@@ -58,7 +58,7 @@ protected:
     }
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   double thresh;;

--- a/test/00_transform/ConvCorr.cu
+++ b/test/00_transform/ConvCorr.cu
@@ -75,7 +75,7 @@ protected:
     }
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   tensor_t<T, 1> av{{a_len0}};
@@ -104,7 +104,7 @@ protected:
     }
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   tensor_t<T, 2> av{{a_len0,a_len1}};
@@ -133,7 +133,7 @@ protected:
     }
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   tensor_t<T, 1> av{{a_len}};

--- a/test/00_transform/Cov.cu
+++ b/test/00_transform/Cov.cu
@@ -55,7 +55,7 @@ protected:
     }
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   tensor_t<T, 2> av{{cov_dim, cov_dim}};
   tensor_t<T, 2> cv{{cov_dim, cov_dim}};

--- a/test/00_transform/FFT.cu
+++ b/test/00_transform/FFT.cu
@@ -53,7 +53,7 @@ protected:
     }
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   float thresh = 0.01f;

--- a/test/00_transform/MatMul.cu
+++ b/test/00_transform/MatMul.cu
@@ -53,7 +53,7 @@ protected:
     }
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   float thresh = 0.01f;

--- a/test/00_transform/PWelch.cu
+++ b/test/00_transform/PWelch.cu
@@ -63,7 +63,7 @@ public:
     if (params.nfft > 8) thresh = 1.f; // use higher threshold for larger fft sizes
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   float thresh = 0.01f;
@@ -102,7 +102,7 @@ TEST_P(PWelchComplexExponentialTest, xin_complex_double)
   helper<cuda::std::complex<double>>(*this);
 }
 
-INSTANTIATE_TEST_CASE_P(PWelchComplexExponentialTests, PWelchComplexExponentialTest,::testing::ValuesIn(CONFIGS));
+INSTANTIATE_TEST_SUITE_P(PWelchComplexExponentialTests, PWelchComplexExponentialTest,::testing::ValuesIn(CONFIGS));
 
 TEST(PWelchOpTest, xin_complex_float)
 {

--- a/test/00_transform/ResamplePoly.cu
+++ b/test/00_transform/ResamplePoly.cu
@@ -57,7 +57,7 @@ protected:
     }
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   std::unique_ptr<detail::MatXPybind> pb;
   double thresh;;

--- a/test/01_radar/MultiChannelRadarPipeline.cu
+++ b/test/01_radar/MultiChannelRadarPipeline.cu
@@ -54,7 +54,7 @@ protected:
     pb->RunTVGenerator("run");
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   uint32_t iterations = 100;
   index_t numChannels = 16;

--- a/test/01_radar/ambgfun.cu
+++ b/test/01_radar/ambgfun.cu
@@ -50,7 +50,7 @@ protected:
     pb->NumpyToTensorView(xv, "x");
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   index_t sig_size = 16;
   tensor_t<complex, 1> xv{{sig_size}};

--- a/test/01_radar/dct.cu
+++ b/test/01_radar/dct.cu
@@ -50,7 +50,7 @@ protected:
     pb->NumpyToTensorView(xv, "x");
   }
 
-  void TearDown() { pb.reset(); }
+  void TearDown() override { pb.reset(); }
 
   tensor_t<float, 1> xv{{sig_size}};
   std::unique_ptr<detail::MatXPybind> pb;


### PR DESCRIPTION
Tested with cuda 12.2.140 on ubuntu 22.04
Tests and examples build in clang 12.0.1 and 14.0.0. All pass except some segfaults in the solvers.
Also tested with GNU 11.4.0; everything still works there.