### PR TITLE
Zero-initialize batches field in CUB params

### DIFF
--- a/include/matx/transforms/cub.h
+++ b/include/matx/transforms/cub.h
@@ -78,7 +78,7 @@ typedef enum {
 struct CubParams_t {
   CUBOperation_t op;
   std::vector<index_t> size{10};
-  index_t batches;
+  index_t batches{0};
   MatXDataType_t dtype;
   cudaStream_t stream;
 };


### PR DESCRIPTION
For some CUB reduction types, the batches field in the CUB params struct is uninitialized. The field is not needed for the reduction, but it is included when performing cache lookups, so the uninitialized value could cause false negatives (cache misses) and additional plan creations. This did not cause correctness issues but could impact performance. Thus, zero-initialize the batches field to prevent false negatives on cache lookup. The CUB cache is currently disabled by default but can be enabled at build time by the user.