### PR TITLE
removing old hardcoded limit for repmat rank size

### DIFF
--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -49,8 +49,6 @@
 #include "matx/core/tie.h"
 #include "matx/kernels/utility.cuh"
 
-static constexpr int MAX_TENSOR_DIM = 4;
-
 // forward declare
 namespace matx {
 template <typename T, int RANK, typename Storage, typename Desc> class tensor_t;

--- a/include/matx/operators/repmat.h
+++ b/include/matx/operators/repmat.h
@@ -53,7 +53,7 @@ namespace matx
     {
       private:
         typename base_type<T1>::type op_;
-        index_t reps_[MAX_TENSOR_DIM];
+        index_t reps_[T1::Rank()];
 
       public:
         using matxop = bool;


### PR DESCRIPTION
Removed old `MAX_TENSOR_DIM` variable and it's use in repmap to limit the rep_ vector. fixes issues with repmat > RANK 4