### PR TITLE
Fix NVTX3 include path

### DIFF
--- a/include/matx/core/nvtx.h
+++ b/include/matx/core/nvtx.h
@@ -35,7 +35,7 @@
 #include <mutex>
 #include <string>
 #include <utility>
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 
 namespace matx
 {


### PR DESCRIPTION
We need to change `#include <nvToolsExt.h>` into `#include <nvtx3/nvToolsExt.h>`.

The old form (`#include <nvToolsExt.h>`) requires linking to dynamic library (`libnvToolsExt.so`), while the new form is header-only. In PR #548, @cliffburdick changed CMakeLists.txt to make matx link to `CUDA::nvtx3` instead of `UDA::nvToolsExt` if CMake has a higher version that supports it. Thus if you use a CMake version >= 3.25, you will only use nvtx3 headers, without linking to `libnvToolsExt.so`. But we are still including the old `<nvToolsExt.h>`, rather than the newer `<nvtx3/nvToolsExt.h>`. For some functions, the old `<nvToolsExt.h>` don't contain implementations. This makes the linking fail with **undefined reference** errors.

For example, using CMake 3.28, I cannot build the `conv2d` target in examples. The linker outputs:

```
[ 50%] Building CUDA object examples/CMakeFiles/conv2d.dir/conv2d.cu.o
[100%] Linking CUDA executable conv2d
/usr/bin/ld: CMakeFiles/conv2d.dir/conv2d.cu.o: in function `matx::endEvent(int)':
/workspaces/MatX/include/matx/core/nvtx.h:189: undefined reference to `nvtxRangeEnd'
collect2: error: ld returned 1 exit status
make[3]: *** [examples/CMakeFiles/conv2d.dir/build.make:110: examples/conv2d] Error 1
make[2]: *** [CMakeFiles/Makefile2:316: examples/CMakeFiles/conv2d.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:323: examples/CMakeFiles/conv2d.dir/rule] Error 2
make: *** [Makefile:255: conv2d] Error 2
```

To fix this error, we can change to use `#include <nvtx3/nvToolsExt.h>`. It's also recommended by [NVTX's README](https://github.com/NVIDIA/NVTX?tab=readme-ov-file#c-and-c):

> _NOTE:_ Older versions of NVTX did require linking against a dynamic library. NVTX version 3 provides the same API, but removes the need to link with any library. Ensure you are including NVTX v3 by using the `nvtx3` directory as a prefix in your #includes:
> #include <nvtx3/nvToolsExt.h>
> ...