### PR TITLE
Fix errors which caused some unit tests failed to compile.

### DIFF
--- a/include/matx/operators/r2c.h
+++ b/include/matx/operators/r2c.h
@@ -90,7 +90,7 @@ namespace matx
         }
         constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) const noexcept
         {
-          if (dim == (uint32_t)(Rank() - 1)) {
+          if (dim == Rank() - 1) {
             return orig_size_;
           }
           else {

--- a/include/matx/transforms/reduce.h
+++ b/include/matx/transforms/reduce.h
@@ -1644,7 +1644,7 @@ void __MATX_INLINE__ softmax_impl(OutType dest, const InType &in, PermDims dims,
   for (int r = 0; r < InType::Rank(); r++) {
     if (axis_ptr >= 0 && dims[axis_ptr] == r) {
       clone_dims[r] = in.Size(r);
-      if (++axis_ptr == dims.size()) {
+      if (static_cast<decltype(dims.size())>(++axis_ptr) == dims.size()) {
         axis_ptr = -1;
       }
     }

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -3367,7 +3367,7 @@ TYPED_TEST(OperatorTestsFloatNonHalf, FftShiftWithTransform)
   using inner_type = typename inner_op_type_t<TestType>::type;
   using complex_type = detail::complex_from_scalar_t<typename inner_op_type_t<TestType>::type>;
 
-  const inner_type thresh = static_cast<inner_type>(1.0e-6);
+  [[maybe_unused]] const inner_type thresh = static_cast<inner_type>(1.0e-6);
 
   // Verify that fftshift1D/ifftshift1D work with nested transforms.
   // These tests are limited to complex-to-complex transforms where we have matched


### PR DESCRIPTION
MatX sets `-Werror` in its main CMakeLists.txt:

```cmake
set(WARN_FLAGS ${WARN_FLAGS} $<$<COMPILE_LANGUAGE:CUDA>:-Werror all-warnings>)
set(WARN_FLAGS ${WARN_FLAGS} $<$<COMPILE_LANGUAGE:CXX>:-Werror>)
```

Thus all warnings are treated as errors, which may lead to compilation failures.

In this PR, I fixed some errors (warnings, e.g. comparing signed/unsigned numbers) and now all unit tests compiles fine.