### PR TITLE
Visibility fix for cache static deinit issue

### DIFF
--- a/include/matx/core/cache.h
+++ b/include/matx/core/cache.h
@@ -46,9 +46,11 @@ namespace detail {
 
 using CacheId = uint64_t;
 
+__attribute__ ((visibility ("default")))
 inline cuda::std::atomic<CacheId> CacheIdCounter{0};
 
 template<typename CacheType>
+__attribute__ ((visibility ("default")))
 CacheId GetCacheIdFromType()
 {
   static CacheId id = CacheIdCounter.fetch_add(1);

--- a/include/matx/core/cache.h
+++ b/include/matx/core/cache.h
@@ -46,7 +46,9 @@ namespace detail {
 
 using CacheId = uint64_t;
 
+#ifndef DOXYGEN_ONLY
 __attribute__ ((visibility ("default")))
+#endif
 inline cuda::std::atomic<CacheId> CacheIdCounter{0};
 
 template<typename CacheType>


### PR DESCRIPTION
Tmartin's visibility fix for static cache variables and functions.
```
__attribute__ ((visibility ("default")))
```