### PR TITLE
Add rapids-cmake-dir, if defined, to CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,8 @@ endif()
 if(NOT DEFINED rapids-cmake-dir)
   add_subdirectory(cmake/rapids-cmake)
 else()
-  list(APPEND CMAKE_PREFIX_PATH "${rapids-cmake-dir}")
+  # The include() commands below search the module path for the corresponding .cmake files
+  list(APPEND CMAKE_MODULE_PATH "${rapids-cmake-dir}")
 endif()
 
 include(rapids-cmake)


### PR DESCRIPTION
On a first cmake run, when rapids-cmake-dir is not defined, we call add_subdirectory(cmake/rapids-cmake) to include the various rapids modules. On subsequent runs, rapids-cmake-dir is defined in the cache, so the path needs to be appended to the module path for the include directives. Currently, we modify CMAKE_PREFIX_PATH instead of CMAKE_MODULE_PATH.