### PR TITLE
Host Solver workspace query fix

### DIFF
--- a/include/matx/transforms/chol/chol_lapack.h
+++ b/include/matx/transforms/chol/chol_lapack.h
@@ -205,7 +205,7 @@ struct DnCholHostParamsKeyEq {
   }
 };
 
-using chol_Host_cache_t = std::unordered_map<DnCholHostParams_t, std::any, DnCholHostParamsKeyHash, DnCholHostParamsKeyEq>;
+using chol_host_cache_t = std::unordered_map<DnCholHostParams_t, std::any, DnCholHostParamsKeyHash, DnCholHostParamsKeyEq>;
 #endif
 
 } // end namespace detail
@@ -284,8 +284,8 @@ void chol_impl([[maybe_unused]] OutputTensor &&out,
   auto params = detail::matxDnCholHostPlan_t<OutputTensor, decltype(tv)>::GetCholParams(tv, uplo_lapack);
 
   using cache_val_type = detail::matxDnCholHostPlan_t<OutputTensor, decltype(a_new)>;
-  detail::GetCache().LookupAndExec<detail::chol_Host_cache_t>(
-    detail::GetCacheIdFromType<detail::chol_Host_cache_t>(),
+  detail::GetCache().LookupAndExec<detail::chol_host_cache_t>(
+    detail::GetCacheIdFromType<detail::chol_host_cache_t>(),
     params,
     [&]() {
       return std::make_shared<cache_val_type>(tv, uplo_lapack);

--- a/include/matx/transforms/chol/chol_lapack.h
+++ b/include/matx/transforms/chol/chol_lapack.h
@@ -77,7 +77,7 @@ public:
    * matrix using the Cholesky method, where M is either the upper or lower
    * triangular portion of A. Input matrix A must be a square Hermitian matrix
    * positive-definite where only the upper or lower triangle is used. This does
-   * require a workspace.
+   * not require a workspace.
    *
    * @tparam T1
    *  Data type of A matrix
@@ -181,38 +181,13 @@ private:
   DnCholHostParams_t params;
 };
 
-/**
- * Crude hash to get a reasonably good delta for collisions. This doesn't need
- * to be perfect, but fast enough to not slow down lookups, and different enough
- * so the common solver parameters change
- */
-struct DnCholHostParamsKeyHash {
-  std::size_t operator()(const DnCholHostParams_t &k) const noexcept
-  {
-    return (std::hash<uint64_t>()(k.n)) + (std::hash<uint64_t>()(k.batch_size));
-  }
-};
-
-/**
- * Test cholesky parameters for equality. Unlike the hash, all parameters must
- * match.
- */
-struct DnCholHostParamsKeyEq {
-  bool operator()(const DnCholHostParams_t &l, const DnCholHostParams_t &t) const
-      noexcept
-  {
-    return l.n == t.n && l.batch_size == t.batch_size && l.dtype == t.dtype;
-  }
-};
-
-using chol_host_cache_t = std::unordered_map<DnCholHostParams_t, std::any, DnCholHostParamsKeyHash, DnCholHostParamsKeyEq>;
 #endif
 
 } // end namespace detail
 
 
 /**
- * Perform a Cholesky decomposition using a cached plan
+ * Perform a Cholesky decomposition.
  *
  * See documentation of matxDnCholHostPlan_t for a description of how the
  * algorithm works. This function provides a simple interface to the LAPACK
@@ -220,6 +195,8 @@ using chol_host_cache_t = std::unordered_map<DnCholHostParams_t, std::any, DnCho
  * from only the matrix A. The input and output parameters may be the same
  * tensor. In that case, the input is destroyed and the output is stored
  * in-place. Input must be a positive-definite Hermitian or real symmetric matrix.
+ * 
+ * No caching as LAPACK allocation/setup is not needed.
  *
  * @tparam T1
  *   Data type of matrix A
@@ -280,20 +257,8 @@ void chol_impl([[maybe_unused]] OutputTensor &&out,
 
   const char uplo_lapack = (uplo == SolverFillMode::UPPER)? 'U' : 'L';
 
-  // Get parameters required by these tensors
-  auto params = detail::matxDnCholHostPlan_t<OutputTensor, decltype(tv)>::GetCholParams(tv, uplo_lapack);
-
-  using cache_val_type = detail::matxDnCholHostPlan_t<OutputTensor, decltype(a_new)>;
-  detail::GetCache().LookupAndExec<detail::chol_host_cache_t>(
-    detail::GetCacheIdFromType<detail::chol_host_cache_t>(),
-    params,
-    [&]() {
-      return std::make_shared<cache_val_type>(tv, uplo_lapack);
-    },
-    [&](std::shared_ptr<cache_val_type> ctype) {
-      ctype->Exec(tv, tv, exec, uplo_lapack);
-    }
-  );
+  detail::matxDnCholHostPlan_t<OutputTensor, decltype(a_new)> chol_plan(tv, uplo_lapack);
+  chol_plan.Exec(tv, tv, exec, uplo_lapack);
 
   if (! allContiguous) {
     matx::copy(out, tv, exec);

--- a/include/matx/transforms/lu/lu_lapack.h
+++ b/include/matx/transforms/lu/lu_lapack.h
@@ -213,7 +213,7 @@ struct DnLUHostParamsKeyEq {
 };
 
 // Static caches of LU this->handles
-using lu_Host_cache_t = std::unordered_map<DnLUHostParams_t, std::any, DnLUHostParamsKeyHash, DnLUHostParamsKeyEq>;
+using lu_host_cache_t = std::unordered_map<DnLUHostParams_t, std::any, DnLUHostParamsKeyHash, DnLUHostParamsKeyEq>;
 #endif
 
 } // end namespace detail
@@ -277,8 +277,8 @@ void lu_impl([[maybe_unused]] OutputTensor &&out,
 
   // Get cache or new LU plan if it doesn't exist
   using cache_val_type = detail::matxDnLUHostPlan_t<OutputTensor, decltype(piv_new), decltype(a_new)>;
-  detail::GetCache().LookupAndExec<detail::lu_Host_cache_t>(
-    detail::GetCacheIdFromType<detail::lu_Host_cache_t>(),
+  detail::GetCache().LookupAndExec<detail::lu_host_cache_t>(
+    detail::GetCacheIdFromType<detail::lu_host_cache_t>(),
     params,
     [&]() {
       return std::make_shared<cache_val_type>(piv_new, tvt);

--- a/include/matx/transforms/qr/qr_lapack.h
+++ b/include/matx/transforms/qr/qr_lapack.h
@@ -234,7 +234,7 @@ struct DnQRHostParamsKeyEq {
   }
 };
 
-using qr_Host_cache_t = std::unordered_map<DnQRHostParams_t, std::any, DnQRHostParamsKeyHash, DnQRHostParamsKeyEq>;
+using qr_host_cache_t = std::unordered_map<DnQRHostParams_t, std::any, DnQRHostParamsKeyHash, DnQRHostParamsKeyEq>;
 #endif
 
 } // end namespace detail
@@ -297,8 +297,8 @@ void qr_solver_impl([[maybe_unused]] OutTensor &&out,
 
   // Get cache or new QR plan if it doesn't exist
   using cache_val_type = detail::matxDnQRHostPlan_t<OutTensor, decltype(tau_new), decltype(a_new)>;
-  detail::GetCache().LookupAndExec<detail::qr_Host_cache_t>(
-    detail::GetCacheIdFromType<detail::qr_Host_cache_t>(),
+  detail::GetCache().LookupAndExec<detail::qr_host_cache_t>(
+    detail::GetCacheIdFromType<detail::qr_host_cache_t>(),
     params,
     [&]() {
       return std::make_shared<cache_val_type>(tau_new, tvt);


### PR DESCRIPTION
- Fix for [LAPACK bug](https://github.com/Reference-LAPACK/lapack/issues/600) causing incorrect workspace size calculations for single-precision routines at large matrix sizes due to float-to-int conversions (only those that may need O(n^2) space like Eig and SVD are affected)
- Removed caching in Host LU and Cholesky since no workspace is required

Misc: Renamed Host solver cache types to be lowercase for consistency