### PR TITLE
Solver SVD Optimizations and Improved cuSolver batching

### DIFF
--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -1121,7 +1121,7 @@ auto OpToTensor(Op &&op, [[maybe_unused]] const Executor &exec) {
 }
 
 /**
- * Get a transposed view of a tensor into a user-supplied buffer
+ * Get a transposed view of a tensor or operator into a user-supplied buffer
  *
  * @param tp
  *   Pointer to pre-allocated memory
@@ -1136,7 +1136,7 @@ TransposeCopy(typename TensorType::value_type *tp, const TensorType &a, const Ex
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
-  auto pa = a.PermuteMatrix();
+  auto pa = transpose_matrix(a);
   auto tv = make_tensor(tp, pa.Shape());
   matx::copy(tv, pa, exec);
   return tv;

--- a/include/matx/transforms/chol/chol_cuda.h
+++ b/include/matx/transforms/chol/chol_cuda.h
@@ -170,7 +170,13 @@ public:
     cudaStreamSynchronize(stream);
 
     for (const auto& info : h_info) {
-      MATX_ASSERT(info == 0, matxSolverError);
+      if (info < 0) {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+          ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xpotrf").c_str());
+      } else {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+          (std::to_string(info) + "-th leading minor is not positive definite in cuSolver Xpotrf").c_str());
+      }
     }
   }
 

--- a/include/matx/transforms/chol/chol_cuda.h
+++ b/include/matx/transforms/chol/chol_cuda.h
@@ -147,8 +147,8 @@ public:
       (out = a).run(exec);
     }
 
-    cusolverDnSetStream(this->handle, exec.getStream());
-    int info;
+    const auto stream = exec.getStream();
+    cusolverDnSetStream(this->handle, stream);
 
     // At this time cuSolver does not have a batched 64-bit cholesky interface.
     // Change this to use the batched version once available.
@@ -161,9 +161,15 @@ public:
           this->d_info + i);
 
       MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
-      
-      // This will block. Figure this out later
-      cudaMemcpy(&info, this->d_info + i, sizeof(info), cudaMemcpyDeviceToHost);
+    }
+
+    std::vector<int> h_info(this->batch_a_ptrs.size());
+    cudaMemcpyAsync(h_info.data(), this->d_info, sizeof(int) * this->batch_a_ptrs.size(), cudaMemcpyDeviceToHost, stream);
+    
+    // This will block. Figure this out later
+    cudaStreamSynchronize(stream);
+
+    for (const auto& info : h_info) {
       MATX_ASSERT(info == 0, matxSolverError);
     }
   }

--- a/include/matx/transforms/chol/chol_lapack.h
+++ b/include/matx/transforms/chol/chol_lapack.h
@@ -144,7 +144,13 @@ public:
                      reinterpret_cast<T1*>(this->batch_a_ptrs[i]),
                      &params.n, &info);
 
-      MATX_ASSERT(info == 0, matxSolverError);
+      if (info < 0) {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+          ("Parameter " + std::to_string(-info) + " had an illegal value in LAPACK potrf").c_str());
+      } else {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+          (std::to_string(info) + "-th leading minor is not positive definite in LAPACK potrf").c_str());
+      }
     }
   }
 

--- a/include/matx/transforms/eig/eig_cuda.h
+++ b/include/matx/transforms/eig/eig_cuda.h
@@ -197,7 +197,13 @@ public:
     cudaStreamSynchronize(stream);
 
     for (const auto& info : h_info) {
-      MATX_ASSERT(info == 0, matxSolverError);
+      if (info < 0) {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+          ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xsyevd").c_str());
+      } else {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+            (std::to_string(info) + " off-diagonal elements of an intermediate tridiagonal form did not converge to zero in cuSolver Xsyevd").c_str());
+      }
     }
   }
 

--- a/include/matx/transforms/eig/eig_cuda.h
+++ b/include/matx/transforms/eig/eig_cuda.h
@@ -173,8 +173,8 @@ public:
       (out = a).run(exec);
     }
 
-    cusolverDnSetStream(this->handle, exec.getStream());
-    int info;
+    const auto stream = exec.getStream();
+    cusolverDnSetStream(this->handle, stream);
 
     // At this time cuSolver does not have a batched 64-bit LU interface. Change
     // this to use the batched version once available.
@@ -188,9 +188,15 @@ public:
           this->d_info + i);
 
       MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+    }
 
-      // This will block. Figure this out later
-      cudaMemcpy(&info, this->d_info + i, sizeof(info), cudaMemcpyDeviceToHost);
+    std::vector<int> h_info(this->batch_a_ptrs.size());
+    cudaMemcpyAsync(h_info.data(), this->d_info, sizeof(int) * this->batch_a_ptrs.size(), cudaMemcpyDeviceToHost, stream);
+
+    // This will block. Figure this out later
+    cudaStreamSynchronize(stream);
+
+    for (const auto& info : h_info) {
       MATX_ASSERT(info == 0, matxSolverError);
     }
   }

--- a/include/matx/transforms/eig/eig_lapack.h
+++ b/include/matx/transforms/eig/eig_lapack.h
@@ -131,7 +131,8 @@ public:
                     nullptr, &work_query, &this->lwork, &rwork_query,
                     &this->lrwork, &iwork_query, &this->liwork, &info);
     
-    MATX_ASSERT(info == 0, matxSolverError);
+    MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+      ("Parameter " + std::to_string(-info) + " had an illegal value in LAPACK syevd workspace query").c_str());
 
     // the real part of the first elem of work holds the optimal lwork.
     if constexpr (is_complex_v<T1>) {
@@ -196,7 +197,8 @@ public:
                       reinterpret_cast<T2*>(this->rwork), &this->lrwork,
                       reinterpret_cast<lapack_int_t*>(this->iwork), &this->liwork, &info);
 
-      MATX_ASSERT(info == 0, matxSolverError);
+      MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+          (std::to_string(info) + " off-diagonal elements of an intermediate tridiagonal form did not converge to zero in LAPACK syevd").c_str());
     }
   }
 

--- a/include/matx/transforms/lu/lu_cuda.h
+++ b/include/matx/transforms/lu/lu_cuda.h
@@ -179,7 +179,13 @@ public:
     cudaStreamSynchronize(stream);
 
     for (const auto& info : h_info) {
-      MATX_ASSERT(info == 0, matxSolverError);
+      if (info < 0) {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+          ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xgetrf").c_str());
+      } else {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+          ("U is singular: U(" + std::to_string(info) + "," + std::to_string(info) + ") = 0 in cuSolver Xgetrf").c_str());
+      }
     }
   }
 

--- a/include/matx/transforms/lu/lu_cuda.h
+++ b/include/matx/transforms/lu/lu_cuda.h
@@ -155,8 +155,8 @@ public:
       (out = a).run(exec);
     }
 
-    cusolverDnSetStream(this->handle, exec.getStream());
-    int info;
+    const auto stream = exec.getStream();
+    cusolverDnSetStream(this->handle, stream);
 
     // At this time cuSolver does not have a batched 64-bit LU interface. Change
     // this to use the batched version once available.
@@ -170,9 +170,15 @@ public:
           this->d_info + i);
 
       MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+    }
 
-      // This will block. Figure this out later
-      cudaMemcpy(&info, this->d_info + i, sizeof(info), cudaMemcpyDeviceToHost);
+    std::vector<int> h_info(this->batch_a_ptrs.size());
+    cudaMemcpyAsync(h_info.data(), this->d_info, sizeof(int) * this->batch_a_ptrs.size(), cudaMemcpyDeviceToHost, stream);
+
+    // This will block. Figure this out later
+    cudaStreamSynchronize(stream);
+
+    for (const auto& info : h_info) {
       MATX_ASSERT(info == 0, matxSolverError);
     }
   }

--- a/include/matx/transforms/lu/lu_lapack.h
+++ b/include/matx/transforms/lu/lu_lapack.h
@@ -150,7 +150,13 @@ public:
       getrf_dispatch(&params.m, &params.n, reinterpret_cast<T1*>(this->batch_a_ptrs[i]),
                      &params.m, reinterpret_cast<T2*>(this->batch_piv_ptrs[i]), &info);
 
-      MATX_ASSERT(info == 0, matxSolverError);
+      if (info < 0) {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+          ("Parameter " + std::to_string(-info) + " had an illegal value in LAPACK getrf").c_str());
+      } else {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+          ("U is singular: U(" + std::to_string(info) + "," + std::to_string(info) + ") = 0 in LAPACK getrf").c_str());
+      }
     }
   }
 

--- a/include/matx/transforms/qr/qr_cuda.h
+++ b/include/matx/transforms/qr/qr_cuda.h
@@ -344,8 +344,8 @@ public:
       (out = a).run(exec);
     }
 
-    cusolverDnSetStream(this->handle, exec.getStream());
-    int info;
+    const auto stream = exec.getStream();
+    cusolverDnSetStream(this->handle, stream);
 
     // At this time cuSolver does not have a batched 64-bit LU interface. Change
     // this to use the batched version once available.
@@ -359,9 +359,15 @@ public:
           this->d_info + i);
 
       MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+    }
 
-      // This will block. Figure this out later
-      cudaMemcpy(&info, this->d_info + i, sizeof(info), cudaMemcpyDeviceToHost);
+    std::vector<int> h_info(this->batch_a_ptrs.size());
+    cudaMemcpyAsync(h_info.data(), this->d_info, sizeof(int) * this->batch_a_ptrs.size(), cudaMemcpyDeviceToHost, stream);
+
+    // This will block. Figure this out later
+    cudaStreamSynchronize(stream);
+
+    for (const auto& info : h_info) {
       MATX_ASSERT(info == 0, matxSolverError);
     }
   }

--- a/include/matx/transforms/qr/qr_cuda.h
+++ b/include/matx/transforms/qr/qr_cuda.h
@@ -368,7 +368,8 @@ public:
     cudaStreamSynchronize(stream);
 
     for (const auto& info : h_info) {
-      MATX_ASSERT(info == 0, matxSolverError);
+      MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+        ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xgeqrf").c_str());
     }
   }
 

--- a/include/matx/transforms/qr/qr_lapack.h
+++ b/include/matx/transforms/qr/qr_lapack.h
@@ -122,7 +122,8 @@ public:
     geqrf_dispatch(&params.m, &params.n, nullptr,
                     &params.m, nullptr,
                     &work_query, &this->lwork, &info);
-    MATX_ASSERT(info == 0, matxSolverError);
+      MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+        ("Parameter " + std::to_string(-info) + " had an illegal value in LAPACK geqrf workspace query").c_str());
     
     // the real part of the first elem of work holds the optimal lwork
     if constexpr (is_complex_v<T1>) {
@@ -176,7 +177,7 @@ public:
                      &params.m, reinterpret_cast<T1*>(this->batch_tau_ptrs[i]),
                      reinterpret_cast<T1*>(this->work), &this->lwork, &info);
 
-      MATX_ASSERT(info == 0, matxSolverError);
+      MATX_ASSERT_STR_EXP(info, 0, matxSolverError, "LAPACK geqrf error");
     }
   }
 

--- a/include/matx/transforms/svd/svd_cuda.h
+++ b/include/matx/transforms/svd/svd_cuda.h
@@ -528,8 +528,7 @@ namespace detail {
 struct DnSVDCUDAParams_t {
   int64_t m;
   int64_t n;
-  char jobu;
-  char jobvt;
+  char jobz;
   void *A;
   void *U;
   void *VT;
@@ -574,19 +573,16 @@ public:
    *   Output tensor view for VT matrix
    * @param a
    *   Input tensor view for A matrix
-   * @param jobu
-   *   Specifies options for computing all or part of the matrix U: = 'A'. See
-   * SVDJob documentation for more info
-   * @param jobvt
-   *   specifies options for computing all or part of the matrix V**T. See
-   * SVDJob documentation for more info
+   * @param jobz
+   *   Specifies options for computing all, part, or none of the matrices U and VT. See
+   *  SVDMode documentation for more info
    *
    */
   matxDnSVDCUDAPlan_t(UTensor &u,
                         STensor &s,
                         VtTensor &vt,
-                        const ATensor &a, const char jobu = 'A',
-                        const char jobvt = 'A')
+                        const ATensor &a,
+                        const char jobz = 'A')
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
@@ -602,7 +598,7 @@ public:
     MATX_STATIC_ASSERT_STR(!is_complex_v<T3>, matxInvalidType, "S type must be real");
     MATX_STATIC_ASSERT_STR((std::is_same_v<typename inner_op_type_t<T1>::type, T3>), matxInvalidType, "A and S inner types must match");
 
-    params = GetSVDParams(u, s, vt, a, jobu, jobvt);
+    params = GetSVDParams(u, s, vt, a, jobz);
     this->GetWorkspaceSize();
     this->AllocateWorkspace(params.batch_size);
   }
@@ -624,7 +620,7 @@ public:
   static DnSVDCUDAParams_t
   GetSVDParams(UTensor &u, STensor &s,
                VtTensor &vt, const ATensor &a,
-               const char jobu = 'A', const char jobvt = 'A')
+               const char jobz = 'A')
   {
     DnSVDCUDAParams_t params;
     params.batch_size = GetNumBatches(a);
@@ -634,8 +630,7 @@ public:
     params.U = u.Data();
     params.VT = vt.Data();
     params.S = s.Data();
-    params.jobu = jobu;
-    params.jobvt = jobvt;
+    params.jobz = jobz;
     params.dtype = TypeToInt<T1>();
 
     return params;
@@ -643,7 +638,7 @@ public:
 
   void Exec(UTensor &u, STensor &s, VtTensor &vt,
             const ATensor &a, const cudaExecutor &exec,
-            const char jobu = 'A', const char jobvt = 'A')
+            const char jobz = 'A')
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
@@ -672,7 +667,7 @@ public:
     for (size_t i = 0; i < this->batch_a_ptrs.size(); i++) {
 
       auto ret = cusolverDnXgesvd(
-          this->handle, this->dn_params, jobu, jobvt, params.m, params.n,
+          this->handle, this->dn_params, jobz, jobz, params.m, params.n,
           MatXTypeToCudaType<T1>(), this->batch_a_ptrs[i], params.m,
           MatXTypeToCudaType<T3>(), this->batch_s_ptrs[i], MatXTypeToCudaType<T2>(),
           this->batch_u_ptrs[i], params.m, MatXTypeToCudaType<T4>(), this->batch_vt_ptrs[i],
@@ -744,7 +739,7 @@ using svd_cuda_cache_t = std::unordered_map<DnSVDCUDAParams_t, std::any, DnSVDCU
  * See documentation of matxDnSVDCUDAPlan_t for a description of how the
  * algorithm works. This function provides a simple interface to the cuSolver
  * library by deducing all parameters needed to perform a SVD decomposition from
- * only the matrix A. cuSolver only support m >= n.
+ * only the matrix A.
  *
  * @tparam T1
  *   Data type of matrix A
@@ -761,72 +756,115 @@ using svd_cuda_cache_t = std::unordered_map<DnSVDCUDAParams_t, std::any, DnSVDCU
  *   Input matrix A
  * @param exec
  *   CUDA Executor
- * @param jobu
- *   Specifies options for computing all or part of the matrix U: = 'A'. See
- * SVDJob documentation for more info
- * @param jobvt
- *   specifies options for computing all or part of the matrix V**T. See
- * SVDJob documentation for more info
+ * @param jobz
+ *   Specifies options for computing all, part, or none of the matrices U and VT. See
+ * SVDMode documentation for more info
  *
  */
 template <typename UTensor, typename STensor, typename VtTensor, typename ATensor>
 void svd_impl(UTensor &&u, STensor &&s,
          VtTensor &&vt, const ATensor &a,
-         const cudaExecutor &exec, const SVDJob jobu = SVDJob::ALL,
-         const SVDJob jobvt = SVDJob::ALL)
+         const cudaExecutor &exec, const SVDMode jobz = SVDMode::ALL)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
   using T1 = typename ATensor::value_type;
   constexpr int RANK = ATensor::Rank();
   const auto stream = exec.getStream();
 
-  auto u_new = OpToTensor(u, exec);
-  auto s_new = OpToTensor(s, exec);
-  auto vt_new = OpToTensor(vt, exec);
-  auto a_new = OpToTensor(a, exec);
-
-  if(!a_new.isSameView(a)) {
-    (a_new = a).run(exec);
-  }
+  auto s_new = getSolverSupportedTensor(s, exec);
 
   /* Temporary WAR
-     cuSolver doesn't support row-major layouts. Since we want to make the
-     library appear as though everything is row-major, we take a performance hit
-     to transpose in and out of the function. Eventually this may be fixed in
-     cuSolver.
+     cuSolver assumes column-major matrices and MatX uses row-major matrices.
+     One way to address this is to create a transposed copy of the input to
+     use with the factorization, followed by transposing the outputs. For SVD,
+     we can skip this by passing in a permuted view of row-major A, which is
+     equivalent to col-major AT, and swapping the inputs U and VT.
+
+     However, cuSolver only supports m>=n. Thus, this optimization can be used
+     for m<=n, but for m>n, we must do temp allocations for U/VT and tranpose the
+     col-major cuSolver outputs.
+
+     Eventually these limitations may be fixed in cuSolver.
   */
  
+  // cuSolver destroys the input, so we need to make a copy of A regardless
   T1 *tp;
-  matxAlloc(reinterpret_cast<void **>(&tp), a_new.Bytes(), MATX_ASYNC_DEVICE_MEMORY, stream);
-  auto tv = TransposeCopy(tp, a_new, exec);
-  auto tvt = tv.PermuteMatrix();
+  auto a_shape = a.Shape();
+  auto a_total_size = std::accumulate(a_shape.begin(), a_shape.begin() + ATensor::Rank(), 1, std::multiplies< typename ATensor::desc_type::shape_type>());
+  matxAlloc(reinterpret_cast<void **>(&tp), sizeof(T1) * a_total_size, MATX_ASYNC_DEVICE_MEMORY, stream);
 
-  auto u_col_maj = make_tensor<T1>(u_new.Shape(), MATX_ASYNC_DEVICE_MEMORY, stream);
-  auto vt_col_maj = make_tensor<T1>(vt_new.Shape(), MATX_ASYNC_DEVICE_MEMORY, stream);
+  const char job_cusolver = detail::SVDModeToChar(jobz);
+  const bool m_leq_n = a.Size(RANK-2) <= a.Size(RANK-1);
+  
+  if (m_leq_n) {
+    // get col-major AT
+    auto a_new = make_tensor(tp, a_shape);
+    (a_new = a).run(exec);
+    auto at_col_maj = transpose_matrix(a_new);
 
-  const char jobu_cusolver = detail::SVDJobToChar(jobu);
-  const char jobvt_cusolver = detail::SVDJobToChar(jobvt);
+    auto u_new = getSolverSupportedTensor(u, exec);
+    auto vt_new = getSolverSupportedTensor(vt, exec);
 
-  // Get parameters required by these tensors
-  auto params = detail::matxDnSVDCUDAPlan_t<decltype(u_new), decltype(s_new), decltype(vt_new), decltype(tvt)>::
-      GetSVDParams(u_col_maj, s_new, vt_col_maj, tvt, jobu_cusolver, jobvt_cusolver);
+    // swap U and VT
+    auto u_in = vt_new;
+    auto vt_in = u_new;
 
-  // Get cache or new QR plan if it doesn't exist
-  using cache_val_type = detail::matxDnSVDCUDAPlan_t<decltype(u_col_maj), decltype(s_new), decltype(vt_col_maj), decltype(tvt)>;
-  detail::GetCache().LookupAndExec<detail::svd_cuda_cache_t>(
-    detail::GetCacheIdFromType<detail::svd_cuda_cache_t>(),
-    params,
-    [&]() {
-      return std::make_shared<cache_val_type>(u_col_maj, s_new, vt_col_maj, tvt, jobu_cusolver, jobvt_cusolver);
-    },
-    [&](std::shared_ptr<cache_val_type> ctype) {
-      ctype->Exec(u_col_maj, s_new, vt_col_maj, tvt, exec, jobu_cusolver, jobvt_cusolver);
+    // Get parameters required by these tensors
+    auto params = detail::matxDnSVDCUDAPlan_t<decltype(u_in), decltype(s_new), decltype(vt_in), decltype(at_col_maj)>::
+      GetSVDParams(u_in, s_new, vt_in, at_col_maj, job_cusolver);
+
+    // Get cache or new SVD plan if it doesn't exist
+    using cache_val_type = detail::matxDnSVDCUDAPlan_t<decltype(u_in), decltype(s_new), decltype(vt_in), decltype(at_col_maj)>;
+    detail::GetCache().LookupAndExec<detail::svd_cuda_cache_t>(
+      detail::GetCacheIdFromType<detail::svd_cuda_cache_t>(),
+      params,
+      [&]() {
+        return std::make_shared<cache_val_type>(u_in, s_new, vt_in, at_col_maj, job_cusolver);
+      },
+      [&](std::shared_ptr<cache_val_type> ctype) {
+        ctype->Exec(u_in, s_new, vt_in, at_col_maj, exec, job_cusolver);
+      }
+    );
+
+    if(!u_new.isSameView(u)) {
+      (u = u_new).run(exec);
     }
-  );
+    if(!vt_new.isSameView(vt)) {
+      (vt = vt_new).run(exec);
+    }
+  } else {
+    // get col-major A
+    auto tv = TransposeCopy(tp, a, exec);
+    auto tvt = tv.PermuteMatrix();
 
-  // cuSolver writes to them in col-major format, so we need to transpose them back.
-  (u = transpose_matrix(u_col_maj)).run(exec);
-  (vt = transpose_matrix(vt_col_maj)).run(exec);
+    auto u_col_maj = make_tensor<T1>(u.Shape(), MATX_ASYNC_DEVICE_MEMORY, stream);
+    auto vt_col_maj = make_tensor<T1>(vt.Shape(), MATX_ASYNC_DEVICE_MEMORY, stream);
+
+    // Get parameters required by these tensors
+    auto params = detail::matxDnSVDCUDAPlan_t<decltype(u_col_maj), decltype(s_new), decltype(vt_col_maj), decltype(tvt)>::
+        GetSVDParams(u_col_maj, s_new, vt_col_maj, tvt, job_cusolver);
+
+    // Get cache or new SVD plan if it doesn't exist
+    using cache_val_type = detail::matxDnSVDCUDAPlan_t<decltype(u_col_maj), decltype(s_new), decltype(vt_col_maj), decltype(tvt)>;
+    detail::GetCache().LookupAndExec<detail::svd_cuda_cache_t>(
+      detail::GetCacheIdFromType<detail::svd_cuda_cache_t>(),
+      params,
+      [&]() {
+        return std::make_shared<cache_val_type>(u_col_maj, s_new, vt_col_maj, tvt, job_cusolver);
+      },
+      [&](std::shared_ptr<cache_val_type> ctype) {
+        ctype->Exec(u_col_maj, s_new, vt_col_maj, tvt, exec, job_cusolver);
+      }
+    );
+
+    // cuSolver writes u and vt in col-major format, so we need to transpose them back.
+    (u = transpose_matrix(u_col_maj)).run(exec);
+    (vt = transpose_matrix(vt_col_maj)).run(exec);
+  }
+
+  if(!s_new.isSameView(s)) {
+    (s = s_new).run(exec);
+  }
 
   matxFree(tp);
 }

--- a/include/matx/transforms/svd/svd_cuda.h
+++ b/include/matx/transforms/svd/svd_cuda.h
@@ -686,7 +686,13 @@ public:
     cudaStreamSynchronize(stream);
 
     for (const auto& info : h_info) {
-      MATX_ASSERT(info == 0, matxSolverError);
+      if (info < 0) {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+          ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xgesvd").c_str());
+      } else {
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+          (std::to_string(info) + " superdiagonals of an intermediate bidiagonal form did not converge to zero in cuSolver Xgesvd").c_str());
+      }
     }
   }
 

--- a/include/matx/transforms/svd/svd_lapack.h
+++ b/include/matx/transforms/svd/svd_lapack.h
@@ -54,10 +54,10 @@ namespace detail {
  * unique factorizations mostly by the data pointer in A.
  */
 struct DnSVDHostParams_t {
+  SVDHostAlgo algo;
   lapack_int_t m;
   lapack_int_t n;
-  char jobu;
-  char jobvt;
+  char jobz;
   void *A;
   void *U;
   void *VT;
@@ -102,19 +102,19 @@ public:
    *   Output tensor view for VT matrix
    * @param a
    *   Input tensor view for A matrix
-   * @param jobu
-   *   Specifies options for computing all or part of the matrix U: = 'A'. See
-   *  SVDJob documentation for more info
-   * @param jobvt
-   *   specifies options for computing all or part of the matrix V**T. See
-   * SVDJob documentation for more info
-   *
+   * @param jobz
+   *   Specifies options for computing all, part, or none of the matrices U and VT. See
+   *  SVDMode documentation for more info
+   * @param algo
+   *   Specifies the algorithm to use for computing SVD. Either QR based 'gesvd' or
+   *  divide-and-conquer based 'gesdd'. See SVDHostAlgo documentation for more info
    */
   matxDnSVDHostPlan_t(UTensor &u,
                       STensor &s,
                       VtTensor &vt,
-                      const ATensor &a, const char jobu = 'A',
-                      const char jobvt = 'A')
+                      const ATensor &a,
+                      const char jobz = 'A',
+                      SVDHostAlgo algo = SVDHostAlgo::DC)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
@@ -130,50 +130,80 @@ public:
     MATX_STATIC_ASSERT_STR(!is_complex_v<T3>, matxInvalidType, "S type must be real");
     MATX_STATIC_ASSERT_STR((std::is_same_v<typename inner_op_type_t<T1>::type, T3>), matxInvalidType, "A and S inner types must match");
 
-    params = GetSVDParams(u, s, vt, a, jobu, jobvt);
+    params = GetSVDParams(u, s, vt, a, jobz, algo);
     this->GetWorkspaceSize();
     this->AllocateWorkspace(params.batch_size);
   }
 
   void GetWorkspaceSize() override
   {
-    // Perform a workspace query with lwork = -1.
+    // Perform a workspace query with lwork = -1, using all mode for a
+    // larger workspace size that works for all modes
 
     lapack_int_t info;
     T1 work_query;
-    // Use all mode for a larger workspace size that works for all modes
-    gesvd_dispatch("A", "A", &params.m, &params.n, nullptr,
-                  &params.m, nullptr, nullptr, &params.m, nullptr, &params.n,
-                  &work_query, &this->lwork, nullptr, &info);
+    lapack_int_t mn = cuda::std::min(params.m, params.n);
+    lapack_int_t mx = cuda::std::max(params.m, params.n);
 
-    MATX_ASSERT(info == 0, matxSolverError);
+    if (params.algo == SVDHostAlgo::QR) {
+      gesvd_dispatch("A", "A", &params.m, &params.n, nullptr,
+                    &params.m, nullptr, nullptr, &params.m, nullptr, &params.n,
+                    &work_query, &this->lwork, nullptr, &info);
 
-    // the real part of the first elem of work holds the optimal lwork.
-    // rwork has size 5*min(M,N) and is only used for complex types
-    if constexpr (is_complex_v<T1>) {
-      this->lwork = static_cast<lapack_int_t>(work_query.real());
-      this->lrwork = 5 * cuda::std::min(params.m, params.n);
+      MATX_ASSERT(info == 0, matxSolverError);
+
+      // the real part of the first elem of work holds the optimal lwork.
+      // rwork has size 5*min(M,N) and is only used for complex types
+      if constexpr (is_complex_v<T1>) {
+        this->lwork = static_cast<lapack_int_t>(work_query.real());
+        this->lrwork = 5 * mn;
+      } else {
+        this->lwork = static_cast<lapack_int_t>(work_query);
+        this->lrwork = 0;
+      }
+    } else if (params.algo == SVDHostAlgo::DC) {
+      gesdd_dispatch("A", &params.m, &params.n, nullptr, &params.m, nullptr,
+                    nullptr, &params.m, nullptr, &params.n, &work_query,
+                    &this->lwork, nullptr, nullptr, &info);
+
+      MATX_ASSERT(info == 0, matxSolverError);
+
+      this->liwork = 8 * mn; // iwork has size 8*min(M,N) and is used for all types
+
+      // the real part of the first elem of work holds the optimal lwork.
+      if constexpr (is_complex_v<T1>) {
+        this->lwork = static_cast<lapack_int_t>(work_query.real());
+        
+        lapack_int_t mnthr = (mn * 5) / 3;
+        if (mx >= mnthr) {
+          this->lrwork = 5*mn*mn + 5*mn;
+        } else {
+          this->lrwork = cuda::std::max(5*mn*mn + 5*mn, 2*mx*mn + 2*mn*mn + mn);
+        }
+      } else {
+        this->lwork = static_cast<lapack_int_t>(work_query);
+        this->lrwork = 0; // rwork is not used for real types
+      }
     } else {
-      this->lwork = static_cast<lapack_int_t>(work_query);
-      this->lrwork = 0; // rwork is not used for real types
+      MATX_THROW(matxInvalidType, "Invalid SVD host algorithm");
     }
   }
 
   static DnSVDHostParams_t
   GetSVDParams(UTensor &u, STensor &s,
                VtTensor &vt, const ATensor &a,
-               const char jobu = 'A', const char jobvt = 'A')
+               const char jobz = 'A', const SVDHostAlgo algo = SVDHostAlgo::DC)
   {
     DnSVDHostParams_t params;
     params.batch_size = GetNumBatches(a);
     params.m = static_cast<lapack_int_t>(a.Size(RANK - 2));
     params.n = static_cast<lapack_int_t>(a.Size(RANK - 1));
+    params.algo = algo;
     params.A = a.Data();
     params.U = u.Data();
     params.VT = vt.Data();
     params.S = s.Data();
-    params.jobu = jobu;
-    params.jobvt = jobvt;
+    params.jobz = jobz;
     params.dtype = TypeToInt<T1>();
 
     return params;
@@ -182,7 +212,7 @@ public:
   template<ThreadsMode MODE>
   void Exec(UTensor &u, STensor &s, VtTensor &vt,
             const ATensor &a, [[maybe_unused]] const HostExecutor<MODE> &exec,
-            const char jobu = 'A', const char jobvt = 'A')
+            const char jobz = 'A')
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
@@ -205,13 +235,24 @@ public:
 
     lapack_int_t info;
     for (size_t i = 0; i < this->batch_a_ptrs.size(); i++) {
-      gesvd_dispatch(&jobu, &jobvt, &params.m, &params.n,
-                      reinterpret_cast<T1*>(this->batch_a_ptrs[i]),
-                      &params.m, reinterpret_cast<T3*>(this->batch_s_ptrs[i]),
-                      reinterpret_cast<T1*>(this->batch_u_ptrs[i]), &params.m,
-                      reinterpret_cast<T1*>(this->batch_vt_ptrs[i]), &params.n,
-                      reinterpret_cast<T1*>(this->work), &this->lwork,
-                      reinterpret_cast<T3*>(this->rwork), &info);
+      if (params.algo == SVDHostAlgo::QR) {
+        gesvd_dispatch(&jobz, &jobz, &params.m, &params.n,
+                        reinterpret_cast<T1*>(this->batch_a_ptrs[i]),
+                        &params.m, reinterpret_cast<T3*>(this->batch_s_ptrs[i]),
+                        reinterpret_cast<T1*>(this->batch_u_ptrs[i]), &params.m,
+                        reinterpret_cast<T1*>(this->batch_vt_ptrs[i]), &params.n,
+                        reinterpret_cast<T1*>(this->work), &this->lwork,
+                        reinterpret_cast<T3*>(this->rwork), &info);
+      } else if (params.algo == SVDHostAlgo::DC) {
+        gesdd_dispatch(&jobz, &params.m, &params.n,
+                        reinterpret_cast<T1*>(this->batch_a_ptrs[i]),
+                        &params.m, reinterpret_cast<T3*>(this->batch_s_ptrs[i]),
+                        reinterpret_cast<T1*>(this->batch_u_ptrs[i]), &params.m,
+                        reinterpret_cast<T1*>(this->batch_vt_ptrs[i]), &params.n,
+                        reinterpret_cast<T1*>(this->work), &this->lwork,
+                        reinterpret_cast<T3*>(this->rwork),
+                        reinterpret_cast<lapack_int_t*>(this->iwork), &info);
+      }
 
       MATX_ASSERT(info == 0, matxSolverError);
     }
@@ -248,6 +289,22 @@ private:
     }
 #pragma GCC diagnostic pop
   }
+
+  void gesdd_dispatch(const char *jobz, const lapack_int_t *m, const lapack_int_t *n,
+                      T1 *a, const lapack_int_t *lda, T3 *s, T1 *u, const lapack_int_t *ldu,
+                      T1 *vt, const lapack_int_t *ldvt, T1 *work_in, const lapack_int_t *lwork_in,
+                      [[maybe_unused]] T3 *rwork_in, lapack_int_t *iwork_in, lapack_int_t *info)
+  {
+    if constexpr (std::is_same_v<T1, float>) {
+      LAPACK_CALL(sgesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, iwork_in, info);
+    } else if constexpr (std::is_same_v<T1, double>) {
+      LAPACK_CALL(dgesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, iwork_in, info);
+    } else if constexpr  (std::is_same_v<T1, cuda::std::complex<float>>) {
+      LAPACK_CALL(cgesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, rwork_in, iwork_in, info);
+    } else if constexpr   (std::is_same_v<T1, cuda::std::complex<double>>)  {
+      LAPACK_CALL(zgesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, rwork_in, iwork_in, info);
+    }
+  }
   
   std::vector<T2 *> batch_u_ptrs;
   std::vector<T3 *> batch_s_ptrs;
@@ -274,7 +331,8 @@ struct DnSVDHostParamsKeyHash {
 struct DnSVDHostParamsKeyEq {
   bool operator()(const DnSVDHostParams_t &l, const DnSVDHostParams_t &t) const noexcept
   {
-    return l.n == t.n && l.m == t.m && l.batch_size == t.batch_size && l.dtype == t.dtype;
+    return l.n == t.n && l.m == t.m && l.batch_size == t.batch_size && l.dtype == t.dtype &&
+           l.algo == t.algo;
   }
 };
 
@@ -306,13 +364,12 @@ using svd_Host_cache_t = std::unordered_map<DnSVDHostParams_t, std::any, DnSVDHo
  *   Input matrix A
  * @param exec
  *   Host Executor
- * @param jobu
- *   Specifies options for computing all or part of the matrix U: = 'A'. See
- * SVDJob documentation for more info
- * @param jobvt
- *   specifies options for computing all or part of the matrix V**T. See
- * SVDJob documentation for more info
- *
+ * @param jobz
+ *   Specifies options for computing all, part, or none of the matrices U and VT. See
+ * SVDMode documentation for more info
+ * @param algo
+ *   Specifies the algorithm to use for computing SVD. Either QR based 'gesvd' or
+ * divide-and-conquer based 'gesdd'. See SVDHostAlgo documentation for more info
  */
 template <typename UTensor, typename STensor, typename VtTensor, typename ATensor, ThreadsMode MODE>
 void svd_impl([[maybe_unused]] UTensor &&u,
@@ -320,8 +377,8 @@ void svd_impl([[maybe_unused]] UTensor &&u,
               [[maybe_unused]] VtTensor &&vt,
               [[maybe_unused]] const ATensor &a,
               [[maybe_unused]] const HostExecutor<MODE> &exec,
-              [[maybe_unused]] const SVDJob jobu = SVDJob::ALL,
-              [[maybe_unused]] const SVDJob jobvt = SVDJob::ALL)
+              [[maybe_unused]] const SVDMode jobz = SVDMode::ALL,
+              [[maybe_unused]] const SVDHostAlgo algo = SVDHostAlgo::DC)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
   MATX_ASSERT_STR(MATX_EN_CPU_SOLVER, matxInvalidExecutor,
@@ -331,54 +388,56 @@ void svd_impl([[maybe_unused]] UTensor &&u,
   using T1 = typename ATensor::value_type;
   constexpr int RANK = ATensor::Rank();
 
-  auto u_new = OpToTensor(u, exec);
-  auto s_new = OpToTensor(s, exec);
-  auto vt_new = OpToTensor(vt, exec);
-  auto a_new = OpToTensor(a, exec);
-
-  if(!a_new.isSameView(a)) {
-    (a_new = a).run(exec);
-  }
+  auto s_new = getSolverSupportedTensor(s, exec);
+  auto u_new = getSolverSupportedTensor(u, exec);
+  auto vt_new = getSolverSupportedTensor(vt, exec);
 
   /* Temporary WAR
-     LAPACK doesn't support row-major layouts. Since we want to make the
-     library appear as though everything is row-major, we take a performance hit
-     to transpose in and out of the function. LAPACKE, however, supports both formats.
+     LAPACK assumes column-major matrices and MatX uses row-major matrices.
+     One way to address this is to create a transposed copy of the input to
+     use with the factorization, followed by transposing the outputs. For SVD,
+     we can skip this by passing in a permuted view of row-major A, which is
+     equivalent to col-major AT, and swapping the inputs U and VT.
   */
- 
-  T1 *tp;
-  matxAlloc(reinterpret_cast<void **>(&tp), a_new.Bytes(), MATX_HOST_MALLOC_MEMORY);
-  auto tv = TransposeCopy(tp, a_new, exec);
-  auto tvt = tv.PermuteMatrix();
-  
-  auto u_col_maj = make_tensor<T1>(u_new.Shape(), MATX_HOST_MALLOC_MEMORY);
-  auto vt_col_maj = make_tensor<T1>(vt_new.Shape(), MATX_HOST_MALLOC_MEMORY);
 
-  const char jobu_lapack = detail::SVDJobToChar(jobu);
-  const char jobvt_lapack = detail::SVDJobToChar(jobvt);
+  // LAPACK destroys the input, so we need to make a copy of A regardless  
+  auto a_copy = make_tensor<T1>(a.Shape(), MATX_HOST_MALLOC_MEMORY);
+  (a_copy = a).run(exec);
+  auto at_col_maj = transpose_matrix(a_copy);
+
+  // swap U and VT
+  auto u_in = vt_new;
+  auto vt_in = u_new;
+
+  const char job_lapack = detail::SVDModeToChar(jobz);
 
   // Get parameters required by these tensors
-  auto params = detail::matxDnSVDHostPlan_t<decltype(u_new), decltype(s_new), decltype(vt_new), decltype(tvt)>::
-    GetSVDParams(u_col_maj, s_new, vt_col_maj, tvt, jobu_lapack, jobvt_lapack);
+  auto params = detail::matxDnSVDHostPlan_t<decltype(u_in), decltype(s_new), decltype(vt_in), decltype(at_col_maj)>::
+    GetSVDParams(u_in, s_new, vt_in, at_col_maj, job_lapack, algo);
 
-  // Get cache or new QR plan if it doesn't exist
-  using cache_val_type = detail::matxDnSVDHostPlan_t<decltype(u_col_maj), decltype(s_new), decltype(vt_col_maj), decltype(tvt)>;
+  // Get cache or new SVD plan if it doesn't exist
+  using cache_val_type = detail::matxDnSVDHostPlan_t<decltype(u_in), decltype(s_new), decltype(vt_in), decltype(at_col_maj)>;
   detail::GetCache().LookupAndExec<detail::svd_Host_cache_t>(
     detail::GetCacheIdFromType<detail::svd_Host_cache_t>(),
     params,
     [&]() {
-      return std::make_shared<cache_val_type>(u_col_maj, s_new, vt_col_maj, tvt, jobu_lapack, jobvt_lapack);
+      return std::make_shared<cache_val_type>(u_in, s_new, vt_in, at_col_maj, job_lapack, algo);
     },
     [&](std::shared_ptr<cache_val_type> ctype) {
-      ctype->Exec(u_col_maj, s_new, vt_col_maj, tvt, exec, jobu_lapack, jobvt_lapack);
+      ctype->Exec(u_in, s_new, vt_in, at_col_maj, exec, job_lapack);
     }
   );
 
-  // LAPACK writes to them in col-major format, so we need to transpose them back.
-  (u = transpose_matrix(u_col_maj)).run(exec);
-  (vt = transpose_matrix(vt_col_maj)).run(exec);
 
-  matxFree(tp);
+  if(!s_new.isSameView(s)) {
+    (s = s_new).run(exec);
+  }
+  if(!u_new.isSameView(u)) {
+    (u = u_new).run(exec);
+  }
+  if(!vt_new.isSameView(vt)) {
+    (vt = vt_new).run(exec);
+  }
 #endif
 }
 


### PR DESCRIPTION
- Bypassed temp allocations and having to transpose outputs in most cases for SVD
- Added m < n CUDA SVD support (cuSolver natively only supports m >= n)
- Added option to use `gesdd` or `gesvd` LAPACK driver for Host SVD
- For cuSolver batching, replaced per-iteration sync & error check with a single check at the end to reduce blocking operations