### PR TITLE
enh: add macro to define cuda functions accessible at global scope

### DIFF
--- a/docs_input/api/math/misc/rsqrt.rst
+++ b/docs_input/api/math/misc/rsqrt.rst
@@ -1,0 +1,18 @@
+.. _rsqrt_func:
+
+rsqrt
+====
+
+Reciprocal square root
+
+.. doxygenfunction:: rsqrt(Op t) 
+  
+Examples
+~~~~~~~~
+
+.. literalinclude:: ../../../../test/00_operators/OperatorTests.cu
+   :language: cpp
+   :start-after: example-begin rsqrt-test-1
+   :end-before: example-end rsqrt-test-1
+   :dedent:
+

--- a/include/matx/core/half.h
+++ b/include/matx/core/half.h
@@ -689,6 +689,41 @@ sqrt(const matxHalf<__nv_bfloat16> &x)
 }
 
 /**
+ * @brief Reciprocal Square root value
+ * 
+ * @tparam T Type of half
+ * @param x Value of half
+ * @return Reciprocal square root of input
+ */
+template <class T>
+__MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxHalf<T> rsqrt(const matxHalf<T> &x)
+{
+#ifdef __CUDA_ARCH__
+  return hrsqrt(x.x);
+#else
+  return static_cast<T>(::rsqrt(static_cast<float>(x.x)));
+#endif
+}
+
+/**
+ * @brief Square root value
+ * 
+ * @tparam T Type of half
+ * @param x Value of half
+ * @return Square root of input
+ */
+template <>
+__MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxHalf<__nv_bfloat16>
+rsqrt(const matxHalf<__nv_bfloat16> &x)
+{
+#if __CUDA_ARCH__ >= 800
+  return hrsqrt(x.x);
+#else
+  return static_cast<__nv_bfloat16>(::rsqrt(static_cast<float>(x.x)));
+#endif
+}
+
+/**
  * @brief Test for infiity
  * 
  * @tparam T Type of half

--- a/include/matx/operators/scalar_ops.h
+++ b/include/matx/operators/scalar_ops.h
@@ -64,6 +64,33 @@ namespace detail {
   };                                                                           \
   template <typename T> using OPNAME##Op = UnOp<T, OPNAME##F<T>>;
 
+#define MATX_GLOBAL_UNARY_OP_GEN(FUNC, OPNAME)                                        \
+  template <typename T>                                                        \
+  static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_##FUNC(T v1)                \
+  {                                                                            \
+    if constexpr (is_matx_type_v<T>) {                                         \
+      return FUNC(v1);                                                         \
+    }                                                                          \
+    else {                                                                     \
+      return ::FUNC(v1);                                              \
+    }                                                                          \
+    if constexpr (!is_matx_type_v<T>) {                                        \
+      return ::FUNC(v1);                                              \
+    }                                                                          \
+    else {                                                                     \
+      return FUNC(v1);                                                         \
+    }                                                                          \
+  }                                                                            \
+  template <typename T> struct OPNAME##F {                                     \
+    static __MATX_INLINE__ std::string str() { return #FUNC; }                 \
+                                                                               \
+    static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto op(T v1)                            \
+    {                                                                          \
+      return _internal_##FUNC(v1);                                             \
+    }                                                                          \
+  };                                                                           \
+  template <typename T> using OPNAME##Op = UnOp<T, OPNAME##F<T>>;
+
 #define MATX_BINARY_OP_GEN(FUNC, OPNAME)                                       \
   template <typename T1, typename T2>                                          \
   static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_##FUNC(T1 v1, T2 v2)        \
@@ -134,6 +161,7 @@ MATX_UNARY_OP_GEN(ceil, Ceil);
 MATX_UNARY_OP_GEN(floor, Floor);
 MATX_UNARY_OP_GEN(round, Round);
 MATX_UNARY_OP_GEN(exp, Exp);
+MATX_GLOBAL_UNARY_OP_GEN(rsqrt, RSqrt);
 
 template <typename T>
 static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_sqrt(T v1)

--- a/include/matx/operators/scalar_ops.h
+++ b/include/matx/operators/scalar_ops.h
@@ -64,33 +64,6 @@ namespace detail {
   };                                                                           \
   template <typename T> using OPNAME##Op = UnOp<T, OPNAME##F<T>>;
 
-#define MATX_GLOBAL_UNARY_OP_GEN(FUNC, OPNAME)                                        \
-  template <typename T>                                                        \
-  static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_##FUNC(T v1)                \
-  {                                                                            \
-    if constexpr (is_matx_type_v<T>) {                                         \
-      return FUNC(v1);                                                         \
-    }                                                                          \
-    else {                                                                     \
-      return ::FUNC(v1);                                              \
-    }                                                                          \
-    if constexpr (!is_matx_type_v<T>) {                                        \
-      return ::FUNC(v1);                                              \
-    }                                                                          \
-    else {                                                                     \
-      return FUNC(v1);                                                         \
-    }                                                                          \
-  }                                                                            \
-  template <typename T> struct OPNAME##F {                                     \
-    static __MATX_INLINE__ std::string str() { return #FUNC; }                 \
-                                                                               \
-    static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto op(T v1)                            \
-    {                                                                          \
-      return _internal_##FUNC(v1);                                             \
-    }                                                                          \
-  };                                                                           \
-  template <typename T> using OPNAME##Op = UnOp<T, OPNAME##F<T>>;
-
 #define MATX_BINARY_OP_GEN(FUNC, OPNAME)                                       \
   template <typename T1, typename T2>                                          \
   static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_##FUNC(T1 v1, T2 v2)        \
@@ -161,7 +134,6 @@ MATX_UNARY_OP_GEN(ceil, Ceil);
 MATX_UNARY_OP_GEN(floor, Floor);
 MATX_UNARY_OP_GEN(round, Round);
 MATX_UNARY_OP_GEN(exp, Exp);
-MATX_GLOBAL_UNARY_OP_GEN(rsqrt, RSqrt);
 
 template <typename T>
 static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_sqrt(T v1)
@@ -182,6 +154,26 @@ template <typename T> struct SqrtF {
 };
 
 template <typename T> using SqrtOp = UnOp<T, SqrtF<T>>;
+
+template <typename T>
+static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_rsqrt(T v1)
+{
+  if constexpr (is_matx_type_v<T>){
+    return rsqrt(v1);
+  }
+  else {
+    return ::rsqrt(v1);
+  }
+}
+template <typename T> struct RSqrtF {
+  static __MATX_INLINE__ std::string str() { return "rsqrt"; }
+  static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto op(T v1)
+  {
+    return _internal_rsqrt(v1);
+  }
+};
+
+template <typename T> using RSqrtOp = UnOp<T, RSqrtF<T>>;
 
 template <typename T>
 static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto _internal_csqrt(T v1)

--- a/include/matx/operators/unary_operators.h
+++ b/include/matx/operators/unary_operators.h
@@ -127,6 +127,13 @@ namespace matx
   Op sqrt(Op t) {}
 
   /**
+ * Compute the square root of each value in a tensor.
+ * @param t
+ *   Tensor or operator input
+ */
+  Op rsqrt(Op t) {}
+
+  /**
  * Compute e^x of each value in a tensor.
  * @param t
  *   Tensor or operator input
@@ -356,6 +363,7 @@ namespace matx
 #else
   DEFINE_UNARY_OP(sqrt, detail::SqrtOp);
   DEFINE_UNARY_OP(csqrt, detail::CsqrtOp);
+  DEFINE_UNARY_OP(rsqrt, detail::RSqrtOp);
   DEFINE_UNARY_OP(exp, detail::ExpOp);
   DEFINE_UNARY_OP(expj, detail::ExpjOp);
   DEFINE_UNARY_OP(log10, detail::Log10Op);

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -1912,6 +1912,12 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, OperatorFuncs)
   exec.sync();
   EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_sqrt(c)));      
 
+  // example-begin rsqrt-test-1
+  (tov0 = rsqrt(tiv0)).run(exec);
+  // example-end rsqrt-test-1
+  exec.sync();
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_rqrt(c)));   
+
   MATX_EXIT_HANDLER();
 }
 

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -1916,7 +1916,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, OperatorFuncs)
   (tov0 = rsqrt(tiv0)).run(exec);
   // example-end rsqrt-test-1
   exec.sync();
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_rqrt(c)));   
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::_internal_rsqrt(c)));   
 
   MATX_EXIT_HANDLER();
 }


### PR DESCRIPTION
Adding a macro to define CUDA intrinsic math functions accessible at global scope, not in `cuda::std` namespace, calling the macro `MATX_GLOBAL_UNARY_OP_GEN`. 

Added the `rsqrt` function for computing reciprocal sqrts using the new macro. When not using the '-use_fast_math' flag, benchmarks using the hyperfine tool show `1.0/matx::sqrt` runs about 1.22x slower than 'matx::rsqrt'. Note when -use_fast_math is enabled, 1.0/sqrtf is replaced with rsqrtf, and the benchmark reflects that in similar run times with 100 runs (and 3 warmup runs). 