### PR TITLE
Added new pinv() operator and updated Reduced SVD

### DIFF
--- a/docs_input/api/linalg/decomp/pinv.rst
+++ b/docs_input/api/linalg/decomp/pinv.rst
@@ -1,0 +1,19 @@
+.. _pinv_func:
+
+pinv
+####
+
+Compute the Moore-Penrose pseudo-inverse of a matrix.
+
+.. doxygenfunction:: pinv(const OpA &a, float rcond = get_default_rcond<typename OpA::value_type>())
+
+Examples
+~~~~~~~~
+
+.. literalinclude:: ../../../../test/00_solver/Pinv.cu
+   :language: cpp
+   :start-after: example-begin pinv-test-1
+   :end-before: example-end pinv-test-1
+   :dedent:
+
+

--- a/docs_input/api/linalg/other/det.rst
+++ b/docs_input/api/linalg/other/det.rst
@@ -1,0 +1,18 @@
+.. _det_func:
+
+det
+=====
+
+Compute the determinant of a tensor.
+
+.. doxygenfunction:: det(const OpA &a)
+
+Examples
+~~~~~~~~
+
+.. literalinclude:: ../../../../test/00_solver/Det.cu
+   :language: cpp
+   :start-after: example-begin det-test-1
+   :end-before: example-end det-test-1
+   :dedent:
+

--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -658,9 +658,10 @@ public:
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
+    [[maybe_unused]] stride_type prod = std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<stride_type>());
     // Ensure new shape's total size is not larger than the original
     MATX_ASSERT_STR(
-        sizeof(M) * shape.TotalSize() <= storage_.Bytes(), matxInvalidSize,
+        sizeof(M) * prod <= storage_.Bytes(), matxInvalidSize,
         "Total size of new tensor must not be larger than the original");
 
     // This could be loosened up to make sure only the fastest changing dims
@@ -877,7 +878,7 @@ public:
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
-    static_assert(RANK >= 2, "Only tensors of rank 2 and higher can be permuted.");
+    static_assert(RANK >= 1, "Only tensors of rank 1 and higher can be permuted.");
     cuda::std::array<shape_type, RANK> n;
     cuda::std::array<stride_type, RANK> s;
     [[maybe_unused]] bool done[RANK] = {0};

--- a/include/matx/operators/det.h
+++ b/include/matx/operators/det.h
@@ -96,8 +96,6 @@ namespace detail {
         }
       }        
 
-      // Size is not relevant in det() since there are multiple return values and it
-      // is not allowed to be called in larger expressions
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
       {
         return a_.Size(dim);
@@ -106,6 +104,13 @@ namespace detail {
   };
 }
 
+/**
+ * Computes the determinant by performing an LU factorization of the input,
+ * and then calculating the product of diagonal entries of the U factor.
+ * 
+ * For tensors of rank > 2, batching is performed.
+ * 
+ */
 template<typename OpA>
 __MATX_INLINE__ auto det(const OpA &a) {
   return detail::DetOp(a);

--- a/include/matx/operators/operators.h
+++ b/include/matx/operators/operators.h
@@ -80,6 +80,7 @@
 #include "matx/operators/outer.h"
 #include "matx/operators/overlap.h"
 #include "matx/operators/percentile.h"
+#include "matx/operators/pinv.h"
 #include "matx/operators/permute.h"
 #include "matx/operators/planar.h"
 #include "matx/operators/polyval.h"

--- a/include/matx/operators/svd.h
+++ b/include/matx/operators/svd.h
@@ -65,6 +65,7 @@ namespace detail {
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
+      // TODO: Handle SVDMode::NONE case better to not require U & VT
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
         static_assert(cuda::std::tuple_size_v<remove_cvref_t<Out>> == 4, "Must use mtie with 3 outputs on svd(). ie: (mtie(U, S, VT) = svd(A))");
@@ -99,6 +100,10 @@ namespace detail {
 /**
  * Perform a singular value decomposition (SVD) using cuSolver or a LAPACK host
  * library.
+ * 
+ * The singular values within each vector are sorted in descending order.
+ * 
+ * For tensors of Rank > 2, batching is performed.
  *
  * @tparam OpA
  *   Operator input type

--- a/include/matx/operators/trace.h
+++ b/include/matx/operators/trace.h
@@ -110,8 +110,6 @@ namespace detail {
 }
 
 /**
- * Computes the trace of a tensor
- *
  * Computes the trace of a square matrix by summing the diagonal
  *
  * @tparam InputOperator

--- a/include/matx/transforms/pinv.h
+++ b/include/matx/transforms/pinv.h
@@ -1,0 +1,188 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx/core/error.h"
+#include "matx/core/nvtx.h"
+#include "matx/core/tensor.h"
+#include "matx/core/cache.h"
+#include "matx/executors/host.h"
+#include "matx/executors/support.h"
+#include "matx/transforms/svd/svd_cuda.h"
+#ifdef MATX_EN_CPU_SOLVER
+  #include "matx/transforms/svd/svd_lapack.h"
+#endif
+
+#include <cstdio>
+#include <numeric>
+
+namespace matx {
+
+/**
+ * Returns an appropriate rcond based on the inner type. This is slightly
+ * higher than the machine epsilon, as these work better to mask small/zero singular
+ * values in singular or ill-conditioned matrices.
+ */
+template <typename T>
+__MATX_INLINE__ constexpr float get_default_rcond() {
+  if constexpr (is_fp32_inner_type_v<T>) {
+    return 1e-6f;
+  } else {
+    return 1e-15f;
+  }
+}
+
+/**
+ * Compute the Moore-penrose pseudo-inverse of a matrix
+ *
+ * Perfom a generalized inverse of a matrix using its singular-value decomposition (SVD).
+ * It automatically removes small singular values for stability.
+ *
+ * @tparam T1
+ *   Data type of matrix A
+ * @tparam RANK
+ *   Rank of matrix A
+ *
+ * @param out
+ *   Output tensor view
+ * @param a
+ *   Input matrix A
+ * @param exec
+ *   Executor
+ * @param rcond
+ *   Cutoff for small singular values. For stability, singular values
+ *   smaller than rcond * largest_singular_value are set to 0 for each matrix
+ *   in the batch. By default, rcond is the machine epsilon of the tensor dtype.
+ */
+template <typename OutputTensor, typename InputTensor, typename Executor>
+void pinv_impl(OutputTensor &out,
+              const InputTensor &a,
+              const Executor &exec,
+              float rcond = get_default_rcond<typename InputTensor::value_type>())
+{
+  MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+  MATX_ASSERT_STR(!(is_host_executor_v<Executor> && !MATX_EN_CPU_SOLVER), matxInvalidExecutor,
+    "Trying to run a host Solver executor but host Solver support is not configured");
+  
+  using T1 = typename InputTensor::value_type;
+  using inner_type = typename inner_op_type_t<T1>::type;
+  constexpr int RANK = InputTensor::Rank();
+
+  MATX_STATIC_ASSERT_STR(OutputTensor::Rank() == InputTensor::Rank(), matxInvalidDim, "Output and input tensors must have same rank for pinv()");
+  MATX_STATIC_ASSERT_STR(RANK >= 2, matxInvalidDim, "Input/Output tensor must be rank 2 or higher");
+  MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutputTensor::value_type>), matxInavlidType, "A and Out types must match");
+
+  const index_t m = a.Size(RANK-2); // rows
+  const index_t n = a.Size(RANK-1); // cols
+  const index_t k = cuda::std::min(m, n);
+
+  // Batch size checks
+  for(int i = 0 ; i < RANK-2; i++) {
+    MATX_ASSERT_STR(out.Size(i) == a.Size(i), matxInvalidDim, "Out and A must have the same batch sizes");
+  }
+
+  MATX_ASSERT_STR((out.Size(RANK-1) == m) && (out.Size(RANK-2) == n), matxInvalidSize,
+      "Out must be ... x n x m for A ... x m x n");
+  
+  /* 
+    Need to perform pinv = V * S^-1 * U^H where svd(A) = U * S * V^H.
+    Alternatively, can run svd(A^H) to get V, S, U^H
+  */ 
+
+  // Allocate v, s, ut
+  auto aShape = a.Shape();
+  auto outShape = out.Shape();
+
+  // v is ... x n x k
+  auto vShape = outShape;
+  vShape[RANK-1] = k;
+
+  // s is ... x k
+  cuda::std::array<index_t, RANK-1> sShape;
+  for(int i = 0; i < RANK-2; i++) {
+    sShape[i] = aShape[i];
+  }
+  sShape[RANK-2] = k;
+
+  // ut is ... x k x m
+  auto utShape = outShape;
+  utShape[RANK-2] = k;
+
+  tensor_t<T1, RANK> v;
+  tensor_t<inner_type, RANK-1> s;
+  tensor_t<bool, RANK-1> s_mask;
+  tensor_t<T1, RANK> ut;
+
+  if constexpr (is_cuda_executor_v<Executor>) {
+    const auto stream = exec.getStream();
+    make_tensor(v, vShape, MATX_ASYNC_DEVICE_MEMORY, stream);
+    make_tensor(s, sShape, MATX_ASYNC_DEVICE_MEMORY, stream);
+    make_tensor(s_mask, sShape, MATX_ASYNC_DEVICE_MEMORY, stream);
+    make_tensor(ut, utShape, MATX_ASYNC_DEVICE_MEMORY, stream);
+  } else {
+    make_tensor(v, vShape, MATX_HOST_MALLOC_MEMORY);
+    make_tensor(s, sShape, MATX_HOST_MALLOC_MEMORY);
+    make_tensor(s_mask, sShape, MATX_HOST_MALLOC_MEMORY);
+    make_tensor(ut, utShape, MATX_HOST_MALLOC_MEMORY);
+  }
+
+  svd_impl(v, s, ut, transpose_matrix(conj(a)), exec, SVDMode::REDUCED);
+
+  // discard small singular values
+  cuda::std::array<index_t, RANK-1> cutoffShape;
+  cutoffShape.fill(matxKeepDim);
+  cutoffShape[RANK-2] = k; // repeat across last dim
+
+  auto cutoff = rcond * max(s, {RANK-2});
+  auto cutoff_add_axis = clone<RANK-1>(cutoff, cutoffShape);
+
+  // Need to explicitly run before inverting s since the mask needs to be created
+  // based on original singular values.
+  (s_mask = s > cutoff_add_axis).run(exec);
+  
+  // IF required to avoid nans when singular value is 0
+  (IF(s != inner_type(0), s = inner_type(1) / s)).run(exec);
+  (s *= s_mask).run(exec);
+
+  // V = V * S^-1
+  auto dShape = v.Shape();
+  dShape.fill(matxKeepDim);
+  dShape[RANK-2] = n;
+  auto d = clone<RANK>(s, dShape);
+  (v = v * d).run(exec);
+  
+  // (V * S-1) * UT
+  matmul_impl(out, v, ut, exec);
+}
+
+} // end namespace matx

--- a/test/00_solver/Pinv.cu
+++ b/test/00_solver/Pinv.cu
@@ -1,0 +1,176 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "assert.h"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+#include "gtest/gtest.h"
+
+using namespace matx;
+
+template <typename T> class PinvSolverTest : public ::testing::Test {
+  using GTestType = cuda::std::tuple_element_t<0, T>;
+  using GExecType = cuda::std::tuple_element_t<1, T>;   
+protected:
+  void SetUp() override
+  {
+    if constexpr (!detail::CheckSolverSupport<GExecType>()) {
+      GTEST_SKIP();
+    }
+
+    // Use an arbitrary number of threads for the select threads host exec.
+    if constexpr (is_select_threads_host_executor_v<GExecType>) {
+      HostExecParams params{4};
+      exec = SelectThreadsHostExecutor{params};
+    }
+
+    pb = std::make_unique<detail::MatXPybind>();
+  }
+
+  void TearDown() override { pb.reset(); }
+  GExecType exec{};
+  std::unique_ptr<detail::MatXPybind> pb;
+  float thresh = 0.001f;
+};
+
+template <typename TensorType>
+class PinvSolverTestFloatTypes : public PinvSolverTest<TensorType> {
+};
+
+
+TYPED_TEST_SUITE(PinvSolverTestFloatTypes,
+                 MatXFloatNonHalfTypesAllExecs);
+
+TYPED_TEST(PinvSolverTestFloatTypes, PinvBasic)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using inner_type = typename inner_op_type_t<TestType>::type;
+
+  constexpr cuda::std::array sizes {
+    std::pair{100, 50},
+    std::pair{100, 100},
+    std::pair{50, 100}
+  };
+
+  for (const auto& [m, n] : sizes) {
+    auto A = make_tensor<TestType>({m, n});
+    auto A_pinv = make_tensor<TestType>({n, m});
+
+    this->pb->template InitAndRunTVGenerator<TestType>("00_solver", "pinv", "run", {m, n});
+    this->pb->NumpyToTensorView(A, "A");
+
+    // example-begin pinv-test-1
+    (A_pinv = pinv(A)).run(this->exec);
+    // example-end pinv-test-1
+    this->exec.sync();
+
+    MATX_TEST_ASSERT_COMPARE(this->pb, A_pinv, "pinv", this->thresh);
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(PinvSolverTestFloatTypes, PinvRankDeficient)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using inner_type = typename inner_op_type_t<TestType>::type;
+
+  constexpr cuda::std::array sizes {
+    std::pair{100, 50},
+    std::pair{100, 100},
+    std::pair{50, 100}
+  };
+
+  for (const auto& [m, n] : sizes) {
+    auto A = make_tensor<TestType>({m, n});
+    auto A_pinv = make_tensor<TestType>({n, m});
+
+    this->pb->template InitAndRunTVGenerator<TestType>("00_solver", "pinv", "run_rank_deficient", {m, n});
+    this->pb->NumpyToTensorView(A, "A");
+
+    (A_pinv = pinv(A)).run(this->exec);
+    this->exec.sync();
+
+    MATX_TEST_ASSERT_COMPARE(this->pb, A_pinv, "pinv", this->thresh);
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(PinvSolverTestFloatTypes, PinvBasicBatched)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using inner_type = typename inner_op_type_t<TestType>::type;
+
+  constexpr int m = 100;
+  constexpr int n = 50;
+  constexpr int batches = 10;
+  auto A = make_tensor<TestType>({batches, m, n});
+  auto A_pinv = make_tensor<TestType>({batches, n, m});
+
+  this->pb->template InitAndRunTVGenerator<TestType>("00_solver", "pinv", "run", {batches, m, n});
+  this->pb->NumpyToTensorView(A, "A");
+
+  (A_pinv = pinv(A)).run(this->exec);
+  this->exec.sync();
+
+  MATX_TEST_ASSERT_COMPARE(this->pb, A_pinv, "pinv", this->thresh);
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(PinvSolverTestFloatTypes, PinvBatchedRankDeficient)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using inner_type = typename inner_op_type_t<TestType>::type;
+
+  constexpr int m = 100;
+  constexpr int n = 50;
+  constexpr int batches = 10;
+  auto A = make_tensor<TestType>({batches, m, n});
+  auto A_pinv = make_tensor<TestType>({batches, n, m});
+
+  this->pb->template InitAndRunTVGenerator<TestType>("00_solver", "pinv", "run_rank_deficient", {batches, m, n});
+  this->pb->NumpyToTensorView(A, "A");
+
+  (A_pinv = pinv(A)).run(this->exec);
+  this->exec.sync();
+
+  MATX_TEST_ASSERT_COMPARE(this->pb, A_pinv, "pinv", this->thresh);
+
+  MATX_EXIT_HANDLER();
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set (test_sources
     00_solver/Eigen.cu
     00_solver/Det.cu
     00_solver/Inverse.cu
+    00_solver/Pinv.cu
     00_operators/PythonEmbed.cu
     00_io/FileIOTests.cu
     00_io/PrintTests.cu


### PR DESCRIPTION
- Created new `pinv()` operator for matrix pseudo-inverse using SVD in Reduced mode. Optional `rcond` parameter which is used to define the cutoff for small singular values. Singular values smaller than `rcond * largest_singular_value` are set to 0.
- Changed `SVDMode::REDUCED` interface so that U and VT tensors passed in must be of reduced size instead of the full size. That is, instead of  U being of shape `... x m x m`, it should have shape `... x m x k` where `k=min(m,n)`. Similarly VT should be of shape `... x k x n`.
- Added `det()` documentation page

Resolves #487 