### PR TITLE
Fixing return types to allow either prvalue or lvalue in operator()

### DIFF
--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -679,7 +679,7 @@ class tensor_impl_t {
      *
      */
     template <int M = RANK, typename... Is>
-    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ const T &operator()(Is... indices) const noexcept
+    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator()(Is... indices) const noexcept
     {
       static_assert(sizeof...(Is) == M, "Number of indices of operator() must match rank of tensor");
 #ifndef NDEBUG
@@ -699,7 +699,7 @@ class tensor_impl_t {
      */
     template <int M = RANK, typename... Is, 
       std::enable_if_t<std::conjunction_v<std::is_integral<Is>...>, bool> = true>
-    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T &operator()(Is... indices) noexcept
+    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator()(Is... indices) noexcept
     {
       static_assert(sizeof...(Is) == M, "Number of indices of operator() must match rank of tensor");
 #ifndef NDEBUG
@@ -714,7 +714,7 @@ class tensor_impl_t {
      * @returns value in tensor
      *
      */
-    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ const T operator()(const std::array<index_t, RANK> &idx) const noexcept
+    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator()(const std::array<index_t, RANK> &idx) const noexcept
     {
       return std::apply([&](auto &&...args) -> T {
           return this->operator()(args...);
@@ -727,7 +727,7 @@ class tensor_impl_t {
      * @returns value in tensor
      *
      */
-    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__  T &operator()(const std::array<index_t, RANK> &idx) noexcept
+    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__  decltype(auto) operator()(const std::array<index_t, RANK> &idx) noexcept
     {
       return std::apply([&](auto &&...args) -> T& {
           return this->operator()(args...);

--- a/include/matx/generators/chirp.h
+++ b/include/matx/generators/chirp.h
@@ -72,7 +72,7 @@ namespace matx
           method_(method)
         {}
 
-        inline __MATX_HOST__ __MATX_DEVICE__ auto operator()(index_t i) const
+        inline __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator()(index_t i) const
         {
           if (method_ == ChirpMethod::CHIRP_METHOD_LINEAR) {
             return cuda::std::cos(2.0f * M_PI * (f0_ * sop_(i) + 0.5f * ((f1_ - f0_) / t1_) * sop_(i) * sop_(i)));
@@ -114,7 +114,7 @@ namespace matx
           method_(method)
         {}
 
-        inline __MATX_HOST__ __MATX_DEVICE__ auto operator()(index_t i) const
+        inline __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator()(index_t i) const
         {
           if (method_ == ChirpMethod::CHIRP_METHOD_LINEAR) {
             FreqType real = cuda::std::cos(2.0f * M_PI * (f0_ * sop_(i) + 0.5f * ((f1_ - f0_) / t1_) * sop_(i) * sop_(i)));

--- a/include/matx/generators/diag.h
+++ b/include/matx/generators/diag.h
@@ -59,7 +59,7 @@ namespace matx
       };
 
       template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
           if (((pp_get<0>(indices...) == indices) && ...)) {
             return T(val_);
           }

--- a/include/matx/generators/generator1d.h
+++ b/include/matx/generators/generator1d.h
@@ -50,7 +50,7 @@ namespace matx
           matxGenerator1D_t(S &&s, Generator1D f) : f_(f), s_(std::forward<S>(s)) {}
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
             return f_(pp_get<Dim>(indices...));
           }
 

--- a/include/matx/generators/meshgrid.h
+++ b/include/matx/generators/meshgrid.h
@@ -58,7 +58,7 @@ namespace matx
           }
 
           template <typename... Is>
-            __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+            __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
 
               std::array<index_t, Rank()> inds{indices...};
               // get index for the axis

--- a/include/matx/operators/all.h
+++ b/include/matx/operators/all.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/ambgfun.h
+++ b/include/matx/operators/ambgfun.h
@@ -89,7 +89,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/any.h
+++ b/include/matx/operators/any.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/argmax.h
+++ b/include/matx/operators/argmax.h
@@ -61,7 +61,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/argmin.h
+++ b/include/matx/operators/argmin.h
@@ -61,7 +61,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/at.h
+++ b/include/matx/operators/at.h
@@ -56,7 +56,7 @@ namespace matx
         __MATX_INLINE__ AtOp(Op op, Is... is) : op_(op), idx_{is...} {};
 
         template <typename... Is2>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()([[maybe_unused]] Is2... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()([[maybe_unused]] Is2... indices) const
         {
           return mapply(op_, idx_);
         }

--- a/include/matx/operators/binary_operators.h
+++ b/include/matx/operators/binary_operators.h
@@ -118,7 +118,7 @@ namespace matx
       }
 
       template <typename... Is, std::enable_if_t<std::conjunction_v<std::is_integral<Is>...>, bool> = true>
-      __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ auto operator()(Is... indices) const
+      __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ decltype(auto) operator()(Is... indices) const
       {
         auto i1 = get_value(in1_, indices...);
         auto i2 = get_value(in2_, indices...);
@@ -126,7 +126,7 @@ namespace matx
       }
 
       template <typename ArrayType, std::enable_if_t<is_std_array_v<ArrayType>, bool> = true>
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ const auto operator()(const ArrayType &idx) const noexcept
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator()(const ArrayType &idx) const noexcept
       {
         return mapply([&](auto &&...args)  {
             return this->operator()(args...);

--- a/include/matx/operators/cart2sph.h
+++ b/include/matx/operators/cart2sph.h
@@ -65,7 +65,7 @@ namespace matx
       }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             auto x = get_value(x_, indices...);
             auto y = get_value(y_, indices...);

--- a/include/matx/operators/cast.h
+++ b/include/matx/operators/cast.h
@@ -70,13 +70,13 @@ namespace matx
         __MATX_INLINE__ CastOp(T op) : op_(op){};  
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
         {
           return static_cast<NewType>(op_(indices...));     
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
         {
           return static_cast<NewType>(op_(indices...));
         }

--- a/include/matx/operators/cgsolve.h
+++ b/include/matx/operators/cgsolve.h
@@ -70,7 +70,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/channelize_poly.h
+++ b/include/matx/operators/channelize_poly.h
@@ -72,7 +72,7 @@ namespace detail {
       }
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) {
         return tmp_out_(indices...);
       }
 

--- a/include/matx/operators/chol.h
+++ b/include/matx/operators/chol.h
@@ -58,7 +58,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/clone.h
+++ b/include/matx/operators/clone.h
@@ -76,7 +76,7 @@ namespace matx
         };
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
         {
 
           // convert variadic type to tuple so we can read/update
@@ -93,7 +93,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
 
           // convert variadic type to tuple so we can read/update

--- a/include/matx/operators/collapse.h
+++ b/include/matx/operators/collapse.h
@@ -70,7 +70,7 @@ namespace matx
       }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             // indices coming in
             std::array<index_t, Rank()> in{indices...};  // index coming in
@@ -95,7 +95,7 @@ namespace matx
           }    
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices) 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
           {
             // indices coming in
             std::array<index_t, Rank()> in{indices...};  // index coming in
@@ -219,7 +219,7 @@ namespace matx
       }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             // indices coming in
             std::array<index_t, Rank()> in{indices...};  // index coming in
@@ -244,7 +244,7 @@ namespace matx
           }    
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
           {
             // indices coming in
             std::array<index_t, Rank()> in{indices...};  // index coming in

--- a/include/matx/operators/concat.h
+++ b/include/matx/operators/concat.h
@@ -138,14 +138,14 @@ namespace matx
         }
 
       template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... is) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is) const
         {
           std::array<index_t, sizeof...(Is)> indices = {{is...}};
           return GetVal<0, sizeof...(Ts)>(indices);
         }
       
       template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... is)
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is)
         {
           std::array<index_t, sizeof...(Is)> indices = {{is...}};
           return GetVal<0, sizeof...(Ts)>(indices);

--- a/include/matx/operators/constval.h
+++ b/include/matx/operators/constval.h
@@ -52,7 +52,7 @@ namespace matx
       ConstVal(ShapeType &&s, T val) : s_(std::forward<ShapeType>(s)), v_(val){};
 
       template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is...) const { 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ T operator()(Is...) const { 
           return v_; };
 
       constexpr inline __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) const

--- a/include/matx/operators/conv.h
+++ b/include/matx/operators/conv.h
@@ -132,7 +132,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }
@@ -303,7 +303,7 @@ namespace detail {
       }
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
       {
         return tmp_out_(indices...);
       }

--- a/include/matx/operators/corr.h
+++ b/include/matx/operators/corr.h
@@ -118,7 +118,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/cov.h
+++ b/include/matx/operators/cov.h
@@ -67,7 +67,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/cumsum.h
+++ b/include/matx/operators/cumsum.h
@@ -64,7 +64,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/det.h
+++ b/include/matx/operators/det.h
@@ -57,7 +57,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const{

--- a/include/matx/operators/diag.h
+++ b/include/matx/operators/diag.h
@@ -62,7 +62,7 @@ namespace matx
         __MATX_INLINE__ DiagOp(T1 op) : op_(op) {}
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             static_assert(sizeof...(Is) == RANK - 1, "Diagonal operator must have one fewer index than rank of operator");
             static_assert(RANK > 1, "Cannot make get diagonals from 0D tensor");

--- a/include/matx/operators/eig.h
+++ b/include/matx/operators/eig.h
@@ -62,7 +62,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/einsum.h
+++ b/include/matx/operators/einsum.h
@@ -62,7 +62,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/fft.h
+++ b/include/matx/operators/fft.h
@@ -126,7 +126,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }
@@ -336,7 +336,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
           return tmp_out_(indices...);
         }
 

--- a/include/matx/operators/fftshift.h
+++ b/include/matx/operators/fftshift.h
@@ -56,7 +56,7 @@ namespace matx
         };
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
         {
           auto tup = cuda::std::make_tuple(indices...);
           cuda::std::get<Rank()-1>(tup) = (cuda::std::get<Rank()-1>(tup) + (Size(Rank()-1) + 1) / 2) % Size(Rank()-1);
@@ -64,7 +64,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
         {
           auto tup = cuda::std::make_tuple(indices...);
           cuda::std::get<Rank()-1>(tup) = (cuda::std::get<Rank()-1>(tup) + (Size(Rank()-1) + 1) / 2) % Size(Rank()-1);
@@ -135,7 +135,7 @@ namespace matx
         };
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             auto tup = cuda::std::make_tuple(indices...);
             cuda::std::get<Rank()-2>(tup) = (cuda::std::get<Rank()-2>(tup) + (Size(Rank()-2) + 1) / 2) % Size(Rank()-2);
@@ -206,7 +206,7 @@ namespace matx
         };
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             auto tup = cuda::std::make_tuple(indices...);
             cuda::std::get<Rank()-1>(tup) = (cuda::std::get<Rank()-1>(tup) + (Size(Rank()-1)) / 2) % Size(Rank()-1);
@@ -276,7 +276,7 @@ namespace matx
         };
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             auto tup = cuda::std::make_tuple(indices...);
             cuda::std::get<Rank()-2>(tup) = (cuda::std::get<Rank()-2>(tup) + (Size(Rank()-2)) / 2) % Size(Rank()-2);

--- a/include/matx/operators/filter.h
+++ b/include/matx/operators/filter.h
@@ -70,7 +70,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       }
 

--- a/include/matx/operators/find.h
+++ b/include/matx/operators/find.h
@@ -60,7 +60,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/find_idx.h
+++ b/include/matx/operators/find_idx.h
@@ -60,7 +60,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/flatten.h
+++ b/include/matx/operators/flatten.h
@@ -64,7 +64,7 @@ namespace matx
         }
 
         template <typename Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is id0) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is id0) 
         {
           return *RandomOperatorOutputIterator{op1_, id0};
         }        

--- a/include/matx/operators/hermitian.h
+++ b/include/matx/operators/hermitian.h
@@ -61,7 +61,7 @@ namespace matx
         }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             auto tup = cuda::std::make_tuple(indices...);
             auto stl = cuda::std::get<Rank()-2>(tup);

--- a/include/matx/operators/hist.h
+++ b/include/matx/operators/hist.h
@@ -66,7 +66,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/if.h
+++ b/include/matx/operators/if.h
@@ -98,7 +98,7 @@ namespace matx
        * @param indices Index values
        */
       template <typename... Is>
-        auto __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ operator()(Is... indices) const {
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto operator()(Is... indices) const {
           if (get_value(cond_, indices...)) {
             get_value(op_, indices...);
           }

--- a/include/matx/operators/ifelse.h
+++ b/include/matx/operators/ifelse.h
@@ -106,7 +106,7 @@ namespace matx
        * @param indices Index values
        */
       template <typename... Is>
-        auto __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ operator()(Is... indices) const {
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto operator()(Is... indices) const {
           if (get_value(cond_, indices...)) {
             get_value(op1_, indices...);
           }

--- a/include/matx/operators/index.h
+++ b/include/matx/operators/index.h
@@ -56,11 +56,11 @@ namespace matx
         __MATX_INLINE__ IndexOp(int dim) : dim_(dim){};  
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
-          {
-            std::array<index_t, sizeof...(Is)> inds{indices...};
-            return inds[dim_];
-          }
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ index_t operator()(Is... indices) const 
+        {
+          std::array<index_t, sizeof...(Is)> inds{indices...};
+          return inds[dim_];
+        }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {

--- a/include/matx/operators/interleaved.h
+++ b/include/matx/operators/interleaved.h
@@ -60,7 +60,7 @@ namespace matx
         };
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ complex_type operator()(Is... indices) const 
         {
           auto real = op_(indices...);
 
@@ -73,7 +73,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ complex_type operator()(Is... indices) 
         {
           auto real = op_(indices...);
 

--- a/include/matx/operators/inverse.h
+++ b/include/matx/operators/inverse.h
@@ -58,7 +58,7 @@ namespace detail {
       __MATX_INLINE__ InvOp(OpA a) : a_(a) {};
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
       {
         return tmp_out_(indices...);
       }

--- a/include/matx/operators/kronecker.h
+++ b/include/matx/operators/kronecker.h
@@ -65,7 +65,7 @@ namespace matx
       }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           auto tup1 = cuda::std::make_tuple(indices...);
           auto tup2 = cuda::std::make_tuple(indices...);
@@ -79,7 +79,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
           auto tup1 = cuda::std::make_tuple(indices...);
           auto tup2 = cuda::std::make_tuple(indices...);

--- a/include/matx/operators/legendre.h
+++ b/include/matx/operators/legendre.h
@@ -100,7 +100,7 @@ namespace matx
         }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             std::array<index_t, Rank()> inds{indices...};
             std::array<index_t, T3::Rank()> xinds;

--- a/include/matx/operators/lu.h
+++ b/include/matx/operators/lu.h
@@ -57,7 +57,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/matmul.h
+++ b/include/matx/operators/matmul.h
@@ -89,7 +89,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/matvec.h
+++ b/include/matx/operators/matvec.h
@@ -71,7 +71,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/max.h
+++ b/include/matx/operators/max.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/mean.h
+++ b/include/matx/operators/mean.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/median.h
+++ b/include/matx/operators/median.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/min.h
+++ b/include/matx/operators/min.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/outer.h
+++ b/include/matx/operators/outer.h
@@ -80,7 +80,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/overlap.h
+++ b/include/matx/operators/overlap.h
@@ -85,12 +85,12 @@ namespace matx
           s_[0] = stride_size;
         };
 
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(index_t i0, index_t i1) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(index_t i0, index_t i1) const
         {
           return op_(i0*s_[0] + i1);
         }
 
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(index_t i0, index_t i1)
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(index_t i0, index_t i1)
         {
           return op_(i0*s_[0] + i1);
         }

--- a/include/matx/operators/percentile.h
+++ b/include/matx/operators/percentile.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -77,7 +77,7 @@ namespace matx
 
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             static_assert(sizeof...(Is)==Rank());
             static_assert((std::is_convertible_v<Is, index_t> && ... ));
@@ -97,7 +97,7 @@ namespace matx
           }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
           {
             static_assert(sizeof...(Is)==Rank());
             //          static_assert((std::is_convertible_v<Is, index_t> && ... ));

--- a/include/matx/operators/planar.h
+++ b/include/matx/operators/planar.h
@@ -70,7 +70,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
         {
           constexpr size_t rank_idx = (Rank() == 1) ? 0 : (Rank() - 2);
           auto tup = cuda::std::make_tuple(indices...);

--- a/include/matx/operators/polyval.h
+++ b/include/matx/operators/polyval.h
@@ -60,7 +60,7 @@ namespace matx
           MATX_STATIC_ASSERT_STR(op.Rank() == 1, matxInvalidDim, "Input operator must be rank 1");
         };
 
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(index_t idx) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ scalar_type operator()(index_t idx) const
         {
           // Horner's method for computing polynomial
           scalar_type ttl{coeffs_(0)};

--- a/include/matx/operators/prod.h
+++ b/include/matx/operators/prod.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/pwelch.h
+++ b/include/matx/operators/pwelch.h
@@ -73,7 +73,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/qr.h
+++ b/include/matx/operators/qr.h
@@ -57,7 +57,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
@@ -124,7 +124,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) {

--- a/include/matx/operators/r2c.h
+++ b/include/matx/operators/r2c.h
@@ -56,6 +56,8 @@ namespace matx
           static_assert(Rank() >= 1, "R2COp must have a rank 1 operator or higher");
         };
 
+        // This version of the operator returns auto rather than decltype(auto) because we need to force the 
+        // return type to be by value and not pass through references
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
         {
@@ -71,7 +73,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
         {
           auto tup = cuda::std::make_tuple(indices...);
 

--- a/include/matx/operators/reduce.h
+++ b/include/matx/operators/reduce.h
@@ -70,7 +70,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -66,7 +66,7 @@ namespace matx
 	__MATX_INLINE__ RemapOp(T op, IdxType idx) : op_(op), idx_(idx) {};
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             static_assert(sizeof...(Is)==Rank());
             static_assert((std::is_convertible_v<Is, index_t> && ... ));
@@ -85,7 +85,7 @@ namespace matx
           }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
           {
             static_assert(sizeof...(Is)==Rank());
             static_assert((std::is_convertible_v<Is, index_t> && ... ));

--- a/include/matx/operators/repmat.h
+++ b/include/matx/operators/repmat.h
@@ -95,7 +95,7 @@ namespace matx
           }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           if constexpr (Rank() == 0) {
             return op_();
@@ -117,7 +117,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
           if constexpr (Rank() == 0) {
             return op_();

--- a/include/matx/operators/resample_poly.h
+++ b/include/matx/operators/resample_poly.h
@@ -76,7 +76,7 @@ namespace detail {
       }
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) {
         return tmp_out_(indices...);
       }
 

--- a/include/matx/operators/reshape.h
+++ b/include/matx/operators/reshape.h
@@ -79,7 +79,7 @@ namespace matx
         };
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
         {
           std::array<index_t, Rank()> inds{indices...};
           std::array<index_t, T::Rank()> ninds;
@@ -105,7 +105,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
           std::array<index_t, Rank()> inds{indices...};
           std::array<index_t, T::Rank()> ninds;

--- a/include/matx/operators/reverse.h
+++ b/include/matx/operators/reverse.h
@@ -64,7 +64,7 @@ namespace matx
 
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
         {
           if constexpr (Rank() == 0) {
             return op_();
@@ -86,7 +86,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
         {
           if constexpr (Rank() == 0) {
             return op_();

--- a/include/matx/operators/scalar_ops.h
+++ b/include/matx/operators/scalar_ops.h
@@ -101,7 +101,7 @@ public:
 
   static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto op(const T1 &v1) { return F::op(v1); }
 
-  __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(const T1 &v1) const { return op(v1); }
+  __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(const T1 &v1) const { return op(v1); }
 
   using scalar_type = std::invoke_result_t<decltype(op), T1>;
 };
@@ -117,7 +117,7 @@ public:
     return F::op(v1, v2);
   }
 
-  __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(const T1 &v1, const T2 &v2) const
+  __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(const T1 &v1, const T2 &v2) const
   {
     return op(v1, v2);
   }
@@ -133,7 +133,7 @@ public:
     return F::op(v1, v2, v3);
   }
 
-  __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(const T1 &v1, const T2 &v2, const T3 &v3) const
+  __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(const T1 &v1, const T2 &v2, const T3 &v3) const
   {
     return op(v1, v2, v3);
   }

--- a/include/matx/operators/select.h
+++ b/include/matx/operators/select.h
@@ -60,14 +60,14 @@ namespace matx
         __MATX_INLINE__ SelectOp(T op, IdxType idx) : op_(op), idx_(idx) {};  
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(index_t i) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(index_t i) const 
         {
           auto arrs = detail::GetIdxFromAbs(op_, idx_(i));
           return op_(arrs);
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(index_t i) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(index_t i) 
         {
           auto arrs = detail::GetIdxFromAbs(op_, idx_(i));
           return op_(arrs);

--- a/include/matx/operators/self.h
+++ b/include/matx/operators/self.h
@@ -60,13 +60,13 @@ namespace matx
 	__MATX_INLINE__ SelfOp(T1 op) : op_(op) {}
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
         {
           return op_(indices...);
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)  
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)  
         {
           return op_(indices...);
         }

--- a/include/matx/operators/set.h
+++ b/include/matx/operators/set.h
@@ -109,7 +109,7 @@ public:
   set &operator=(const set &) = delete;
 
   template <typename... Is>
-  __MATX_DEVICE__ __MATX_HOST__ inline auto operator()(Is... indices) const noexcept
+  __MATX_DEVICE__ __MATX_HOST__ inline decltype(auto) operator()(Is... indices) const noexcept
   {
     if constexpr (is_matx_half_v<T> &&
                   std::is_integral_v<decltype(detail::get_value(op_, indices...))>) {
@@ -150,7 +150,7 @@ public:
       return r;
     }
   }
-  __MATX_DEVICE__ __MATX_HOST__ inline auto operator()(std::array<shape_type, T::Rank()> idx) const noexcept
+  __MATX_DEVICE__ __MATX_HOST__ inline decltype(auto) operator()(std::array<shape_type, T::Rank()> idx) const noexcept
   {
     auto res = mapply([&](auto &&...args)  {
         return _internal_mapply(args...);

--- a/include/matx/operators/shift.h
+++ b/include/matx/operators/shift.h
@@ -72,7 +72,7 @@ namespace matx
       }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             auto tup = cuda::std::make_tuple(indices...);
             index_t shift = -get_value(shift_, indices...);
@@ -88,7 +88,7 @@ namespace matx
           }    
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
           {
             auto tup = cuda::std::make_tuple(indices...);
             index_t shift = -get_value(shift_, indices...);

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -102,7 +102,7 @@ namespace matx
         };
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
           {
             static_assert(sizeof...(Is)==Rank());
             static_assert((std::is_convertible_v<Is, index_t> && ... ));
@@ -126,7 +126,7 @@ namespace matx
           }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)
+          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
           {
             static_assert(sizeof...(Is)==Rank());
             static_assert((std::is_convertible_v<Is, index_t> && ... ));

--- a/include/matx/operators/softmax.h
+++ b/include/matx/operators/softmax.h
@@ -67,7 +67,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_(indices...);
         }

--- a/include/matx/operators/sort.h
+++ b/include/matx/operators/sort.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/stack.h
+++ b/include/matx/operators/stack.h
@@ -123,7 +123,7 @@ namespace matx
         }
 
       template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... is) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is) const
         {
           std::array<index_t, RANK + 1> indices = {{is...}};
           std::array<index_t, RANK> indices_o;
@@ -144,7 +144,7 @@ namespace matx
         }
 
       template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... is)
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is)
         {
           std::array<index_t, RANK + 1> indices = {{is...}};
           std::array<index_t, RANK> indices_o;

--- a/include/matx/operators/stdd.h
+++ b/include/matx/operators/stdd.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/sum.h
+++ b/include/matx/operators/sum.h
@@ -65,7 +65,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/svd.h
+++ b/include/matx/operators/svd.h
@@ -61,7 +61,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
@@ -120,7 +120,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) {
@@ -197,7 +197,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) {

--- a/include/matx/operators/trace.h
+++ b/include/matx/operators/trace.h
@@ -60,7 +60,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 

--- a/include/matx/operators/transpose.h
+++ b/include/matx/operators/transpose.h
@@ -71,12 +71,12 @@ namespace detail {
       }
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       }
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto& operator()(Is... indices)  {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)  {
         return tmp_out_(indices...);
       }      
 

--- a/include/matx/operators/unary_operators.h
+++ b/include/matx/operators/unary_operators.h
@@ -79,7 +79,7 @@ namespace matx
       }
     }
 
-    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ const auto operator()(const std::array<index_t, detail::get_rank<I1>()> &idx) const noexcept
+    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator()(const std::array<index_t, detail::get_rank<I1>()> &idx) const noexcept
     {
       return mapply([&](auto &&...args)  {
           return this->operator()(args...);
@@ -87,7 +87,7 @@ namespace matx
     }  
 
     template <typename... Is, std::enable_if_t<std::conjunction_v<std::is_integral<Is>...>, bool> = true>
-    __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
+    __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
     {
       auto i1 = get_value(in1_, indices...);
       return op_(i1);

--- a/include/matx/operators/unique.h
+++ b/include/matx/operators/unique.h
@@ -59,7 +59,7 @@ namespace detail {
 
       // This should never be called
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const = delete;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/updownsample.h
+++ b/include/matx/operators/updownsample.h
@@ -80,7 +80,7 @@ namespace matx
             return mapply(op_, ind);
           }
 
-          return static_cast<scalar_type>(0);
+          return static_cast<typename decltype(op_)::scalar_type>(0);
         }
 
         constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int32_t dim) const

--- a/include/matx/operators/var.h
+++ b/include/matx/operators/var.h
@@ -66,7 +66,7 @@ namespace detail {
       };
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
       };
 


### PR DESCRIPTION
Fixes #550 