### PR TITLE
Added missing synchronization 

### DIFF
--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -760,6 +760,7 @@ void PrintData(const Op &op, Args... dims) {
   else {
     auto tmpv = make_tensor<typename Op::scalar_type>(op.Shape());
     (tmpv = op).run();    
+    cudaStreamSynchronize(0);
     InternalPrint(tmpv, dims...);
   }
 #else


### PR DESCRIPTION
When printing operators there is a race condition between the copy and the print.  This patch adds synchronization to avoid that race condition.