### PR TITLE
Implement csqrt

### DIFF
--- a/include/matx/operators/scalar_ops.h
+++ b/include/matx/operators/scalar_ops.h
@@ -173,22 +173,8 @@ template <typename T> struct SqrtF {
 template <typename T>
 static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_csqrt(T v1)
 {
-  if constexpr (is_cuda_complex_v<T>) 
-  {
-    return cuda::std::sqrt(v1);
-  }
-  else {
-    ///\todo TYLER_TODO should probably protect for only float types
-    return sqrt(static_cast<cuda::std::complex<T>>(v1));
-  }
-  if constexpr (!is_cuda_complex_v<T>) {
-    ///\todo TYLER_TODO should probably protect for only float types
-    return sqrt(static_cast<cuda::std::complex<T>>(v1));
-  }
-  else {
-    return cuda::std::sqrt(v1);
-  }  
-
+  static_assert(std::is_floating_point_v<T>, "csqrt() only supports non-complex floating point inputs");
+  return sqrt(static_cast<cuda::std::complex<T>>(v1));
 }
 
 template <typename T> struct CSqrtF {

--- a/include/matx/operators/scalar_ops.h
+++ b/include/matx/operators/scalar_ops.h
@@ -178,9 +178,11 @@ static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_csqrt(T v1)
     return cuda::std::sqrt(v1);
   }
   else {
+    ///\todo TYLER_TODO should probably protect for only float types
     return sqrt(static_cast<cuda::std::complex<T>>(v1));
   }
   if constexpr (!is_cuda_complex_v<T>) {
+    ///\todo TYLER_TODO should probably protect for only float types
     return sqrt(static_cast<cuda::std::complex<T>>(v1));
   }
   else {

--- a/include/matx/operators/scalar_ops.h
+++ b/include/matx/operators/scalar_ops.h
@@ -170,8 +170,36 @@ template <typename T> struct SqrtF {
   }
 };
 
-template <typename T> using SqrtOp = UnOp<T, SqrtF<T>>;
+template <typename T>
+static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_csqrt(T v1)
+{
+  if constexpr (is_cuda_complex_v<T>) 
+  {
+    return cuda::std::sqrt(v1);
+  }
+  else {
+    return sqrt(static_cast<cuda::std::complex<T>>(v1));
+  }
+  if constexpr (!is_cuda_complex_v<T>) {
+    return sqrt(static_cast<cuda::std::complex<T>>(v1));
+  }
+  else {
+    return cuda::std::sqrt(v1);
+  }  
 
+}
+
+template <typename T> struct CSqrtF {
+  static __MATX_INLINE__ std::string str() { return "csqrt"; }
+  static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto op(T v1)
+  {
+    return _internal_csqrt(v1);
+  }
+};
+
+
+template <typename T> using SqrtOp = UnOp<T, SqrtF<T>>;
+template <typename T> using CsqrtOp = UnOp<T, CSqrtF<T>>;
 
 template <typename T>
 static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_conj(T v1)

--- a/include/matx/operators/scalar_ops.h
+++ b/include/matx/operators/scalar_ops.h
@@ -170,6 +170,8 @@ template <typename T> struct SqrtF {
   }
 };
 
+template <typename T> using SqrtOp = UnOp<T, SqrtF<T>>;
+
 template <typename T>
 static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_csqrt(T v1)
 {
@@ -186,7 +188,6 @@ template <typename T> struct CSqrtF {
 };
 
 
-template <typename T> using SqrtOp = UnOp<T, SqrtF<T>>;
 template <typename T> using CsqrtOp = UnOp<T, CSqrtF<T>>;
 
 template <typename T>

--- a/include/matx/operators/unary_operators.h
+++ b/include/matx/operators/unary_operators.h
@@ -362,6 +362,7 @@ namespace matx
 
 #else
   DEFINE_UNARY_OP(sqrt, detail::SqrtOp);
+  DEFINE_UNARY_OP(csqrt, detail::CsqrtOp);
   DEFINE_UNARY_OP(exp, detail::ExpOp);
   DEFINE_UNARY_OP(expj, detail::ExpjOp);
   DEFINE_UNARY_OP(log10, detail::Log10Op);


### PR DESCRIPTION
Add a complex sqrt function equivalent to the C++ functionality of [csqrt](https://en.cppreference.com/w/c/numeric/complex/csqrt), 

The high-level functionality supported is to always generate a complex return, even if the input is only real. I've come across situations where users sqrt negative data, with the expectation of getting complex from real.