### PR TITLE
Add smem-based polyphase channelizer kernel

### DIFF
--- a/test/00_transform/ChannelizePoly.cu
+++ b/test/00_transform/ChannelizePoly.cu
@@ -145,6 +145,8 @@ TYPED_TEST(ChannelizePolyTestNonHalfFloatTypes, Simple)
     { 271374, 31*14+4, 14 },
     { 27137, 301*13+3, 13 },
     { 27138, 301*14+4, 14 },
+    { 1000000, 32*16, 32 },
+    { 1000000, 40*16, 40 }
   };
 
   cudaStream_t stream = 0;


### PR DESCRIPTION
Add a new polyphase channelizer kernel that utilizes shared memory for both the filter coefficients and input samples. This kernel is automatically selected in cases where the corresponding data will fit in shared memory.