### PR TITLE
Add matxStreamDestroy function to better handle device_async allocations.

### DIFF
--- a/test/00_tensor/BasicTensorTests.cu
+++ b/test/00_tensor/BasicTensorTests.cu
@@ -489,3 +489,18 @@ TYPED_TEST(BasicTensorTestsAll, DLPack)
   MATX_EXIT_HANDLER();
 }
 
+TYPED_TEST(BasicTensorTestsAll, StreamDestroy)
+{
+  MATX_ENTER_HANDLER();
+
+  cudaStream_t stream;
+  cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
+
+  auto t = make_tensor<TypeParam>({3}, MATX_ASYNC_DEVICE_MEMORY, stream);
+  (t = ones(t.Shape())).run();
+  print(t);
+
+  matxStreamDestroy(stream);
+
+  MATX_EXIT_HANDLER();
+}


### PR DESCRIPTION
When making tensors with `MATX_ASYNC_DEVICE_MEMORY` the stream is recorded in the memtracker. If the stream is destroyed, before the tensor is deallocated a segfault will occur because the stream is no longer valid. 

Since there is no way to check if a stream is valid after it has been destroyed, the proposed fix is to add a `matxStreamDestroy` that changes references to the stream to be destroyed to the null stream. This keeps the allocations alive and allows the memtracker to properly deallocate device_async allocations even if the original stream is gone.