### PR TITLE
Add configurable precision support of `print()`.

### DIFF
--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -41,6 +41,7 @@
 #include "matx/kernels/utility.cuh"
 
 static constexpr bool PRINT_ON_DEVICE = false;      ///< print() uses printf on device
+static unsigned int PRINT_PRECISION = 4;            ///< control PrintVal()'s precision
 
 namespace matx
 {
@@ -509,15 +510,23 @@ namespace detail {
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
+    using namespace std::literals::string_literals;
+
     if constexpr (is_complex_v<T>) {
-      printf("%.4e%+.4ej ", static_cast<float>(val.real()),
+      auto prec = std::to_string(PRINT_PRECISION);
+      auto fmt_s = ("%."s + prec + "e%+." + prec + "ej ").c_str();
+      printf(fmt_s, static_cast<float>(val.real()),
             static_cast<float>(val.imag()));
     }
     else if constexpr (is_matx_half_v<T> || is_half_v<T>) {
-      printf("%.4e ", static_cast<float>(val));
+      auto prec = std::to_string(PRINT_PRECISION);
+      auto fmt_s = ("%."s + prec + "e ").c_str();
+      printf(fmt_s, static_cast<float>(val));
     }
     else if constexpr (std::is_floating_point_v<T>) {
-      printf("%.4e ", val);
+      auto prec = std::to_string(PRINT_PRECISION);
+      auto fmt_s = ("%."s + prec + "e ").c_str();
+      printf(fmt_s, val);
     }
     else if constexpr (std::is_same_v<T, long long int>) {
       printf("%lld ", val);
@@ -904,6 +913,24 @@ auto OpToTensor(Op &&op, [[maybe_unused]] cudaStream_t stream) {
   } else {
     return op;
   }
+}
+
+/**
+ * @brief Set the print() precision for floating point values
+ * 
+ * @param precision Number of digits of precision for floating point output (default 4).
+ */
+void set_print_precision(unsigned int precision) {
+  PRINT_PRECISION = precision;
+}
+
+/**
+ * @brief Get the print() precision for floating point values
+ * 
+ * @return Number of digits of precision for floating point output (default 4).
+ */
+unsigned int get_print_precision() {
+  return PRINT_PRECISION;
 }
 
 }


### PR DESCRIPTION
This PR aims to implement what #495 needs. I mimic NumPy's [`numpy.set_printoptions()`](https://numpy.org/doc/stable/reference/generated/numpy.set_printoptions.html) - it allows users to set a precision. So I added a similar function `set_print_precision()` into `tensor_utils.h`.

Example usage:

```cpp
cudaStream_t stream;
cudaStreamCreate(&stream);

tensor_t<float, 2> x({2, 3});
(x = random<float>({2, 3}, NORMAL)).run(stream);
cudaStreamSynchronize(stream);

printf("x:\n");
print(x);

printf("Current precision: %u.\n", get_print_precision());
set_print_precision(6);
printf("Current precision: %u.\n", get_print_precision());

printf("x:\n");
print(x);
```

Output:
```
x:
Tensor{float} Rank: 2, Sizes:[2, 3], Strides:[3,1]
000000: -9.2466e-01 -4.2534e-01 -2.6438e+00 
000001: 1.4518e-01 -1.2087e-01 -5.7973e-01 
Current precision: 4.
Current precision: 6.
x:
Tensor{float} Rank: 2, Sizes:[2, 3], Strides:[3,1]
000000: -9.246624e-01 -4.253442e-01 -2.643846e+00 
000001: 1.451839e-01 -1.208664e-01 -5.797257e-01
```