### PR TITLE
Fixed base operator types

### DIFF
--- a/include/matx/operators/at.h
+++ b/include/matx/operators/at.h
@@ -45,7 +45,7 @@ namespace matx
     class AtOp : public BaseOp<AtOp<Op, Is...>>
     {
       private:
-        Op op_;
+        typename base_type<Op>::type op_;
         cuda::std::array<index_t, sizeof...(Is)> idx_;
 
       public:

--- a/include/matx/operators/concat.h
+++ b/include/matx/operators/concat.h
@@ -227,7 +227,7 @@ namespace matx
       }
 
       private:
-      cuda::std::tuple<Ts...> ops_;
+      cuda::std::tuple<typename base_type<Ts>::type ...> ops_;
       index_t size_;    
       int axis_;
     }; // end class ConcatOp

--- a/include/matx/operators/frexp.h
+++ b/include/matx/operators/frexp.h
@@ -44,7 +44,7 @@ namespace detail {
   class FrexpOp : public BaseOp<FrexpOp<OpA, WHICH>>
   {
     private:
-      OpA a_;
+      typename base_type<OpA>::type a_;
 
     public:
       using matxop = bool;

--- a/include/matx/operators/reshape.h
+++ b/include/matx/operators/reshape.h
@@ -50,7 +50,7 @@ namespace matx
         using value_type = typename T::value_type;
 	
       private:
-        T op_;
+        typename base_type<T>::type op_;
 	      ShapeType sizes_;
 
       public:

--- a/include/matx/operators/stack.h
+++ b/include/matx/operators/stack.h
@@ -199,7 +199,7 @@ namespace matx
       }
 
       private:
-      cuda::std::tuple<Ts...> ops_;
+      cuda::std::tuple<typename base_type<Ts>::type ...> ops_;
       index_t size_;    
       int axis_;
     }; // end class StackOp


### PR DESCRIPTION
Closes #688 

`reshape` did not downcast the base operator to the correct type, and was inadvertently passing a shared_ptr to the device.