### PR TITLE
Fix batched cov transform

### DIFF
--- a/docs_input/api/manipulation/rearranging/transpose.rst
+++ b/docs_input/api/manipulation/rearranging/transpose.rst
@@ -12,7 +12,7 @@ than calling `permute()` since it's not lazily evaluated and can use an optimize
 Examples
 ~~~~~~~~
 
-.. literalinclude:: ../../../../include/matx/transforms/cov.h
+.. literalinclude:: ../../../../test/00_operators/OperatorTests.cu
    :language: cpp
    :start-after: example-begin transpose-test-1
    :end-before: example-end transpose-test-1

--- a/include/matx/transforms/matmul.h
+++ b/include/matx/transforms/matmul.h
@@ -782,7 +782,8 @@ private:
     
     if constexpr (RANK > 3) {
       // Get total number of batches
-      total_iter = std::accumulate(a_shape.begin(), a_shape.begin() + TensorTypeA::Rank() - 3, 1, std::multiplies<shape_type>());
+      [[maybe_unused]] auto c_shape = c.Shape();
+      total_iter = std::accumulate(c_shape.begin(), c_shape.begin() + TensorTypeC::Rank() - 3, 1, std::multiplies<shape_type>());
     }
 
     // For cuBLASLt most of the parameters have already been set in the
@@ -1003,11 +1004,11 @@ private:
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
     
-    if (b.Stride(RANK - 1) == 1) {
+    if (b.Stride(TensorTypeB::Rank() - 1) == 1) {
       MatMulDispatchC<OrderA, MEM_ORDER_ROW_MAJOR>(a, b, c, stream, alpha,
                                                    beta);
     }
-    else if (b.Stride(RANK - 2) == 1) {
+    else if (b.Stride(TensorTypeB::Rank() - 2) == 1) {
       MatMulDispatchC<OrderA, MEM_ORDER_COL_MAJOR>(a, b, c, stream, alpha,
                                                    beta);
     }
@@ -1024,10 +1025,10 @@ private:
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
     
-    if (a.Stride(RANK - 1) == 1) {
+    if (a.Stride(TensorTypeA::Rank() - 1) == 1) {
       MatMulDispatchB<MEM_ORDER_ROW_MAJOR>(a, b, c, stream, alpha, beta);
     }
-    else if (a.Stride(RANK - 2) == 1) {
+    else if (a.Stride(TensorTypeA::Rank() - 2) == 1) {
       MatMulDispatchB<MEM_ORDER_COL_MAJOR>(a, b, c, stream, alpha, beta);
     }
     else {

--- a/test/00_transform/Cov.cu
+++ b/test/00_transform/Cov.cu
@@ -41,12 +41,13 @@ using namespace matx;
 template <typename T> class CovarianceTest : public ::testing::Test {
 
 protected:
-  const index_t cov_dim = 4;
+  const index_t cov_dim1 = 4;
+  const index_t cov_dim2 = 3;
   void SetUp() override
   {
     CheckTestTensorCoreTypeSupport<T>();
     pb = std::make_unique<detail::MatXPybind>();
-    pb->InitTVGenerator<T>("00_transforms", "cov_operators", {cov_dim});
+    pb->InitTVGenerator<T>("00_transforms", "cov_operators", {cov_dim1, cov_dim2});
 
     // Half precision needs a bit more tolerance when compared to
     // fp32
@@ -57,8 +58,8 @@ protected:
 
   void TearDown() { pb.reset(); }
 
-  tensor_t<T, 2> av{{cov_dim, cov_dim}};
-  tensor_t<T, 2> cv{{cov_dim, cov_dim}};
+  tensor_t<T, 2> av{{cov_dim1, cov_dim2}};
+  tensor_t<T, 2> cv{{cov_dim2, cov_dim2}};
 
   float thresh = 0.01f;
   std::unique_ptr<detail::MatXPybind> pb;
@@ -94,8 +95,8 @@ TYPED_TEST(CovarianceTestFloatTypes, BatchedCov)
   const int k = 7;
 
   // Test a batched 5D input
-  auto batched_in = make_tensor<TypeParam>({m, n, k, this->cov_dim, this->cov_dim});
-  auto batched_out = make_tensor<TypeParam>({m, n, k, this->cov_dim, this->cov_dim});
+  auto batched_in = make_tensor<TypeParam>({m, n, k, this->cov_dim1, this->cov_dim2});
+  auto batched_out = make_tensor<TypeParam>({m, n, k, this->cov_dim2, this->cov_dim2});
   (batched_in = clone<5>(this->av, {m, n, k, matxKeepDim, matxKeepDim})).run();
 
   (batched_out = cov(batched_in)).run();

--- a/test/test_vectors/generators/00_transforms.py
+++ b/test/test_vectors/generators/00_transforms.py
@@ -102,7 +102,7 @@ class cov_operators:
         np.random.seed(1234)
         self.size = size
         self.res = {
-            'a': matx_common.randn_ndarray((size[0], size[0]), dtype)
+            'a': matx_common.randn_ndarray((size[0], size[1]), dtype)
         }
 
     def cov(self) -> Dict[str, np.ndarray]:


### PR DESCRIPTION
Fix a few issues with batched cov() transforms:

- Use transpose_matrix instead of transpose for the batched transposed deviations. Thus, dimensions [0, RANK-2) match the sizes of the batched dimensions from the non-transposed deviations.
- Use stream-oriented async allocators for temporaries and set the memory space to MATX_ASYNC_DEVICE_MEMORY.
- Make some changes in dimension-checking for batched matmul() transforms. Compute the number of batches using the dimensions of C and, if necessary, broadcast A or B into the batched dimensions.
- Add a cov() unit test case with batching and rectangular inputs.

One remaining issue is that we allocate 3-4 times the size of the input for temporary storage. This storage is part of a cached plan that currently is not evicted/freed, so if the dimensions of cov() inputs are changing over time, the cache will grow quickly.