### PR TITLE
Add explicit FFT length to fft_conv example

### DIFF
--- a/examples/fft_conv.cu
+++ b/examples/fft_conv.cu
@@ -123,8 +123,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
     if (i == 1) {
       cudaEventRecord(start, stream);
     }    
-    (sig_freq = fft(sig_time)).run(stream);
-    (filt_freq = fft(filt_time)).run(stream);
+    (sig_freq = fft(sig_time, filtered_size)).run(stream);
+    (filt_freq = fft(filt_time, filtered_size)).run(stream);
 
     (sig_freq = sig_freq * filt_freq).run(stream);
 

--- a/include/matx/operators/fft.h
+++ b/include/matx/operators/fft.h
@@ -109,7 +109,7 @@ namespace matx
             // deduce which is correct, so explicitly set the transform size here. For C2C
             // transforms, we do not want to implicitly zero-pad. Users can opt-in to
             // zero-padding by providing the desired padded fft_size_ as a parameter.
-            // For R2C transforms, we do not know the fft size -- it could be either
+            // For C2R transforms, we do not know the fft size -- it could be either
             // (N-1)*2 or (N-1)*2+1. If the operator is used such that the output is a
             // real tensor, then the size will be set to the output tensor length. If we
             // create a temporary, then this will be a C2C transform and the output length


### PR DESCRIPTION
FFT no longer implicitly zero-pads input signals, so pass the expected transform length explicitly.