### PR TITLE
Automatic Enumeration of NVTX Range IDs

### DIFF
--- a/docs_input/basics/nvtx.rst
+++ b/docs_input/basics/nvtx.rst
@@ -31,7 +31,11 @@ call is needed, with optional inputs defined below. If no message is provided, t
 the NVTX range’s message.
 
 The Manual Range NVTX API requires the user to make a call to the NVTX API at both the beginning and end of the desired range. The Manual 
-Range API uses a user defined handle (int) to reference the NVTX range. A Manual NVTX Range must be fully qualified on every instantiation. 
+Range API uses a user defined handle (int) to reference the NVTX range. A Manual NVTX Range can be fully qualified, or the user can allow the API to auto-enumerate the range. 
+If the user chooses to allow the API to define the handle, an int is returned from the call for the user.
+
+.. note::
+  If a user chooses to use a manual range, they must manually call ``MATX_NVTX_END_RANGE(RANGE_HANDLE)``, or the range will not terminate until the end of execution.
 
 NVTX Examples
 -------------
@@ -43,11 +47,15 @@ NVTX Examples
   * - Command 
     - Result
   * - MATX_NVTX_START("")
-    - NVTX range scoped to this function, named the same as function with log level of Internal 
+    - NVTX range scoped to this function, named the same as function with log level of User 
   * - MATX_NVTX_START("MY_MESSAGE")
-    - NVTX range scoped to this function, named “MY_MESSAGE” with log level of Internal
+    - NVTX range scoped to this function, named “MY_MESSAGE” with log level of User
   * - MATX_NVTX_START("MY_MESSAGE", matx::MATX_NVTX_LOG_API )
     - NVTX range scoped to this function, named “MY_MESSAGE” with log level of API
+  * - MATX_NVTX_START_RANGE( "MY_MESSAGE" )
+    - NVTX range with manual scope, named “MY_MESSAGE”, log level of User, and an auto-enumerated handle
+  * - MATX_NVTX_START_RANGE( "MY_MESSAGE", matx_nvxtLogLevels::MATX_NVTX_LOG_INTERNAL )
+    - NVTX range with manual scope, named “MY_MESSAGE”, log level of Internal, and an auto-enumerated handle    
   * - MATX_NVTX_START_RANGE( "MY_MESSAGE", matx_nvxtLogLevels::MATX_NVTX_LOG_USER, 1 )
     - NVTX range with manual scope, named “MY_MESSAGE”, log level of USER, and handle ID of 1
   * - MATX_NVTX_END_RANGE(1)

--- a/include/matx/core/nvtx.h
+++ b/include/matx/core/nvtx.h
@@ -261,7 +261,7 @@ class NvtxEvent
 
   ///
   ////////////////////////////////////////////////////////////////////////////////
-  NvtxEvent( std::string functionName, std::string message="",  matx_nvxtLogLevels nvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_INTERNAL, int registerId = -1 )
+  NvtxEvent( std::string functionName, std::string message="",  matx_nvxtLogLevels nvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_USER, int registerId = -1 )
   {
     userHandle_ = -1;
     persistent_ = false;

--- a/include/matx/core/nvtx.h
+++ b/include/matx/core/nvtx.h
@@ -309,7 +309,7 @@ class NvtxEvent
 
   }
 
-  NvtxEvent( int invalidClass)
+  NvtxEvent( [[maybe_unused]] int invalidClass )
   {     
     userHandle_ = -1;
     persistent_ = false;

--- a/include/matx/core/nvtx.h
+++ b/include/matx/core/nvtx.h
@@ -116,9 +116,7 @@ inline matx_nvxtLogLevels globalNvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_AP
                                 MATX_NVTX_1(__VA_ARGS__)\
                                 )
 
-  
-  
-                                       
+                           
   #define MATX_NVTX_RANGE_1( message ) matx::autoCreateNvtxEvent(__FUNCTION__, message );
   #define MATX_NVTX_RANGE_2( message, nvtxLevel ) matx::autoCreateNvtxEvent(__FUNCTION__, message, nvtxLevel );
   #define MATX_NVTX_RANGE_3( message, nvtxLevel, id) matx::NvtxEvent MATX_UNIQUE_NAME(nvtxFlag_)( __FUNCTION__, message, nvtxLevel, id );
@@ -151,15 +149,13 @@ inline matx_nvxtLogLevels globalNvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_AP
                                   )
 
 
-
-
   #define MATX_NVTX_RANGE_1( message ) 0;
   #define MATX_NVTX_RANGE_2( message, nvtxLevel ) 0;
-  #define MATX_NVTX_RANGE_3( message, nvtxLevel, id) 0;
+  #define MATX_NVTX_RANGE_3( message, nvtxLevel, id);
 
   #define MATX_NVTX_RANGE_X(x,A,B,C,FUNC, ...)  FUNC 
   
-  #define MATX_NVTX_START_RANGE(...)  MATX_NVTX_RANGE_X(,##__VA_ARGS__,\
+  #define MATX_NVTX_START_RANGE(...)   MATX_NVTX_RANGE_X(,##__VA_ARGS__,\
                                        MATX_NVTX_RANGE_3(__VA_ARGS__),\
                                        MATX_NVTX_RANGE_2(__VA_ARGS__),\
                                        MATX_NVTX_RANGE_1(__VA_ARGS__)\
@@ -181,6 +177,8 @@ inline matx_nvxtLogLevels globalNvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_AP
 ////////////////////////////////////////////////////////////////////////////////
 [[maybe_unused]] static int getNVTX_Range_ID( )
 {
+  std::unique_lock lck(nvtx_memory_mtx);
+    
   int newID = ++numNvtxTrackedRanges;
   auto foundIter = nvtx_eventMap.find( newID );
   
@@ -202,6 +200,7 @@ inline matx_nvxtLogLevels globalNvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_AP
 ////////////////////////////////////////////////////////////////////////////////
 [[maybe_unused]] static void setNVTXLogLevel( matx_nvxtLogLevels newNVTXLevel)
 {
+  std::unique_lock lck(nvtx_memory_mtx);  
   globalNvtxLevel = newNVTXLevel;
 }
 
@@ -345,7 +344,7 @@ class NvtxEvent
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-///\brief Utility Function to get a unique ID for an NVTX range
+///\brief Utility Function to create an NVTX range with a unique ID and return it
 ///
 ////////////////////////////////////////////////////////////////////////////////
 int autoCreateNvtxEvent(std::string functionName, std::string message="",  matx_nvxtLogLevels nvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_USER)

--- a/include/matx/core/nvtx.h
+++ b/include/matx/core/nvtx.h
@@ -225,7 +225,7 @@ inline matx_nvxtLogLevels globalNvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_AP
 ///       MATX_NVTX_END_RANGE macro with the same parameters
 ///
 ////////////////////////////////////////////////////////////////////////////////
-static void endEvent( int id )
+[[maybe_unused]] static void endEvent( int id )
 {
   std::unique_lock lck(nvtx_memory_mtx);
 
@@ -347,7 +347,7 @@ class NvtxEvent
 ///\brief Utility Function to create an NVTX range with a unique ID and return it
 ///
 ////////////////////////////////////////////////////////////////////////////////
-int autoCreateNvtxEvent(std::string functionName, std::string message="",  matx_nvxtLogLevels nvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_USER)
+[[maybe_unused]] static int autoCreateNvtxEvent(std::string functionName, std::string message="",  matx_nvxtLogLevels nvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_USER)
 {
   int newID = matx::getNVTX_Range_ID();
   

--- a/include/matx/core/nvtx.h
+++ b/include/matx/core/nvtx.h
@@ -116,24 +116,31 @@ inline matx_nvxtLogLevels globalNvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_AP
                                 MATX_NVTX_1(__VA_ARGS__)\
                                 )
 
-  #define MATX_NVTX_START_RANGE( message, nvtxLevel, id ) matx::NvtxEvent MATX_UNIQUE_NAME(nvtxFlag_)( __FUNCTION__, message, nvtxLevel, id );
-  #define MATX_NVTX_START_RANGE_RETURN( message, nvtxLevel ) matx::NvtxEvent( __FUNCTION__, message, nvtxLevel, __COUNTER__ );
-  #define MATX_NVTX_START_RANGE_AUTO(message, nvtxLevel) matx::autoCreateNvtxEvent(__FUNCTION__, message, nvtxLevel );
-
+  
+  
+                                       
+  #define MATX_NVTX_RANGE_1( message ) matx::autoCreateNvtxEvent(__FUNCTION__, message );
+  #define MATX_NVTX_RANGE_2( message, nvtxLevel ) matx::autoCreateNvtxEvent(__FUNCTION__, message, nvtxLevel );
+  #define MATX_NVTX_RANGE_3( message, nvtxLevel, id) matx::NvtxEvent MATX_UNIQUE_NAME(nvtxFlag_)( __FUNCTION__, message, nvtxLevel, id );
+  
+  #define MATX_NVTX_RANGE_X(x,A,B,C,FUNC, ...)  FUNC 
+  
+  #define MATX_NVTX_START_RANGE(...)   MATX_NVTX_RANGE_X(,##__VA_ARGS__,\
+                                       MATX_NVTX_RANGE_3(__VA_ARGS__),\
+                                       MATX_NVTX_RANGE_2(__VA_ARGS__),\
+                                       MATX_NVTX_RANGE_1(__VA_ARGS__)\
+                                       )
+                                       
   #define MATX_NVTX_END_RANGE( id ) matx::endEvent( id );
-
-  #define MATX_NVTX_END_RANGE_EVENT( event ) matx::endEvent( event.userHandle_ );
 
   #define MATX_NVTX_SET_LOG_LEVEL( nvtxLevel ) matx::setNVTXLogLevel( nvtxLevel );
   
-  #define MATX_NVTX_GET_ID() matx::getNVTX_Range_ID();
 
 ////////////             Disable NVTX Macros          /////////////////
 #else
 
   #define MATX_NVTX_1( message );
   #define MATX_NVTX_2( message, customId );
-  #define MATX_NVTX_START_RANGE( message, nvtxLevel, id );
 
   #define MATX_NVTX_X(x,A,B,FUNC, ...)  FUNC
 
@@ -143,13 +150,25 @@ inline matx_nvxtLogLevels globalNvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_AP
                                   MATX_NVTX_1(__VA_ARGS__)\
                                   )
 
+
+
+
+  #define MATX_NVTX_RANGE_1( message ) 0;
+  #define MATX_NVTX_RANGE_2( message, nvtxLevel ) 0;
+  #define MATX_NVTX_RANGE_3( message, nvtxLevel, id) 0;
+
+  #define MATX_NVTX_RANGE_X(x,A,B,C,FUNC, ...)  FUNC 
+  
+  #define MATX_NVTX_START_RANGE(...)  MATX_NVTX_RANGE_X(,##__VA_ARGS__,\
+                                       MATX_NVTX_RANGE_3(__VA_ARGS__),\
+                                       MATX_NVTX_RANGE_2(__VA_ARGS__),\
+                                       MATX_NVTX_RANGE_1(__VA_ARGS__)\
+                                       )
+
   #define MATX_NVTX_END_RANGE( id );
 
   #define MATX_NVTX_SET_LOG_LEVEL( nvtxLevel );
-  // #define MATX_NVTX_END_RANGE_EVENT( event );
-  #define MATX_NVTX_START_RANGE_RETURN( message, nvtxLevel ) 0;
-  #define MATX_NVTX_START_RANGE_AUTO(message, nvtxLevel) 0;
-  #define MATX_NVTX_GET_ID() 0; 
+  
 
 #endif
 ////////////////////////////////////////////////////////////////////////////////
@@ -329,7 +348,7 @@ class NvtxEvent
 ///\brief Utility Function to get a unique ID for an NVTX range
 ///
 ////////////////////////////////////////////////////////////////////////////////
-int autoCreateNvtxEvent(std::string functionName, std::string message="",  matx_nvxtLogLevels nvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_INTERNAL)
+int autoCreateNvtxEvent(std::string functionName, std::string message="",  matx_nvxtLogLevels nvtxLevel = matx_nvxtLogLevels::MATX_NVTX_LOG_USER)
 {
   int newID = matx::getNVTX_Range_ID();
   


### PR DESCRIPTION
Enable an automatic enumeration capability to free users from needing to unique ID each range. 
Overloads the MATX_NVTX_RANGE to work with any number of parameters.

This PR also addresses an issue where all ranges created by the MATX_NVTX_RANGE macro were limited to the scope they were created in; now the NVTX range will persist until ended by the user. 

Changed the default log level to USER from internal, to not require the user to manually set the log level each time.