### PR TITLE
Fix matvec output dims to match A rather than B

### DIFF
--- a/include/matx/operators/matvec.h
+++ b/include/matx/operators/matvec.h
@@ -48,8 +48,9 @@ namespace matx
         OpB b_;
         float alpha_;
         float beta_;
-        std::array<index_t, 2> out_dims_;
-        mutable matx::tensor_t<typename OpA::scalar_type, 2> tmp_out_;
+        static constexpr int RANK = remove_cvref_t<OpB>::Rank();
+        std::array<index_t, RANK> out_dims_;
+        mutable matx::tensor_t<typename OpA::scalar_type, RANK> tmp_out_;
 
       public:
         using matxop = bool;
@@ -65,7 +66,7 @@ namespace matx
               a_(A), b_(B), alpha_(alpha), beta_(beta) {
           
           for (int r = 0; r < Rank(); r++) {
-            out_dims_[r] = b_.Size(r);
+            out_dims_[r] = a_.Size(r);
           }
         }
 


### PR DESCRIPTION
For matvecs, the batch dimensions for A and B should match and the final output dimension should match dim Rank-1 from A. Also generalize batching support so that the size of out_dims_ is based on the output rank.