### PR TITLE
Adding workarounds for false positives on gcc14

### DIFF
--- a/include/matx/generators/range.h
+++ b/include/matx/generators/range.h
@@ -55,10 +55,16 @@ namespace matx
         __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ T operator()(index_t idx) const
         {
           if constexpr (is_matx_half_v<T>) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
             return first_ + T(static_cast<T>((float)idx) * step_);
+#pragma GCC diagnostic pop
           }
           else {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
             return first_ + T(static_cast<T>(idx) * step_);
+#pragma GCC diagnostic pop
           }
         }
     };
@@ -107,6 +113,6 @@ namespace matx
     {
       return range<Dim>(detail::to_array(s), first, step);
     }
- 
+
 
 } // end namespace matx

--- a/include/matx/operators/diag.h
+++ b/include/matx/operators/diag.h
@@ -84,12 +84,18 @@ namespace matx
               if (k_ < 0) {
                 auto tup = cuda::std::make_tuple(indices..., static_cast<tt>(0));
                 cuda::std::get<RANK - 1>(tup) = pp_get<RANK-2>(indices...) ;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
                 cuda::std::get<RANK - 2>(tup) = cuda::std::get<RANK - 2>(tup) - k_;
+#pragma GCC diagnostic pop
                 return cuda::std::apply(op_, tup);
               }
               else {
                 auto tup = cuda::std::make_tuple(indices..., static_cast<tt>(0));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
                 cuda::std::get<RANK - 1>(tup) = pp_get<RANK-2>(indices...) + k_;
+#pragma GCC diagnostic pop
                 return cuda::std::apply(op_, tup);                
               }
             }


### PR DESCRIPTION
gcc 13.2 and above show erroneous error messages related to uninitialized variables that are not possible. Suppress these with pragmas.