### PR TITLE
Workaround for maybe_unused parse bug in old gcc

### DIFF
--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -232,7 +232,9 @@ public:
    * @param shape
    *   Tensor shape (empty braces)
    */
-  __MATX_INLINE__ tensor_t([[maybe_unused]] const std::initializer_list<detail::no_size_t> shape) :
+  __MATX_INLINE__ tensor_t(const std::initializer_list<detail::no_size_t> /* unused */) :
+    // The ctor argument is unused, but matches {} for rank-0 tensors. We do
+    // not use [[maybe_unused]] due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429 in gcc < 9.3
     detail::tensor_impl_t<T, RANK, Desc>(std::array<index_t, 0>{}),
     storage_{typename Storage::container{sizeof(T)}}
   {

--- a/include/matx/transforms/filter.h
+++ b/include/matx/transforms/filter.h
@@ -53,13 +53,17 @@ class matxFilter_t {
   using filter_tensor = matx::tensor_t<FilterType, 1>;
 
 public:
-  matxFilter_t([[maybe_unused]] OutType &o, const InType &i,
+  matxFilter_t(OutType &o, const InType &i,
                const filter_tensor &h_rec,
                const filter_tensor &h_nonrec)
       : h_nonr_copy(h_nonrec)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
     
+    // o may be unused. We use the (void) idiom rather than [[maybe_unused]] due to
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429
+    (void) o;
+
     if constexpr (RANK == 1) {
       MATX_ASSERT(o.Size(0) == i.Size(0), matxInvalidSize);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,20 +44,17 @@ set (test_sources
 # '../test/00_io/small_csv_complex_comma_nh.csv' respectively. Therefore
 # they must be copied to the correct location:
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/test/00_io)
-file(COPY_FILE
+file(COPY
 	${CMAKE_SOURCE_DIR}/test/00_io/small_csv_comma_nh.csv
-	${CMAKE_BINARY_DIR}/test/00_io/small_csv_comma_nh.csv
-	ONLY_IF_DIFFERENT
+	DESTINATION ${CMAKE_BINARY_DIR}/test/00_io
 )
-file(COPY_FILE
+file(COPY
 	${CMAKE_SOURCE_DIR}/test/00_io/small_csv_complex_comma_nh.csv
-	${CMAKE_BINARY_DIR}/test/00_io/small_csv_complex_comma_nh.csv
-	ONLY_IF_DIFFERENT
+	DESTINATION ${CMAKE_BINARY_DIR}/test/00_io
 )
-file(COPY_FILE
+file(COPY
 	${CMAKE_SOURCE_DIR}/test/00_io/test.mat
-	${CMAKE_BINARY_DIR}/test/00_io/test.mat
-	ONLY_IF_DIFFERENT
+	DESTINATION ${CMAKE_BINARY_DIR}/test/00_io
 )
 
 # Find proprietary parameters


### PR DESCRIPTION
Versions of gcc prior to 9.3 have a bug parsing [[maybe_unused]] when applied to the first argument in a constructor:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429

Although we do not officially support gcc versions prior to 9.3, this is a workaround for a couple such cases.

Also, switch from CMake COPY_FILE to COPY to maintain compatability with CMake 3.20 (COPY_FILE was added in 3.21)