### PR TITLE
Add in-place transform support for inv()

### DIFF
--- a/test/00_solver/Inverse.cu
+++ b/test/00_solver/Inverse.cu
@@ -81,13 +81,29 @@ TYPED_TEST(InvSolverTestFloatTypes, Inv4x4)
   this->exec.sync();
 
   for (index_t i = 0; i < A.Size(0); i++) {
-    for (index_t j = 0; j <= i; j++) {
+    for (index_t j = 0; j < A.Size(1); j++) {
       if constexpr (is_complex_v<TestType>) {
         ASSERT_NEAR(Ainv_ref(i, j).real(), Ainv(i, j).real(), this->thresh);
         ASSERT_NEAR(Ainv_ref(i, j).imag(), Ainv(i, j).imag(), this->thresh);
       }
       else {
         ASSERT_NEAR(Ainv_ref(i, j), Ainv(i, j), this->thresh);
+      }
+    }
+  }
+
+  // Repeat the test using in-place transforms
+  (A = inv(A)).run(this->exec);
+  this->exec.sync();
+
+  for (index_t i = 0; i < A.Size(0); i++) {
+    for (index_t j = 0; j < A.Size(1); j++) {
+      if constexpr (is_complex_v<TestType>) {
+        ASSERT_NEAR(Ainv_ref(i, j).real(), A(i, j).real(), this->thresh);
+        ASSERT_NEAR(Ainv_ref(i, j).imag(), A(i, j).imag(), this->thresh);
+      }
+      else {
+        ASSERT_NEAR(Ainv_ref(i, j), A(i, j), this->thresh);
       }
     }
   }
@@ -113,13 +129,32 @@ TYPED_TEST(InvSolverTestFloatTypes, Inv4x4Batched)
 
   for (index_t b = 0; b < A.Size(0); b++) {
     for (index_t i = 0; i < A.Size(1); i++) {
-      for (index_t j = 0; j <= i; j++) {
+      for (index_t j = 0; j < A.Size(2); j++) {
         if constexpr (is_complex_v<TestType>) {
           ASSERT_NEAR(Ainv_ref(b, i, j).real(), Ainv(b, i, j).real(), this->thresh);
           ASSERT_NEAR(Ainv_ref(b, i, j).imag(), Ainv(b, i, j).imag(), this->thresh);
         }
         else {
           ASSERT_NEAR(Ainv_ref(b, i, j), Ainv(b, i, j), this->thresh);
+        }
+      }
+    }
+  }
+
+  // Repeat the test using in-place transforms
+  (A = inv(A)).run(this->exec);
+  this->exec.sync();
+  cudaDeviceSynchronize();
+
+  for (index_t b = 0; b < A.Size(0); b++) {
+    for (index_t i = 0; i < A.Size(1); i++) {
+      for (index_t j = 0; j < A.Size(2); j++) {
+        if constexpr (is_complex_v<TestType>) {
+          ASSERT_NEAR(Ainv_ref(b, i, j).real(), A(b, i, j).real(), this->thresh);
+          ASSERT_NEAR(Ainv_ref(b, i, j).imag(), A(b, i, j).imag(), this->thresh);
+        }
+        else {
+          ASSERT_NEAR(Ainv_ref(b, i, j), A(b, i, j), this->thresh);
         }
       }
     }
@@ -145,13 +180,29 @@ TYPED_TEST(InvSolverTestFloatTypes, Inv8x8)
   this->exec.sync();
 
   for (index_t i = 0; i < A.Size(0); i++) {
-    for (index_t j = 0; j <= i; j++) {
+    for (index_t j = 0; j < A.Size(1); j++) {
       if constexpr (is_complex_v<TestType>) {
         ASSERT_NEAR(Ainv_ref(i, j).real(), Ainv(i, j).real(), this->thresh);
         ASSERT_NEAR(Ainv_ref(i, j).imag(), Ainv(i, j).imag(), this->thresh);
       }
       else {
         ASSERT_NEAR(Ainv_ref(i, j), Ainv(i, j), this->thresh);
+      }
+    }
+  }
+
+  // Repeat the test using in-place transforms
+  (A = inv(A)).run(this->exec);
+  this->exec.sync();
+
+  for (index_t i = 0; i < A.Size(0); i++) {
+    for (index_t j = 0; j < A.Size(1); j++) {
+      if constexpr (is_complex_v<TestType>) {
+        ASSERT_NEAR(Ainv_ref(i, j).real(), A(i, j).real(), this->thresh);
+        ASSERT_NEAR(Ainv_ref(i, j).imag(), A(i, j).imag(), this->thresh);
+      }
+      else {
+        ASSERT_NEAR(Ainv_ref(i, j), A(i, j), this->thresh);
       }
     }
   }
@@ -177,13 +228,31 @@ TYPED_TEST(InvSolverTestFloatTypes, Inv8x8Batched)
 
   for (index_t b = 0; b < A.Size(0); b++) {
     for (index_t i = 0; i < A.Size(1); i++) {
-      for (index_t j = 0; j <= i; j++) {
+      for (index_t j = 0; j < A.Size(2); j++) {
         if constexpr (is_complex_v<TestType>) {
           ASSERT_NEAR(Ainv_ref(b, i, j).real(), Ainv(b, i, j).real(), this->thresh);
           ASSERT_NEAR(Ainv_ref(b, i, j).imag(), Ainv(b, i, j).imag(), this->thresh);
         }
         else {
           ASSERT_NEAR(Ainv_ref(b, i, j), Ainv(b, i, j), this->thresh);
+        }
+      }
+    }
+  }
+
+  // Repeat the test using in-place transforms
+  (A = inv(A)).run(this->exec);
+  this->exec.sync();
+
+  for (index_t b = 0; b < A.Size(0); b++) {
+    for (index_t i = 0; i < A.Size(1); i++) {
+      for (index_t j = 0; j < A.Size(2); j++) {
+        if constexpr (is_complex_v<TestType>) {
+          ASSERT_NEAR(Ainv_ref(b, i, j).real(), A(b, i, j).real(), this->thresh);
+          ASSERT_NEAR(Ainv_ref(b, i, j).imag(), A(b, i, j).imag(), this->thresh);
+        }
+        else {
+          ASSERT_NEAR(Ainv_ref(b, i, j), A(b, i, j), this->thresh);
         }
       }
     }
@@ -200,7 +269,7 @@ TYPED_TEST(InvSolverTestFloatTypes, Inv256x256)
   //int dim_size = 8;
   auto A = make_tensor<TestType>({256, 256});
   auto Ainv = make_tensor<TestType>({256, 256});
-  auto Ainv_ref = make_tensor<TestType>({256, 256});  
+  auto Ainv_ref = make_tensor<TestType>({256, 256});
 
   this->pb->template InitAndRunTVGenerator<TestType>("00_solver", "inv", "run", {256});
   this->pb->NumpyToTensorView(A, "A");
@@ -210,7 +279,7 @@ TYPED_TEST(InvSolverTestFloatTypes, Inv256x256)
   this->exec.sync();
 
   for (index_t i = 0; i < A.Size(0); i++) {
-    for (index_t j = 0; j <= i; j++) {
+    for (index_t j = 0; j < A.Size(1); j++) {
       if constexpr (is_complex_v<TestType>) {
         ASSERT_NEAR(Ainv_ref(i, j).real(), Ainv(i, j).real(), this->thresh);
         ASSERT_NEAR(Ainv_ref(i, j).imag(), Ainv(i, j).imag(), this->thresh);
@@ -221,6 +290,57 @@ TYPED_TEST(InvSolverTestFloatTypes, Inv256x256)
     }
   }
 
+  // Repeat the test using in-place transforms
+  (A = inv(A)).run(this->exec);
+  this->exec.sync();
+
+  for (index_t i = 0; i < A.Size(0); i++) {
+    for (index_t j = 0; j < A.Size(1); j++) {
+      if constexpr (is_complex_v<TestType>) {
+        ASSERT_NEAR(Ainv_ref(i, j).real(), A(i, j).real(), this->thresh);
+        ASSERT_NEAR(Ainv_ref(i, j).imag(), A(i, j).imag(), this->thresh);
+      }
+      else {
+        ASSERT_NEAR(Ainv_ref(i, j), A(i, j), this->thresh);
+      }
+    }
+  }
+
   MATX_EXIT_HANDLER();
 }
 
+TYPED_TEST(InvSolverTestFloatTypes, InvOperatorInput)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  const int num_batches = 3;
+  const int N = 16;
+  auto Afull = make_tensor<TestType>({num_batches, 1, 1, N, N});
+  auto A = lcollapse<3>(Afull);
+  auto Ainv = make_tensor<TestType>({num_batches, N, N});
+  auto Ainv_ref = make_tensor<TestType>({num_batches, N, N});
+
+  this->pb->template InitAndRunTVGenerator<TestType>("00_solver", "inv", "run", {num_batches, N});
+  this->pb->NumpyToTensorView(A, "A");
+  this->pb->NumpyToTensorView(Ainv_ref, "A_inv");
+
+  (Ainv = inv(A)).run(this->exec);
+  this->exec.sync();
+
+  for (index_t b = 0; b < A.Size(0); b++) {
+    for (index_t i = 0; i < A.Size(1); i++) {
+      for (index_t j = 0; j < A.Size(2); j++) {
+        if constexpr (is_complex_v<TestType>) {
+          ASSERT_NEAR(Ainv_ref(b, i, j).real(), Ainv(b, i, j).real(), this->thresh);
+          ASSERT_NEAR(Ainv_ref(b, i, j).imag(), Ainv(b, i, j).imag(), this->thresh);
+        }
+        else {
+          ASSERT_NEAR(Ainv_ref(b, i, j), Ainv(b, i, j), this->thresh);
+        }
+      }
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}


### PR DESCRIPTION
Change the behavior of the inv() transform as follows:

- No longer unconditionally overwrite the input with factorized data. Previously, (Ainv = inv(A)).run() would write the inverse to Ainv and the LU factorization to A.
- Support in-place transforms like (A = inv(A)).run(). Previously, this would run, but the results would be incorrect because the underlying cuBLAS calls only support out-of-place solves.
- The above are achieved by always creating a temporary work buffer and copying the input into that work buffer.
- Add support for input operators (i.e., not just tensors). The operator runs when populating the temporary input work buffer.
- Use host-pinned memory and async memcpys to test the success of the factorization/inversion. This still synchronizes the provided stream, but no longer synchronizes the default stream.