### PR TITLE
Add PreRun methods for slice/fftshift operators

### DIFF
--- a/include/matx/operators/fft.h
+++ b/include/matx/operators/fft.h
@@ -258,7 +258,7 @@ namespace matx
         PermDims perm_;
         FFTType type_;
         std::array<index_t, OpA::Rank()> out_dims_;
-        matx::tensor_t<std::conditional_t<is_complex_v<typename OpA::scalar_type>, 
+        mutable matx::tensor_t<std::conditional_t<is_complex_v<typename OpA::scalar_type>,
                                           typename OpA::scalar_type, 
                                           typename scalar_to_complex<OpA>::ctype>, OpA::Rank()> tmp_out_;
 
@@ -307,7 +307,7 @@ namespace matx
         }
 
         template <typename Out, typename Executor>
-        void Exec(Out &&out, Executor &&ex) {
+        void Exec(Out &&out, Executor &&ex) const {
           static_assert(is_device_executor_v<Executor>, "fft()/ifft() only supports the CUDA executor currently");
           if constexpr (std::is_same_v<PermDims, no_permute_t>) {
             if constexpr (std::is_same_v<FFTType, fft_t>) { 
@@ -328,7 +328,7 @@ namespace matx
         }
 
         template <typename ShapeType, typename Executor>
-        __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) noexcept
+        __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
           if constexpr (is_matx_op<OpA>()) {
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));

--- a/include/matx/operators/fftshift.h
+++ b/include/matx/operators/fftshift.h
@@ -49,7 +49,7 @@ namespace matx
         using matxop = bool;
         using scalar_type = typename T1::scalar_type; 
 
-	__MATX_INLINE__ std::string str() const { return "fftshift(" + op_.str() + ")"; }
+        __MATX_INLINE__ std::string str() const { return "fftshift(" + op_.str() + ")"; }
 
         __MATX_INLINE__ FFTShift1DOp(T1 op) : op_(op){
           static_assert(Rank() >= 1, "1D FFT shift must have a rank 1 operator or higher");
@@ -80,6 +80,22 @@ namespace matx
         constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) const noexcept
         {
           return op_.Size(dim);
+        }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T1>()) {
+            op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T1>()) {
+            op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
         }
     };
   }
@@ -136,6 +152,22 @@ namespace matx
         {
           return op_.Size(dim);
         }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T1>()) {
+            op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T1>()) {
+            op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
     };
   }
 
@@ -190,6 +222,22 @@ namespace matx
         {
           return op_.Size(dim);
         }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T1>()) {
+            op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T1>()) {
+            op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
     };
   }
 
@@ -243,6 +291,22 @@ namespace matx
         constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) const noexcept
         {
           return op_.Size(dim);
+        }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T1>()) {
+            op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T1>()) {
+            op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
         }
     };
   }

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -160,6 +160,22 @@ namespace matx
             return set(*this, rhs); 
           }
         }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PreRun(ShapeType &&shape, Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T>()) {
+            op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PostRun(ShapeType &&shape, Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<T>()) {
+            op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
     };
   }
 

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -57,6 +57,9 @@ template <typename TensorType>
 class OperatorTestsFloatNonComplex : public ::testing::Test {
 };
 template <typename TensorType>
+class OperatorTestsFloatNonHalf : public ::testing::Test {
+};
+template <typename TensorType>
 class OperatorTestsFloatNonComplexNonHalf : public ::testing::Test {
 };
 template <typename TensorType>
@@ -121,6 +124,7 @@ TYPED_TEST_SUITE(OperatorTestsNumeric, MatXNumericTypes);
 TYPED_TEST_SUITE(OperatorTestsIntegral, MatXAllIntegralTypes);
 TYPED_TEST_SUITE(OperatorTestsNumericNonComplex,
                  MatXNumericNonComplexTypes);
+TYPED_TEST_SUITE(OperatorTestsFloatNonHalf, MatXFloatNonHalfTypes);
 TYPED_TEST_SUITE(OperatorTestsFloatNonComplex, MatXFloatNonComplexTypes);
 TYPED_TEST_SUITE(OperatorTestsFloatNonComplexNonHalf,
                  MatXFloatNonComplexNonHalfTypes);
@@ -786,6 +790,20 @@ TYPED_TEST(OperatorTestsNumericAllExecs, SliceOp)
       }
     }
   }
+
+  // Test SliceOp applied to a transform, using transpose() as an example transform
+  auto t2trans = make_tensor<TestType>({3, 2});
+  (t2trans = slice(transpose(t2), {2, 1}, {5, 3})).run(exec);
+  cudaStreamSynchronize(0);
+
+  ASSERT_EQ(t2trans.Size(0), 3);
+  ASSERT_EQ(t2trans.Size(1), 2);
+  for (index_t i = 0; i < t2trans.Size(0); i++) {
+    for (index_t j = 0; j < t2trans.Size(1); j++) {
+      ASSERT_EQ(t2trans(i, j), t2(j + 1, i + 2));
+    }
+  }
+
   MATX_EXIT_HANDLER();
 }
 
@@ -3213,6 +3231,101 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Downsample)
       MatXUtils::MatXTypeCompare(ds_op(i), t1(i * n));
     }
   }  
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(OperatorTestsFloatNonHalf, FftShiftWithTransform)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = TypeParam;
+  using inner_type = typename inner_op_type_t<TestType>::type;
+  using complex_type = detail::complex_from_scalar_t<typename inner_op_type_t<TestType>::type>;
+
+  const inner_type thresh = static_cast<inner_type>(1.0e-6);
+
+  // Verify that fftshift1D/ifftshift1D work with nested transforms.
+  // These tests are limited to complex-to-complex transforms where we have matched
+  // dimensions and types for the inputs/outputs. Adding tests that include real-to-complex
+  // or complex-to-real fft compositions is TBD.
+  if constexpr (is_complex_v<TestType>)
+  {
+    const int N1 = 3;
+    const int N2 = 4;
+
+    auto t3 = make_tensor<complex_type>({N1});
+    auto t4 = make_tensor<complex_type>({N2});
+    auto T3 = make_tensor<complex_type>({N1});
+    auto T4 = make_tensor<complex_type>({N2});
+
+    const std::array<complex_type, N1> t3_vals = {{ { 1.0, 0.0 }, { 2.0, 0.0 }, { 3.0, 0.0 } }};
+    const std::array<complex_type, N2> t4_vals = {{ { 1.0, 0.0 }, { 2.0, 0.0 }, { 3.0, 0.0 }, { 4.0, 0.0 } }};
+
+    for (int i = 0; i < N1; i++) { t3(i) = t3_vals[i]; };
+    for (int i = 0; i < N2; i++) { t4(i) = t4_vals[i]; };
+
+    cudaStreamSynchronize(0);
+
+    (T3 = fftshift1D(fft(t3))).run();
+    (T4 = fftshift1D(fft(t4))).run();
+
+    cudaStreamSynchronize(0);
+
+    const std::array<complex_type, N1> T3_expected = {{
+      { -1.5, static_cast<inner_type>(-0.8660254) }, { 6.0, 0.0 }, { -1.5, static_cast<inner_type>(0.8660254) }
+    }};
+    const std::array<complex_type, N2> T4_expected = {{
+      { -2.0, 0.0 }, { -2.0, -2.0 }, { 10.0, 0.0 }, { -2.0, 2.0 }
+    }};
+
+    for (int i = 0; i < N1; i++) {
+      ASSERT_NEAR(T3(i).real(), T3_expected[i].real(), thresh);
+      ASSERT_NEAR(T3(i).imag(), T3_expected[i].imag(), thresh);
+    }
+
+    for (int i = 0; i < N2; i++) {
+      ASSERT_NEAR(T4(i).real(), T4_expected[i].real(), thresh);
+      ASSERT_NEAR(T4(i).imag(), T4_expected[i].imag(), thresh);
+    }
+
+    (T3 = ifftshift1D(fft(t3))).run();
+    (T4 = ifftshift1D(fft(t4))).run();
+
+    cudaStreamSynchronize(0);
+
+    const std::array<complex_type, N1> T3_ifftshift_expected = {{
+      { -1.5, static_cast<inner_type>(0.8660254) }, { -1.5, static_cast<inner_type>(-0.8660254) }, { 6.0, 0.0 }
+    }};
+
+    for (int i = 0; i < N1; i++) {
+      ASSERT_NEAR(T3(i).real(), T3_ifftshift_expected[i].real(), thresh);
+      ASSERT_NEAR(T3(i).imag(), T3_ifftshift_expected[i].imag(), thresh);
+    }
+
+    // For even length vectors, fftshift() and ifftshift() are identical
+    for (int i = 0; i < N2; i++) {
+      ASSERT_NEAR(T4(i).real(), T4_expected[i].real(), thresh);
+      ASSERT_NEAR(T4(i).imag(), T4_expected[i].imag(), thresh);
+    }
+  }
+
+  // Verify that fftshift2D/ifftshift2D work with nested transforms. We do not
+  // check correctness here, but there are fftshift2D correctness tests elsewhere.
+  if constexpr (is_complex_v<TestType>) {
+    [[maybe_unused]] const int N = 4;
+
+    auto x = make_tensor<complex_type>({N,N});
+    auto X = make_tensor<complex_type>({N,N});
+
+    (x = 0).run();
+
+    (X = fftshift2D(fft2(x))).run();
+    (X = fftshift2D(ifft2(x))).run();
+    (X = ifftshift2D(fft2(x))).run();
+    (X = ifftshift2D(ifft2(x))).run();
+
+    cudaStreamSynchronize(0);
+  }
 
   MATX_EXIT_HANDLER();
 }


### PR DESCRIPTION
Add PreRun methods for slice and fftshift operators. This allows the operators to be composed with transforms (e.g. fftshift1D(fft(x))).