### PR TITLE
Increase cublas workspace to 32 MiB for Hopper+

### DIFF
--- a/include/matx/core/utils.h
+++ b/include/matx/core/utils.h
@@ -38,6 +38,7 @@
 #include "matx/core/defines.h"
 #include "matx/core/error.h"
 
+#define HOPPER_CC 9
 #define AMPERE_CC 8
 #define VOLTA_CC 7
 #define PASCAL_CC 6
@@ -47,14 +48,19 @@ namespace detail {
 __MATX_INLINE__ int GetDeviceAttr(cudaDeviceAttr attr) {
     int val;
     int dev;
-    cudaGetDevice(&dev);
-    [[maybe_unused]] auto err = cudaDeviceGetAttribute(&val, attr, dev);
+    [[maybe_unused]] auto err = cudaGetDevice(&dev);
+    MATX_ASSERT(err == cudaSuccess, matxCudaError);
+    err = cudaDeviceGetAttribute(&val, attr, dev);
     MATX_ASSERT(err == cudaSuccess, matxCudaError);
     return val;
 }
 
 __MATX_INLINE__ int GetComputeCapabilityMajor() {
     return GetDeviceAttr(cudaDevAttrComputeCapabilityMajor);
+}
+
+__MATX_INLINE__ bool IsHopperOrAbove() {
+    return GetComputeCapabilityMajor() >= HOPPER_CC;
 }
 
 __MATX_INLINE__ bool IsAmpereOrAbove() {

--- a/include/matx/transforms/matmul.h
+++ b/include/matx/transforms/matmul.h
@@ -218,15 +218,8 @@ public:
       // https://docs.nvidia.com/cuda/cublas/#cublassetworkspace
       // Thus, try to detect if we are running on Hopper or newer and use a 32 MiB workspace
       // if so. Otherwise, default to 4 MiB, which still works on Hopper+.
-      int device = 0, value = 0;
       constexpr size_t MiB = 1024*1024;
-      constexpr int computeCompatMajorHopper = 9;
-      workspaceSize = 4*MiB;
-      if (cudaGetDevice(&device) == cudaSuccess &&
-        cudaDeviceGetAttribute(&value, cudaDevAttrComputeCapabilityMajor, device) == cudaSuccess &&
-        value >= computeCompatMajorHopper) {
-          workspaceSize = 32*MiB;
-      }
+      workspaceSize = detail::IsHopperOrAbove() ? 32*MiB : 4*MiB;
 
       // Workspace buffer
       matxAlloc((void **)&workspace, workspaceSize, MATX_DEVICE_MEMORY);


### PR DESCRIPTION
The recommended workspace size for Hopper+ is 32 MiB. Increasing the workspace size from 4 MiB to 32 MiB improves matmul performance for smaller matrices on H100.