### PR TITLE
Avoid async alloc in some Cholesky decomp cases

### DIFF
--- a/test/test_vectors/generators/00_solver.py
+++ b/test/test_vectors/generators/00_solver.py
@@ -40,7 +40,10 @@ class cholesky:
     def run(self):
         n = self.size[0]
 
-        A = np.random.randn(n, n)
+        if self.dtype in ('complex64', 'complex128'):
+            A = np.random.randn(n, n) + 1j*np.random.randn(n, n)
+        else:
+            A = np.random.randn(n, n)
         B = np.matmul(A, A.conj().T)
         B = B + n*np.eye(n)
 


### PR DESCRIPTION
For contiguous input/output tensors, avoid creating a temporary tensor for use with cusolver. Also clear old batch pointers when populating new batch pointers prior to the factorization.