### PR TITLE
MATX_EN_CUTENSOR / MATX_ENABLE_CUTENSOR Unified Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ if (MATX_EN_CUTENSOR)
 
     include(cmake/FindcuTENSOR.cmake)
     include(cmake/FindcuTensorNet.cmake)
-    target_compile_definitions(matx INTERFACE MATX_ENABLE_CUTENSOR)
+    target_compile_definitions(matx INTERFACE MATX_EN_CUTENSOR)
 
     target_link_libraries(matx INTERFACE cuTENSOR::cuTENSOR)
     target_link_libraries(matx INTERFACE cuTensorNet::cuTensorNet)

--- a/include/matx/transforms/einsum.h
+++ b/include/matx/transforms/einsum.h
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#ifdef MATX_ENABLE_CUTENSOR
+#ifdef MATX_EN_CUTENSOR
 #include <cstdio>
 #include <numeric>
 #include "error.h"
@@ -486,7 +486,7 @@ namespace cutensor {
   template <typename OutputType, typename... InT>
   void einsum_impl([[maybe_unused]] OutputType &out, [[maybe_unused]] const std::string &subscripts, [[maybe_unused]] cudaStream_t stream, [[maybe_unused]] InT... tensors)
   {
-#ifdef MATX_ENABLE_CUTENSOR
+#ifdef MATX_EN_CUTENSOR
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
     // Get parameters required by these tensors
@@ -507,7 +507,7 @@ namespace cutensor {
       }
     );
 #else
-    MATX_THROW(matxNotSupported, "einsum() currently requires MATX_ENABLE_CUTENSOR=ON but MATX_ENABLE_CUTENSOR=OFF");
+    MATX_THROW(matxNotSupported, "einsum() currently requires MATX_EN_CUTENSOR=ON but MATX_EN_CUTENSOR=OFF");
 #endif
   }
 }

--- a/test/00_tensor/EinsumTests.cu
+++ b/test/00_tensor/EinsumTests.cu
@@ -96,7 +96,7 @@ TYPED_TEST_SUITE(EinsumTestsIntegral, MatXAllIntegralTypesCUDAExec);
 TYPED_TEST_SUITE(EinsumTestsNumericNonComplex, MatXNumericNonComplexTypesCUDAExec);
 TYPED_TEST_SUITE(EinsumTestsBoolean, MatXBoolTypesCUDAExec);
 
-#if MATX_ENABLE_CUTENSOR
+#if MATX_EN_CUTENSOR
 TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Contraction3D)
 {
   MATX_ENTER_HANDLER();


### PR DESCRIPTION
Currently we use MATX_EN_CUTENSOR as the cmake flag to control using cuTensor, but use MATX_ENABLE_CUTENSOR for the internal macro define check in code. This causes confusing reporting/error messages, and requires different variables depending how the user is building MatX.