### PR TITLE
Add workaround for pre-11.8 CTK smem init errors

### DIFF
--- a/include/matx/kernels/channelize_poly.cuh
+++ b/include/matx/kernels/channelize_poly.cuh
@@ -61,7 +61,11 @@ __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter
     // Opportunistically store the filter taps in shared memory if the static shared memory
     // size is sufficient. Otherwise, we will read directly from global memory on use.
     const int SMEM_MAX_FILTER_TAPS = 128;
-    __shared__ filter_t smem_filter[SMEM_MAX_FILTER_TAPS];
+    // Versions of CUDA prior to 11.8 do not allow static shared memory allocations of
+    // cuda::std::complex types due to it having no trivial constructor. This workaround
+    // prevents an 'initializer not allowed for __shared__ variable' error.
+    __align__(sizeof(filter_t)) __shared__ uint8_t smem_filter_workaround[sizeof(filter_t)*SMEM_MAX_FILTER_TAPS];
+    filter_t (&smem_filter)[SMEM_MAX_FILTER_TAPS] = reinterpret_cast<filter_t (&)[SMEM_MAX_FILTER_TAPS]>(smem_filter_workaround);
 
     constexpr int InRank = InType::Rank();
     constexpr int OutRank = OutType::Rank();
@@ -345,8 +349,12 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
     const index_t last_out_elem = cuda::std::min(
         output_len_per_channel - 1, first_out_elem + ELEMS_PER_BLOCK - 1);
 
+    // Versions of CUDA prior to 11.8 do not allow static shared memory allocations of
+    // cuda::std::complex types due to it having no trivial constructor. This workaround
+    // prevents an 'initializer not allowed for __shared__ variable' error.
+    __align__(sizeof(output_t)) __shared__ uint8_t smem_eij_workaround[sizeof(output_t)*NUM_CHAN*NUM_CHAN];
+    output_t (&smem_eij)[NUM_CHAN][NUM_CHAN] = reinterpret_cast<output_t (&)[NUM_CHAN][NUM_CHAN]>(smem_eij_workaround);
     // Pre-compute the DFT complex exponentials and store in shared memory
-    __shared__ output_t smem_eij[NUM_CHAN][NUM_CHAN];
     for (int t = tid; t < NUM_CHAN*NUM_CHAN; t += THREADS) {
         const int i = t / NUM_CHAN;
         const int j = t % NUM_CHAN;


### PR DESCRIPTION
Static shared memory cannot be initialized by constructors, so the lack of trivial constructors in the std::complex types causes older CUDA toolkit releases to report an error on static shared memory declarations of complex types. Treat the memory as an aligned byte array and cast to the appropriate type as a workaround.

Fixes issue #669.