### PR TITLE
Add FFT1D tensor size checks

### DIFF
--- a/examples/simple_radar_pipeline.h
+++ b/examples/simple_radar_pipeline.h
@@ -249,7 +249,7 @@ public:
     (norms = sqrt(norms)).run(stream);
 
     (waveformPart = waveformPart / norms).run(stream);
-    (waveformFull = fft(waveformPart)).run(stream);
+    (waveformFull = fft(waveformPart, numSamplesRnd)).run(stream);
     (waveformFull = conj(waveformFull)).run(stream);
 
     (x = fft(x)).run(stream);

--- a/include/matx/operators/base_operator.h
+++ b/include/matx/operators/base_operator.h
@@ -58,7 +58,7 @@ namespace matx
          * 
          * @param stream CUDA stream
          */
-        __MATX_INLINE__ void run(cudaStream_t stream = 0) noexcept
+        __MATX_INLINE__ void run(cudaStream_t stream = 0)
         {
           MATX_NVTX_START(detail::get_type_str(*static_cast<T *>(this)), matx::MATX_NVTX_LOG_API)
           auto tp = static_cast<T *>(this);
@@ -88,7 +88,7 @@ namespace matx
          * @param ev CUDA event
          * @param stream CUDA stream
          */
-        __MATX_INLINE__ void run(cudaEvent_t ev, cudaStream_t stream = 0) noexcept
+        __MATX_INLINE__ void run(cudaEvent_t ev, cudaStream_t stream = 0)
         {
           MATX_NVTX_START(static_cast<T *>(this)->str(), matx::MATX_NVTX_LOG_API)
           auto ex = cudaExecutor(stream);


### PR DESCRIPTION
Add explicit checking of the input/output tensor sizes for 1D FFTs. Throw an exception if the sizes are not as expected, even in Release builds. One consequence of the checks is that they enforce that zero padding applied within the fft() operator be explicit (via the fft_size) param rather than implicit.