### PR TITLE
Update caching for transforms to fixing all leaks reported by compute-sanitizer

### DIFF
--- a/include/matx/core/pybind.h
+++ b/include/matx/core/pybind.h
@@ -102,9 +102,9 @@ public:
     sys.attr("path").attr("append")(path);
   }
 
-  void RunTVGenerator(const std::string &func)
+  void RunTVGenerator(const char *func)
   {
-    res_dict = sx_obj.attr(func.c_str())();
+    res_dict = sx_obj.attr(func)();
   }
 
   template <typename T>
@@ -122,7 +122,7 @@ public:
 
   template <typename T>
   void InitAndRunTVGenerator(const std::string &mname, const std::string &cname,
-                             const std::string &func,
+                             const char *func,
                              const std::vector<index_t> &sizes)
   {
     InitTVGenerator<T>(mname, cname, sizes);
@@ -131,7 +131,7 @@ public:
 
   template <typename T>
   void InitAndRunTVGeneratorWithCfg(const std::string &mname, const std::string &cname,
-                             const std::string &func,
+                             const char *func,
                              const pybind11::dict &cfg)
   {
     mod = pybind11::module_::import(mname.c_str());

--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -758,7 +758,9 @@ void PrintData(const Op &op, Args... dims) {
     }
   }
   else {
-    InternalPrint(op, dims...);
+    auto tmpv = make_tensor<typename Op::scalar_type>(op.Shape());
+    (tmpv = op).run();    
+    InternalPrint(tmpv, dims...);
   }
 #else
   InternalPrint(op, dims...);

--- a/include/matx/transforms/copy.h
+++ b/include/matx/transforms/copy.h
@@ -105,7 +105,7 @@ namespace matx
   __MATX_INLINE__ Tensor copy(const Tensor &in, Executor exec)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-    Tensor out(in.Descriptor());
+    auto out = make_tensor<typename Tensor::value_type>(in.Shape());
     matx::copy(out, in, exec);
     return out;
   };

--- a/test/00_tensor/BasicTensorTests.cu
+++ b/test/00_tensor/BasicTensorTests.cu
@@ -450,6 +450,17 @@ TYPED_TEST(BasicTensorTestsAll, Print)
   MATX_EXIT_HANDLER();
 }
 
+TYPED_TEST(BasicTensorTestsAll, DevicePrint)
+{
+  MATX_ENTER_HANDLER();
+
+  auto t = make_tensor<TypeParam>({3}, MATX_DEVICE_MEMORY);
+  (t = ones(t.Shape())).run();
+  print(t);
+
+  MATX_EXIT_HANDLER();
+}
+
 TYPED_TEST(BasicTensorTestsAll, DLPack)
 {
   MATX_ENTER_HANDLER();


### PR DESCRIPTION
Leaks in pybind are still reported, but are considered innocuous at this point since it's only in unit tests.