### PR TITLE
Added ARM FFT Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(MATX_EN_VISUALIZATION "Enable visualization support" OFF)
 option(MATX_EN_CUTLASS OFF)
 option(MATX_EN_CUTENSOR OFF)
 option(MATX_EN_FILEIO OFF)
+option(MATX_EN_NVPL OFF, "Enable NVIDIA Performance Libraries for optimized ARM CPU support")
 option(MATX_DISABLE_CUB_CACHE "Disable caching for CUB allocations" ON)
 
 set(MATX_EN_PYBIND11 OFF CACHE BOOL "Enable pybind11 support")
@@ -150,6 +151,15 @@ if (MATX_EN_CUTLASS)
 else()
     set (CUTLASS_INC "")
     target_compile_definitions(matx INTERFACE MATX_ENABLE_CUTLASS=0)
+endif()
+
+if (MATX_EN_NVPL)
+    message(STATUS "Enabling NVPL library support")
+    # find_package is currently broken in NVPL. Use proper targets once working
+    #find_package(nvpl REQUIRED COMPONENTS fft)
+    #target_link_libraries(matx INTERFACE nvpl::fftw)
+    target_link_libraries(matx INTERFACE nvpl_fftw)
+    target_compile_definitions(matx INTERFACE MATX_EN_NVPL=1)
 endif()
 
 if (MATX_DISABLE_CUB_CACHE)
@@ -291,4 +301,3 @@ if (MATX_BUILD_TESTS)
     include(cmake/GetGTest.cmake)
     add_subdirectory(test)
 endif()
-

--- a/docs_input/api/dft/fft/fft2d.rst
+++ b/docs_input/api/dft/fft/fft2d.rst
@@ -9,8 +9,8 @@ Perform a 2D FFT
    These functions are currently not supported with host-based executors (CPU)
 
 
-.. doxygenfunction:: fft2(OpA &&a)
-.. doxygenfunction:: fft2(OpA &&a, const int32_t (&axis)[2])  
+.. doxygenfunction:: fft2(OpA &&a, FFTNorm norm = FFTNorm::BACKWARD)
+.. doxygenfunction:: fft2(OpA &&a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD)  
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/dft/fft/ifft2.rst
+++ b/docs_input/api/dft/fft/ifft2.rst
@@ -9,8 +9,8 @@ Perform a 2D inverse FFT
    These functions are currently not supported with host-based executors (CPU)
 
 
-.. doxygenfunction:: ifft2(OpA &&a)
-.. doxygenfunction:: ifft2(OpA &&a, const int32_t (&axis)[2])  
+.. doxygenfunction:: ifft2(OpA &&a, FFTNorm norm = FFTNorm::BACKWARD)
+.. doxygenfunction:: ifft2(OpA &&a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD)  
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/basic/copy.rst
+++ b/docs_input/api/manipulation/basic/copy.rst
@@ -14,7 +14,7 @@ since it cannot be chained with other expressions.
 Examples
 ~~~~~~~~
 
-.. literalinclude:: ../../../../include/matx/transforms/fft.h
+.. literalinclude:: ../../../../include/matx/transforms/fft/fft_common.h
    :language: cpp
    :start-after: example-begin copy-test-1
    :end-before: example-end copy-test-1

--- a/docs_input/build.rst
+++ b/docs_input/build.rst
@@ -43,6 +43,16 @@ Optional Third-party Dependencies
 - `cutensor <https://developer.nvidia.com/cutensor>`_ 1.7.0.1+ (Required when using `einsum`)
 - `cutensornet <https://docs.nvidia.com/cuda/cuquantum/cutensornet>`_ 23.03.0.20+ (Required when using `einsum`)
 
+Host (CPU) Support
+------------------
+Host support is provided both by the C++ standard library and NVIDIA's NVPL_ library. Host support is
+considered experimental and is still a work in progress. Currently all reduction functions are supported, 
+but only FFT transforms are supported. All host support is limited to a single thread in this release.
+
+To enable NVPL support use the CMake option `-DMATX_EN_NVPL=ON`.
+
+.. _NVPL: https://developer.nvidia.com/nvpl
+
 Build Options
 =============
 MatX provides 5 primary options for builds, and each can be configured independently:

--- a/include/matx/core/error.h
+++ b/include/matx/core/error.h
@@ -65,7 +65,8 @@ namespace matx
     matxLUError,
     matxInverseError,
     matxSolverError,
-    matxcuTensorError
+    matxcuTensorError,
+    matxInvalidExecutor
   };
 
   static constexpr const char *matxErrorString(matxError_t e)

--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -1486,6 +1486,7 @@ public:
 
       if constexpr (N > 0) {
         if (end != matxDropDim) {
+          MATX_ASSERT_STR(end != matxKeepDim, matxInvalidParameter, "matxKeepDim only valid for clone(), not slice()");
           if (end == matxEnd) {
             n[d] = this->Size(i) - first;
           }

--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -272,8 +272,8 @@ constexpr bool is_executor_t()
 
 
 namespace detail {
-template<typename T> struct is_device_executor : std::false_type {};
-template<> struct is_device_executor<matx::cudaExecutor> : std::true_type {};
+template<typename T> struct is_cuda_executor : std::false_type {};
+template<> struct is_cuda_executor<matx::cudaExecutor> : std::true_type {};
 }
 
 /**
@@ -282,11 +282,11 @@ template<> struct is_device_executor<matx::cudaExecutor> : std::true_type {};
  * @tparam T Type to test
  */
 template <typename T> 
-inline constexpr bool is_device_executor_v = detail::is_device_executor<typename remove_cvref<T>::type>::value;
+inline constexpr bool is_cuda_executor_v = detail::is_cuda_executor<typename remove_cvref<T>::type>::value;
 
 namespace detail {
-template<typename T> struct is_single_thread_host_executor : std::false_type {};
-template<> struct is_single_thread_host_executor<matx::HostExecutor> : std::true_type {};
+template<typename T> struct is_host_executor : std::false_type {};
+template<> struct is_host_executor<matx::HostExecutor> : std::true_type {};
 }
 
 /**
@@ -295,7 +295,7 @@ template<> struct is_single_thread_host_executor<matx::HostExecutor> : std::true
  * @tparam T Type to test
  */
 template <typename T> 
-inline constexpr bool is_single_thread_host_executor_v = detail::is_single_thread_host_executor<remove_cvref_t<T>>::value;
+inline constexpr bool is_host_executor_v = detail::is_host_executor<remove_cvref_t<T>>::value;
 
 
 namespace detail {

--- a/include/matx/executors/device.h
+++ b/include/matx/executors/device.h
@@ -66,7 +66,7 @@ namespace matx
       /*
        * @breif Returns stream associated with executor
        */
-      auto getStream() { return stream_; }
+      auto getStream() const { return stream_; }
 
       /**
        * Execute an operator on a device

--- a/include/matx/executors/host.h
+++ b/include/matx/executors/host.h
@@ -95,6 +95,8 @@ class HostExecutor {
       }
     }
 
+    int GetNumThreads() const { return params_.GetNumThreads(); }
+
     private:
       HostExecParams params_;
 };

--- a/include/matx/executors/support.h
+++ b/include/matx/executors/support.h
@@ -32,6 +32,29 @@
 
 #pragma once
 
-#include "matx/executors/support.h"
-#include "matx/executors/device.h"
-#include "matx/executors/host.h"
+#include "matx/core/type_utils.h"
+
+// Utility functions to determine what support is available per-executor
+
+namespace matx {
+  namespace detail {
+
+// FFT
+#if defined(MATX_EN_NVPL)
+    #define MATX_EN_CPU_FFT 1
+#else
+    #define MATX_EN_CPU_FFT 0
+#endif  
+
+template <typename Exec>
+constexpr bool CheckFFTSupport() {
+  if constexpr (is_host_executor_v<Exec>) {
+    return MATX_EN_CPU_FFT;
+  }
+  else {
+    return true;
+  }
+}
+
+}; // detail
+}; // matx

--- a/include/matx/generators/random.h
+++ b/include/matx/generators/random.h
@@ -432,7 +432,7 @@ public:
       __MATX_INLINE__ void PreRun([[maybe_unused]] ST &&shape, Executor &&ex)
       {
 #ifdef __CUDACC__
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           if (!init_) {
             auto stream = ex.getStream();
             matxAlloc((void **)&states_,
@@ -446,7 +446,7 @@ public:
             device_ = true;
           }
         }
-        else if constexpr (is_single_thread_host_executor_v<Executor>) {
+        else if constexpr (is_host_executor_v<Executor>) {
           if (!init_) {
             [[maybe_unused]] curandStatus_t ret;
 
@@ -468,10 +468,10 @@ public:
       template <typename ST, typename Executor>
       __MATX_INLINE__ void PostRun([[maybe_unused]] ST &&shape, [[maybe_unused]] Executor &&ex) noexcept
       {
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           matxFree(states_);
         }
-        else if constexpr (is_single_thread_host_executor_v<Executor>) {
+        else if constexpr (is_host_executor_v<Executor>) {
           curandDestroyGenerator(gen_);
           //matxFree(val);
         }

--- a/include/matx/operators/all.h
+++ b/include/matx/operators/all.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/ambgfun.h
+++ b/include/matx/operators/ambgfun.h
@@ -105,7 +105,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          static_assert(is_device_executor_v<Executor>, "ambgfun() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "ambgfun() only supports the CUDA executor currently");
           static_assert(std::tuple_element_t<0, remove_cvref_t<Out>>::Rank() == 2, "Output tensor of ambgfun must be 2D");
           ambgfun_impl(std::get<0>(out), x_, y_, fs_, cut_, cut_val_, ex.getStream());
         }
@@ -121,7 +121,7 @@ namespace matx
             y_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }          
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/any.h
+++ b/include/matx/operators/any.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/cgsolve.h
+++ b/include/matx/operators/cgsolve.h
@@ -87,7 +87,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex)  const{
-          static_assert(is_device_executor_v<Executor>, "cgsolve() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "cgsolve() only supports the CUDA executor currently");
           cgsolve_impl(std::get<0>(out), a_, b_, tol_, max_iters_, ex.getStream());
         }
 
@@ -102,7 +102,7 @@ namespace matx
             b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }          
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/channelize_poly.h
+++ b/include/matx/operators/channelize_poly.h
@@ -78,7 +78,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "channelize_poly() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "channelize_poly() only supports the CUDA executor currently");
 
         channelize_poly_impl(std::get<0>(out), a_, f_, num_channels_, decimation_factor_, ex.getStream());
       }
@@ -99,7 +99,7 @@ namespace detail {
           f_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }          
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
 

--- a/include/matx/operators/chol.h
+++ b/include/matx/operators/chol.h
@@ -62,7 +62,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "chol() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "chol() only supports the CUDA executor currently");
 
         chol_impl(std::get<0>(out),  a_, ex.getStream(), uplo_);  
       }
@@ -79,7 +79,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, a_.Shape(), MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/conv.h
+++ b/include/matx/operators/conv.h
@@ -148,7 +148,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          static_assert(is_device_executor_v<Executor>, "conv1d() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "conv1d() only supports the CUDA executor currently");
           MATX_STATIC_ASSERT_STR((Rank() == std::tuple_element_t<0, remove_cvref_t<Out>>::Rank()), 
                 matxInvalidParameter, "conv1d: inputs and outputs must have same rank to use conv1d with axis parameter");
           if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
@@ -170,7 +170,7 @@ namespace matx
             b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 
@@ -319,7 +319,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "conv2d() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "conv2d() only supports the CUDA executor currently");
 
         if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
           conv2d_impl(permute(std::get<0>(out), perm_), a_, b_, mode_, ex.getStream());
@@ -340,7 +340,7 @@ namespace detail {
           b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }          
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
 

--- a/include/matx/operators/corr.h
+++ b/include/matx/operators/corr.h
@@ -134,7 +134,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          static_assert(is_device_executor_v<Executor>, "corr() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "corr() only supports the CUDA executor currently");
           MATX_STATIC_ASSERT_STR((Rank() == std::tuple_element_t<0, remove_cvref_t<Out>>::Rank()), 
                 matxInvalidParameter, "corr: inputs and outputs must have same rank to use corr with axis parameter");
           if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
@@ -156,7 +156,7 @@ namespace matx
             b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }          
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/cov.h
+++ b/include/matx/operators/cov.h
@@ -83,7 +83,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          static_assert(is_device_executor_v<Executor>, "cov() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "cov() only supports the CUDA executor currently");
           cov_impl(std::get<0>(out), a_, ex.getStream());
         }
 
@@ -94,7 +94,7 @@ namespace matx
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }     
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/cumsum.h
+++ b/include/matx/operators/cumsum.h
@@ -85,7 +85,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
 

--- a/include/matx/operators/dct.h
+++ b/include/matx/operators/dct.h
@@ -39,7 +39,7 @@
 #include "matx/core/error.h"
 #include "matx/core/tensor.h"
 #include "matx/core/type_utils.h"
-#include "matx/transforms/fft.h"
+#include "matx/transforms/fft/fft_cuda.h"
 
 namespace matx {
 

--- a/include/matx/operators/det.h
+++ b/include/matx/operators/det.h
@@ -61,7 +61,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const{
-        static_assert(is_device_executor_v<Executor>, "det() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "det() only supports the CUDA executor currently");
 
         det_impl(std::get<0>(out), a_, ex.getStream());
       }
@@ -78,7 +78,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, a_.Shape(), MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/eig.h
+++ b/include/matx/operators/eig.h
@@ -66,7 +66,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "eig () only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "eig () only supports the CUDA executor currently");
         static_assert(std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 2 outputs on eig(). ie: (mtie(O, w) = eig(A))");     
 
         eig_impl(std::get<0>(out), std::get<1>(out), a_, ex.getStream(), jobz_, uplo_);

--- a/include/matx/operators/einsum.h
+++ b/include/matx/operators/einsum.h
@@ -66,7 +66,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "einsum() only supports the CUDA executor currently");   
+        static_assert(is_cuda_executor_v<Executor>, "einsum() only supports the CUDA executor currently");   
 
         std::apply([&](auto... args) {
           ::matx::cutensor::einsum_impl(std::get<0>(out), subscripts_, ex.getStream(), args...);

--- a/include/matx/operators/filter.h
+++ b/include/matx/operators/filter.h
@@ -76,7 +76,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "filter() only supports the CUDA executor currently");   
+        static_assert(is_cuda_executor_v<Executor>, "filter() only supports the CUDA executor currently");   
 
         filter_impl(std::get<0>(out), a_, h_rec_, h_nonrec_, ex.getStream());
       }
@@ -93,7 +93,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
 

--- a/include/matx/operators/hist.h
+++ b/include/matx/operators/hist.h
@@ -72,7 +72,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "hist() only supports the CUDA executor currently"); 
+        static_assert(is_cuda_executor_v<Executor>, "hist() only supports the CUDA executor currently"); 
 
         hist_impl(std::get<0>(out), a_, lower_, upper_, ex.getStream());
       }
@@ -89,7 +89,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
 

--- a/include/matx/operators/inverse.h
+++ b/include/matx/operators/inverse.h
@@ -74,7 +74,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "inv() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "inv() only supports the CUDA executor currently");
         inv_impl(std::get<0>(out), a_, ex.getStream());
       }
 
@@ -85,7 +85,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, a_.Shape(), MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/lu.h
+++ b/include/matx/operators/lu.h
@@ -61,7 +61,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "lu() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "lu() only supports the CUDA executor currently");
         static_assert(std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 2 outputs on cusolver_qr(). ie: (mtie(O, piv) = lu(A))");     
 
         lu_impl(std::get<0>(out), std::get<1>(out), a_, ex.getStream());        

--- a/include/matx/operators/matmul.h
+++ b/include/matx/operators/matmul.h
@@ -106,7 +106,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          static_assert(is_device_executor_v<Executor>, "matmul() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "matmul() only supports the CUDA executor currently");
           if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
             matmul_impl(permute(std::get<0>(out), perm_), a_, b_, ex.getStream(), alpha_, beta_);
           }
@@ -126,7 +126,7 @@ namespace matx
             b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/matvec.h
+++ b/include/matx/operators/matvec.h
@@ -88,7 +88,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex)  const{
-          static_assert(is_device_executor_v<Executor>, "matvec() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "matvec() only supports the CUDA executor currently");
           matvec_impl(std::get<0>(out), a_, b_, ex.getStream(), alpha_, beta_);
         }
 
@@ -103,7 +103,7 @@ namespace matx
             b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }          
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/mean.h
+++ b/include/matx/operators/mean.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/median.h
+++ b/include/matx/operators/median.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/outer.h
+++ b/include/matx/operators/outer.h
@@ -97,7 +97,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex)  const{
-          static_assert(is_device_executor_v<Executor>, "outer() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "outer() only supports the CUDA executor currently");
           outer_impl(std::get<0>(out), a_, b_, ex.getStream(), alpha_, beta_);
         }
 
@@ -112,7 +112,7 @@ namespace matx
             b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }          
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/percentile.h
+++ b/include/matx/operators/percentile.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/prod.h
+++ b/include/matx/operators/prod.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/pwelch.h
+++ b/include/matx/operators/pwelch.h
@@ -90,7 +90,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex)  const{
-          static_assert(is_device_executor_v<Executor>, "pwelch() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "pwelch() only supports the CUDA executor currently");
           pwelch_impl(std::get<0>(out), x_, w_, nperseg_, noverlap_, nfft_, ex.getStream());
         }
 
@@ -105,7 +105,7 @@ namespace matx
             w_.PreRun(Shape(w_), std::forward<Executor>(ex));
           }
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/qr.h
+++ b/include/matx/operators/qr.h
@@ -61,7 +61,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "svd() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "svd() only supports the CUDA executor currently");
         static_assert(std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 3 outputs on qr(). ie: (mtie(Q, R) = qr(A))");
 
         qr_impl(std::get<0>(out), std::get<1>(out), a_, ex.getStream());
@@ -128,7 +128,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) {
-        static_assert(is_device_executor_v<Executor>, "cusolver_qr() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "cusolver_qr() only supports the CUDA executor currently");
         static_assert(std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 2 outputs on cusolver_qr(). ie: (mtie(A, tau) = eig(A))");     
 
         cusolver_qr_impl(std::get<0>(out), std::get<1>(out), a_, ex.getStream());

--- a/include/matx/operators/reduce.h
+++ b/include/matx/operators/reduce.h
@@ -86,7 +86,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          static_assert(is_device_executor_v<Executor>, "reduce() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "reduce() only supports the CUDA executor currently");
 
           if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
             reduce_impl(std::get<0>(out), a_, perm_, reduction_op_, ex.getStream(), init_);
@@ -103,7 +103,7 @@ namespace matx
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }           
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/resample_poly.h
+++ b/include/matx/operators/resample_poly.h
@@ -82,7 +82,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "resample_poly() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "resample_poly() only supports the CUDA executor currently");
 
         resample_poly_impl(std::get<0>(out), a_, f_, up_, down_, ex.getStream());
       }
@@ -103,7 +103,7 @@ namespace detail {
           f_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }          
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
 

--- a/include/matx/operators/rmax.h
+++ b/include/matx/operators/rmax.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/rmin.h
+++ b/include/matx/operators/rmin.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -83,6 +83,8 @@ namespace matx
 
             // compute dims and sizes
             if(end != matxDropDim) {
+              MATX_ASSERT_STR(end != matxKeepDim, matxInvalidParameter, "matxKeepDim only valid for clone(), not slice()");
+              
               dims_[d] = i;
 
               if(end == matxEnd) {

--- a/include/matx/operators/softmax.h
+++ b/include/matx/operators/softmax.h
@@ -83,7 +83,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          static_assert(is_device_executor_v<Executor>, "softmax() only supports the CUDA executor currently");
+          static_assert(is_cuda_executor_v<Executor>, "softmax() only supports the CUDA executor currently");
 
           if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
             softmax_impl(std::get<0>(out), a_, perm_, ex.getStream());
@@ -100,7 +100,7 @@ namespace matx
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }           
 
-          if constexpr (is_device_executor_v<Executor>) {
+          if constexpr (is_cuda_executor_v<Executor>) {
             make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
           }
 

--- a/include/matx/operators/sort.h
+++ b/include/matx/operators/sort.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/stdd.h
+++ b/include/matx/operators/stdd.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/sum.h
+++ b/include/matx/operators/sum.h
@@ -86,7 +86,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/svd.h
+++ b/include/matx/operators/svd.h
@@ -65,7 +65,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(is_device_executor_v<Executor>, "svd() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "svd() only supports the CUDA executor currently");
         static_assert(std::tuple_size_v<remove_cvref_t<Out>> == 4, "Must use mtie with 3 outputs on svd(). ie: (mtie(U, S, V) = svd(A))");
 
         svd_impl(std::get<0>(out), std::get<1>(out), std::get<2>(out), a_, ex.getStream(), jobu_, jobv_);
@@ -124,7 +124,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) {
-        static_assert(is_device_executor_v<Executor>, "svdpi() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "svdpi() only supports the CUDA executor currently");
         static_assert(std::tuple_size_v<remove_cvref_t<Out>> == 4, "Must use mtie with 3 outputs on svdpi(). ie: (mtie(U, S, V) = svdpi(A))");
 
         svdpi_impl(std::get<0>(out), std::get<1>(out), std::get<2>(out), a_, x_, iterations_, ex.getStream(), k_);
@@ -201,7 +201,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) {
-        static_assert(is_device_executor_v<Executor>, "svdbpi() only supports the CUDA executor currently");
+        static_assert(is_cuda_executor_v<Executor>, "svdbpi() only supports the CUDA executor currently");
         static_assert(std::tuple_size_v<remove_cvref_t<Out>> == 4, "Must use mtie with 3 outputs on svdbpi(). ie: (mtie(U, S, V) = svdbpi(A))");
 
         svdbpi_impl(std::get<0>(out), std::get<1>(out), std::get<2>(out), a_, max_iters_, tol_, ex.getStream());

--- a/include/matx/operators/trace.h
+++ b/include/matx/operators/trace.h
@@ -81,7 +81,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/transpose.h
+++ b/include/matx/operators/transpose.h
@@ -98,7 +98,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/operators/var.h
+++ b/include/matx/operators/var.h
@@ -87,7 +87,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_device_executor_v<Executor>) {
+        if constexpr (is_cuda_executor_v<Executor>) {
           make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
         }
         else {

--- a/include/matx/transforms/ambgfun.h
+++ b/include/matx/transforms/ambgfun.h
@@ -43,7 +43,7 @@
 #include "matx/core/type_utils.h"
 
 #include "matx/transforms/copy.h"
-#include "matx/transforms/fft.h"
+#include "matx/transforms/fft/fft_cuda.h"
 
 namespace matx {
 typedef enum {

--- a/include/matx/transforms/fft/fft_common.h
+++ b/include/matx/transforms/fft/fft_common.h
@@ -1,0 +1,211 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace matx {
+
+enum class FFTNorm {
+  BACKWARD, /// fft is unscaled, ifft is 1/N
+  FORWARD, /// fft is scaled 1/N, ifft is not scaled
+  ORTHO /// fft is scaled 1/sqrt(N), ifft is scaled 1/sqrt(N)
+};
+
+namespace detail {
+
+  static constexpr int MAX_FFT_RANK = 2;
+
+  enum class FFTType {
+    C2C,
+    R2C,
+    C2R,
+    Z2Z,
+    D2Z,
+    Z2D
+  };
+
+  enum class FFTDirection {
+    FORWARD,
+    BACKWARD
+  };
+    
+  template <typename OutputTensor, typename InputTensor, typename Executor>
+  __MATX_INLINE__ auto  GetFFTInputView([[maybe_unused]] OutputTensor &o,
+                      const InputTensor &i, uint64_t fft_size,
+                      [[maybe_unused]] const Executor &exec)
+  {
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+    
+    using index_type = typename OutputTensor::shape_type;
+    using T1    = typename OutputTensor::scalar_type;
+    using T2    = typename InputTensor::scalar_type;
+    constexpr int RANK = OutputTensor::Rank();
+
+    index_type starts[RANK] = {0};
+    index_type ends[RANK];
+    index_type in_size = i.Lsize();
+    index_type nom_fft_size = in_size;
+    index_type act_fft_size;
+
+    // Auto-detect FFT size
+    if (fft_size == 0) {
+      act_fft_size = o.Lsize();
+
+      // If R2C transform, set length of FFT appropriately
+      if constexpr ((std::is_same_v<T2, float> &&
+                    std::is_same_v<T1, cuda::std::complex<float>>) ||
+                    (std::is_same_v<T2, double> &&
+                    std::is_same_v<T1, cuda::std::complex<double>>) ||
+                    (std::is_same_v<T2, matxBf16> &&
+                    std::is_same_v<T1, matxBf16Complex>) ||
+                    (std::is_same_v<T2, matxFp16> &&
+                    std::is_same_v<T1, matxFp16Complex>)) { // R2C
+        nom_fft_size = in_size;
+        act_fft_size = (o.Lsize() - 1) * 2;
+      }
+      else if constexpr ((std::is_same_v<T1, float> &&
+                          std::is_same_v<T2, cuda::std::complex<float>>) ||
+                        (std::is_same_v<T1, double> &&
+                          std::is_same_v<T2, cuda::std::complex<double>>) ||
+                        (std::is_same_v<T1, matxBf16> &&
+                          std::is_same_v<T2, matxBf16Complex>) ||
+                        (std::is_same_v<T1, matxFp16> &&
+                          std::is_same_v<T2, matxFp16Complex>)) { // C2R
+        nom_fft_size = (in_size - 1) * 2;
+        act_fft_size = (o.Lsize() / 2) + 1;
+      }
+    }
+    else {
+      // Force FFT size
+      act_fft_size = static_cast<index_type>(fft_size);
+    }
+
+    // Set up new shape if transform size doesn't match tensor
+    if (nom_fft_size != act_fft_size) {
+      std::fill_n(ends, RANK, matxEnd);
+
+      // FFT shorter than the size of the input signal. Create a new view of this
+      // slice.
+      if (act_fft_size < nom_fft_size) {
+        ends[RANK - 1] = act_fft_size;
+        return i.Slice(starts, ends);
+      }
+      else { // FFT length is longer than the input. Pad input
+
+        // If the input needs to be padded we have to temporarily allocate a new
+        // buffer, zero the output, then copy our input buffer. This is not very
+        // efficient, but if cufft adds a zero-padding feature later we can take
+        // advantage of that without changing the API.
+
+        // Create a new shape where n is the size of the last dimension
+        auto shape = i.Shape();
+        *(shape.end() - 1) = act_fft_size;
+        auto tot = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<typename decltype(shape)::value_type>());
+
+        // Make a new buffer large enough for our input
+        if constexpr (is_cuda_executor_v<Executor>) {
+          const auto stream = exec.getStream();
+          auto i_new = make_tensor<T2>(shape, MATX_ASYNC_DEVICE_MEMORY, stream);
+          ends[RANK - 1] = i.Lsize();
+          auto i_pad_part_v = i_new.Slice(starts, ends);
+
+          (i_new = static_cast<promote_half_t<T2>>(0)).run(stream);
+          // example-begin copy-test-1
+          matx::copy(i_pad_part_v, i, stream);
+          // example-end copy-test-1
+          return i_new;
+        }
+        else {
+          auto i_new = make_tensor<T2>(shape, MATX_HOST_MALLOC_MEMORY);
+          ends[RANK - 1] = i.Lsize();
+          auto i_pad_part_v = i_new.Slice(starts, ends);
+
+          (i_new = static_cast<promote_half_t<T2>>(0)).run(exec);
+          matx::copy(i_pad_part_v, i, exec);
+          return i_new;        
+        }
+      }
+    }
+
+    return i;
+  }  
+
+  template <typename T1T, typename T2T>
+  constexpr __MATX_INLINE__ FFTType DeduceFFTTransformType()
+  {
+    using T1 = typename T1T::scalar_type;
+    using T2 = typename T2T::scalar_type;
+
+    // Deduce plan type from view types
+    if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+      if constexpr (std::is_same_v<T2, cuda::std::complex<float>>) {
+        return FFTType::C2C;
+      }
+      else if constexpr (std::is_same_v<T2, float>) {
+
+        return FFTType::R2C;
+      }
+    }
+    else if constexpr (std::is_same_v<T1, float> &&
+                       std::is_same_v<T2, cuda::std::complex<float>>) {
+      return FFTType::C2R;
+    }
+    else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+      if constexpr (std::is_same_v<T2, cuda::std::complex<double>>) {
+        return FFTType::Z2Z;
+      }
+      else if constexpr (std::is_same_v<T2, double>) {
+        return FFTType::D2Z;
+      }
+    }
+    else if constexpr (std::is_same_v<T1, double> &&
+                       std::is_same_v<T2, cuda::std::complex<double>>) {
+      return FFTType::Z2D;
+    }
+    else if constexpr (is_complex_half_v<T1>) {
+      if constexpr (is_complex_half_v<T2>) {
+        return FFTType::C2C;
+      }
+      else if constexpr (is_half_v<T2>) {
+        return FFTType::R2C;
+      }
+    }
+    else if constexpr (is_half_v<T1> && is_complex_half_v<T2>) {
+      return FFTType::C2R;
+    }
+    //else {
+      return FFTType::C2C;
+    //}    
+  }
+}
+
+};

--- a/include/matx/transforms/fft/fft_fftw.h
+++ b/include/matx/transforms/fft/fft_fftw.h
@@ -1,0 +1,556 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx/core/cache.h"
+#include "matx/core/error.h"
+#include "matx/core/make_tensor.h"
+#include "matx/core/nvtx.h"
+#include "matx/core/tensor.h"
+#include "matx/executors/host.h"
+#include "matx/transforms/fft/fft_common.h"
+#include "matx/transforms/copy.h"
+#include "matx/executors/support.h"
+#ifdef MATX_EN_NVPL
+#include <nvpl_fftw.h>
+#endif
+
+#include <cstdio>
+#include <functional>
+#include <optional>
+
+namespace matx {
+
+namespace detail {
+
+/**
+ * Parameters needed to execute an FFT/IFFT in cuFFT
+ */
+struct FftFFTWparams_t {
+  int irank, orank;
+  int n[MAX_FFT_RANK] = {0};
+  int batch;
+  int       batch_dims;
+  int inembed[MAX_FFT_RANK] = {0};
+  int onembed[MAX_FFT_RANK] = {0};
+  int istride, ostride;
+  int idist, odist;
+  FFTType transform_type; // Known from input/output type, but still useful
+  int fft_rank;
+};
+
+
+  template <typename OutTensorType, typename InTensorType>
+  static FftFFTWparams_t GetFFTParams(OutTensorType &o,
+                          const InTensorType &i, int fft_rank)
+  {
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+    FftFFTWparams_t params;
+    constexpr auto RANK = OutTensorType::Rank();   
+    using T1    = typename OutTensorType::scalar_type;
+    using T2    = typename InTensorType::scalar_type;    
+
+    params.irank = i.Rank();
+    params.orank = o.Rank();
+
+    params.transform_type = DeduceFFTTransformType<OutTensorType, InTensorType>();
+    params.fft_rank =  fft_rank;
+
+    if (fft_rank == 1) {
+      params.batch_dims = 0;
+      params.n[0] = (params.transform_type == FFTType::C2R ||
+                      params.transform_type == FFTType::Z2D)
+                        ? static_cast<int>(o.Size(RANK - 1))
+                        : static_cast<int>(i.Size(RANK - 1));
+
+      if (i.IsContiguous() && o.IsContiguous()) {
+        params.batch = 1;
+        for (int dim = i.Rank() - 2; dim >= 0; dim--) {
+          params.batch_dims++;
+          params.batch *= static_cast<int>(i.Size(dim));
+        }
+      }
+      else {
+        if (RANK == 1) {
+          params.batch = 1;
+          params.batch_dims = 0;
+        }
+        else {
+          params.batch = static_cast<int>(TotalSize(i) / i.Size(RANK - 1));
+          params.batch_dims = 1; 
+        }
+      }
+      
+      params.inembed[0] = static_cast<int>(i.Size(RANK - 1)); // Unused
+      params.onembed[0] = static_cast<int>(o.Size(RANK - 1)); // Unused
+      params.istride = static_cast<int>(i.Stride(RANK - 1));
+      params.ostride = static_cast<int>(o.Stride(RANK - 1));
+      params.idist = (RANK == 1) ? 1 : static_cast<int>(i.Stride(RANK - 2));  
+      params.odist = (RANK == 1) ? 1 : static_cast<int>(o.Stride(RANK - 2));
+    }
+    else if (fft_rank == 2) {
+      if (params.transform_type == FFTType::C2R ||
+          params.transform_type == FFTType::Z2D) {
+        params.n[1] = static_cast<int>(o.Size(RANK-1));
+        params.n[0] = static_cast<int>(o.Size(RANK-2));
+      }
+      else {
+        params.n[1] = static_cast<int>(i.Size(RANK-1));
+        params.n[0] = static_cast<int>(i.Size(RANK-2));
+      }
+
+      params.batch = (RANK == 2) ? 1 : static_cast<int>(TotalSize(i) / ((i.Size(RANK - 1) * i.Size(RANK - 2))));
+      params.inembed[1] = static_cast<int>(i.Size(RANK-1));
+      params.onembed[1] = static_cast<int>(o.Size(RANK-1));
+      params.istride = static_cast<int>(i.Stride(RANK-1));
+      params.ostride = static_cast<int>(o.Stride(RANK-1));
+      params.idist = (RANK<=2) ? 1 : (int) static_cast<int>(i.Stride(RANK-3));
+      params.odist = (RANK<=2) ? 1 : (int) static_cast<int>(o.Stride(RANK-3));
+    }
+
+    if (params.fft_rank == 1) {
+      if (params.transform_type == FFTType::C2R ||
+          params.transform_type == FFTType::Z2D) {
+        if (is_cuda_complex_v<T1> || !is_cuda_complex_v<T2>) {
+          MATX_THROW(matxInvalidType, "FFT types inconsistent with C2R/Z2D transform");
+        }
+        if (params.n[0] != o.Size(OutTensorType::Rank()-1) ||
+          (params.n[0]/2)+1 != i.Size(InTensorType::Rank()-1)) {
+          MATX_THROW(matxInvalidSize, "Tensor sizes inconsistent with C2R/Z2D transform");
+        }
+      }
+      else if (params.transform_type == FFTType::R2C ||
+              params.transform_type == FFTType::D2Z) {
+        if (is_cuda_complex_v<T2> || !is_cuda_complex_v<T1>) {
+          MATX_THROW(matxInvalidType, "FFT types inconsistent with R2C/D2Z transform");
+        }
+        if (params.n[0] != i.Size(InTensorType::Rank()-1) ||
+          (params.n[0]/2)+1 != o.Size(OutTensorType::Rank()-1)) {
+          MATX_THROW(matxInvalidSize, "Tensor sizes inconsistent with R2C/D2Z transform");
+        }
+      }
+      else {
+        if (!is_complex_v<T2> || !is_complex_v<T1> || !std::is_same_v<T1, T2>) {
+          MATX_THROW(matxInvalidType, "FFT types inconsistent with C2C transform");
+        }
+        if (params.n[0] != o.Size(OutTensorType::Rank()-1) ||
+            params.n[0] != i.Size(OutTensorType::Rank()-1)) {
+          MATX_THROW(matxInvalidSize, "Tensor sizes inconsistent with C2C transform");
+        }
+      }  
+    }
+    else {
+      if (params.transform_type == FFTType::C2R ||
+          params.transform_type == FFTType::Z2D) {
+        MATX_ASSERT((o.Size(RANK-2) * (o.Size(RANK-1) / 2 + 1)) == i.Size(RANK-1) * i.Size(RANK-2),
+                    matxInvalidSize);
+        MATX_ASSERT(!is_cuda_complex_v<T1> && is_cuda_complex_v<T2>,
+                    matxInvalidType);
+      }
+      else if (params.transform_type == FFTType::R2C ||
+              params.transform_type == FFTType::D2Z) {
+        MATX_ASSERT(o.Size(RANK-1) * o.Size(RANK-2) == (i.Size(RANK-2) * (i.Size(RANK-1) / 2 + 1)),
+                    matxInvalidSize);
+        MATX_ASSERT(!is_cuda_complex_v<T2> && is_cuda_complex_v<T1>,
+                    matxInvalidType);
+      }
+      else {
+        MATX_ASSERT((std::is_same_v<T1, T2>), matxInvalidType);
+        MATX_ASSERT(is_complex_v<T2> && is_complex_v<T1>, matxInvalidType);
+        MATX_ASSERT(o.Size(RANK-2) * o.Size(RANK-1) == i.Size(RANK-2) * i.Size(RANK-1),
+                    matxInvalidSize);
+      }
+
+      for (int r = 0; r < RANK - 2; r++) {
+        MATX_ASSERT(o.Size(r) == i.Size(r), matxInvalidSize);
+      }         
+    }
+
+    MATX_ASSERT_STR(params.idist > 0, matxInvalidDim, "FFTs do not support batch strides of 0 (no cloned views)");
+
+    return params;
+  }
+
+
+  template <typename TensorOp>
+  __MATX_INLINE__ auto getFFTW1DSupportedTensor( const TensorOp &in) {
+
+    constexpr int RANK=TensorOp::Rank();
+
+    if constexpr ( !(is_tensor_view_v<TensorOp>)) {
+      return make_tensor<typename TensorOp::scalar_type>(in.Shape(), MATX_HOST_MALLOC_MEMORY); 
+    } else {
+
+      bool supported = true;
+
+      // If there are any unsupported layouts for fftw add them here
+      if (supported) {
+        return in;
+      } else {
+        return make_tensor<typename TensorOp::scalar_type>(in.Shape(), MATX_HOST_MALLOC_MEMORY); 
+      }
+    }
+  }
+
+  template <typename TensorOp>
+  __MATX_INLINE__ auto getFFTW2DSupportedTensor( const TensorOp &in) {
+
+    constexpr int RANK=TensorOp::Rank();
+
+    if constexpr ( !is_tensor_view_v<TensorOp>) {
+      return make_tensor<typename TensorOp::scalar_type>(in.Shape(), MATX_HOST_MALLOC_MEMORY); 
+    } else {
+      bool supported = true;
+
+      // only a subset of strides are supported per fftw indexing scheme.
+      if ( in.Stride(RANK-2) != in.Stride(RANK-1) * in.Size(RANK-1)) {
+        supported = false;
+      } else if constexpr ( RANK > 2) {
+        if(in.Stride(RANK-3) != in.Size(RANK-2) * in.Stride(RANK-2)) {
+          supported = false;
+        }
+      }
+  
+      if (supported) {
+        return in;
+      } else {
+        return make_tensor<typename TensorOp::scalar_type>(in.Shape(), MATX_HOST_MALLOC_MEMORY); 
+      }
+    }
+  }
+
+  template <typename OutputTensor, typename InputTensor>
+  __MATX_INLINE__ void fft_exec([[maybe_unused]] OutputTensor &o, 
+                                [[maybe_unused]] const InputTensor &i, 
+                                [[maybe_unused]] const FftFFTWparams_t &params, 
+                                [[maybe_unused]] detail::FFTDirection dir) {
+    [[maybe_unused]] static constexpr bool fp32 = std::is_same_v<typename inner_op_type_t<typename OutputTensor::scalar_type>::type, float>;
+
+#if MATX_EN_CPU_FFT
+    auto fft_dir = (dir == detail::FFTDirection::FORWARD) ? FFTW_FORWARD : FFTW_BACKWARD;
+
+    auto exec_plans = [&](typename OutputTensor::value_type *out_ptr, 
+                          typename InputTensor::value_type *in_ptr) {
+      fftwf_plan plan{};
+      if constexpr (fp32) {
+        if constexpr (DeduceFFTTransformType<OutputTensor, InputTensor>() == FFTType::C2C) {
+          plan  = fftwf_plan_many_dft( params.fft_rank, 
+                                      params.n, 
+                                      params.batch, 
+                                      reinterpret_cast<fftwf_complex*>(in_ptr), 
+                                      params.inembed, 
+                                      params.istride, 
+                                      params.idist,
+                                      reinterpret_cast<fftwf_complex*>(out_ptr), 
+                                      params.onembed, 
+                                      params.ostride, 
+                                      params.odist,  
+                                      fft_dir, 
+                                      FFTW_ESTIMATE);
+        }
+        else if constexpr (DeduceFFTTransformType<OutputTensor, InputTensor>() == FFTType::C2R) {
+          plan  = fftwf_plan_many_dft_c2r( params.fft_rank, 
+                                      params.n, 
+                                      params.batch, 
+                                      reinterpret_cast<fftwf_complex*>(in_ptr), 
+                                      params.inembed, 
+                                      params.istride, 
+                                      params.idist,
+                                      out_ptr, 
+                                      params.onembed, 
+                                      params.ostride, 
+                                      params.odist,  
+                                      FFTW_ESTIMATE);
+        }
+        else if constexpr (DeduceFFTTransformType<OutputTensor, InputTensor>() == FFTType::R2C) {        
+          plan  = fftwf_plan_many_dft_r2c( params.fft_rank, 
+                                      params.n, 
+                                      params.batch, 
+                                      in_ptr, 
+                                      params.inembed, 
+                                      params.istride, 
+                                      params.idist,
+                                      reinterpret_cast<fftwf_complex*>(out_ptr), 
+                                      params.onembed, 
+                                      params.ostride, 
+                                      params.odist,  
+                                      FFTW_ESTIMATE);
+        }
+
+        fftwf_execute(plan);
+        fftwf_destroy_plan(plan);
+        fftwf_cleanup();         
+      }
+      else {
+        if constexpr (DeduceFFTTransformType<OutputTensor, InputTensor>() == FFTType::Z2Z) {
+          plan  = fftw_plan_many_dft( params.fft_rank, 
+                                      params.n, 
+                                      params.batch, 
+                                      reinterpret_cast<fftw_complex*>(in_ptr), 
+                                      params.inembed, 
+                                      params.istride, 
+                                      params.idist,
+                                      reinterpret_cast<fftw_complex*>(out_ptr), 
+                                      params.onembed, 
+                                      params.ostride, 
+                                      params.odist,  
+                                      fft_dir, 
+                                      FFTW_ESTIMATE);
+        }
+        else if constexpr (DeduceFFTTransformType<OutputTensor, InputTensor>() == FFTType::Z2D) {
+          plan  = fftw_plan_many_dft_c2r( params.fft_rank, 
+                                      params.n, 
+                                      params.batch, 
+                                      reinterpret_cast<fftw_complex*>(in_ptr), 
+                                      params.inembed, 
+                                      params.istride, 
+                                      params.idist,
+                                      out_ptr, 
+                                      params.onembed, 
+                                      params.ostride, 
+                                      params.odist,  
+                                      FFTW_ESTIMATE);
+        }
+        else if constexpr (DeduceFFTTransformType<OutputTensor, InputTensor>() == FFTType::D2Z) {
+          plan  = fftw_plan_many_dft_r2c( params.fft_rank, 
+                                      params.n, 
+                                      params.batch, 
+                                      in_ptr, 
+                                      params.inembed, 
+                                      params.istride, 
+                                      params.idist,
+                                      reinterpret_cast<fftw_complex*>(out_ptr), 
+                                      params.onembed, 
+                                      params.ostride, 
+                                      params.odist,  
+                                      FFTW_ESTIMATE);
+        } 
+        
+        fftw_execute(plan);
+        fftw_destroy_plan(plan);
+        fftw_cleanup();           
+      }
+    };
+
+    exec_plans(o.Data(), i.Data());
+#endif
+  }
+
+  template <typename OutputTensor, typename InputTensor>
+  __MATX_INLINE__ void fft1d_dispatch(OutputTensor o, const InputTensor i,
+          uint64_t fft_size, detail::FFTDirection dir, FFTNorm norm, const HostExecutor &exec)
+  {
+    MATX_STATIC_ASSERT_STR(OutputTensor::Rank() == InputTensor::Rank(), matxInvalidDim,
+      "Input and output tensor ranks must match");  
+
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    MATX_ASSERT_STR(exec.GetNumThreads() == 1, matxInvalidParameter, "Only single-threaded host FFT supported");
+    MATX_ASSERT_STR(TotalSize(i) < std::numeric_limits<int>::max(), matxInvalidSize, "Dimensions too large for host FFT currently");
+
+    // converts operators to tensors
+    auto out = getFFTW1DSupportedTensor(o);
+    auto in_t = getFFTW1DSupportedTensor(i); 
+    
+    if(!in_t.isSameView(i)) {
+      (in_t = i).run(exec);
+    }
+  
+    auto in = detail::GetFFTInputView(out, in_t, fft_size, exec);
+
+    // Get parameters required by these tensors
+    auto params = GetFFTParams(out, in, 1);
+
+    fft_exec(o, in, params, dir);
+
+    if(!out.isSameView(o)) {
+      (o = out).run(exec);
+    }
+
+    using s_type = typename detail::value_promote_t<typename inner_op_type_t<typename InputTensor::scalar_type>::type>;
+    s_type factor;
+    constexpr s_type s_one = static_cast<s_type>(1.0);
+
+    if (dir == detail::FFTDirection::FORWARD) {
+      factor = static_cast<s_type>(params.n[0]);
+
+      if (norm == FFTNorm::ORTHO) {
+        (o *= s_one / std::sqrt(factor)).run(exec);
+      } else if (norm == FFTNorm::FORWARD) {
+        (o *= s_one / factor).run(exec);
+      }
+    }
+    else {
+      factor = static_cast<s_type>(params.n[0]);
+
+      if (norm == FFTNorm::ORTHO) {
+        (o *= s_one / std::sqrt(factor)).run(exec);
+      } else if (norm == FFTNorm::BACKWARD) {
+        (o *= s_one / factor).run(exec);
+      }    
+    }  
+  }
+
+
+  template <typename OutputTensor, typename InputTensor>
+  __MATX_INLINE__ void fft2d_dispatch(OutputTensor o, const InputTensor i,
+          detail::FFTDirection dir, FFTNorm norm, const HostExecutor &exec)
+  {
+    MATX_STATIC_ASSERT_STR(OutputTensor::Rank() == InputTensor::Rank(), matxInvalidDim,
+      "Input and output tensor ranks must match");  
+    MATX_ASSERT_STR(TotalSize(i) < std::numeric_limits<int>::max(), matxInvalidSize, "Dimensions too large for host FFT currently");
+
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    MATX_ASSERT_STR(exec.GetNumThreads() == 1, matxInvalidParameter, "Only single-threaded host FFT supported");
+
+    // converts operators to tensors
+    auto out = getFFTW2DSupportedTensor(o);
+    auto in = getFFTW2DSupportedTensor(i); 
+    
+    if(!in.isSameView(i)) {
+      (in = i).run(exec);
+    }
+
+    // Get parameters required by these tensors
+    auto params = GetFFTParams(out, in, 2);
+
+    fft_exec(o, in, params, dir);
+
+    if(!out.isSameView(o)) {
+      (o = out).run(exec);
+    }
+
+    using s_type = typename detail::value_promote_t<typename inner_op_type_t<typename InputTensor::scalar_type>::type>;
+    s_type factor;
+    constexpr s_type s_one = static_cast<s_type>(1.0);
+
+    if (dir == detail::FFTDirection::FORWARD) {
+      factor = static_cast<s_type>(params.n[0] * params.n[1]);
+
+      if (norm == FFTNorm::ORTHO) {
+        (o *= s_one / std::sqrt(factor)).run(exec);
+      } else if (norm == FFTNorm::FORWARD) {
+        (o *= s_one / factor).run(exec);
+      }
+    }
+    else {
+      factor = static_cast<s_type>(params.n[0] * params.n[1]);
+
+      if (norm == FFTNorm::ORTHO) {
+        (o *= s_one / std::sqrt(factor)).run(exec);
+      } else if (norm == FFTNorm::BACKWARD) {
+        (o *= s_one / factor).run(exec);
+      }    
+    }  
+  }  
+
+
+  template <typename OutputTensor, typename InputTensor>
+  __MATX_INLINE__ void fft_impl(OutputTensor o, const InputTensor i,
+          uint64_t fft_size, FFTNorm norm, const HostExecutor &exec)
+  {
+    MATX_STATIC_ASSERT_STR(OutputTensor::Rank() == InputTensor::Rank(), matxInvalidDim,
+      "Input and output tensor ranks must match");  
+    MATX_STATIC_ASSERT_STR( (std::is_same_v<typename inner_op_type_t<typename OutputTensor::scalar_type>::type, float> ||
+                            std::is_same_v<typename inner_op_type_t<typename  InputTensor::scalar_type>::type, double>), matxInvalidType,
+                            "Host FFTs only support single or double precision floats");    
+    
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    MATX_ASSERT_STR(MATX_EN_CPU_FFT, matxInvalidExecutor, "Trying to run a host FFT executor but host FFT support is not configured");
+
+    fft1d_dispatch(o, i, fft_size, FFTDirection::FORWARD, norm, exec);
+  }
+
+
+  template <typename OutputTensor, typename InputTensor>
+  __MATX_INLINE__ void ifft_impl(OutputTensor o, const InputTensor i,
+          uint64_t fft_size, FFTNorm norm, const HostExecutor &exec)
+  {
+    MATX_STATIC_ASSERT_STR(OutputTensor::Rank() == InputTensor::Rank(), matxInvalidDim,
+      "Input and output tensor ranks must match");  
+    MATX_STATIC_ASSERT_STR( (std::is_same_v<typename inner_op_type_t<typename OutputTensor::scalar_type>::type, float> ||
+                            std::is_same_v<typename inner_op_type_t<typename  InputTensor::scalar_type>::type, double>), matxInvalidType,
+                            "Host FFTs only support single or double precision floats");      
+    
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    MATX_ASSERT_STR(MATX_EN_CPU_FFT, matxInvalidExecutor, "Trying to run a host FFT executor but host FFT support is not configured");
+
+    fft1d_dispatch(o, i, fft_size, FFTDirection::BACKWARD, norm, exec);
+  }
+
+
+
+  template <typename OutputTensor, typename InputTensor>
+  __MATX_INLINE__ void fft2_impl(OutputTensor o, const InputTensor i, FFTNorm norm, 
+            const HostExecutor &exec)
+  {
+    MATX_STATIC_ASSERT_STR(OutputTensor::Rank() == InputTensor::Rank(), matxInvalidDim,
+      "Input and output tensor ranks must match");
+    MATX_STATIC_ASSERT_STR(InputTensor::Rank() >= 2, matxInvalidSize, "2D FFT must be rank 2 tensor or higher");      
+    MATX_STATIC_ASSERT_STR( (std::is_same_v<typename inner_op_type_t<typename OutputTensor::scalar_type>::type, float> ||
+                            std::is_same_v<typename inner_op_type_t<typename  InputTensor::scalar_type>::type, double>), matxInvalidType,
+                            "Host FFTs only support single or double precision floats");     
+    
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    MATX_ASSERT_STR(MATX_EN_CPU_FFT, matxInvalidExecutor, "Trying to run a host FFT executor but host FFT support is not configured");
+
+    fft2d_dispatch(o, i, FFTDirection::FORWARD, norm, exec);
+  }
+
+  template <typename OutputTensor, typename InputTensor>
+  __MATX_INLINE__ void ifft2_impl(OutputTensor o, const InputTensor i, FFTNorm norm, 
+            const HostExecutor &exec)
+  {
+    MATX_STATIC_ASSERT_STR(OutputTensor::Rank() == InputTensor::Rank(), matxInvalidDim,
+      "Input and output tensor ranks must match");  
+    MATX_STATIC_ASSERT_STR(InputTensor::Rank() >= 2, matxInvalidSize, "2D FFT must be rank 2 tensor or higher");      
+    MATX_STATIC_ASSERT_STR( (std::is_same_v<typename inner_op_type_t<typename OutputTensor::scalar_type>::type, float> ||
+                            std::is_same_v<typename inner_op_type_t<typename  InputTensor::scalar_type>::type, double>), matxInvalidType,
+                            "Host FFTs only support single or double precision floats");      
+    
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    MATX_ASSERT_STR(MATX_EN_CPU_FFT, matxInvalidExecutor, "Trying to run a host FFT executor but host FFT support is not configured");
+
+    fft2d_dispatch(o, i, FFTDirection::BACKWARD, norm, exec);  
+  }
+    
+} // end namespace detail
+
+
+
+}; // end namespace matx

--- a/include/matx/transforms/percentile.h
+++ b/include/matx/transforms/percentile.h
@@ -103,7 +103,7 @@ void __MATX_INLINE__ percentile_impl(OutType dest, const InType &in, uint32_t q,
   if constexpr (OutType::Rank() == 0) {
     auto insize = TotalSize(in);
     matx::tensor_t<typename InType::scalar_type, 1> sort_out;
-    if constexpr (is_device_executor_v<Executor>) {
+    if constexpr (is_cuda_executor_v<Executor>) {
       make_tensor(sort_out, {insize}, MATX_ASYNC_DEVICE_MEMORY, exec.getStream());
     }
     else {

--- a/include/matx/transforms/reduce.h
+++ b/include/matx/transforms/reduce.h
@@ -2545,7 +2545,7 @@ void __MATX_INLINE__ var_impl(OutType dest, const InType &in, Executor &&exec, i
   matxMemorySpace_t space;
   using inner_type = typename inner_op_type_t<typename InType::scalar_type>::type;
 
-  if constexpr (is_device_executor_v<Executor>) {
+  if constexpr (is_cuda_executor_v<Executor>) {
     space = MATX_ASYNC_DEVICE_MEMORY;
   }
   else {

--- a/test/00_operators/GeneratorTests.cu
+++ b/test/00_operators/GeneratorTests.cu
@@ -73,58 +73,62 @@ template <typename TensorType>
 class BasicGeneratorTestsAll : public ::testing::Test {
 };
 
-TYPED_TEST_SUITE(BasicGeneratorTestsAll, MatXAllTypes);
-TYPED_TEST_SUITE(BasicGeneratorTestsComplex, MatXComplexTypes);
-TYPED_TEST_SUITE(BasicGeneratorTestsFloat, MatXFloatTypes);
-TYPED_TEST_SUITE(BasicGeneratorTestsNumeric, MatXNumericTypes);
-TYPED_TEST_SUITE(BasicGeneratorTestsIntegral, MatXAllIntegralTypes);
+TYPED_TEST_SUITE(BasicGeneratorTestsAll, MatXAllTypesCUDAExec);
+TYPED_TEST_SUITE(BasicGeneratorTestsComplex, MatXComplexTypesCUDAExec);
+TYPED_TEST_SUITE(BasicGeneratorTestsFloat, MatXFloatTypesCUDAExec);
+TYPED_TEST_SUITE(BasicGeneratorTestsNumeric, MatXNumericTypesCUDAExec);
+TYPED_TEST_SUITE(BasicGeneratorTestsIntegral, MatXAllIntegralTypesCUDAExec);
 TYPED_TEST_SUITE(BasicGeneratorTestsNumericNonComplex,
-                 MatXNumericNonComplexTypes);
-TYPED_TEST_SUITE(BasicGeneratorTestsFloatNonComplex, MatXFloatNonComplexTypes);
+                 MatXNumericNonComplexTypesCUDAExec);
+TYPED_TEST_SUITE(BasicGeneratorTestsFloatNonComplex, MatXFloatNonComplexTypesCUDAExec);
 TYPED_TEST_SUITE(BasicGeneratorTestsFloatNonComplexNonHalf,
-                 MatXFloatNonComplexNonHalfTypes);
-TYPED_TEST_SUITE(BasicGeneratorTestsBoolean, MatXBoolTypes);
-TYPED_TEST_SUITE(BasicGeneratorTestsFloatHalf, MatXFloatHalfTypes);
-TYPED_TEST_SUITE(BasicGeneratorTestsNumericNoHalf, MatXNumericNoHalfTypes);
+                 MatXFloatNonComplexNonHalfTypesCUDAExec);
+TYPED_TEST_SUITE(BasicGeneratorTestsBoolean, MatXBoolTypesCUDAExec);
+TYPED_TEST_SUITE(BasicGeneratorTestsFloatHalf, MatXFloatHalfTypesCUDAExec);
+TYPED_TEST_SUITE(BasicGeneratorTestsNumericNoHalf, MatXNumericNonHalfTypesCUDAExec);
 
 TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Windows)
 {
   MATX_ENTER_HANDLER();
 
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};
+
   auto pb = std::make_unique<detail::MatXPybind>();
   const index_t win_size = 100;
-  pb->InitAndRunTVGenerator<TypeParam>("00_operators", "window", "run",
+  pb->InitAndRunTVGenerator<TestType>("00_operators", "window", "run",
                                        {win_size});
   std::array<index_t, 1> shape({win_size});
-  auto ov = make_tensor<TypeParam>(shape);
+  auto ov = make_tensor<TestType>(shape);
 
   // example-begin hanning-gen-test-1
   // Assign a Hanning window of size `win_size` to `ov`
-  (ov = hanning<0>({win_size})).run();
+  (ov = hanning<0>({win_size})).run(exec);
   // example-end hanning-gen-test-1
   MATX_TEST_ASSERT_COMPARE(pb, ov, "hanning", 0.01);
 
   // example-begin hamming-gen-test-1
   // Assign a Hamming window of size `win_size` to `ov`
-  (ov = hamming<0>({win_size})).run();
+  (ov = hamming<0>({win_size})).run(exec);
   // example-end hamming-gen-test-1
   MATX_TEST_ASSERT_COMPARE(pb, ov, "hamming", 0.01);
 
   // example-begin bartlett-gen-test-1
   // Assign a bartlett window of size `win_size` to `ov`
-  (ov = bartlett<0>({win_size})).run();
+  (ov = bartlett<0>({win_size})).run(exec);
   // example-end bartlett-gen-test-1
   MATX_TEST_ASSERT_COMPARE(pb, ov, "bartlett", 0.01);
 
   // example-begin blackman-gen-test-1
   // Assign a blackman window of size `win_size` to `ov`
-  (ov = blackman<0>({win_size})).run();
+  (ov = blackman<0>({win_size})).run(exec);
   // example-end blackman-gen-test-1
   MATX_TEST_ASSERT_COMPARE(pb, ov, "blackman", 0.01);
 
   // example-begin flattop-gen-test-1
   // Assign a flattop window of size `win_size` to `ov`
-  (ov = flattop<0>({win_size})).run();
+  (ov = flattop<0>({win_size})).run(exec);
   // example-end flattop-gen-test-1
   MATX_TEST_ASSERT_COMPARE(pb, ov, "flattop", 0.01);
 
@@ -134,24 +138,28 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Windows)
 
 TYPED_TEST(BasicGeneratorTestsAll, Diag)
 {
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};
+
   MATX_ENTER_HANDLER();
   {
     // example-begin diag-op-test-1
     // The generator form of `diag()` takes an operator input and returns only
     // the diagonal elements as output
-    auto tc = make_tensor<TypeParam>({10, 10});
-    auto td = make_tensor<TypeParam>({10});
+    auto tc = make_tensor<TestType>({10, 10});
+    auto td = make_tensor<TestType>({10});
 
     // Initialize the diagonal elements of `tc`
     for (int i = 0; i < 10; i++) {
       for (int j = 0; j < 10; j++) {
-        TypeParam val(static_cast<detail::value_promote_t<TypeParam>>(i * 10 + j));
+        TestType val(static_cast<detail::value_promote_t<TestType>>(i * 10 + j));
         tc(i, j) = val;
       }
     }
 
     // Assign the diagonal elements of `tc` to `td`.
-    (td = diag(tc)).run();
+    (td = diag(tc)).run(exec);
     // example-end diag-op-test-1
     cudaStreamSynchronize(0);
 
@@ -165,14 +173,14 @@ TYPED_TEST(BasicGeneratorTestsAll, Diag)
 
     // Test with a nested transform. Restrict to floating point types for
     // the convolution
-    if constexpr (std::is_same_v<TypeParam,float> || std::is_same_v<TypeParam,double>)
+    if constexpr (std::is_same_v<TestType,float> || std::is_same_v<TestType,double>)
     {
-      auto delta = make_tensor<TypeParam>({1});
-      delta(0) = static_cast<TypeParam>(1.0);
+      auto delta = make_tensor<TestType>({1});
+      delta(0) = static_cast<TestType>(1.0);
       cudaStreamSynchronize(0);
 
-      (td = 0).run();
-      (td = diag(conv1d(tc, delta, MATX_C_MODE_SAME))).run();
+      (td = 0).run(exec);
+      (td = diag(conv1d(tc, delta, MATX_C_MODE_SAME))).run(exec);
       cudaStreamSynchronize(0);
 
       for (int i = 0; i < 10; i++) {
@@ -190,18 +198,21 @@ TYPED_TEST(BasicGeneratorTestsAll, Diag)
 TYPED_TEST(BasicGeneratorTestsFloat, Alternate)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};  
 
   // example-begin alternate-gen-test-1
-  auto td = make_tensor<TypeParam>({10});
+  auto td = make_tensor<TestType>({10});
 
   // td contains the sequence 1, -1, 1, -1, 1, -1, 1, -1, 1, -1
-  (td = alternate(10)).run();
+  (td = alternate(10)).run(exec);
   // example-end alternate-gen-test-1
 
   cudaStreamSynchronize(0);
 
   for (int i = 0; i < 10; i++) {
-    MATX_ASSERT_EQ(td(i), (TypeParam)-2* (TypeParam)(i&1) + (TypeParam)1)
+    MATX_ASSERT_EQ(td(i), (TestType)-2* (TestType)(i&1) + (TestType)1)
   }
 
   MATX_EXIT_HANDLER();
@@ -210,6 +221,8 @@ TYPED_TEST(BasicGeneratorTestsFloat, Alternate)
 TEST(OperatorTests, Kron)
 {
   MATX_ENTER_HANDLER();
+
+  cudaExecutor exec{};    
   using dtype = int;
   auto pb = std::make_unique<detail::MatXPybind>();
   pb->InitTVGenerator<dtype>("00_operators", "kron_operator", {});
@@ -220,7 +233,7 @@ TEST(OperatorTests, Kron)
   auto ov = make_tensor<dtype>({8, 8});
   bv.SetVals({{1, -1}, {-1, 1}});
 
-  (ov = kron(eye({4, 4}), bv)).run();
+  (ov = kron(eye({4, 4}), bv)).run(exec);
   // example-end kron-gen-test-1
   cudaStreamSynchronize(0);
   MATX_TEST_ASSERT_COMPARE(pb, ov, "square", 0);
@@ -229,7 +242,7 @@ TEST(OperatorTests, Kron)
   tensor_t<dtype, 2> ov2({4, 6});
   av.SetVals({{1, 2, 3}, {4, 5, 6}});
 
-  (ov2 = kron(av, ones({2, 2}))).run();
+  (ov2 = kron(av, ones({2, 2}))).run(exec);
   cudaStreamSynchronize(0);
   MATX_TEST_ASSERT_COMPARE(pb, ov2, "rect", 0);
 
@@ -239,6 +252,8 @@ TEST(OperatorTests, Kron)
 TEST(OperatorTests, MeshGrid)
 {
   MATX_ENTER_HANDLER();
+  
+  cudaExecutor exec{};  
   using dtype = int;
   auto pb = std::make_unique<detail::MatXPybind>();
   constexpr dtype xd = 3;
@@ -255,8 +270,8 @@ TEST(OperatorTests, MeshGrid)
   // Create a mesh grid with "x" as x extents and "y" as y extents and assign it to "xv"/"yv"
   auto [xx, yy] = meshgrid(x, y);
 
-  (xv = xx).run();
-  (yv = yy).run();
+  (xv = xx).run(exec);
+  (yv = yy).run(exec);
   // example-end meshgrid-gen-test-1
 
   cudaStreamSynchronize(0);
@@ -269,28 +284,32 @@ TEST(OperatorTests, MeshGrid)
 TYPED_TEST(BasicGeneratorTestsFloatNonComplex, FFTFreq)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};
+
   auto pb = std::make_unique<detail::MatXPybind>();
-  pb->template InitAndRunTVGenerator<TypeParam>(
+  pb->template InitAndRunTVGenerator<TestType>(
       "01_signal", "fftfreq", "run", {100});
 
 
-  auto t1 = make_tensor<TypeParam>({100});
-  auto t2 = make_tensor<TypeParam>({101});
+  auto t1 = make_tensor<TestType>({100});
+  auto t2 = make_tensor<TestType>({101});
 
   // example-begin fftfreq-gen-test-1
   // Generate FFT frequencies using the length of the "t1" tensor and assign to t1
-  (t1 = fftfreq(t1.Size(0))).run();
+  (t1 = fftfreq(t1.Size(0))).run(exec);
   // example-end fftfreq-gen-test-1
   cudaStreamSynchronize(0);
   MATX_TEST_ASSERT_COMPARE(pb, t1, "F1", 0.1);
 
-  (t2 = fftfreq(t2.Size(0))).run();
+  (t2 = fftfreq(t2.Size(0))).run(exec);
   cudaStreamSynchronize(0);
   MATX_TEST_ASSERT_COMPARE(pb, t2, "F2", 0.1);
 
   // example-begin fftfreq-gen-test-2
   // Generate FFT frequencies using the length of the "t1" tensor and a sample spacing of 0.5 and assign to t1
-  (t1 = fftfreq(t1.Size(0), 0.5)).run();
+  (t1 = fftfreq(t1.Size(0), 0.5)).run(exec);
   // example-end fftfreq-gen-test-2
   cudaStreamSynchronize(0);
   MATX_TEST_ASSERT_COMPARE(pb, t1, "F3", 0.1);  
@@ -302,23 +321,26 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, FFTFreq)
 TYPED_TEST(BasicGeneratorTestsAll, Zeros)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};    
   // example-begin zeros-gen-test-1    
   index_t count = 100;
 
   std::array<index_t, 1> s({count});
-  auto t1 = make_tensor<TypeParam>(s);
+  auto t1 = make_tensor<TestType>(s);
 
-  (t1 = zeros(s)).run();
+  (t1 = zeros(s)).run(exec);
   // example-end zeros-gen-test-1
 
   cudaStreamSynchronize(0);
 
   for (index_t i = 0; i < count; i++) {
-    if constexpr (IsHalfType<TypeParam>()) {
+    if constexpr (IsHalfType<TestType>()) {
       EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (float)0));
     }
     else {
-      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (TypeParam)0));
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (TestType)0));
     }
   }
   MATX_EXIT_HANDLER();
@@ -327,21 +349,24 @@ TYPED_TEST(BasicGeneratorTestsAll, Zeros)
 TYPED_TEST(BasicGeneratorTestsAll, Ones)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};    
   // example-begin ones-gen-test-1    
   index_t count = 100;
   std::array<index_t, 1> s({count});
-  auto t1 = make_tensor<TypeParam>(s);
+  auto t1 = make_tensor<TestType>(s);
 
-  (t1 = ones(s)).run();
+  (t1 = ones(s)).run(exec);
   // example-end ones-gen-test-1    
   cudaStreamSynchronize(0);
 
   for (index_t i = 0; i < count; i++) {
-    if constexpr (IsHalfType<TypeParam>()) {
+    if constexpr (IsHalfType<TestType>()) {
       EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (float)1));
     }
     else {
-      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (TypeParam)1));
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (TestType)1));
     }
   }
   MATX_EXIT_HANDLER();
@@ -350,51 +375,55 @@ TYPED_TEST(BasicGeneratorTestsAll, Ones)
 TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Range)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};   
+
   // example-begin range-gen-test-1
   index_t count = 100;
-  tensor_t<TypeParam, 1> t1{{count}};
+  tensor_t<TestType, 1> t1{{count}};
 
   // Generate a sequence of 100 numbers starting at 1 and spaced by 1
-  (t1 = range<0>(t1.Shape(), 1, 1)).run();
+  (t1 = range<0>(t1.Shape(), 1, 1)).run(exec);
   // example-end range-gen-test-1  
   cudaStreamSynchronize(0);
 
-  TypeParam one = 1;
-  TypeParam two = 1;
-  TypeParam three = 1;
+  TestType one = 1;
+  TestType two = 1;
+  TestType three = 1;
 
   for (index_t i = 0; i < count; i++) {
-    TypeParam it = static_cast<detail::value_promote_t<TypeParam>>(i);
+    TestType it = static_cast<detail::value_promote_t<TestType>>(i);
     EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), it + one));
   }
 
   {
-    (t1 = t1 * t1).run();
+    (t1 = t1 * t1).run(exec);
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count; i++) {
-      TypeParam it = static_cast<detail::value_promote_t<TypeParam>>(i);
+      TestType it = static_cast<detail::value_promote_t<TestType>>(i);
       EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), (it + one) * (it + one)));
     }
   }
 
   {
-    (t1 = t1 * two).run();
+    (t1 = t1 * two).run(exec);
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count; i++) {
-      TypeParam it = static_cast<detail::value_promote_t<TypeParam>>(i);
+      TestType it = static_cast<detail::value_promote_t<TestType>>(i);
       EXPECT_TRUE(
           MatXUtils::MatXTypeCompare(t1(i), ((it + one) * (it + one)) * two));
     }
   }
 
   {
-    (t1 = three * t1).run();
+    (t1 = three * t1).run(exec);
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count; i++) {
-      TypeParam it = static_cast<detail::value_promote_t<TypeParam>>(i);
+      TestType it = static_cast<detail::value_promote_t<TestType>>(i);
       EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), ((it + one) * (it + one)) *
                                                         two * three));
     }
@@ -406,13 +435,17 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Range)
 TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};   
+
   // example-begin linspace-gen-test-1
   index_t count = 100;
-  auto t1 = make_tensor<TypeParam>({count});
+  auto t1 = make_tensor<TestType>({count});
 
   // Create a set of linearly-spaced numbers starting at 1, ending at 100, and 
   // with `count` points in between
-  (t1 = linspace<0>(t1.Shape(), (TypeParam)1, (TypeParam)100)).run();
+  (t1 = linspace<0>(t1.Shape(), (TestType)1, (TestType)100)).run(exec);
   // example-end linspace-gen-test-1
   cudaStreamSynchronize(0);
 
@@ -421,7 +454,7 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
   }
 
   {
-    (t1 = t1 + t1).run();
+    (t1 = t1 + t1).run(exec);
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count; i++) {
@@ -430,7 +463,7 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
   }
 
   {
-    (t1 = (TypeParam)1 + t1).run();
+    (t1 = (TestType)1 + t1).run(exec);
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count; i++) {
@@ -440,7 +473,7 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
   }
 
   {
-    (t1 = t1 + (TypeParam)2).run();
+    (t1 = t1 + (TestType)2).run(exec);
     cudaStreamSynchronize(0);
 
     for (index_t i = 0; i < count; i++) {
@@ -454,15 +487,19 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
 TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Logspace)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};   
+
   // example-begin logspace-gen-test-1
   index_t count = 20;
-  tensor_t<TypeParam, 1> t1{{count}};
-  TypeParam start = 1.0f;
-  TypeParam stop = 2.0f;
+  tensor_t<TestType, 1> t1{{count}};
+  TestType start = 1.0f;
+  TestType stop = 2.0f;
   auto s = t1.Shape();
 
   // Create a logarithmically-spaced sequence of numbers and assign to tensor "t1"
-  (t1 = logspace<0>(s, start, stop)).run();
+  (t1 = logspace<0>(s, start, stop)).run(exec);
   // example-end logspace-gen-test-1
 
   cudaStreamSynchronize(0);
@@ -473,7 +510,7 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Logspace)
                 static_cast<double>(s[s.size() - 1] - 1);
 
   for (index_t i = 0; i < count; i++) {
-    if constexpr (IsHalfType<TypeParam>()) {
+    if constexpr (IsHalfType<TestType>()) {
       EXPECT_TRUE(MatXUtils::MatXTypeCompare(
           t1(i),
           cuda::std::powf(10, static_cast<double>(start) +
@@ -498,25 +535,29 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Logspace)
 TYPED_TEST(BasicGeneratorTestsNumeric, Eye)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};   
+
   // example-begin eye-gen-test-1
   index_t count = 10;
 
-  auto t2 = make_tensor<TypeParam>({count, count});
-  auto t3 = make_tensor<TypeParam>({count, count, count});
-  auto t4 = make_tensor<TypeParam>({count, count, count, count});
+  auto t2 = make_tensor<TestType>({count, count});
+  auto t3 = make_tensor<TestType>({count, count, count});
+  auto t4 = make_tensor<TestType>({count, count, count, count});
 
-  auto eye_op = eye<TypeParam>();
+  auto eye_op = eye<TestType>();
 
 
   // For each of t2, t3, and t4 the values on the diagonal where each index is the same
   // is 1, and 0 everywhere else
-  (t2 = eye_op).run();
-  (t3 = eye_op).run();
-  (t4 = eye_op).run();
+  (t2 = eye_op).run(exec);
+  (t3 = eye_op).run(exec);
+  (t4 = eye_op).run(exec);
   // example-end eye-gen-test-1
 
-  TypeParam one = 1.0f;
-  TypeParam zero = 0.0f;
+  TestType one = 1.0f;
+  TestType zero = 0.0f;
 
   cudaDeviceSynchronize();
 
@@ -558,25 +599,28 @@ TYPED_TEST(BasicGeneratorTestsNumeric, Eye)
 TYPED_TEST(BasicGeneratorTestsNumeric, Diag)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};     
   index_t count = 10;
-  TypeParam c = GenerateData<TypeParam>();
+  TestType c = GenerateData<TestType>();
 
   // example-begin diag-gen-test-1
   // Create a 2D, 3D, and 4D tensor and make only their diagonal elements set to `c`
-  auto t2 = make_tensor<TypeParam>({count, count});
-  auto t3 = make_tensor<TypeParam>({count, count, count});
-  auto t4 = make_tensor<TypeParam>({count, count, count, count});
+  auto t2 = make_tensor<TestType>({count, count});
+  auto t3 = make_tensor<TestType>({count, count, count});
+  auto t4 = make_tensor<TestType>({count, count, count, count});
 
-  auto diag2 = diag<TypeParam>({count, count}, c);
-  auto diag3 = diag<TypeParam>({count, count, count}, c);
-  auto diag4 = diag<TypeParam>({count, count, count, count}, c);
+  auto diag2 = diag<TestType>({count, count}, c);
+  auto diag3 = diag<TestType>({count, count, count}, c);
+  auto diag4 = diag<TestType>({count, count, count, count}, c);
 
-  (t2 = diag2).run();
-  (t3 = diag3).run();
-  (t4 = diag4).run();
+  (t2 = diag2).run(exec);
+  (t3 = diag3).run(exec);
+  (t4 = diag4).run(exec);
   // example-end diag-gen-test-1
 
-  TypeParam zero = 0.0f;
+  TestType zero = 0.0f;
 
   cudaDeviceSynchronize();
 
@@ -618,27 +662,31 @@ TYPED_TEST(BasicGeneratorTestsNumeric, Diag)
 TYPED_TEST(BasicGeneratorTestsFloatNonComplexNonHalf, Chirp)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};   
+    
   index_t count = 1500;
-  TypeParam end = 10;
-  TypeParam f0 = -200;
-  TypeParam f1 = 300;
+  TestType end = 10;
+  TestType f0 = -200;
+  TestType f1 = 300;
   
   auto pb = std::make_unique<detail::MatXPybind>();
-  pb->template InitAndRunTVGenerator<TypeParam>(
+  pb->template InitAndRunTVGenerator<TestType>(
       "01_signal", "chirp", "run", {count, static_cast<index_t>(end), static_cast<index_t>(f0), static_cast<index_t>(f1)});  
 
   // example-begin chirp-gen-test-1
-  auto t1 = make_tensor<TypeParam>({count});
+  auto t1 = make_tensor<TestType>({count});
   // Create a chirp of length "count" and assign it to tensor "t1"
-  (t1 = chirp(count, end, f0, end, f1)).run();
+  (t1 = chirp(count, end, f0, end, f1)).run(exec);
   // example-end chirp-gen-test-1
 
   MATX_TEST_ASSERT_COMPARE(pb, t1, "Y", 0.01);
 
   // example-begin cchirp-gen-test-1
-  auto t1c = make_tensor<cuda::std::complex<TypeParam>>({count});
+  auto t1c = make_tensor<cuda::std::complex<TestType>>({count});
   // Create a complex chirp of length "count" and assign it to tensor "t1"
-  (t1c = cchirp(count, end, f0, end, f1, ChirpMethod::CHIRP_METHOD_LINEAR)).run();
+  (t1c = cchirp(count, end, f0, end, f1, ChirpMethod::CHIRP_METHOD_LINEAR)).run(exec);
   // example-end cchirp-gen-test-1
 
   pb.reset();

--- a/test/00_operators/ReductionTests.cu
+++ b/test/00_operators/ReductionTests.cu
@@ -94,20 +94,20 @@ template <typename TensorType>
 class ReductionTestsNumericNonComplexAllExecs : public ::testing::Test {
 };
 
-TYPED_TEST_SUITE(ReductionTestsAll, MatXAllTypes);
-TYPED_TEST_SUITE(ReductionTestsComplex, MatXComplexTypes);
-TYPED_TEST_SUITE(ReductionTestsFloat, MatXFloatTypes);
-TYPED_TEST_SUITE(ReductionTestsNumeric, MatXNumericTypes);
-TYPED_TEST_SUITE(ReductionTestsIntegral, MatXAllIntegralTypes);
+TYPED_TEST_SUITE(ReductionTestsAll, MatXAllTypesCUDAExec);
+TYPED_TEST_SUITE(ReductionTestsComplex, MatXComplexTypesCUDAExec);
+TYPED_TEST_SUITE(ReductionTestsFloat, MatXFloatTypesCUDAExec);
+TYPED_TEST_SUITE(ReductionTestsNumeric, MatXNumericTypesCUDAExec);
+TYPED_TEST_SUITE(ReductionTestsIntegral, MatXAllIntegralTypesCUDAExec);
 TYPED_TEST_SUITE(ReductionTestsNumericNonComplex,
-                 MatXNumericNonComplexTypes);               
-TYPED_TEST_SUITE(ReductionTestsFloatNonComplex, MatXFloatNonComplexTypes);
+                 MatXNumericNonComplexTypesCUDAExec);               
+TYPED_TEST_SUITE(ReductionTestsFloatNonComplex, MatXFloatNonComplexTypesCUDAExec);
 TYPED_TEST_SUITE(ReductionTestsFloatNonComplexNonHalf,
-                 MatXFloatNonComplexNonHalfTypes);
-TYPED_TEST_SUITE(ReductionTestsBoolean, MatXBoolTypes);
-TYPED_TEST_SUITE(ReductionTestsFloatHalf, MatXFloatHalfTypes);
-TYPED_TEST_SUITE(ReductionTestsNumericNoHalf, MatXNumericNoHalfTypes);
-TYPED_TEST_SUITE(ReductionTestsComplexNonHalfTypes, MatXComplexNonHalfTypes);
+                 MatXFloatNonComplexNonHalfTypesCUDAExec);
+TYPED_TEST_SUITE(ReductionTestsBoolean, MatXBoolTypesCUDAExec);
+TYPED_TEST_SUITE(ReductionTestsFloatHalf, MatXFloatHalfTypesCUDAExec);
+TYPED_TEST_SUITE(ReductionTestsNumericNoHalf, MatXNumericNonHalfTypesCUDAExec);
+TYPED_TEST_SUITE(ReductionTestsComplexNonHalfTypes, MatXComplexNonHalfTypesCUDAExec);
 
 
 TYPED_TEST_SUITE(ReductionTestsNumericNonComplexAllExecs,
@@ -312,26 +312,30 @@ TYPED_TEST(ReductionTestsNumericNoHalfAllExecs, Sum)
 TYPED_TEST(ReductionTestsFloatNonComplex, Softmax)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};  
 
   auto pb = std::make_unique<detail::MatXPybind>();
   constexpr index_t size = 300;
-  pb->InitAndRunTVGenerator<TypeParam>("00_reductions", "softmax", "run", {80, size, size});
+  pb->InitAndRunTVGenerator<TestType>("00_reductions", "softmax", "run", {80, size, size});
 
-  tensor_t<TypeParam, 1> t1({size});
-  tensor_t<TypeParam, 1> t1_out({size});
+  tensor_t<TestType, 1> t1({size});
+  tensor_t<TestType, 1> t1_out({size});
   pb->NumpyToTensorView(t1, "t1");
 
   // example-begin softmax-test-1
-  (t1_out = softmax(t1)).run();
+  (t1_out = softmax(t1)).run(exec);
   // example-end softmax-test-1
 
   MATX_TEST_ASSERT_COMPARE(pb, t1_out, "t1_sm", 0.01);
 
-  auto t3    = make_tensor<TypeParam>({80,size,size});
-  auto t3_out = make_tensor<TypeParam>({80,size,size});
+  auto t3    = make_tensor<TestType>({80,size,size});
+  auto t3_out = make_tensor<TestType>({80,size,size});
   pb->NumpyToTensorView(t3, "t3");
   // example-begin softmax-test-2
-  (t3_out = softmax(t3, {2})).run();
+  (t3_out = softmax(t3, {2})).run(exec);
   // example-end softmax-test-2
   
   MATX_TEST_ASSERT_COMPARE(pb, t3_out, "t3_sm_axis2", 0.01);

--- a/test/00_solver/QR2.cu
+++ b/test/00_solver/QR2.cu
@@ -43,11 +43,11 @@ class QR2SolverTestNonHalfTypes : public ::testing::Test{
 };
 
 TYPED_TEST_SUITE(QR2SolverTestNonHalfTypes,
-                 MatXFloatNonHalfTypes);
+  MatXFloatNonHalfTypesCUDAExec);
 
-template <typename TypeParam, int RANK>
-void qr_test( const index_t (&AshapeA)[RANK]) {
-  using AType = TypeParam;
+template <typename TestType, int RANK>
+void qr_test( const index_t (&AshapeA)[RANK]) { 
+  using AType = TestType;
   using SType = typename inner_op_type_t<AType>::type;
   
   cudaStream_t stream = 0;
@@ -114,18 +114,19 @@ void qr_test( const index_t (&AshapeA)[RANK]) {
 TYPED_TEST(QR2SolverTestNonHalfTypes, QR2)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;  
   
-  qr_test<TypeParam>({4,4});
-  qr_test<TypeParam>({4,16});
-  qr_test<TypeParam>({16,4});
+  qr_test<TestType>({4,4});
+  qr_test<TestType>({4,16});
+  qr_test<TestType>({16,4});
 
-  qr_test<TypeParam>({25,4,4});
-  qr_test<TypeParam>({25,4,16});
-  qr_test<TypeParam>({25,16,4});
+  qr_test<TestType>({25,4,4});
+  qr_test<TestType>({25,4,16});
+  qr_test<TestType>({25,16,4});
 
-  qr_test<TypeParam>({5,5,4,4});
-  qr_test<TypeParam>({5,5,4,16});
-  qr_test<TypeParam>({5,5,16,4});
+  qr_test<TestType>({5,5,4,4});
+  qr_test<TestType>({5,5,4,16});
+  qr_test<TestType>({5,5,16,4});
   
   MATX_EXIT_HANDLER();
 }

--- a/test/00_tensor/BasicTensorTests.cu
+++ b/test/00_tensor/BasicTensorTests.cu
@@ -38,16 +38,19 @@
 
 using namespace matx;
 
-template <typename TensorType> struct BasicTensorTestsData {
-  tensor_t<TensorType, 0> t0{{}};
-  tensor_t<TensorType, 1> t1{{10}};
-  tensor_t<TensorType, 2> t2{{20, 10}};
-  tensor_t<TensorType, 3> t3{{30, 20, 10}};
-  tensor_t<TensorType, 4> t4{{40, 30, 20, 10}};
+template <typename T> struct BasicTensorTestsData {
+  using GTestType = std::tuple_element_t<0, T>;
+  using GExecType = std::tuple_element_t<1, T>;    
+  tensor_t<GTestType, 0> t0{{}};
+  tensor_t<GTestType, 1> t1{{10}};
+  tensor_t<GTestType, 2> t2{{20, 10}};
+  tensor_t<GTestType, 3> t3{{30, 20, 10}};
+  tensor_t<GTestType, 4> t4{{40, 30, 20, 10}};
 
-  tensor_t<TensorType, 2> t2s = t2.Permute({1, 0});
-  tensor_t<TensorType, 3> t3s = t3.Permute({2, 1, 0});
-  tensor_t<TensorType, 4> t4s = t4.Permute({3, 2, 1, 0});
+  tensor_t<GTestType, 2> t2s = t2.Permute({1, 0});
+  tensor_t<GTestType, 3> t3s = t3.Permute({2, 1, 0});
+  tensor_t<GTestType, 4> t4s = t4.Permute({3, 2, 1, 0});
+  GExecType exec{};
 };
 
 template <typename TensorType>
@@ -85,14 +88,14 @@ class BasicTensorTestsAll : public ::testing::Test,
                             public BasicTensorTestsData<TensorType> {
 };
 
-TYPED_TEST_SUITE(BasicTensorTestsAll, MatXAllTypes);
-TYPED_TEST_SUITE(BasicTensorTestsComplex, MatXComplexTypes);
-TYPED_TEST_SUITE(BasicTensorTestsFloat, MatXFloatTypes);
-TYPED_TEST_SUITE(BasicTensorTestsFloatNonComplex, MatXFloatNonComplexTypes);
-TYPED_TEST_SUITE(BasicTensorTestsNumeric, MatXNumericTypes);
-TYPED_TEST_SUITE(BasicTensorTestsIntegral, MatXAllIntegralTypes);
-TYPED_TEST_SUITE(BasicTensorTestsNumericNonComplex, MatXNumericNonComplexTypes);
-TYPED_TEST_SUITE(BasicTensorTestsBoolean, MatXBoolTypes);
+TYPED_TEST_SUITE(BasicTensorTestsAll, MatXAllTypesCUDAExec);
+TYPED_TEST_SUITE(BasicTensorTestsComplex, MatXComplexTypesCUDAExec);
+TYPED_TEST_SUITE(BasicTensorTestsFloat, MatXFloatTypesCUDAExec);
+TYPED_TEST_SUITE(BasicTensorTestsFloatNonComplex, MatXFloatNonComplexTypesCUDAExec);
+TYPED_TEST_SUITE(BasicTensorTestsNumeric, MatXNumericTypesCUDAExec);
+TYPED_TEST_SUITE(BasicTensorTestsIntegral, MatXAllIntegralTypesCUDAExec);
+TYPED_TEST_SUITE(BasicTensorTestsNumericNonComplex, MatXNumericNonComplexTypesCUDAExec);
+TYPED_TEST_SUITE(BasicTensorTestsBoolean, MatXBoolTypesCUDAExec);
 
 TYPED_TEST(BasicTensorTestsAll, DataSize)
 {
@@ -130,8 +133,10 @@ TYPED_TEST(BasicTensorTestsAll, Swap)
 {
   MATX_ENTER_HANDLER();
 
-  tensor_t<TypeParam, 2> tmp{{10,4}};
-  tensor_t<TypeParam, 2> tmp2{{100,40}};
+  using TestType = std::tuple_element_t<0, TypeParam>; 
+
+  tensor_t<TestType, 2> tmp{{10,4}};
+  tensor_t<TestType, 2> tmp2{{100,40}};
 
   ASSERT_EQ(tmp.Rank(), 2);
   ASSERT_EQ(tmp2.Rank(), 2);
@@ -162,28 +167,30 @@ TYPED_TEST(BasicTensorTestsAll, RefCnt)
 {
   MATX_ENTER_HANDLER();
 
-  tensor_t<TypeParam, 2> tmp{{10,4}};
+  using TestType = std::tuple_element_t<0, TypeParam>;
+
+  tensor_t<TestType, 2> tmp{{10,4}};
   ASSERT_EQ(tmp.GetRefCount(), 1);
 
-  tensor_t<TypeParam, 2> tmp2{tmp};
+  tensor_t<TestType, 2> tmp2{tmp};
   ASSERT_EQ(tmp.GetRefCount(), 2);
   ASSERT_EQ(tmp2.GetRefCount(), 2);  
 
-  tensor_t<TypeParam, 2> tmp3{{10,4}};
+  tensor_t<TestType, 2> tmp3{{10,4}};
   tmp3.Shallow(tmp2);  
   ASSERT_EQ(tmp.GetRefCount(), 3);
   ASSERT_EQ(tmp2.GetRefCount(), 3);  
   ASSERT_EQ(tmp3.GetRefCount(), 3);
 
-  TypeParam *data = tmp.Data();
+  TestType *data = tmp.Data();
 
-  tmp3.Reset(reinterpret_cast<TypeParam*>(0x1234567));
+  tmp3.Reset(reinterpret_cast<TestType*>(0x1234567));
   ASSERT_EQ(tmp3.GetRefCount(), 1);   
 
-  tmp2.Reset(reinterpret_cast<TypeParam*>(0x1234567));
+  tmp2.Reset(reinterpret_cast<TestType*>(0x1234567));
   ASSERT_EQ(tmp.GetRefCount(), 1);  
 
-  tmp.Reset(reinterpret_cast<TypeParam*>(0x1234567)); 
+  tmp.Reset(reinterpret_cast<TestType*>(0x1234567)); 
 
   // Check if pointer was freed
   ASSERT_EQ(IsAllocated(data), false);  
@@ -221,17 +228,19 @@ TYPED_TEST(BasicTensorTestsAll, ViewSize)
 TYPED_TEST(BasicTensorTestsAll, AssignmentOps)
 {
   MATX_ENTER_HANDLER();
-  tensor_t<TypeParam, 2> t2c{{20, 10}};
-  tensor_t<TypeParam, 2> t2c2{{20, 10}};    
+  using TestType = std::tuple_element_t<0, TypeParam>;   
+
+  tensor_t<TestType, 2> t2c{{20, 10}};
+  tensor_t<TestType, 2> t2c2{{20, 10}};    
 
   for (index_t i = 0; i < this->t2.Size(0); i++) {
     for (index_t j = 0; j < this->t2.Size(1); j++) {
-      this->t2(i,j) = static_cast<TypeParam>(1);
-      t2c2(i,j) = static_cast<TypeParam>(2);
+      this->t2(i,j) = static_cast<TestType>(1);
+      t2c2(i,j) = static_cast<TestType>(2);
     }
   }  
 
-  (t2c = this->t2).run();
+  (t2c = this->t2).run(this->exec);
 
   cudaStreamSynchronize(0);
   for (index_t i = 0; i < t2c.Size(0); i++) {
@@ -240,7 +249,7 @@ TYPED_TEST(BasicTensorTestsAll, AssignmentOps)
     }
   }
 
-  (this->t2 = t2c = t2c2).run();
+  (this->t2 = t2c = t2c2).run(this->exec);
   cudaStreamSynchronize(0);  
   for (index_t i = 0; i < t2c.Size(0); i++) {
     for (index_t j = 0; j < t2c.Size(1); j++) {
@@ -255,17 +264,19 @@ TYPED_TEST(BasicTensorTestsAll, AssignmentOps)
 TYPED_TEST(BasicTensorTestsNumeric, AssignmentOps)
 {
   MATX_ENTER_HANDLER();
-  tensor_t<TypeParam, 2> t2c{{20, 10}};
-  tensor_t<TypeParam, 2> t2c2{{20, 10}};    
+  using TestType = std::tuple_element_t<0, TypeParam>;
+
+  tensor_t<TestType, 2> t2c{{20, 10}};
+  tensor_t<TestType, 2> t2c2{{20, 10}};    
 
   for (index_t i = 0; i < this->t2.Size(0); i++) {
     for (index_t j = 0; j < this->t2.Size(1); j++) {
-      this->t2(i,j) = static_cast<TypeParam>(1);
-      t2c(i,j) = static_cast<TypeParam>(1);
+      this->t2(i,j) = static_cast<TestType>(1);
+      t2c(i,j) = static_cast<TestType>(1);
     }
   }  
 
-  (this->t2 += t2c).run();
+  (this->t2 += t2c).run(this->exec);
   cudaStreamSynchronize(0);  
   for (index_t i = 0; i < t2c.Size(0); i++) {
     for (index_t j = 0; j < t2c.Size(1); j++) {
@@ -273,7 +284,7 @@ TYPED_TEST(BasicTensorTestsNumeric, AssignmentOps)
     }
   }
 
-  (this->t2 -= t2c).run();
+  (this->t2 -= t2c).run(this->exec);
   cudaStreamSynchronize(0);  
   for (index_t i = 0; i < t2c.Size(0); i++) {
     for (index_t j = 0; j < t2c.Size(1); j++) {
@@ -281,16 +292,16 @@ TYPED_TEST(BasicTensorTestsNumeric, AssignmentOps)
     }
   }  
 
-  (this->t2 *= t2c).run();
+  (this->t2 *= t2c).run(this->exec);
   cudaStreamSynchronize(0);  
   for (index_t i = 0; i < t2c.Size(0); i++) {
     for (index_t j = 0; j < t2c.Size(1); j++) {
-      ASSERT_EQ(this->t2(i,j), static_cast<TypeParam>(1));
+      ASSERT_EQ(this->t2(i,j), static_cast<TestType>(1));
     }
   }
 
-  (t2c = this->t2).run();
-  (this->t2 /= static_cast<TypeParam>(1)).run();
+  (t2c = this->t2).run(this->exec);
+  (this->t2 /= static_cast<TestType>(1)).run();
   cudaStreamSynchronize(0);  
   for (index_t i = 0; i < t2c.Size(0); i++) {
     for (index_t j = 0; j < t2c.Size(1); j++) {
@@ -304,17 +315,19 @@ TYPED_TEST(BasicTensorTestsNumeric, AssignmentOps)
 TYPED_TEST(BasicTensorTestsIntegral, AssignmentOps)
 {
   MATX_ENTER_HANDLER();
-  tensor_t<TypeParam, 2> t2c{{20, 10}};
-  tensor_t<TypeParam, 2> t2c2{{20, 10}};
+  using TestType = std::tuple_element_t<0, TypeParam>;
+ 
+  tensor_t<TestType, 2> t2c{{20, 10}};
+  tensor_t<TestType, 2> t2c2{{20, 10}};
 
   for (index_t i = 0; i < this->t2.Size(0); i++) {
     for (index_t j = 0; j < this->t2.Size(1); j++) {
-      this->t2(i,j) = static_cast<TypeParam>(1);
-      t2c(i,j) = static_cast<TypeParam>(2);
+      this->t2(i,j) = static_cast<TestType>(1);
+      t2c(i,j) = static_cast<TestType>(2);
     }
   }
 
-  (this->t2 |= t2c).run();
+  (this->t2 |= t2c).run(this->exec);
   cudaStreamSynchronize(0);
   for (index_t i = 0; i < t2c.Size(0); i++) {
     for (index_t j = 0; j < t2c.Size(1); j++) {
@@ -322,7 +335,7 @@ TYPED_TEST(BasicTensorTestsIntegral, AssignmentOps)
     }
   }
 
-  (this->t2 &= t2c).run();
+  (this->t2 &= t2c).run(this->exec);
   cudaStreamSynchronize(0);
   for (index_t i = 0; i < t2c.Size(0); i++) {
     for (index_t j = 0; j < t2c.Size(1); j++) {
@@ -330,7 +343,7 @@ TYPED_TEST(BasicTensorTestsIntegral, AssignmentOps)
     }
   }       
 
-  (this->t2 ^= t2c).run();
+  (this->t2 ^= t2c).run(this->exec);
   cudaStreamSynchronize(0);
   for (index_t i = 0; i < t2c.Size(0); i++) {
     for (index_t j = 0; j < t2c.Size(1); j++) {
@@ -344,6 +357,8 @@ TYPED_TEST(BasicTensorTestsIntegral, AssignmentOps)
 TYPED_TEST(BasicTensorTestsIntegral, Swizzle)
 {
   MATX_ENTER_HANDLER();
+
+  using TestType = std::tuple_element_t<0, TypeParam>;    
 
   ASSERT_EQ(this->t2.Size(0), this->t2s.Size(1));
   ASSERT_EQ(this->t2.Size(1), this->t2s.Size(0));
@@ -362,7 +377,7 @@ TYPED_TEST(BasicTensorTestsIntegral, Swizzle)
   // Rank 2 swizzle
   for (index_t i = 0; i < this->t2.Size(0); i++) {
     for (index_t j = 0; j < this->t2.Size(1); j++) {
-      this->t2(i, j) = static_cast<TypeParam>(i * 100 + j);
+      this->t2(i, j) = static_cast<TestType>(i * 100 + j);
     }
   }
 
@@ -376,7 +391,7 @@ TYPED_TEST(BasicTensorTestsIntegral, Swizzle)
   for (index_t i = 0; i < this->t3.Size(0); i++) {
     for (index_t j = 0; j < this->t3.Size(1); j++) {
       for (index_t k = 0; k < this->t3.Size(2); k++) {
-        this->t3(i, j, k) = static_cast<TypeParam>(i * 10000 + j * 100 + k);
+        this->t3(i, j, k) = static_cast<TestType>(i * 10000 + j * 100 + k);
       }
     }
   }
@@ -395,7 +410,7 @@ TYPED_TEST(BasicTensorTestsIntegral, Swizzle)
       for (index_t k = 0; k < this->t4.Size(2); k++) {
         for (index_t l = 0; l < this->t4.Size(3); l++) {
           this->t4(i, j, k, l) =
-              static_cast<TypeParam>(i * 1000000 + j * 10000 + k * 100 + l);
+              static_cast<TestType>(i * 1000000 + j * 10000 + k * 100 + l);
         }
       }
     }
@@ -419,13 +434,15 @@ TYPED_TEST(BasicTensorTestsIntegral, InitAssign)
 {
   MATX_ENTER_HANDLER();
 
-  tensor_t<TypeParam, 1> t1v_small{{4}};
+  using TestType = std::tuple_element_t<0, TypeParam>;
+
+  tensor_t<TestType, 1> t1v_small{{4}};
   t1v_small.SetVals({1, 2, 3, 4});
   for (index_t i = 0; i < 4; i++) {
     ASSERT_EQ(t1v_small(i), i + 1);
   }
 
-  tensor_t<TypeParam, 2> t2v_small{{4, 4}};
+  tensor_t<TestType, 2> t2v_small{{4, 4}};
   t2v_small.SetVals(
       {{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}});
 
@@ -442,9 +459,10 @@ TYPED_TEST(BasicTensorTestsIntegral, InitAssign)
 TYPED_TEST(BasicTensorTestsAll, Print)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
 
-  auto t = make_tensor<TypeParam>({3});
-  (t = ones(t.Shape())).run();
+  auto t = make_tensor<TestType>({3});
+  (t = ones(t.Shape())).run(this->exec);
   print(t);
 
   MATX_EXIT_HANDLER();
@@ -453,9 +471,10 @@ TYPED_TEST(BasicTensorTestsAll, Print)
 TYPED_TEST(BasicTensorTestsAll, DevicePrint)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>; 
 
-  auto t = make_tensor<TypeParam>({3}, MATX_DEVICE_MEMORY);
-  (t = ones(t.Shape())).run();
+  auto t = make_tensor<TestType>({3}, MATX_DEVICE_MEMORY);
+  (t = ones(t.Shape())).run(this->exec);
   print(t);
 
   MATX_EXIT_HANDLER();
@@ -465,14 +484,16 @@ TYPED_TEST(BasicTensorTestsAll, DLPack)
 {
   MATX_ENTER_HANDLER();
 
-  auto t = make_tensor<TypeParam>({5,10,20});
+  using TestType = std::tuple_element_t<0, TypeParam>;  
+
+  auto t = make_tensor<TestType>({5,10,20});
   auto dl = t.GetDLPackTensor();
 
   ASSERT_EQ(dl->dl_tensor.ndim, 3);
   ASSERT_EQ(dl->dl_tensor.data, t.Data());
   ASSERT_EQ(dl->dl_tensor.device.device_id, 0);
   ASSERT_EQ(dl->dl_tensor.device.device_type, kDLCUDA);
-  auto dlt = detail::TypeToDLPackType<TypeParam>();
+  auto dlt = detail::TypeToDLPackType<TestType>();
   ASSERT_EQ(dl->dl_tensor.dtype.code, dlt.code);
   ASSERT_EQ(dl->dl_tensor.dtype.bits, dlt.bits);
   ASSERT_EQ(dl->dl_tensor.dtype.lanes, dlt.lanes);

--- a/test/00_tensor/CUBTests.cu
+++ b/test/00_tensor/CUBTests.cu
@@ -39,20 +39,20 @@
 using namespace matx;
 
 
-template <typename TensorType> struct CUBTestsData {
-  using TypeParam = std::tuple_element_t<0, TensorType>;
-  using ExecType = std::tuple_element_t<1, TensorType>;
-  ExecType exec{};   
+template <typename T> struct CUBTestsData {
+  using GTestType = std::tuple_element_t<0, T>;
+  using GExecType = std::tuple_element_t<1, T>;   
+  GExecType exec{};   
 
-  tensor_t<TypeParam, 0> t0{{}};
-  tensor_t<TypeParam, 1> t1{{10}};
-  tensor_t<TypeParam, 2> t2{{20, 10}};
-  tensor_t<TypeParam, 3> t3{{30, 20, 10}};
-  tensor_t<TypeParam, 4> t4{{40, 30, 20, 10}};
+  tensor_t<GTestType, 0> t0{{}};
+  tensor_t<GTestType, 1> t1{{10}};
+  tensor_t<GTestType, 2> t2{{20, 10}};
+  tensor_t<GTestType, 3> t3{{30, 20, 10}};
+  tensor_t<GTestType, 4> t4{{40, 30, 20, 10}};
 
-  tensor_t<TypeParam, 2> t2s = t2.Permute({1, 0});
-  tensor_t<TypeParam, 3> t3s = t3.Permute({2, 1, 0});
-  tensor_t<TypeParam, 4> t4s = t4.Permute({3, 2, 1, 0});
+  tensor_t<GTestType, 2> t2s = t2.Permute({1, 0});
+  tensor_t<GTestType, 3> t3s = t3.Permute({2, 1, 0});
+  tensor_t<GTestType, 4> t4s = t4.Permute({3, 2, 1, 0});
 };
 
 template <typename TensorType>
@@ -95,21 +95,21 @@ class CUBTestsNumericNonComplexAllExecs : public ::testing::Test, public CUBTest
 };
 
 
-TYPED_TEST_SUITE(CUBTestsAll, MatXAllTypes);
-TYPED_TEST_SUITE(CUBTestsComplex, MatXComplexTypes);
-TYPED_TEST_SUITE(CUBTestsFloat, MatXFloatTypes);
-TYPED_TEST_SUITE(CUBTestsFloatNonComplex, MatXFloatNonComplexTypes);
-TYPED_TEST_SUITE(CUBTestsNumeric, MatXNumericTypes);
-TYPED_TEST_SUITE(CUBTestsIntegral, MatXAllIntegralTypes);
-TYPED_TEST_SUITE(CUBTestsNumericNonComplex, MatXNumericNonComplexTypes);
-TYPED_TEST_SUITE(CUBTestsBoolean, MatXBoolTypes);
+TYPED_TEST_SUITE(CUBTestsAll, MatXAllTypesCUDAExec);
+TYPED_TEST_SUITE(CUBTestsComplex, MatXComplexTypesCUDAExec);
+TYPED_TEST_SUITE(CUBTestsFloat, MatXFloatTypesCUDAExec);
+TYPED_TEST_SUITE(CUBTestsFloatNonComplex, MatXFloatNonComplexTypesCUDAExec);
+TYPED_TEST_SUITE(CUBTestsNumeric, MatXNumericTypesCUDAExec);
+TYPED_TEST_SUITE(CUBTestsIntegral, MatXAllIntegralTypesCUDAExec);
+TYPED_TEST_SUITE(CUBTestsNumericNonComplex, MatXNumericNonComplexTypesCUDAExec);
+TYPED_TEST_SUITE(CUBTestsBoolean, MatXBoolTypesCUDAExec);
 
 TYPED_TEST_SUITE(CUBTestsNumericNonComplexAllExecs,
                  MatXFloatNonComplexNonHalfTypesAllExecs);  
 
 TEST(TensorStats, Hist)
 {
-  MATX_ENTER_HANDLER();
+  MATX_ENTER_HANDLER(); 
 
   constexpr int levels = 7;
   tensor_t<float, 1> inv({10});

--- a/test/00_tensor/EinsumTests.cu
+++ b/test/00_tensor/EinsumTests.cu
@@ -86,36 +86,40 @@ template <typename TensorType>
 class EinsumTestsAll : public EinsumTest<TensorType> {
 };
 
-TYPED_TEST_SUITE(EinsumTestsAll, MatXAllTypes);
-TYPED_TEST_SUITE(EinsumTestsComplex, MatXComplexTypes);
-TYPED_TEST_SUITE(EinsumTestsFloat, MatXFloatTypes);
-TYPED_TEST_SUITE(EinsumTestsFloatNonComplex, MatXFloatNonComplexTypes);
-TYPED_TEST_SUITE(EinsumTestsFloatNonComplexNonHalfTypes, MatXFloatNonComplexNonHalfTypes);
-TYPED_TEST_SUITE(EinsumTestsNumeric, MatXNumericTypes);
-TYPED_TEST_SUITE(EinsumTestsIntegral, MatXAllIntegralTypes);
-TYPED_TEST_SUITE(EinsumTestsNumericNonComplex, MatXNumericNonComplexTypes);
-TYPED_TEST_SUITE(EinsumTestsBoolean, MatXBoolTypes);
+TYPED_TEST_SUITE(EinsumTestsAll, MatXAllTypesCUDAExec);
+TYPED_TEST_SUITE(EinsumTestsComplex, MatXComplexTypesCUDAExec);
+TYPED_TEST_SUITE(EinsumTestsFloat, MatXFloatTypesCUDAExec);
+TYPED_TEST_SUITE(EinsumTestsFloatNonComplex, MatXFloatNonComplexTypesCUDAExec);
+TYPED_TEST_SUITE(EinsumTestsFloatNonComplexNonHalfTypes, MatXFloatNonComplexNonHalfTypesCUDAExec);
+TYPED_TEST_SUITE(EinsumTestsNumeric, MatXNumericTypesCUDAExec);
+TYPED_TEST_SUITE(EinsumTestsIntegral, MatXAllIntegralTypesCUDAExec);
+TYPED_TEST_SUITE(EinsumTestsNumericNonComplex, MatXNumericNonComplexTypesCUDAExec);
+TYPED_TEST_SUITE(EinsumTestsBoolean, MatXBoolTypesCUDAExec);
 
 #if MATX_ENABLE_CUTENSOR
 TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Contraction3D)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
 
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  ExecType exec{};    
+
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_operators", "contraction", "run", {});  
 
   // example-begin einsum-contraction-1
-  auto a1 = make_tensor<TypeParam>({60});
-  auto b1 = make_tensor<TypeParam>({24});
-  auto c2 = make_tensor<TypeParam>({5,2});
+  auto a1 = make_tensor<TestType>({60});
+  auto b1 = make_tensor<TestType>({24});
+  auto c2 = make_tensor<TestType>({5,2});
 
-  (a1 = linspace<0>(a1.Shape(), (TypeParam)0, static_cast<TypeParam>(a1.Size(0) - 1))).run();
-  (b1 = linspace<0>(b1.Shape(), (TypeParam)0, static_cast<TypeParam>(b1.Size(0) - 1))).run();
+  (a1 = linspace<0>(a1.Shape(), (TestType)0, static_cast<TestType>(a1.Size(0) - 1))).run(exec);
+  (b1 = linspace<0>(b1.Shape(), (TestType)0, static_cast<TestType>(b1.Size(0) - 1))).run(exec);
   auto a = a1.View({3,4,5});
   auto b = b1.View({4,3,2});
 
   // Perform a 3D tensor contraction
-  (c2 = cutensor::einsum("ijk,jil->kl", a, b)).run();
+  (c2 = cutensor::einsum("ijk,jil->kl", a, b)).run(exec);
   // example-end einsum-contraction-1
   cudaStreamSynchronize(0);
   MATX_TEST_ASSERT_COMPARE(this->pb, c2, "c_float3d", 0.01);
@@ -127,15 +131,20 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Dot)
 {
   MATX_ENTER_HANDLER();
 
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{}; 
+
   // example-begin einsum-dot-1
-  auto a1 = make_tensor<TypeParam>({60});
-  auto b1 = make_tensor<TypeParam>({60});
-  auto c0 = make_tensor<TypeParam>({});
-  (a1 = ones(a1.Shape()) * 2).run();
-  (b1 = ones(b1.Shape()) * 2).run(); 
+  auto a1 = make_tensor<TestType>({60});
+  auto b1 = make_tensor<TestType>({60});
+  auto c0 = make_tensor<TestType>({});
+  (a1 = ones(a1.Shape()) * 2).run(exec);
+  (b1 = ones(b1.Shape()) * 2).run(exec); 
 
   // Perform a dot product of b1 with itself and store in a1
-  (c0 = cutensor::einsum("i,i->", a1, b1)).run();
+  (c0 = cutensor::einsum("i,i->", a1, b1)).run(exec);
   // example-end einsum-dot-1
   cudaStreamSynchronize(0);
   MATX_ASSERT_EQ(c0(), 4 * a1.Size(0));
@@ -146,18 +155,23 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Dot)
 TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, GEMM)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{}; 
+
 
   // example-begin einsum-gemm-1
-  auto a2 = make_tensor<TypeParam>({10,20});
-  auto b2 = make_tensor<TypeParam>({20,10});
-  auto c2 = make_tensor<TypeParam>({10,10});    
-  auto c22 = make_tensor<TypeParam>({10,10});   
-  (a2 = ones(a2.Shape())).run();
-  (b2 = ones(b2.Shape())).run(); 
+  auto a2 = make_tensor<TestType>({10,20});
+  auto b2 = make_tensor<TestType>({20,10});
+  auto c2 = make_tensor<TestType>({10,10});    
+  auto c22 = make_tensor<TestType>({10,10});   
+  (a2 = ones(a2.Shape())).run(exec);
+  (b2 = ones(b2.Shape())).run(exec); 
 
   // Perform a GEMM of a2 * b2. Compare results to traditional matmul call
-  (c2 = cutensor::einsum("mk,kn->mn", a2, b2)).run();
-  (c22 = matmul(a2, b2)).run();
+  (c2 = cutensor::einsum("mk,kn->mn", a2, b2)).run(exec);
+  (c22 = matmul(a2, b2)).run(exec);
   // example-end einsum-gemm-1
   cudaStreamSynchronize(0);
 
@@ -172,41 +186,51 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, GEMM)
 
 TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, GEMMTranspose)
 {
-    // example-begin einsum-gemm-2
-    auto a2 = make_tensor<TypeParam>({5,20});
-    auto b2 = make_tensor<TypeParam>({20,10});
-    auto c2 = make_tensor<TypeParam>({10,5});    
-    auto c22 = make_tensor<TypeParam>({5,10});   
-    (a2 = ones(a2.Shape())).run();
-    (b2 = ones(b2.Shape())).run(); 
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
 
-    // Perform a GEMM of a2 * b2 and store the results transposed
-    (c2 = cutensor::einsum("mk,kn->nm", a2, b2)).run();
-    // example-end einsum-gemm-2
-    (c22 = matmul(a2, b2)).run();
-    cudaStreamSynchronize(0);
+  ExecType exec{}; 
 
-    auto c22t = c22.Permute({1,0}); // Permute to match cutensor
+  // example-begin einsum-gemm-2
+  auto a2 = make_tensor<TestType>({5,20});
+  auto b2 = make_tensor<TestType>({20,10});
+  auto c2 = make_tensor<TestType>({10,5});    
+  auto c22 = make_tensor<TestType>({5,10});   
+  (a2 = ones(a2.Shape())).run(exec);
+  (b2 = ones(b2.Shape())).run(exec); 
 
-    for (auto i = 0; i < c2.Size(0); i++) {
-      for (auto j = 0; j < c2.Size(1); j++) {
-        MATX_ASSERT_EQ(c2(i,j), c22t(i,j));
-      }
+  // Perform a GEMM of a2 * b2 and store the results transposed
+  (c2 = cutensor::einsum("mk,kn->nm", a2, b2)).run(exec);
+  // example-end einsum-gemm-2
+  (c22 = matmul(a2, b2)).run(exec);
+  cudaStreamSynchronize(0);
+
+  auto c22t = c22.Permute({1,0}); // Permute to match cutensor
+
+  for (auto i = 0; i < c2.Size(0); i++) {
+    for (auto j = 0; j < c2.Size(1); j++) {
+      MATX_ASSERT_EQ(c2(i,j), c22t(i,j));
     }
+  }
 }
 
 TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Permute)
 {
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{}; 
+
   // example-begin einsum-permute-1
-  auto a = make_tensor<TypeParam>({5,20,4,3});
-  auto b = make_tensor<TypeParam>({20,3,4,5});
-  auto b2 = make_tensor<TypeParam>({20,3,4,5});
-  (a = ones(a.Shape())).run();
-  (b = ones(b.Shape())).run();
+  auto a = make_tensor<TestType>({5,20,4,3});
+  auto b = make_tensor<TestType>({20,3,4,5});
+  auto b2 = make_tensor<TestType>({20,3,4,5});
+  (a = ones(a.Shape())).run(exec);
+  (b = ones(b.Shape())).run(exec);
 
   // Permute a 4D tensor. This gives the same output as Permute, but is much faster
-  (b = cutensor::einsum("ijkl->jlki", a)).run();
-  (b2 = a.Permute({1,3,2,0})).run();
+  (b = cutensor::einsum("ijkl->jlki", a)).run(exec);
+  (b2 = a.Permute({1,3,2,0})).run(exec);
   // example-end einsum-permute-1
   cudaStreamSynchronize(0);
 
@@ -223,21 +247,26 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Permute)
 
 TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Sum)
 {
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{}; 
+
   // example-begin einsum-sum-1
-  auto a = matx::make_tensor<TypeParam>({2, 3});
+  auto a = matx::make_tensor<TestType>({2, 3});
   a.SetVals({
       {1, 2, 3},
       {4, 5, 6}
   });  
 
-  auto b = matx::make_tensor<TypeParam>({3});
+  auto b = matx::make_tensor<TestType>({3});
   // Sum the columns of "a"
-  (b = matx::cutensor::einsum("ij->j", a)).run();
+  (b = matx::cutensor::einsum("ij->j", a)).run(exec);
   // example-end einsum-sum-1
     
   cudaStreamSynchronize(0);
   for (auto i = 0; i < a.Size(1); i++) {
-    TypeParam s = 0;
+    TestType s = 0;
     for (auto j = 0; j < a.Size(0); j++) {
       s += a(j, i);
     }
@@ -249,16 +278,20 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Sum)
 TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Trace)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};  
 
   // example-begin einsum-trace-1
-  auto a2 = make_tensor<TypeParam>({10,10});
-  auto c0_0 = make_tensor<TypeParam>({});
-  auto c0_1 = make_tensor<TypeParam>({});
-  (a2 = ones(a2.Shape())).run();
+  auto a2 = make_tensor<TestType>({10,10});
+  auto c0_0 = make_tensor<TestType>({});
+  auto c0_1 = make_tensor<TestType>({});
+  (a2 = ones(a2.Shape())).run(exec);
 
   // Perform a GEMM of a2 * b2. Compare results to traditional matmul call
-  (c0_0 = cutensor::einsum("ii->", a2)).run();
-  (c0_1 = trace(a2)).run();
+  (c0_0 = cutensor::einsum("ii->", a2)).run(exec);
+  (c0_1 = trace(a2)).run(exec);
 
   // example-end einsum-trace-1
   cudaStreamSynchronize(0);

--- a/test/00_tensor/TensorCreationTests.cu
+++ b/test/00_tensor/TensorCreationTests.cu
@@ -38,16 +38,18 @@
 
 using namespace matx;
 
-template <typename TensorType> struct TensorCreationTestsData {
-  tensor_t<TensorType, 0> t0{{}};
-  tensor_t<TensorType, 1> t1{{10}};
-  tensor_t<TensorType, 2> t2{{20, 10}};
-  tensor_t<TensorType, 3> t3{{30, 20, 10}};
-  tensor_t<TensorType, 4> t4{{40, 30, 20, 10}};
+template <typename T> struct TensorCreationTestsData {
+  using GTestType = std::tuple_element_t<0, T>;
+  using GExecType = std::tuple_element_t<1, T>;     
+  tensor_t<GTestType, 0> t0{{}};
+  tensor_t<GTestType, 1> t1{{10}};
+  tensor_t<GTestType, 2> t2{{20, 10}};
+  tensor_t<GTestType, 3> t3{{30, 20, 10}};
+  tensor_t<GTestType, 4> t4{{40, 30, 20, 10}};
 
-  tensor_t<TensorType, 2> t2s = t2.Permute({1, 0});
-  tensor_t<TensorType, 3> t3s = t3.Permute({2, 1, 0});
-  tensor_t<TensorType, 4> t4s = t4.Permute({3, 2, 1, 0});
+  tensor_t<GTestType, 2> t2s = t2.Permute({1, 0});
+  tensor_t<GTestType, 3> t3s = t3.Permute({2, 1, 0});
+  tensor_t<GTestType, 4> t4s = t4.Permute({3, 2, 1, 0});
 };
 
 template <typename TensorType>
@@ -85,25 +87,24 @@ class TensorCreationTestsAll : public ::testing::Test,
                             public TensorCreationTestsData<TensorType> {
 };
 
-TYPED_TEST_SUITE(TensorCreationTestsAll, MatXAllTypes);
-TYPED_TEST_SUITE(TensorCreationTestsComplex, MatXComplexTypes);
-TYPED_TEST_SUITE(TensorCreationTestsFloat, MatXFloatTypes);
-TYPED_TEST_SUITE(TensorCreationTestsFloatNonComplex, MatXFloatNonComplexTypes);
-TYPED_TEST_SUITE(TensorCreationTestsNumeric, MatXNumericTypes);
-TYPED_TEST_SUITE(TensorCreationTestsIntegral, MatXAllIntegralTypes);
-TYPED_TEST_SUITE(TensorCreationTestsNumericNonComplex, MatXNumericNonComplexTypes);
-TYPED_TEST_SUITE(TensorCreationTestsBoolean, MatXBoolTypes);
+
+
+TYPED_TEST_SUITE(TensorCreationTestsAll, MatXAllTypesAllExecs);
 
 TYPED_TEST(TensorCreationTestsAll, MakeShape)
 {
-  auto mt2 = make_tensor<TypeParam>({2, 2});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};  
+  auto mt2 = make_tensor<TestType>({2, 2});
   ASSERT_EQ(mt2.Size(0), 2);
   ASSERT_EQ(mt2.Size(1), 2);
 
-  auto mt0 = make_tensor<TypeParam>({});
-  auto mt1 = make_tensor<TypeParam>({10});
-  auto mt3 = make_tensor<TypeParam>({10, 5, 4});
-  auto mt4 = make_tensor<TypeParam>({10, 5, 4, 3});
+  auto mt0 = make_tensor<float>({});
+  auto mt1 = make_tensor<cuda::std::complex<float>>({10});
+  auto mt3 = make_tensor<TestType>({10, 5, 4});
+  auto mt4 = make_tensor<TestType>({10, 5, 4, 3});
 
   ASSERT_EQ(mt1.Size(0), 10);
   ASSERT_EQ(mt3.Size(0), 10);
@@ -120,7 +121,7 @@ TYPED_TEST(TensorCreationTestsAll, MakeShape)
 //   auto mt1 = make_static_tensor<TypeParam, 10>();
 //   ASSERT_EQ(mt1.Size(0), 10);
 
-//   auto mt2 = make_static_tensor<TypeParam, 10, 40>();
+//   auto mt2 = make_static_tensor<float, 10, 40>();
 //   ASSERT_EQ(mt2.Size(0), 10);
 //   ASSERT_EQ(mt2.Size(1), 40);
 

--- a/test/00_tensor/VizTests.cu
+++ b/test/00_tensor/VizTests.cu
@@ -41,15 +41,17 @@
 using namespace matx;
 
 template <typename TensorType> struct VizTestsData {
-  tensor_t<TensorType, 0> t0{{}};
-  tensor_t<TensorType, 1> t1{{10}};
-  tensor_t<TensorType, 2> t2{{20, 10}};
-  tensor_t<TensorType, 3> t3{{30, 20, 10}};
-  tensor_t<TensorType, 4> t4{{40, 30, 20, 10}};
+  using GTestType = std::tuple_element_t<0, T>;
+  using GExecType = std::tuple_element_t<1, T>;   
+  tensor_t<GTestType, 0> t0{{}};
+  tensor_t<GTestType, 1> t1{{10}};
+  tensor_t<GTestType, 2> t2{{20, 10}};
+  tensor_t<GTestType, 3> t3{{30, 20, 10}};
+  tensor_t<GTestType, 4> t4{{40, 30, 20, 10}};
 
-  tensor_t<TensorType, 2> t2s = t2.Permute({1, 0});
-  tensor_t<TensorType, 3> t3s = t3.Permute({2, 1, 0});
-  tensor_t<TensorType, 4> t4s = t4.Permute({3, 2, 1, 0});
+  tensor_t<GTestType, 2> t2s = t2.Permute({1, 0});
+  tensor_t<GTestType, 3> t3s = t3.Permute({2, 1, 0});
+  tensor_t<GTestType, 4> t4s = t4.Permute({3, 2, 1, 0});
 };
 
 template <typename TensorType>
@@ -83,14 +85,14 @@ template <typename TensorType>
 class VizTestsAll : public ::testing::Test, public VizTestsData<TensorType> {
 };
 
-TYPED_TEST_SUITE(VizTestsAll, MatXAllTypes);
-TYPED_TEST_SUITE(VizTestsComplex, MatXComplexTypes);
-TYPED_TEST_SUITE(VizTestsFloat, MatXFloatTypes);
-TYPED_TEST_SUITE(VizTestsFloatNonComplex, MatXFloatNonComplexTypes);
-TYPED_TEST_SUITE(VizTestsNumeric, MatXNumericTypes);
-TYPED_TEST_SUITE(VizTestsIntegral, MatXAllIntegralTypes);
-TYPED_TEST_SUITE(VizTestsNumericNonComplex, MatXNumericNonComplexTypes);
-TYPED_TEST_SUITE(VizTestsBoolean, MatXBoolTypes);
+TYPED_TEST_SUITE(VizTestsAll, MatXAllTypesCUDAExec);
+TYPED_TEST_SUITE(VizTestsComplex, MatXComplexTypesCUDAExec);
+TYPED_TEST_SUITE(VizTestsFloat, MatXFloatTypesCUDAExec);
+TYPED_TEST_SUITE(VizTestsFloatNonComplex, MatXFloatNonComplexTypesCUDAExec);
+TYPED_TEST_SUITE(VizTestsNumeric, MatXNumericTypesCUDAExec);
+TYPED_TEST_SUITE(VizTestsIntegral, MatXAllIntegralTypesCUDAExec);
+TYPED_TEST_SUITE(VizTestsNumericNonComplex, MatXNumericNonComplexTypesCUDAExec);
+TYPED_TEST_SUITE(VizTestsBoolean, MatXBoolTypesCUDAExec);
 
 TYPED_TEST(VizTestsNumericNonComplex, Line)
 {
@@ -105,9 +107,10 @@ TYPED_TEST(VizTestsNumericNonComplex, Line)
 TYPED_TEST(VizTestsNumericNonComplex, Scatter)
 {
   MATX_ENTER_HANDLER();
-
+  using TestType = std::tuple_element_t<0, TypeParam>;
+   
   this->t1.SetVals({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-  tensor_t<TypeParam, 1> t1y({10});
+  tensor_t<TestType, 1> t1y({10});
 
   t1y.SetVals({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
   viz::scatter(this->t1, t1y, "My Scatter Plot", "Y label", "X label",
@@ -119,9 +122,10 @@ TYPED_TEST(VizTestsNumericNonComplex, Scatter)
 TYPED_TEST(VizTestsNumericNonComplex, Bar)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
 
   this->t1.SetVals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
-  tensor_t<TypeParam, 1> t1y({10});
+  tensor_t<TestType, 1> t1y({10});
 
   t1y.SetVals({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
   viz::bar(this->t1, "My Bar Plot", "X label", "bar.html");

--- a/test/00_transform/ConvCorr.cu
+++ b/test/00_transform/ConvCorr.cu
@@ -62,83 +62,91 @@ constexpr index_t c_len = a_len + b_len - 1;
 
 template <typename T>
 class CorrelationConvolutionTest : public ::testing::Test {
+  using GTestType = std::tuple_element_t<0, T>;
+  using GExecType = std::tuple_element_t<1, T>;
 protected:
   void SetUp() override
   {
-    CheckTestTypeSupport<T>();
+    CheckTestTypeSupport<GTestType>();
     pb = std::make_unique<detail::MatXPybind>();
 
     // Half precision needs a bit more tolerance when compared to
     // fp32
-    if constexpr (is_complex_half_v<T> || is_matx_half_v<T>) {
+    if constexpr (is_complex_half_v<GTestType> || is_matx_half_v<GTestType>) {
       thresh = 0.2f;
     }
   }
 
   void TearDown() { pb.reset(); }
-
+  GExecType exec{};   
   std::unique_ptr<detail::MatXPybind> pb;
-  tensor_t<T, 1> av{{a_len0}};
-  tensor_t<T, 1> bv_even{{b_len0_even}};
-  tensor_t<T, 1> bv_odd{{b_len0_odd}};
-  tensor_t<T, 1> cv_full_even{{c_len0_full_even}};
-  tensor_t<T, 1> cv_full_odd{{c_len0_full_odd}};  
-  tensor_t<T, 1> cv_valid_even{{c_len0_valid_even}};
-  tensor_t<T, 1> cv_valid_odd{{c_len0_valid_odd}};
-  tensor_t<T, 1> cv_same{{c_len0_same}};
+  tensor_t<GTestType, 1> av{{a_len0}};
+  tensor_t<GTestType, 1> bv_even{{b_len0_even}};
+  tensor_t<GTestType, 1> bv_odd{{b_len0_odd}};
+  tensor_t<GTestType, 1> cv_full_even{{c_len0_full_even}};
+  tensor_t<GTestType, 1> cv_full_odd{{c_len0_full_odd}};  
+  tensor_t<GTestType, 1> cv_valid_even{{c_len0_valid_even}};
+  tensor_t<GTestType, 1> cv_valid_odd{{c_len0_valid_odd}};
+  tensor_t<GTestType, 1> cv_same{{c_len0_same}};
   float thresh = 0.01f;
 };
 
 template <typename T>
 class CorrelationConvolution2DTest : public ::testing::Test {
 protected:
+  using GTestType = std::tuple_element_t<0, T>;
+  using GExecType = std::tuple_element_t<1, T>;
+
   void SetUp() override
   {
-    CheckTestTypeSupport<T>();
+    CheckTestTypeSupport<GTestType>();
     pb = std::make_unique<detail::MatXPybind>();
 
     // Half precision needs a bit more tolerance when compared to
     // fp32
-    if constexpr (is_complex_half_v<T> || is_matx_half_v<T>) {
+    if constexpr (is_complex_half_v<GTestType> || is_matx_half_v<GTestType>) {
       thresh = .2f;
     }
   }
 
   void TearDown() { pb.reset(); }
-
+  GExecType exec{};   
   std::unique_ptr<detail::MatXPybind> pb;
-  tensor_t<T, 2> av{{a_len0,a_len1}};
-  tensor_t<T, 2> bv_even{{b_len0_even,b_len1_even}};
-  tensor_t<T, 2> bv_odd{{b_len0_odd,b_len1_odd}};
-  tensor_t<T, 2> cv_full_even{{c_len0_full_even,c_len1_full_even}};
-  tensor_t<T, 2> cv_full_odd{{c_len0_full_odd,c_len1_full_odd}};  
-  tensor_t<T, 2> cv_valid_even{{c_len0_valid_even,c_len1_valid_even}};
-  tensor_t<T, 2> cv_valid_odd{{c_len0_valid_odd,c_len1_valid_odd}};
-  tensor_t<T, 2> cv_same{{c_len0_same,c_len1_same}};
+  tensor_t<GTestType, 2> av{{a_len0,a_len1}};
+  tensor_t<GTestType, 2> bv_even{{b_len0_even,b_len1_even}};
+  tensor_t<GTestType, 2> bv_odd{{b_len0_odd,b_len1_odd}};
+  tensor_t<GTestType, 2> cv_full_even{{c_len0_full_even,c_len1_full_even}};
+  tensor_t<GTestType, 2> cv_full_odd{{c_len0_full_odd,c_len1_full_odd}};  
+  tensor_t<GTestType, 2> cv_valid_even{{c_len0_valid_even,c_len1_valid_even}};
+  tensor_t<GTestType, 2> cv_valid_odd{{c_len0_valid_odd,c_len1_valid_odd}};
+  tensor_t<GTestType, 2> cv_same{{c_len0_same,c_len1_same}};
   float thresh = 0.01f;
 };
 
 template <typename T>
 class CorrelationConvolutionLargeTest : public ::testing::Test {
 protected:
+  using GTestType = std::tuple_element_t<0, T>;
+  using GExecType = std::tuple_element_t<1, T>;
+
   void SetUp() override
   {
-    CheckTestTypeSupport<T>();
+    CheckTestTypeSupport<GTestType>();
     pb = std::make_unique<detail::MatXPybind>();
 
     // Half precision needs a bit more tolerance when compared to
     // fp32
-    if constexpr (is_complex_half_v<T> || is_matx_half_v<T>) {
+    if constexpr (is_complex_half_v<GTestType> || is_matx_half_v<GTestType>) {
       thresh = 0.2f;
     }
   }
 
   void TearDown() { pb.reset(); }
-
+  GExecType exec{};   
   std::unique_ptr<detail::MatXPybind> pb;
-  tensor_t<T, 1> av{{a_len}};
-  tensor_t<T, 1> bv{{b_len}};
-  tensor_t<T, 1> cv{{c_len}};
+  tensor_t<GTestType, 1> av{{a_len}};
+  tensor_t<GTestType, 1> bv{{b_len}};
+  tensor_t<GTestType, 1> cv{{c_len}};
   float thresh = 0.01f;
 };
 
@@ -167,22 +175,23 @@ class CorrelationConvolutionComplexTypes
     : public CorrelationConvolutionTest<TensorType> {
 };
 
-TYPED_TEST_SUITE(CorrelationConvolutionTestFloatTypes, MatXFloatTypes);
-TYPED_TEST_SUITE(CorrelationConvolutionTestNonHalfFloatTypes, MatXFloatNonHalfTypes);
-TYPED_TEST_SUITE(CorrelationConvolutionLargeTestFloatTypes, MatXFloatNonHalfTypes);
-TYPED_TEST_SUITE(CorrelationConvolution2DTestFloatTypes, MatXFloatNonHalfTypes);
+TYPED_TEST_SUITE(CorrelationConvolutionTestFloatTypes, MatXFloatTypesCUDAExec);
+TYPED_TEST_SUITE(CorrelationConvolutionTestNonHalfFloatTypes, MatXFloatNonHalfTypesCUDAExec);
+TYPED_TEST_SUITE(CorrelationConvolutionLargeTestFloatTypes, MatXFloatNonHalfTypesCUDAExec);
+TYPED_TEST_SUITE(CorrelationConvolution2DTestFloatTypes, MatXFloatNonHalfTypesCUDAExec);
 
 // Real/real direct 1D convolution Large
 TYPED_TEST(CorrelationConvolutionLargeTestFloatTypes, Direct1DConvolutionLarge)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len, b_len});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len, b_len});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv, "b_op");
   // example-begin conv1d-test-1
   // 1D convolution in FULL mode where every output is stored
-  (this->cv = conv1d(this->av, this->bv, MATX_C_MODE_FULL)).run();
+  (this->cv = conv1d(this->av, this->bv, MATX_C_MODE_FULL)).run(this->exec);
   // example-end conv1d-test-1
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv, "conv_full", this->thresh);
@@ -193,13 +202,14 @@ TYPED_TEST(CorrelationConvolutionLargeTestFloatTypes, Direct1DConvolutionLarge)
 TYPED_TEST(CorrelationConvolutionLargeTestFloatTypes, FFT1DConvolutionLarge)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len, b_len});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len, b_len});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv, "b_op");
 
   // 1D convolution in FULL mode where every output is stored
-  (this->cv = conv1d(this->av, this->bv, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run();
+  (this->cv = conv1d(this->av, this->bv, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv, "conv_full", this->thresh);
 
@@ -211,11 +221,12 @@ TYPED_TEST(CorrelationConvolutionLargeTestFloatTypes, FFT1DConvolutionLarge)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionFullEven)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_full_even = conv1d(this->av, this->bv_even, MATX_C_MODE_FULL)).run();
+  (this->cv_full_even = conv1d(this->av, this->bv_even, MATX_C_MODE_FULL)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_even, "conv_full", this->thresh);
   MATX_EXIT_HANDLER();
@@ -224,11 +235,12 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionFullEven)
 TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionFullEven)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_full_even = conv1d(this->av, this->bv_even, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run();
+  (this->cv_full_even = conv1d(this->av, this->bv_even, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_even, "conv_full", this->thresh);
   MATX_EXIT_HANDLER();
@@ -239,11 +251,12 @@ TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionFullEven
 TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionFullEven)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_even, b_len1_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_even, b_len1_even});
   this->pb->RunTVGenerator("conv2d");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_full_even = conv2d(this->av, this->bv_even, MATX_C_MODE_FULL)).run();
+  (this->cv_full_even = conv2d(this->av, this->bv_even, MATX_C_MODE_FULL)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_even, "conv_full", this->thresh);
   MATX_EXIT_HANDLER();
@@ -254,11 +267,12 @@ TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionFullEven)
 TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, Direct1DConvolutionSameEven)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_same = conv1d(this->av, this->bv_even, MATX_C_MODE_SAME)).run();
+  (this->cv_same = conv1d(this->av, this->bv_even, MATX_C_MODE_SAME)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_same, "conv_same", this->thresh);
   MATX_EXIT_HANDLER();
@@ -267,11 +281,12 @@ TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, Direct1DConvolutionSameE
 TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionSameEven)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_same = conv1d(this->av, this->bv_even, MATX_C_MODE_SAME, MATX_C_METHOD_FFT)).run();
+  (this->cv_same = conv1d(this->av, this->bv_even, MATX_C_MODE_SAME, MATX_C_METHOD_FFT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_same, "conv_same", this->thresh);
   MATX_EXIT_HANDLER();
@@ -280,12 +295,13 @@ TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionSameEven
 TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionSameEven)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_even, b_len1_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_even, b_len1_even});
   this->pb->RunTVGenerator("conv2d");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
   // example-begin conv2d-test-1
-  (this->cv_same = conv2d(this->av, this->bv_even, MATX_C_MODE_SAME)).run();
+  (this->cv_same = conv2d(this->av, this->bv_even, MATX_C_MODE_SAME)).run(this->exec);
   // example-end conv2d-test-1
   
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_same, "conv_same", this->thresh);
@@ -295,11 +311,12 @@ TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionSameEven)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionValidEven)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_valid_even = conv1d(this->av, this->bv_even, MATX_C_MODE_VALID)).run();
+  (this->cv_valid_even = conv1d(this->av, this->bv_even, MATX_C_MODE_VALID)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_valid_even, "conv_valid", this->thresh);
   MATX_EXIT_HANDLER();
@@ -308,11 +325,12 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionValidEven)
 TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionValidEven)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_valid_even = conv1d(this->av, this->bv_even, MATX_C_MODE_VALID, MATX_C_METHOD_FFT)).run();
+  (this->cv_valid_even = conv1d(this->av, this->bv_even, MATX_C_MODE_VALID, MATX_C_METHOD_FFT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_valid_even, "conv_valid", this->thresh);
   MATX_EXIT_HANDLER();
@@ -321,11 +339,12 @@ TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionValidEve
 TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionValidEven)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_even, b_len1_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_even, b_len1_even});
   this->pb->RunTVGenerator("conv2d");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_valid_even = conv2d(this->av, this->bv_even, MATX_C_MODE_VALID)).run();
+  (this->cv_valid_even = conv2d(this->av, this->bv_even, MATX_C_MODE_VALID)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_valid_even, "conv_valid", this->thresh);
   MATX_EXIT_HANDLER();
@@ -334,11 +353,12 @@ TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionValidEven)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionFullOdd)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_odd});  
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_odd});  
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_odd, "b_op");
-  (this->cv_full_odd = conv1d(this->av, this->bv_odd, MATX_C_MODE_FULL)).run();
+  (this->cv_full_odd = conv1d(this->av, this->bv_odd, MATX_C_MODE_FULL)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_odd, "conv_full", this->thresh);
   MATX_EXIT_HANDLER();
@@ -347,11 +367,12 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionFullOdd)
 TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionFullOdd)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_odd});  
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_odd});  
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_odd, "b_op");
-  (this->cv_full_odd = conv1d(this->av, this->bv_odd, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run();
+  (this->cv_full_odd = conv1d(this->av, this->bv_odd, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_odd, "conv_full", this->thresh);
   MATX_EXIT_HANDLER();
@@ -362,11 +383,12 @@ TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionFullOdd)
 TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionFullOdd)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_odd, b_len1_odd});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_odd, b_len1_odd});
   this->pb->RunTVGenerator("conv2d");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_odd, "b_op");
-  (this->cv_full_odd = conv2d(this->av, this->bv_odd, MATX_C_MODE_FULL)).run();
+  (this->cv_full_odd = conv2d(this->av, this->bv_odd, MATX_C_MODE_FULL)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_odd, "conv_full", this->thresh);
   MATX_EXIT_HANDLER();
@@ -375,11 +397,12 @@ TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionFullOdd)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionSameOdd)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_odd});   
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_odd});   
   this->pb->RunTVGenerator("conv");   
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_odd, "b_op");
-  (this->cv_same = conv1d(this->av, this->bv_odd, MATX_C_MODE_SAME)).run();
+  (this->cv_same = conv1d(this->av, this->bv_odd, MATX_C_MODE_SAME)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_same, "conv_same", this->thresh);
   MATX_EXIT_HANDLER();
@@ -388,11 +411,12 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionSameOdd)
 TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionSameOdd)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_odd});   
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_odd});   
   this->pb->RunTVGenerator("conv");   
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_odd, "b_op");
-  (this->cv_same = conv1d(this->av, this->bv_odd, MATX_C_MODE_SAME, MATX_C_METHOD_FFT)).run();
+  (this->cv_same = conv1d(this->av, this->bv_odd, MATX_C_MODE_SAME, MATX_C_METHOD_FFT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_same, "conv_same", this->thresh);
   MATX_EXIT_HANDLER();
@@ -401,11 +425,12 @@ TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionSameOdd)
 TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionSameOdd)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_odd, b_len1_odd});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_odd, b_len1_odd});
   this->pb->RunTVGenerator("conv2d");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_odd, "b_op");
-  (this->cv_same = conv2d(this->av, this->bv_odd, MATX_C_MODE_SAME)).run();
+  (this->cv_same = conv2d(this->av, this->bv_odd, MATX_C_MODE_SAME)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_same, "conv_same", this->thresh);
   MATX_EXIT_HANDLER();
@@ -414,11 +439,12 @@ TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionSameOdd)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionValidOdd)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_odd});   
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_odd});   
   this->pb->RunTVGenerator("conv");   
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_odd, "b_op");
-  (this->cv_valid_odd = conv1d(this->av, this->bv_odd, MATX_C_MODE_VALID)).run();
+  (this->cv_valid_odd = conv1d(this->av, this->bv_odd, MATX_C_MODE_VALID)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_valid_odd, "conv_valid", this->thresh);
   MATX_EXIT_HANDLER();
@@ -427,11 +453,12 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionValidOdd)
 TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionValidOdd)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_odd});   
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_odd});   
   this->pb->RunTVGenerator("conv");   
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_odd, "b_op");
-  (this->cv_valid_odd = conv1d(this->av, this->bv_odd, MATX_C_MODE_VALID, MATX_C_METHOD_FFT)).run();
+  (this->cv_valid_odd = conv1d(this->av, this->bv_odd, MATX_C_MODE_VALID, MATX_C_METHOD_FFT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_valid_odd, "conv_valid", this->thresh);
   MATX_EXIT_HANDLER();
@@ -440,11 +467,12 @@ TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionValidOdd
 TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionValidOdd)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_odd, b_len1_odd});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_odd, b_len1_odd});
   this->pb->RunTVGenerator("conv2d");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_odd, "b_op");
-  (this->cv_valid_odd = conv2d(this->av, this->bv_odd, MATX_C_MODE_VALID)).run();
+  (this->cv_valid_odd = conv2d(this->av, this->bv_odd, MATX_C_MODE_VALID)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_valid_odd, "conv_valid", this->thresh);
   MATX_EXIT_HANDLER();
@@ -453,11 +481,12 @@ TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionValidOdd)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionSwap)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_full_even = conv1d(this->bv_even, this->av, MATX_C_MODE_FULL)).run();
+  (this->cv_full_even = conv1d(this->bv_even, this->av, MATX_C_MODE_FULL)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_even, "conv_full", this->thresh);
   MATX_EXIT_HANDLER();
@@ -466,11 +495,12 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DConvolutionSwap)
 TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionSwap)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});
   this->pb->RunTVGenerator("conv");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_full_even = conv1d(this->bv_even, this->av, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run();
+  (this->cv_full_even = conv1d(this->bv_even, this->av, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_even, "conv_full", this->thresh);
   MATX_EXIT_HANDLER();
@@ -479,11 +509,12 @@ TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DConvolutionSwap)
 TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionSwap)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_even, b_len1_even});
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv2d_operators", {a_len0, a_len1, b_len0_even, b_len1_even});
   this->pb->RunTVGenerator("conv2d");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_full_even = conv2d(this->bv_even, this->av, MATX_C_MODE_FULL)).run();
+  (this->cv_full_even = conv2d(this->bv_even, this->av, MATX_C_MODE_FULL)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_even, "conv_full", this->thresh);
   MATX_EXIT_HANDLER();
@@ -492,13 +523,14 @@ TYPED_TEST(CorrelationConvolution2DTestFloatTypes, Direct2DConvolutionSwap)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DCorrelation)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});  
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});  
   this->pb->RunTVGenerator("corr");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
   // example-begin corr-test-1
   // Full correlation mode with direct correlation
-  (this->cv_full_even = corr(this->av, this->bv_even, MATX_C_MODE_FULL, MATX_C_METHOD_DIRECT)).run();
+  (this->cv_full_even = corr(this->av, this->bv_even, MATX_C_MODE_FULL, MATX_C_METHOD_DIRECT)).run(this->exec);
   // example-end corr-test-1
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_even, "corr", this->thresh);
@@ -508,12 +540,13 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DCorrelation)
 TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DCorrelation)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});  
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});  
   this->pb->RunTVGenerator("corr");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
   // Full correlation mode with direct correlation
-  (this->cv_full_even = corr(this->av, this->bv_even, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run();
+  (this->cv_full_even = corr(this->av, this->bv_even, MATX_C_MODE_FULL, MATX_C_METHOD_FFT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_even, "corr", this->thresh);
   MATX_EXIT_HANDLER();
@@ -522,11 +555,12 @@ TYPED_TEST(CorrelationConvolutionTestNonHalfFloatTypes, FFT1DCorrelation)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DCorrelationSwap)
 {
   MATX_ENTER_HANDLER();
-  this->pb->template InitTVGenerator<TypeParam>("00_transforms", "conv_operators", {a_len0, b_len0_even});  
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  this->pb->template InitTVGenerator<TestType>("00_transforms", "conv_operators", {a_len0, b_len0_even});  
   this->pb->RunTVGenerator("corr_swap");
   this->pb->NumpyToTensorView(this->av, "a_op");
   this->pb->NumpyToTensorView(this->bv_even, "b_op");
-  (this->cv_full_even = corr(this->bv_even, this->av, MATX_C_MODE_FULL, MATX_C_METHOD_DIRECT)).run();
+  (this->cv_full_even = corr(this->bv_even, this->av, MATX_C_MODE_FULL, MATX_C_METHOD_DIRECT)).run(this->exec);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, this->cv_full_even, "corr_swap", this->thresh);
   MATX_EXIT_HANDLER();
@@ -535,27 +569,28 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Direct1DCorrelationSwap)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv1Axis)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const int d1 = 8;
   const int d2 = 512;
   const int d3 = 1024;
 
-  auto in1 = make_tensor<TypeParam>({d1, d2, d3});
-  auto in2 = make_tensor<TypeParam>({d1, d2, d3});
-  auto out1 = make_tensor<TypeParam>({d1, d2, d3});
-  auto out2 = make_tensor<TypeParam>({d1, d2, d3});
+  auto in1 = make_tensor<TestType>({d1, d2, d3});
+  auto in2 = make_tensor<TestType>({d1, d2, d3});
+  auto out1 = make_tensor<TestType>({d1, d2, d3});
+  auto out2 = make_tensor<TestType>({d1, d2, d3});
 
   for(int i = 0; i < d1; i++) {
     for(int j = 0; j < d2; j++) {
       for(int k = 0; k < d3; k++) {
-        in1(i,j,k) = static_cast<TypeParam>((float)(i+j+k));
-        in2(i,j,k) = static_cast<TypeParam>((float)(1));
+        in1(i,j,k) = static_cast<TestType>((float)(i+j+k));
+        in2(i,j,k) = static_cast<TestType>((float)(1));
       }
     }
   }
 
-  (out1 = conv1d(in1, in2, MATX_C_MODE_SAME)).run();
+  (out1 = conv1d(in1, in2, MATX_C_MODE_SAME)).run(this->exec);
   // example-begin conv1d-test-2
-  (out2 = conv1d(in1, in2, {2}, MATX_C_MODE_SAME)).run();
+  (out2 = conv1d(in1, in2, {2}, MATX_C_MODE_SAME)).run(this->exec);
   // example-end conv1d-test-2
 
   cudaStreamSynchronize(0);
@@ -568,9 +603,9 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv1Axis)
     }
   }
 
-  (out1.Permute({0,2,1}) = conv1d(in1.Permute({0,2,1}), in2.Permute({0,2,1}), MATX_C_MODE_SAME)).run();
+  (out1.Permute({0,2,1}) = conv1d(in1.Permute({0,2,1}), in2.Permute({0,2,1}), MATX_C_MODE_SAME)).run(this->exec);
   // example-begin conv1d-test-3
-  (out2 = conv1d(in1, in2, {1}, MATX_C_MODE_SAME)).run();
+  (out2 = conv1d(in1, in2, {1}, MATX_C_MODE_SAME)).run(this->exec);
   // example-end conv1d-test-3
 
   cudaStreamSynchronize(0);
@@ -583,8 +618,8 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv1Axis)
     }
   }
 
-  (out1.Permute({1,2,0}) = conv1d(in1.Permute({1,2,0}), in2.Permute({1,2,0}), MATX_C_MODE_SAME)).run();
-  (out2 = conv1d(in1, in2, {0}, MATX_C_MODE_SAME)).run();
+  (out1.Permute({1,2,0}) = conv1d(in1.Permute({1,2,0}), in2.Permute({1,2,0}), MATX_C_MODE_SAME)).run(this->exec);
+  (out2 = conv1d(in1, in2, {0}, MATX_C_MODE_SAME)).run(this->exec);
 
   cudaStreamSynchronize(0);
 
@@ -596,8 +631,8 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv1Axis)
     }
   }
 
-  (out1 = corr(in1, in2, MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run();
-  (out2 = corr(in1, in2, {2}, MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run();
+  (out1 = corr(in1, in2, MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run(this->exec);
+  (out2 = corr(in1, in2, {2}, MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run(this->exec);
 
   cudaStreamSynchronize(0);
 
@@ -609,8 +644,8 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv1Axis)
     }
   }
 
-  (out1.Permute({0,2,1}) = corr(in1.Permute({0,2,1}), in2.Permute({0,2,1}), MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run();
-  (out2 = corr(in1, in2, {1}, MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run();
+  (out1.Permute({0,2,1}) = corr(in1.Permute({0,2,1}), in2.Permute({0,2,1}), MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run(this->exec);
+  (out2 = corr(in1, in2, {1}, MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run(this->exec);
 
   cudaStreamSynchronize(0);
 
@@ -622,8 +657,8 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv1Axis)
     }
   }
 
-  (out1.Permute({1,2,0}) = corr(in1.Permute({1,2,0}), in2.Permute({1,2,0}), MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run();
-  (out2 = corr(in1, in2, {0}, MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run();
+  (out1.Permute({1,2,0}) = corr(in1.Permute({1,2,0}), in2.Permute({1,2,0}), MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run(this->exec);
+  (out2 = corr(in1, in2, {0}, MATX_C_MODE_SAME, MATX_C_METHOD_DIRECT)).run(this->exec);
 
   cudaStreamSynchronize(0);
 
@@ -641,27 +676,28 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv1Axis)
 TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv2Axis)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
 #if 1  // currently doesn't work because Conv2D requires rank2 filter.
   const int d1 = 8;
   const int d2 = 512;
   const int d3 = 1024;
 
-  auto in1 = make_tensor<TypeParam>({d1, d2, d3});
-  auto in2 = make_tensor<TypeParam>({d1, d2, d3});
-  auto out1 = make_tensor<TypeParam>({d1, d2, d3});
-  auto out2 = make_tensor<TypeParam>({d1, d2, d3});
+  auto in1 = make_tensor<TestType>({d1, d2, d3});
+  auto in2 = make_tensor<TestType>({d1, d2, d3});
+  auto out1 = make_tensor<TestType>({d1, d2, d3});
+  auto out2 = make_tensor<TestType>({d1, d2, d3});
 
   for(int i = 0; i < d1; i++) {
     for(int j = 0; j < d2; j++) {
 			for(int k = 0; k < d3; k++) {
-				in1(i,j,k) = static_cast<TypeParam>((float)(i+j+k));
-				in2(i,j,k) = static_cast<TypeParam>((float)(1));
+				in1(i,j,k) = static_cast<TestType>((float)(i+j+k));
+				in2(i,j,k) = static_cast<TestType>((float)(1));
       }
     }
   }
 
-  (out1 = conv2d(in1, in2, MATX_C_MODE_SAME)).run();
-  (out2 = conv2d(in1, in2, {1, 2}, MATX_C_MODE_SAME)).run();
+  (out1 = conv2d(in1, in2, MATX_C_MODE_SAME)).run(this->exec);
+  (out2 = conv2d(in1, in2, {1, 2}, MATX_C_MODE_SAME)).run(this->exec);
 
   cudaStreamSynchronize(0);
 
@@ -673,8 +709,8 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv2Axis)
     }
   }
  
-  (out1.Permute({0,2,1}) = conv2d(in1.Permute({0,2,1}), in2.Permute({0,2,1}), MATX_C_MODE_SAME)).run();
-  (out2 = conv2d(in1, in2, {2, 1}, MATX_C_MODE_SAME)).run();
+  (out1.Permute({0,2,1}) = conv2d(in1.Permute({0,2,1}), in2.Permute({0,2,1}), MATX_C_MODE_SAME)).run(this->exec);
+  (out2 = conv2d(in1, in2, {2, 1}, MATX_C_MODE_SAME)).run(this->exec);
 
   cudaStreamSynchronize(0);
 
@@ -686,8 +722,8 @@ TYPED_TEST(CorrelationConvolutionTestFloatTypes, Conv2Axis)
     }
   }
   
-  (out1.Permute({1,2,0}) = conv2d(in1.Permute({1,2,0}), in2.Permute({1,2,0}), MATX_C_MODE_SAME)).run();
-  (out2 = conv2d(in1, in2, {2, 0}, MATX_C_MODE_SAME)).run();
+  (out1.Permute({1,2,0}) = conv2d(in1.Permute({1,2,0}), in2.Permute({1,2,0}), MATX_C_MODE_SAME)).run(this->exec);
+  (out2 = conv2d(in1, in2, {2, 0}, MATX_C_MODE_SAME)).run(this->exec);
 
   cudaStreamSynchronize(0);
 

--- a/test/00_transform/Copy.cu
+++ b/test/00_transform/Copy.cu
@@ -43,7 +43,7 @@ class CopyTestsAll : public ::testing::Test
 {
 };
 
-TYPED_TEST_SUITE(CopyTestsAll, MatXTypesAllExecs);
+TYPED_TEST_SUITE(CopyTestsAll, MatXAllTypesAllExecs);
 
 TYPED_TEST(CopyTestsAll, CopyOutParam)
 {

--- a/test/00_transform/FFT.cu
+++ b/test/00_transform/FFT.cu
@@ -41,20 +41,26 @@ using namespace matx;
 template <typename T> class FFTTest : public ::testing::Test {
 
 protected:
+  using GTestType = std::tuple_element_t<0, T>;
+  using GExecType = std::tuple_element_t<1, T>;
+  GExecType exec{};   
   void SetUp() override
   {
-    CheckTestTypeSupport<T>();
+    CheckTestTypeSupport<GTestType>();
+
+    if constexpr (!detail::CheckFFTSupport<GExecType>()) {
+      GTEST_SKIP();
+    }
 
     pb = std::make_unique<detail::MatXPybind>();
 
     // Half precision needs a bit more tolerance when compared to fp32
-    if constexpr (is_complex_half_v<T>) {
+    if constexpr (is_complex_half_v<GTestType>) {
       thresh = 0.4f;
     }
   }
 
   void TearDown() { pb.reset(); }
-
   std::unique_ptr<detail::MatXPybind> pb;
   float thresh = 0.01f;
 };
@@ -67,24 +73,30 @@ template <typename TensorType>
 class FFTTestComplexNonHalfTypes : public FFTTest<TensorType> {
 };
 
-TYPED_TEST_SUITE(FFTTestComplexTypes, MatXComplexTypes);
-TYPED_TEST_SUITE(FFTTestComplexNonHalfTypes, MatXComplexNonHalfTypes);
+template <typename TensorType>
+class FFTTestComplexNonHalfTypesAllExecs : public FFTTest<TensorType> {
+};
+
+TYPED_TEST_SUITE(FFTTestComplexTypes, MatXComplexTypesCUDAExec);
+TYPED_TEST_SUITE(FFTTestComplexNonHalfTypes, MatXComplexNonHalfTypesAllExecs);
+TYPED_TEST_SUITE(FFTTestComplexNonHalfTypesAllExecs, MatXComplexNonHalfTypesAllExecs);
 
 TYPED_TEST(FFTTestComplexTypes, FFT1D1024C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_1d", {fft_dim, fft_dim});
 
-  tensor_t<TypeParam, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim}};
+  tensor_t<TestType, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
   // example-begin fft-1
   // Perform a 1D FFT from input av into output avo. Input and output sizes will be deduced by the
   // type of the tensors and output size.
-  (avo = fft(av)).run();
+  (avo = fft(av)).run(this->exec);
   // example-end fft-1
   cudaStreamSynchronize(0);
 
@@ -95,18 +107,19 @@ TYPED_TEST(FFTTestComplexTypes, FFT1D1024C2C)
 TYPED_TEST(FFTTestComplexTypes, FFT1DFWD1024C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_1d_fwd", {fft_dim, fft_dim});
 
-  tensor_t<TypeParam, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim}};
+  tensor_t<TestType, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
   // example-begin fft-1-fwd
   // Perform a 1D FFT from input av into output avo with FORWARD scaling (1/N). Input and output sizes will be deduced by the
   // type of the tensors and output size.
-  (avo = fft(av, fft_dim, FFTNorm::FORWARD)).run();
+  (avo = fft(av, fft_dim, FFTNorm::FORWARD)).run(this->exec);
   // example-end fft-1
   cudaStreamSynchronize(0);
 
@@ -117,18 +130,19 @@ TYPED_TEST(FFTTestComplexTypes, FFT1DFWD1024C2C)
 TYPED_TEST(FFTTestComplexTypes, FFT1DORTHO1024C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_1d_ortho", {fft_dim, fft_dim});
 
-  tensor_t<TypeParam, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim}};
+  tensor_t<TestType, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
   // example-begin fft-1
   // Perform a 1D FFT from input av into output avo with ORTHO scaling (1/sqrt(N)). Input and output sizes will be deduced by the
   // type of the tensors and output size.
-  (avo = fft(av, fft_dim, FFTNorm::ORTHO)).run();
+  (avo = fft(av, fft_dim, FFTNorm::ORTHO)).run(this->exec);
   // example-end fft-1
   cudaStreamSynchronize(0);
 
@@ -136,30 +150,32 @@ TYPED_TEST(FFTTestComplexTypes, FFT1DORTHO1024C2C)
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1Axis)
+TYPED_TEST(FFTTestComplexNonHalfTypesAllExecs, FFT1Axis)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+
   const int d1 = 8;
   const int d2 = 512;
   const int d3 = 1024;
 
   // example-begin fft-2
-  auto in = make_tensor<TypeParam>({d1, d2, d3});
-  auto out1 = make_tensor<TypeParam>({d1, d2, d3});
-  auto out2 = make_tensor<TypeParam>({d1, d2, d3});
+  auto in = make_tensor<TestType>({d1, d2, d3});
+  auto out1 = make_tensor<TestType>({d1, d2, d3});
+  auto out2 = make_tensor<TestType>({d1, d2, d3});
 
   for(int i = 0; i < d1; i++) {
     for(int j = 0; j < d2; j++) {
       for(int k = 0; k < d3; k++) {
-        in(i,j,k) = static_cast<TypeParam>((float)(i+j+k));
+        in(i,j,k) = static_cast<TestType>((float)(i+j+k));
       }
     }
   }
 
   // Perform a batched 1D FFT on a 3D tensor across axis 2. Since axis 2 is the last dimension,
   // this is equivalent to not specifying the axis
-  (out1 = fft(in)).run();
-  (out2 = fft(in, {2})).run();
+  (out1 = fft(in)).run(this->exec);
+  (out2 = fft(in, {2})).run(this->exec);
 
   // example-end fft-2
   cudaStreamSynchronize(0);
@@ -175,8 +191,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1Axis)
   // example-begin fft-3
   // Perform a batched 1D FFT on a 3D tensor across axis 1. This is equivalent to permuting the last
   // two axes before input and after the output
-  (out1.Permute({0,2,1}) = fft(in.Permute({0,2,1}))).run();
-  (out2 = fft(in, {1})).run();  
+  (out1.Permute({0,2,1}) = fft(in.Permute({0,2,1}))).run(this->exec);
+  (out2 = fft(in, {1})).run(this->exec);  
 
   // example-end fft-3
   cudaStreamSynchronize(0);
@@ -192,8 +208,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1Axis)
   // example-begin ifft-1
   // Perform a batched 1D IFFT on a 3D tensor across axis 2. Since axis 2 is the last dimension,
   // this is equivalent to not specifying the axis
-  (out1 = ifft(in)).run();
-  (out2 = ifft(in, {2})).run();    
+  (out1 = ifft(in)).run(this->exec);
+  (out2 = ifft(in, {2})).run(this->exec);    
   // example-end ifft-1
   cudaStreamSynchronize(0);
 
@@ -208,8 +224,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1Axis)
   // example-begin ifft-2
   // Perform a batched 1D IFFT on a 3D tensor across axis 1. This is equivalent to permuting the last
   // two axes before input and after the output
-  (out1.Permute({0,2,1}) = ifft(in.Permute({0,2,1}))).run();
-  (out2 = ifft(in, {1})).run();    
+  (out1.Permute({0,2,1}) = ifft(in.Permute({0,2,1}))).run(this->exec);
+  (out2 = ifft(in, {1})).run(this->exec);    
   // example-end ifft-2
   cudaStreamSynchronize(0);
   
@@ -222,9 +238,9 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1Axis)
   }
   
   {
-    auto in1 =  ones<TypeParam>(in.Shape());
-    (out1.Permute({0,2,1}) = fft(permute(in1, {0,2,1}))).run();
-    (out2 = fft(in1, {1})).run();
+    auto in1 =  ones<TestType>(in.Shape());
+    (out1.Permute({0,2,1}) = fft(permute(in1, {0,2,1}))).run(this->exec);
+    (out2 = fft(in1, {1})).run(this->exec);
 
     cudaStreamSynchronize(0);
 
@@ -237,8 +253,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1Axis)
     }
 
 
-    (out1.Permute({1,2,0}) = ifft(permute(in1, {1,2,0}))).run();
-    (out2 = ifft(in1, {0})).run();
+    (out1.Permute({1,2,0}) = ifft(permute(in1, {1,2,0}))).run(this->exec);
+    (out2 = ifft(in1, {0})).run(this->exec);
     cudaStreamSynchronize(0);
 
     for(int i = 0; i < d1; i++) {
@@ -253,16 +269,18 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1Axis)
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
+TYPED_TEST(FFTTestComplexNonHalfTypesAllExecs, FFT2Axis)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+; 
   const int d1 = 128;
   const int d2 = 256;
   const int d3 = 512;
 
-  auto in = make_tensor<TypeParam>({d1, d2, d3});
-  auto out1 = make_tensor<TypeParam>({d1, d2, d3});
-  auto out2 = make_tensor<TypeParam>({d1, d2, d3});
+  auto in = make_tensor<TestType>({d1, d2, d3});
+  auto out1 = make_tensor<TestType>({d1, d2, d3});
+  auto out2 = make_tensor<TestType>({d1, d2, d3});
 
   for(int i = 0; i < d1; i++) {
     for(int j = 0; j < d2; j++) {
@@ -275,8 +293,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
   // example-begin fft2-1
   // Perform a 2D FFT from 3D tensor "in" into "out1". This is equivalent to performing the FFT
   // on the last two dimension unpermuted.
-  (out1 = fft2(in)).run();
-  (out2 = fft2(in, {1,2})).run();
+  (out1 = fft2(in)).run(this->exec);
+  (out2 = fft2(in, {1,2})).run(this->exec);
   // example-end fft2-1
   cudaStreamSynchronize(0);
 
@@ -291,8 +309,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
   // example-begin fft2-2
   // Perform a 2D FFT from 3D tensor "in" into "out2" across dimensions 2, 0. This is equivalent
   // to permuting the tensor before input and after output
-  (out1.Permute({1,2,0}) = fft2(in.Permute({1,2,0}))).run();
-  (out2 = fft2(in, {2,0})).run();
+  (out1.Permute({1,2,0}) = fft2(in.Permute({1,2,0}))).run(this->exec);
+  (out2 = fft2(in, {2,0})).run(this->exec);
   // example-end fft2-2
   cudaStreamSynchronize(0);
   
@@ -304,8 +322,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
     }
   }
 
-  (out1.Permute({1,0,2}) = fft2(in.Permute({1,0,2}))).run();
-  (out2 = fft2(in, {0,2})).run();
+  (out1.Permute({1,0,2}) = fft2(in.Permute({1,0,2}))).run(this->exec);
+  (out2 = fft2(in, {0,2})).run(this->exec);
   cudaStreamSynchronize(0);
   
   for(int i = 0; i < d1; i++) {
@@ -319,8 +337,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
   // example-begin ifft2-1
   // Perform a 2D FFT from 3D tensor "in" into "out1". This is equivalent to performing the FFT
   // on the last two dimension unpermuted.
-  (out1 = ifft2(in)).run();
-  (out2 = ifft2(in, {1,2})).run();
+  (out1 = ifft2(in)).run(this->exec);
+  (out2 = ifft2(in, {1,2})).run(this->exec);
   // example-end ifft2-1
   cudaStreamSynchronize(0);
 
@@ -335,8 +353,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
   // example-begin ifft2-2
   // Perform a 2D FFT from 3D tensor "in" into "out2" across dimensions 2, 0. This is equivalent
   // to permuting the tensor before input and after output
-  (out1.Permute({1,2,0}) = ifft2(in.Permute({1,2,0}))).run();
-  (out2 = ifft2(in, {2,0})).run();
+  (out1.Permute({1,2,0}) = ifft2(in.Permute({1,2,0}))).run(this->exec);
+  (out2 = ifft2(in, {2,0})).run(this->exec);
   // example-end ifft2-2
   cudaStreamSynchronize(0);
   
@@ -348,8 +366,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
     }
   }
 
-  (out1.Permute({1,0,2}) = ifft2(in.Permute({1,0,2}))).run();
-  (out2 = ifft2(in, {0,2})).run();
+  (out1.Permute({1,0,2}) = ifft2(in.Permute({1,0,2}))).run(this->exec);
+  (out2 = ifft2(in, {0,2})).run(this->exec);
   cudaStreamSynchronize(0);
   
   for(int i = 0; i < d1; i++) {
@@ -361,10 +379,10 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
   }
  
   {
-    auto in1 =  ones<TypeParam>(in.Shape());
+    auto in1 =  ones<TestType>(in.Shape());
 
-    (out1.Permute({1,0,2}) = fft2(permute(in1, {1,0,2}))).run();
-    (out2 = fft2(in1, {0,2})).run();
+    (out1.Permute({1,0,2}) = fft2(permute(in1, {1,0,2}))).run(this->exec);
+    (out2 = fft2(in1, {0,2})).run(this->exec);
     cudaStreamSynchronize(0);
 
     for(int i = 0; i < d1; i++) {
@@ -376,8 +394,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
     }
     
 
-    (out1.Permute({1,0,2}) = ifft2(permute(in1, {1,0,2}))).run();
-    (out2 = ifft2(in1, {0,2})).run();
+    (out1.Permute({1,0,2}) = ifft2(permute(in1, {1,0,2}))).run(this->exec);
+    (out2 = ifft2(in1, {0,2})).run(this->exec);
     cudaStreamSynchronize(0);
 
     for(int i = 0; i < d1; i++) {
@@ -395,14 +413,15 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2Axis)
 TYPED_TEST(FFTTestComplexTypes, IFFT1D1024C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "ifft_1d", {fft_dim, fft_dim});
-  tensor_t<TypeParam, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim}};
+  tensor_t<TestType, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = ifft(av)).run();
+  (avo = ifft(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -412,14 +431,15 @@ TYPED_TEST(FFTTestComplexTypes, IFFT1D1024C2C)
 TYPED_TEST(FFTTestComplexTypes, IFFT1DORTHO1024C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "ifft_1d_ortho", {fft_dim, fft_dim});
-  tensor_t<TypeParam, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim}};
+  tensor_t<TestType, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = ifft(av, fft_dim, FFTNorm::ORTHO)).run();
+  (avo = ifft(av, fft_dim, FFTNorm::ORTHO)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -429,14 +449,15 @@ TYPED_TEST(FFTTestComplexTypes, IFFT1DORTHO1024C2C)
 TYPED_TEST(FFTTestComplexTypes, IFFT1DFWD1024C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "ifft_1d_fwd", {fft_dim, fft_dim});
-  tensor_t<TypeParam, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim}};
+  tensor_t<TestType, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = ifft(av, fft_dim, FFTNorm::FORWARD)).run();
+  (avo = ifft(av, fft_dim, FFTNorm::FORWARD)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -446,16 +467,17 @@ TYPED_TEST(FFTTestComplexTypes, IFFT1DFWD1024C2C)
 TYPED_TEST(FFTTestComplexTypes, FFT1D1024PadC2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_1d", {fft_dim, fft_dim * 2});
   // example-begin fft-4
-  auto av = make_tensor<TypeParam>({fft_dim});
-  auto avo = make_tensor<TypeParam>({fft_dim * 2});
+  auto av = make_tensor<TestType>({fft_dim});
+  auto avo = make_tensor<TestType>({fft_dim * 2});
   this->pb->NumpyToTensorView(av, "a_in");
 
   // Specify the FFT size as bigger than av. Thus, av will be zero-padded to the appropriate size
-  (avo = fft(av, fft_dim * 2)).run();
+  (avo = fft(av, fft_dim * 2)).run(this->exec);
   // example-end fft-4
   cudaStreamSynchronize(0);
 
@@ -466,21 +488,22 @@ TYPED_TEST(FFTTestComplexTypes, FFT1D1024PadC2C)
 TYPED_TEST(FFTTestComplexTypes, FFT1D1024PadBatchedC2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 4;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_1d_batched", {fft_dim+1, fft_dim+2, fft_dim*2});
-  tensor_t<TypeParam, 2> av{{fft_dim + 1, fft_dim + 2}};
-  tensor_t<TypeParam, 2> avo{{fft_dim + 1, fft_dim * 2}};
+  tensor_t<TestType, 2> av{{fft_dim + 1, fft_dim + 2}};
+  tensor_t<TestType, 2> avo{{fft_dim + 1, fft_dim * 2}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft(av, fft_dim*2)).run();
+  (avo = fft(av, fft_dim*2)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
 
   // example-begin fft-5
   // Perform an FFT but force the size to be fft_dim * 2 instead of the output size
-  (avo = fft(av, fft_dim * 2)).run(); // Force the FFT size
+  (avo = fft(av, fft_dim * 2)).run(this->exec); // Force the FFT size
   // example-end fft-5
   cudaStreamSynchronize(0);
 
@@ -491,65 +514,70 @@ TYPED_TEST(FFTTestComplexTypes, FFT1D1024PadBatchedC2C)
 TYPED_TEST(FFTTestComplexTypes, IFFT1D1024PadC2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "ifft_1d", {fft_dim, fft_dim * 2});
-  tensor_t<TypeParam, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim * 2}};
+  tensor_t<TestType, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim * 2}};
   this->pb->NumpyToTensorView(av, "a_in");
 
   // Specify the IFFT size as bigger than av. Thus, av will be zero-padded to the appropriate size
-  (avo = ifft(av, fft_dim * 2)).run();
+  (avo = ifft(av, fft_dim * 2)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1D1024R2C)
+TYPED_TEST(FFTTestComplexNonHalfTypesAllExecs, FFT1D1024R2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+
   const index_t fft_dim = 1024;
-  using rtype = typename TypeParam::value_type;
+  using rtype = typename TestType::value_type;
   this->pb->template InitAndRunTVGenerator<rtype>(
       "00_transforms", "fft_operators", "rfft_1d", {fft_dim, fft_dim});
 
-  tensor_t<typename TypeParam::value_type, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim / 2 + 1}};
+  tensor_t<typename TestType::value_type, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim / 2 + 1}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft(av)).run();
+  (avo = fft(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1D1024PadR2C)
+TYPED_TEST(FFTTestComplexNonHalfTypesAllExecs, FFT1D1024PadR2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>; 
+
   const index_t fft_dim = 4;
-  using rtype = typename TypeParam::value_type;
+  using rtype = typename TestType::value_type;
   this->pb->template InitAndRunTVGenerator<rtype>(
       "00_transforms", "fft_operators", "rfft_1d", {fft_dim, fft_dim*2});
 
-  tensor_t<typename TypeParam::value_type, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim + 1}};
+  tensor_t<typename TestType::value_type, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim + 1}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft(av, fft_dim*2)).run();
+  (avo = fft(av, fft_dim*2)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1DSizeChecks)
+TYPED_TEST(FFTTestComplexNonHalfTypesAllExecs, FFT1DSizeChecks)
 {
   MATX_ENTER_HANDLER();
-
-  using ComplexType = TypeParam;
-  using RealType = typename TypeParam::value_type;
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ComplexType = TestType;
+  using RealType = typename TestType::value_type;
 
   const index_t N = 16;
   auto tc = make_tensor<ComplexType>({N});
@@ -559,28 +587,28 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1DSizeChecks)
   ASSERT_THROW({
     auto t2 = make_tensor<ComplexType>({2*N});
     // We do not implicitly zero-pad to a larger transform size
-    (t2 = fft(tc)).run();
+    (t2 = fft(tc)).run(this->exec);
     cudaDeviceSynchronize();
   }, matx::detail::matxException);
 
   // C2C, output size smaller than input size
   ASSERT_THROW({
     auto t2 = make_tensor<ComplexType>({(N/2)+1});
-    (t2 = fft(tc)).run();
+    (t2 = fft(tc)).run(this->exec);
     cudaDeviceSynchronize();
   }, matx::detail::matxException);
 
   // R2C, output size smaller than N/2 + 1
   ASSERT_THROW({
     auto t2 = make_tensor<ComplexType>({N/2});
-    (t2 = fft(tr)).run();
+    (t2 = fft(tr)).run(this->exec);
     cudaDeviceSynchronize();
   }, matx::detail::matxException);
 
   // R2C, output size larger than N/2 + 1
   ASSERT_THROW({
     auto t2 = make_tensor<ComplexType>({N/2+2});
-    (t2 = fft(tr)).run();
+    (t2 = fft(tr)).run(this->exec);
     cudaDeviceSynchronize();
   }, matx::detail::matxException);
 
@@ -588,7 +616,7 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1DSizeChecks)
   ASSERT_THROW({
     auto tcs = slice(tc, {0}, {N/2+1});
     auto t2 = make_tensor<RealType>({N-1});
-    (t2 = fft(tcs)).run();
+    (t2 = fft(tcs)).run(this->exec);
     cudaDeviceSynchronize();
   }, matx::detail::matxException);
 
@@ -596,26 +624,27 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1DSizeChecks)
  ASSERT_THROW({
     auto tcs = slice(tc, {0}, {N/2+1});
     auto t2 = make_tensor<RealType>({N+2});
-    (t2 = fft(tcs)).run();
+    (t2 = fft(tcs)).run(this->exec);
     cudaDeviceSynchronize();
  }, matx::detail::matxException);
 
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1D1024PadBatchedR2C)
+TYPED_TEST(FFTTestComplexNonHalfTypesAllExecs, FFT1D1024PadBatchedR2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 4;
-  using rtype = typename TypeParam::value_type;
+  using rtype = typename TestType::value_type;
   this->pb->template InitAndRunTVGenerator<rtype>(
       "00_transforms", "fft_operators", "rfft_1d_batched", {fft_dim, fft_dim, fft_dim*2});
 
-  tensor_t<typename TypeParam::value_type, 2> av{{fft_dim, fft_dim}};
-  tensor_t<TypeParam, 2> avo{{fft_dim, fft_dim + 1}};
+  tensor_t<typename TestType::value_type, 2> av{{fft_dim, fft_dim}};
+  tensor_t<TestType, 2> avo{{fft_dim, fft_dim + 1}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft(av, fft_dim*2)).run();
+  (avo = fft(av, fft_dim*2)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -625,15 +654,16 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1D1024PadBatchedR2C)
 TYPED_TEST(FFTTestComplexTypes, FFT2D16C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 16;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_2d", {fft_dim, fft_dim});
 
-  tensor_t<TypeParam, 2> av{{fft_dim, fft_dim}};
-  tensor_t<TypeParam, 2> avo{{fft_dim, fft_dim}};
+  tensor_t<TestType, 2> av{{fft_dim, fft_dim}};
+  tensor_t<TestType, 2> avo{{fft_dim, fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft2(av)).run();
+  (avo = fft2(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -643,15 +673,16 @@ TYPED_TEST(FFTTestComplexTypes, FFT2D16C2C)
 TYPED_TEST(FFTTestComplexTypes, FFT2D16x32C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim[] = {16, 32};
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_2d", {fft_dim[0], fft_dim[1]});
 
-  tensor_t<TypeParam, 2> av{{fft_dim[0], fft_dim[1]}};
-  tensor_t<TypeParam, 2> avo{{fft_dim[0], fft_dim[1]}};
+  tensor_t<TestType, 2> av{{fft_dim[0], fft_dim[1]}};
+  tensor_t<TestType, 2> avo{{fft_dim[0], fft_dim[1]}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft2(av)).run();
+  (avo = fft2(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -661,17 +692,18 @@ TYPED_TEST(FFTTestComplexTypes, FFT2D16x32C2C)
 TYPED_TEST(FFTTestComplexTypes, FFT2D16BatchedC2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t batch_size = 10;
   const index_t fft_dim = 16;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_2d_batched",
       {batch_size, fft_dim, fft_dim});
 
-  tensor_t<TypeParam, 3> av{{batch_size, fft_dim, fft_dim}};
-  tensor_t<TypeParam, 3> avo{{batch_size, fft_dim, fft_dim}};
+  tensor_t<TestType, 3> av{{batch_size, fft_dim, fft_dim}};
+  tensor_t<TestType, 3> avo{{batch_size, fft_dim, fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft2(av)).run();
+  (avo = fft2(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -681,18 +713,19 @@ TYPED_TEST(FFTTestComplexTypes, FFT2D16BatchedC2C)
 TYPED_TEST(FFTTestComplexTypes, FFT2D16BatchedStridedC2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t batch_size = 10;
   const index_t fft_dim = 16;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_2d_batched_strided",
       {fft_dim, batch_size, fft_dim});
 
-  tensor_t<TypeParam, 3> av{{fft_dim, batch_size, fft_dim}};
-  tensor_t<TypeParam, 3> avo{{fft_dim, batch_size, fft_dim}};
+  tensor_t<TestType, 3> av{{fft_dim, batch_size, fft_dim}};
+  tensor_t<TestType, 3> avo{{fft_dim, batch_size, fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
   const int32_t axes[] = {0, 2};
-  (avo = fft2(av, axes)).run();
+  (avo = fft2(av, axes)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -702,15 +735,16 @@ TYPED_TEST(FFTTestComplexTypes, FFT2D16BatchedStridedC2C)
 TYPED_TEST(FFTTestComplexTypes, IFFT2D16C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 16;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "ifft_2d", {fft_dim, fft_dim});
 
-  tensor_t<TypeParam, 2> av{{fft_dim, fft_dim}};
-  tensor_t<TypeParam, 2> avo{{fft_dim, fft_dim}};
+  tensor_t<TestType, 2> av{{fft_dim, fft_dim}};
+  tensor_t<TestType, 2> avo{{fft_dim, fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = ifft2(av)).run();
+  (avo = ifft2(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -720,15 +754,16 @@ TYPED_TEST(FFTTestComplexTypes, IFFT2D16C2C)
 TYPED_TEST(FFTTestComplexTypes, IFFT2D16x32C2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim[] = {16, 32};
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "ifft_2d", {fft_dim[0], fft_dim[1]});
 
-  tensor_t<TypeParam, 2> av{{fft_dim[0], fft_dim[1]}};
-  tensor_t<TypeParam, 2> avo{{fft_dim[0], fft_dim[1]}};
+  tensor_t<TestType, 2> av{{fft_dim[0], fft_dim[1]}};
+  tensor_t<TestType, 2> avo{{fft_dim[0], fft_dim[1]}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = ifft2(av)).run();
+  (avo = ifft2(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -738,16 +773,17 @@ TYPED_TEST(FFTTestComplexTypes, IFFT2D16x32C2C)
 TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2D16R2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 16;
-  using rtype = typename TypeParam::value_type;
+  using rtype = typename TestType::value_type;
   this->pb->template InitAndRunTVGenerator<rtype>(
       "00_transforms", "fft_operators", "rfft_2d", {fft_dim, fft_dim});
 
   tensor_t<rtype, 2> av{{fft_dim, fft_dim}};
-  tensor_t<TypeParam, 2> avo{{fft_dim, fft_dim / 2 + 1}};
+  tensor_t<TestType, 2> avo{{fft_dim, fft_dim / 2 + 1}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft2(av)).run();
+  (avo = fft2(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -757,16 +793,17 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2D16R2C)
 TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2D16x32R2C)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim[] = {16, 32};
-  using rtype = typename TypeParam::value_type;
+  using rtype = typename TestType::value_type;
   this->pb->template InitAndRunTVGenerator<rtype>(
       "00_transforms", "fft_operators", "rfft_2d", {fft_dim[0], fft_dim[1]});
 
   tensor_t<rtype, 2> av{{fft_dim[0], fft_dim[1]}};
-  tensor_t<TypeParam, 2> avo{{fft_dim[0], fft_dim[1] / 2 + 1}};
+  tensor_t<TestType, 2> avo{{fft_dim[0], fft_dim[1] / 2 + 1}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft2(av)).run();
+  (avo = fft2(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -776,16 +813,17 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2D16x32R2C)
 TYPED_TEST(FFTTestComplexNonHalfTypes, IFFT2D16C2R)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim = 16;
-  using rtype = typename TypeParam::value_type;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  using rtype = typename TestType::value_type;
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "irfft_2d", {fft_dim, fft_dim});
 
-  tensor_t<TypeParam, 2> av{{fft_dim, fft_dim / 2 + 1}};
+  tensor_t<TestType, 2> av{{fft_dim, fft_dim / 2 + 1}};
   tensor_t<rtype, 2> avo{{fft_dim, fft_dim}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = ifft2(av)).run();
+  (avo = ifft2(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
@@ -795,51 +833,56 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, IFFT2D16C2R)
 TYPED_TEST(FFTTestComplexNonHalfTypes, IFFT2D16x32C2R)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
   const index_t fft_dim[] = {16, 32};
-  using rtype = typename TypeParam::value_type;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  using rtype = typename TestType::value_type;
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "irfft_2d", {fft_dim[0], fft_dim[1]});
 
-  tensor_t<TypeParam, 2> av{{fft_dim[0], fft_dim[1] / 2 + 1}};
+  tensor_t<TestType, 2> av{{fft_dim[0], fft_dim[1] / 2 + 1}};
   tensor_t<rtype, 2> avo{{fft_dim[0], fft_dim[1]}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = ifft2(av)).run();
+  (avo = ifft2(av)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, FFT1D1024C2CShort)
+TYPED_TEST(FFTTestComplexNonHalfTypesAllExecs, FFT1D1024C2CShort)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "fft_1d", {fft_dim, fft_dim - 16});
 
-  tensor_t<TypeParam, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim - 16}};
+  tensor_t<TestType, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim - 16}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = fft(av, fft_dim - 16)).run();
+  (avo = fft(av, fft_dim - 16)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, IFFT1D1024C2CShort)
+TYPED_TEST(FFTTestComplexNonHalfTypesAllExecs, IFFT1D1024C2CShort)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+ 
   const index_t fft_dim = 1024;
-  this->pb->template InitAndRunTVGenerator<TypeParam>(
+  this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "fft_operators", "ifft_1d", {fft_dim, fft_dim - 16});
-  tensor_t<TypeParam, 1> av{{fft_dim}};
-  tensor_t<TypeParam, 1> avo{{fft_dim - 16}};
+  tensor_t<TestType, 1> av{{fft_dim}};
+  tensor_t<TestType, 1> avo{{fft_dim - 16}};
   this->pb->NumpyToTensorView(av, "a_in");
 
-  (avo = ifft(av, fft_dim - 16)).run();
+  (avo = ifft(av, fft_dim - 16)).run(this->exec);
   cudaStreamSynchronize(0);
 
   MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);

--- a/test/00_transform/Solve.cu
+++ b/test/00_transform/Solve.cu
@@ -43,26 +43,29 @@ template <typename TensorType>
 class SolveTestsFloatNonComplexNonHalf : public ::testing::Test {
 };
 
-TYPED_TEST_SUITE(SolveTestsFloatNonComplexNonHalf, MatXFloatNonComplexNonHalfTypes);
+TYPED_TEST_SUITE(SolveTestsFloatNonComplexNonHalf, MatXFloatNonComplexNonHalfTypesCUDAExec);
 
 TYPED_TEST(SolveTestsFloatNonComplexNonHalf, CGSolve)
 {
   MATX_ENTER_HANDLER();
+  using TestType = std::tuple_element_t<0, TypeParam>;
+  using ExecType = std::tuple_element_t<1, TypeParam>;  
+  ExecType exec{};
 
   int gN = 4;
   int N = gN * gN;
   int BATCH = 4;
 
-  auto A = make_tensor<TypeParam, 3> ({BATCH, N, N}); 
-  auto X = make_tensor<TypeParam, 2> ({BATCH, N}); 
-  auto B = make_tensor<TypeParam, 2> ({BATCH, N}); 
+  auto A = make_tensor<TestType, 3> ({BATCH, N, N}); 
+  auto X = make_tensor<TestType, 2> ({BATCH, N}); 
+  auto B = make_tensor<TestType, 2> ({BATCH, N}); 
 
 
   // Simple 1D Poisson matrix
   for(int b = 0; b < BATCH; b++) {
     for(int i = 0; i < N; i++) {
-      X(b,i) = TypeParam(0+b);
-      B(b,i) = TypeParam(1+b);
+      X(b,i) = TestType(0+b);
+      B(b,i) = TestType(1+b);
       for(int j = 0; j < N; j++) {
         if(i==j) 
           A(b,i,j) = 2;
@@ -77,14 +80,14 @@ TYPED_TEST(SolveTestsFloatNonComplexNonHalf, CGSolve)
   }
 
   // example-begin cgsolve-test-1
-  (X = cgsolve(A, B, .00001, 10)).run();
+  (X = cgsolve(A, B, .00001, 10)).run(exec);
   // example-end cgsolve-test-1
-  (B = matvec(A, X)).run();
+  (B = matvec(A, X)).run(exec);
   cudaDeviceSynchronize();
 
   for(int i = 0; i < BATCH; i++) {
     for(int j = 0; j < N; j++) {
-      ASSERT_NEAR(B(i,j), TypeParam(1+i), .0001);
+      ASSERT_NEAR(B(i,j), TestType(1+i), .0001);
     }
   }
   MATX_EXIT_HANDLER();

--- a/test/include/test_types.h
+++ b/test/include/test_types.h
@@ -73,38 +73,7 @@ template <> auto inline GenerateData<cuda::std::complex<double>>()
 }
 
 using ExecutorTypesAll = std::tuple<matx::cudaExecutor, matx::HostExecutor>;
-
-// Define the types to test for each group. If a type is put into a list that
-// isn't compatible with a test type, a compiler error will occur
-
-using MatXAllTypes = Types<matx::matxFp16, matx::matxBf16, bool, uint32_t, int32_t, uint64_t,
-              int64_t, float, double, cuda::std::complex<float>,
-              cuda::std::complex<double>, matx::matxFp16Complex,
-              matx::matxBf16Complex>;
-using MatXFloatTypes = Types<matx::matxFp16, matx::matxBf16, float, double,
-              cuda::std::complex<float>, cuda::std::complex<double>,
-              matx::matxFp16Complex, matx::matxBf16Complex>;
-using MatXFloatNonHalfTypes = Types<float, double,
-              cuda::std::complex<float>, cuda::std::complex<double>>;
-using MatXFloatNonComplexTypes = Types<matx::matxFp16, matx::matxBf16, float, double>;
-  
-using MatXFloatHalfTypes = Types<matx::matxFp16, matx::matxBf16>;
-using MatXNumericTypes = Types<matx::matxFp16, matx::matxBf16, uint32_t, int32_t, uint64_t,
-              int64_t, float, double, cuda::std::complex<float>,
-              cuda::std::complex<double>, matx::matxFp16Complex,
-              matx::matxBf16Complex>;
-
-using MatXNumericNoHalfTypes = Types<uint32_t, int32_t, uint64_t, int64_t, float, double,
-              cuda::std::complex<float>, cuda::std::complex<double>>;
-using MatXBoolTypes =  Types<bool>;
-using MatXFloatNonComplexNonHalfTypes = Types<float, double>;
-using MatXComplexTypes = Types<cuda::std::complex<float>, cuda::std::complex<double>,
-              matx::matxFp16Complex, matx::matxBf16Complex>;
-using MatXComplexNonHalfTypes = Types<cuda::std::complex<float>, cuda::std::complex<double>>;
-using MatXNumericNonComplexTypes = Types<uint32_t, int32_t, uint64_t, int64_t, float, double>;
-using MatXAllIntegralTypes = Types<uint32_t, int32_t, uint64_t, int64_t>;
-using MatXSignedIntegralTypes = Types<int32_t, int64_t>;
-using MatXUnsignedIntegralTypes = Types<uint32_t, uint64_t>;
+using ExecutorTypesCUDAOnly = std::tuple<matx::cudaExecutor>;
 
 
 /* Taken from https://stackoverflow.com/questions/70404549/cartesian-product-of-stdtuple */
@@ -135,10 +104,11 @@ struct TupleToTypes<std::tuple<T...>>
   using type = ::Types<T...>;
 };
 
-
+// Groups of types used for a specific test
 using MatXFloatNonComplexNonHalfTuple        = std::tuple<float, double>;
-using MatXNumericNoHalfTuple                 = std::tuple<uint32_t, int32_t, uint64_t, int64_t, float, double,
+using MatXNumericNonHalfTuple                = std::tuple<uint32_t, int32_t, uint64_t, int64_t, float, double,
                                                           cuda::std::complex<float>, cuda::std::complex<double>>;
+using MatXFloatNonHalfTuple                  = std::tuple<float, double, cuda::std::complex<float>, cuda::std::complex<double>>;
 using MatXComplexNonHalfTuple                = std::tuple<cuda::std::complex<float>, cuda::std::complex<double>>;
 using MatXNumericNonComplexTuple             = std::tuple<uint32_t, int32_t, uint64_t, int64_t, float, double>;
 using MatXComplexTuple                       = std::tuple<cuda::std::complex<float>, cuda::std::complex<double>,
@@ -158,18 +128,38 @@ using MatXNumericTuple                       = std::tuple<matx::matxFp16, matx::
                                               matx::matxBf16Complex>;     
 using MatXIntegralTuple                      = std::tuple<uint32_t, int32_t, uint64_t, int64_t>;                                                                                                                                                         
 
-using MatXFloatNonComplexTuple               = std::tuple<matx::matxFp16, matx::matxBf16, float, double>;                                                      
-using MatXBooleanTuple                       = std::tuple<bool>;   
+using MatXFloatNonComplexTuple               = std::tuple<matx::matxFp16, matx::matxBf16, float, double>;                     
+using MatXFloatHalfTuple                     = std::tuple<matx::matxFp16, matx::matxBf16>;                                           
+using MatXBooleanTuple                       = std::tuple<bool>;  
+using MatXDoubleOnlyTuple                    = std::tuple<double>; 
 
+// CUDA-only types
+using MatXAllTypesCUDAExec                    = TupleToTypes<TypedCartesianProduct<MatXAllTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXFloatTypesCUDAExec                  = TupleToTypes<TypedCartesianProduct<MatXFloatTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXFloatNonHalfTypesCUDAExec           = TupleToTypes<TypedCartesianProduct<MatXFloatNonHalfTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXFloatNonComplexTypesCUDAExec        = TupleToTypes<TypedCartesianProduct<MatXFloatNonComplexTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXFloatHalfTypesCUDAExec              = TupleToTypes<TypedCartesianProduct<MatXFloatHalfTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXNumericTypesCUDAExec                = TupleToTypes<TypedCartesianProduct<MatXNumericTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXNumericNonHalfTypesCUDAExec         = TupleToTypes<TypedCartesianProduct<MatXNumericNonHalfTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXBoolTypesCUDAExec                   = TupleToTypes<TypedCartesianProduct<MatXBooleanTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXFloatNonComplexNonHalfTypesCUDAExec = TupleToTypes<TypedCartesianProduct<MatXFloatNonComplexNonHalfTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXComplexTypesCUDAExec                = TupleToTypes<TypedCartesianProduct<MatXComplexTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXComplexNonHalfTypesCUDAExec         = TupleToTypes<TypedCartesianProduct<MatXComplexNonHalfTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXNumericNonComplexTypesCUDAExec      = TupleToTypes<TypedCartesianProduct<MatXNumericNonComplexTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXAllIntegralTypesCUDAExec            = TupleToTypes<TypedCartesianProduct<MatXIntegralTuple, ExecutorTypesCUDAOnly>::type>::type;
+using MatXDoubleOnlyTypeCUDAExec              = TupleToTypes<TypedCartesianProduct<MatXDoubleOnlyTuple, ExecutorTypesCUDAOnly>::type>::type;
+
+
+// All executor types
 using MatXNumericNonComplexTypesAllExecs      = TupleToTypes<TypedCartesianProduct<MatXNumericNonComplexTuple, ExecutorTypesAll>::type>::type;
+using MatXFloatNonHalfTypesAllExecs           = TupleToTypes<TypedCartesianProduct<MatXFloatNonHalfTuple, ExecutorTypesAll>::type>::type;
 using MatXFloatNonComplexNonHalfTypesAllExecs = TupleToTypes<TypedCartesianProduct<MatXFloatNonComplexNonHalfTuple, ExecutorTypesAll>::type>::type;
-using MatXNumericNoHalfTypesAllExecs          = TupleToTypes<TypedCartesianProduct<MatXNumericNoHalfTuple, ExecutorTypesAll>::type>::type;
+using MatXNumericNoHalfTypesAllExecs          = TupleToTypes<TypedCartesianProduct<MatXNumericNonHalfTuple, ExecutorTypesAll>::type>::type;
 using MatXComplexNonHalfTypesAllExecs         = TupleToTypes<TypedCartesianProduct<MatXComplexNonHalfTuple, ExecutorTypesAll>::type>::type;
 using MatXComplexTypesAllExecs                = TupleToTypes<TypedCartesianProduct<MatXComplexTuple, ExecutorTypesAll>::type>::type;
-
-using MatXTypesAllExecs                       = TupleToTypes<TypedCartesianProduct<MatXAllTuple, ExecutorTypesAll>::type>::type;
+using MatXAllTypesAllExecs                    = TupleToTypes<TypedCartesianProduct<MatXAllTuple, ExecutorTypesAll>::type>::type;
 using MatXTypesFloatNonComplexAllExecs        = TupleToTypes<TypedCartesianProduct<MatXFloatNonComplexTuple, ExecutorTypesAll>::type>::type;
 using MatXTypesFloatAllExecs                  = TupleToTypes<TypedCartesianProduct<MatXFloatTuple, ExecutorTypesAll>::type>::type;
-using MatXTypesNumericAllExecs                  = TupleToTypes<TypedCartesianProduct<MatXNumericTuple, ExecutorTypesAll>::type>::type;
-using MatXTypesIntegralAllExecs                  = TupleToTypes<TypedCartesianProduct<MatXIntegralTuple, ExecutorTypesAll>::type>::type;
-using MatXTypesBooleanAllExecs                  = TupleToTypes<TypedCartesianProduct<MatXIntegralTuple, ExecutorTypesAll>::type>::type;
+using MatXTypesNumericAllExecs                = TupleToTypes<TypedCartesianProduct<MatXNumericTuple, ExecutorTypesAll>::type>::type;
+using MatXTypesIntegralAllExecs               = TupleToTypes<TypedCartesianProduct<MatXIntegralTuple, ExecutorTypesAll>::type>::type;
+using MatXTypesBooleanAllExecs                = TupleToTypes<TypedCartesianProduct<MatXIntegralTuple, ExecutorTypesAll>::type>::type;

--- a/test/test_vectors/generators/00_transforms.py
+++ b/test/test_vectors/generators/00_transforms.py
@@ -349,6 +349,7 @@ class fft_operators:
     def rfft_2d(self) -> Dict[str, np.ndarray]:
         seq = matx_common.randn_ndarray(
             (self.size[0], self.size[1]), self.dtype)
+
         return {
             'a_in': seq,
             'a_out': np.fft.rfft2(seq, (self.size[0], self.size[1]))


### PR DESCRIPTION
This PR adds initial support for FFTs on ARM using NVPL. NVPL follows the FFTW interface, which prevents a few features cuFFT has. Most notable half-precision support is missing and FFTW requires the data pointer to be part of the plan. This makes caching somewhat pointless since the same size FFT with different pointers cannot reuse a plan. 

Included in the PR is full unit test coverage for all FFT tests that had fp32/fp64 support. Once the NVPL API evolves to possible allow plans without pointers we can rewrite this to use the cuFFT method of having plans based on 1D/2D classes.  

You may also notice a seemingly unrelated change in conv2d. This is an nvcc compiler bug that only affects ARM. This change will be reverted once the compiler bug is addressed

This commit also moves all unit tests to the tuple format so we can switch executors per test quickly.