### PR TITLE
Fix for erroneous errors on gcc14.1

### DIFF
--- a/include/matx/core/defines.h
+++ b/include/matx/core/defines.h
@@ -65,17 +65,7 @@ namespace matx {
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 
-#ifdef __GNUC__ 
-    #define IGNORE_WARNING_PUSH_CLANG(WARN_MSG)
-    #define IGNORE_WARNING_POP_CLANG
-
-    #define IGNORE_WARNING_PUSH_GCC(WARN_MSG) \
-        _Pragma("GCC diagnostic push") \
-        _Pragma(TOSTRING(GCC diagnostic ignored WARN_MSG))
-
-    #define IGNORE_WARNING_POP_GCC \
-        _Pragma("GCC diagnostic pop")
-#elif defined(__clang__ )
+#if defined(__clang__ )
     #define IGNORE_WARNING_PUSH_GCC(WARN_MSG)
     #define IGNORE_WARNING_POP_GCC
 
@@ -85,6 +75,16 @@ namespace matx {
 
     #define IGNORE_WARNING_POP_CLANG \
         _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+    #define IGNORE_WARNING_PUSH_CLANG(WARN_MSG)
+    #define IGNORE_WARNING_POP_CLANG
+
+    #define IGNORE_WARNING_PUSH_GCC(WARN_MSG) \
+        _Pragma("GCC diagnostic push") \
+        _Pragma(TOSTRING(GCC diagnostic ignored WARN_MSG))
+
+    #define IGNORE_WARNING_POP_GCC \
+        _Pragma("GCC diagnostic pop")
 #endif        
 
 // std::ceil is not constexpr until C++23

--- a/include/matx/core/defines.h
+++ b/include/matx/core/defines.h
@@ -61,6 +61,26 @@ namespace matx {
     #define __MATX_INLINE__ inline
 #endif
 
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#ifdef __GNUC__ 
+    #define IGNORE_WARNING_PUSH(WARN_MSG) \
+        _Pragma("GCC diagnostic push") \
+        _Pragma(TOSTRING(GCC diagnostic ignored WARN_MSG))
+
+    #define IGNORE_WARNING_POP \
+        _Pragma("GCC diagnostic pop")
+#elif defined(__clang__ )
+    #define IGNORE_WARNING_PUSH(WARN_MSG) \
+        _Pragma("clang diagnostic push") \
+        _Pragma(TOSTRING(clang diagnostic ignored WARN_MSG))
+
+    #define IGNORE_WARNING_POP \
+        _Pragma("clang diagnostic pop")
+#endif        
+
 // std::ceil is not constexpr until C++23
 #define MATX_ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
 

--- a/include/matx/core/defines.h
+++ b/include/matx/core/defines.h
@@ -66,18 +66,24 @@ namespace matx {
 #define TOSTRING(x) STRINGIFY(x)
 
 #ifdef __GNUC__ 
-    #define IGNORE_WARNING_PUSH(WARN_MSG) \
+    #define IGNORE_WARNING_PUSH_CLANG(WARN_MSG)
+    #define IGNORE_WARNING_POP_CLANG
+
+    #define IGNORE_WARNING_PUSH_GCC(WARN_MSG) \
         _Pragma("GCC diagnostic push") \
         _Pragma(TOSTRING(GCC diagnostic ignored WARN_MSG))
 
-    #define IGNORE_WARNING_POP \
+    #define IGNORE_WARNING_POP_GCC \
         _Pragma("GCC diagnostic pop")
 #elif defined(__clang__ )
-    #define IGNORE_WARNING_PUSH(WARN_MSG) \
+    #define IGNORE_WARNING_PUSH_GCC(WARN_MSG)
+    #define IGNORE_WARNING_POP_GCC
+
+    #define IGNORE_WARNING_PUSH_CLANG(WARN_MSG) \
         _Pragma("clang diagnostic push") \
         _Pragma(TOSTRING(clang diagnostic ignored WARN_MSG))
 
-    #define IGNORE_WARNING_POP \
+    #define IGNORE_WARNING_POP_CLANG \
         _Pragma("clang diagnostic pop")
 #endif        
 

--- a/include/matx/core/half.h
+++ b/include/matx/core/half.h
@@ -82,13 +82,23 @@ template <typename T> struct alignas(sizeof(T)) matxHalf {
   __MATX_INLINE__ ~matxHalf() = default;
 
   /**
-   * @brief Float casting operator
+   * @brief Half casting operator
    * 
-   * @return float of value
+   * @return Underlying half type
    */
   __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ operator T() const
   {
-    return static_cast<T>(x);
+    return x;
+  }  
+
+  /**
+   * @brief Half reference casting operator
+   * 
+   * @return Underlying reference to half type
+   */
+  __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ operator T&()
+  {
+    return x;
   }  
 
   /**

--- a/include/matx/core/iterator.h
+++ b/include/matx/core/iterator.h
@@ -71,12 +71,14 @@ struct RandomOperatorIterator {
   [[nodiscard]] __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ value_type operator*() const
   {
     if constexpr (OperatorType::Rank() == 0) {
-      return static_cast<value_type>(t_.operator()());
+      const auto tmp = t_.operator()();
+      return tmp;
     }
     else {
       auto arrs = detail::GetIdxFromAbs(t_, offset_);
-      return cuda::std::apply([&](auto &&...args) {
-          return static_cast<value_type>(t_.operator()(args...));
+      return cuda::std::apply([&](auto &&...args) -> value_type {
+          const auto tmp = t_.operator()(args...);
+          return tmp;
         }, arrs);     
     }
   }  
@@ -103,7 +105,7 @@ struct RandomOperatorIterator {
     }
     else {
       auto arrs = detail::GetIdxFromAbs(t_, offset_+offset);
-      return cuda::std::apply([&](auto &&...args) {
+      return cuda::std::apply([&](auto &&...args) -> value_type {
           return static_cast<value_type>(t_.operator()(args...));
         }, arrs);     
     }
@@ -200,13 +202,15 @@ struct RandomOperatorOutputIterator {
   [[nodiscard]] __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ reference operator*()
   {
     if constexpr (OperatorType::Rank() == 0) {
-      return (reference)(t_.operator()());
+      auto &tmp = t_.operator()();
+      return tmp;
     }
     else {
       auto arrs = detail::GetIdxFromAbs(t_, offset_);
 
       return cuda::std::apply([&](auto &&...args) -> reference {
-          return (reference)(t_.operator()(args...));
+          auto &tmp = t_.operator()(args...);
+          return tmp;
         }, arrs);    
     }
   }  

--- a/include/matx/core/tensor_desc.h
+++ b/include/matx/core/tensor_desc.h
@@ -287,9 +287,9 @@ public:
     }
 
 // gcc 14.1 incorrectly reports shape_ as uninitialized in some contexts
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized") 
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized") 
     return *(shape_.begin() + dim); 
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
   }
 
   /**
@@ -314,9 +314,9 @@ IGNORE_WARNING_POP
     /*  In release mode with O3 on g++ seems to give incorrect warnings on this line from Clone()
         and clone(). It appears there's no valid code path that would cause this to be unitialized,
         so we're ignoring the warning in this one spot. */
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
     return *(stride_.begin() + dim);
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
   }
 
   /**

--- a/include/matx/core/tensor_desc.h
+++ b/include/matx/core/tensor_desc.h
@@ -287,10 +287,9 @@ public:
     }
 
 // gcc 14.1 incorrectly reports shape_ as uninitialized in some contexts
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"     
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized") 
     return *(shape_.begin() + dim); 
-#pragma GCC diagnostic pop    
+IGNORE_WARNING_POP
   }
 
   /**
@@ -315,14 +314,9 @@ public:
     /*  In release mode with O3 on g++ seems to give incorrect warnings on this line from Clone()
         and clone(). It appears there's no valid code path that would cause this to be unitialized,
         so we're ignoring the warning in this one spot. */
-#if defined(__GNUC__) && !defined(__clang__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-    return *(stride_.begin() + dim); 
-    #pragma GCC diagnostic pop
-#else
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
     return *(stride_.begin() + dim);
-#endif    
+IGNORE_WARNING_POP
   }
 
   /**

--- a/include/matx/core/tensor_desc.h
+++ b/include/matx/core/tensor_desc.h
@@ -286,7 +286,11 @@ public:
       return static_cast<shape_type>(1);
     }
 
+// gcc 14.1 incorrectly reports shape_ as uninitialized in some contexts
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"     
     return *(shape_.begin() + dim); 
+#pragma GCC diagnostic pop    
   }
 
   /**

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -208,12 +208,16 @@ class tensor_impl_t {
      * @param ldata
      *   Data type
      */
+// gcc 14.1 incorrectly reports desc as uninitialized in some contexts
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"           
     template <typename DescriptorType, std::enable_if_t<is_matx_descriptor_v<typename remove_cvref<DescriptorType>::type>, bool> = true>
-    __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ tensor_impl_t(T *const ldata,
-                    DescriptorType &&desc)
+    __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ tensor_impl_t(T *const ldata,  
+                    DescriptorType &&desc)                
         : ldata_(ldata), desc_{std::forward<DescriptorType>(desc)}
     {
     }
+#pragma GCC diagnostic pop    
 
     /**
      * Constructor for creating a view with only a descriptor

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -209,15 +209,14 @@ class tensor_impl_t {
      *   Data type
      */
 // gcc 14.1 incorrectly reports desc as uninitialized in some contexts
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"           
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
     template <typename DescriptorType, std::enable_if_t<is_matx_descriptor_v<typename remove_cvref<DescriptorType>::type>, bool> = true>
     __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ tensor_impl_t(T *const ldata,  
                     DescriptorType &&desc)                
         : ldata_(ldata), desc_{std::forward<DescriptorType>(desc)}
     {
     }
-#pragma GCC diagnostic pop    
+IGNORE_WARNING_POP  
 
     /**
      * Constructor for creating a view with only a descriptor
@@ -655,10 +654,9 @@ class tensor_impl_t {
     template <int I = 0, typename ...Is>
     __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ stride_type GetVal([[maybe_unused]] cuda::std::tuple<Is...> tup)  {
       if constexpr (I < sizeof...(Is)) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
         return GetVal<I+1, Is...>(tup) + cuda::std::get<I>(tup)*this->desc_.Stride(I);
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
       }
       else {
         return 0;
@@ -668,10 +666,9 @@ class tensor_impl_t {
     template <int I = 0, typename ...Is>
     __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ stride_type GetValC([[maybe_unused]] const cuda::std::tuple<Is...> tup) const {
       if constexpr (I < sizeof...(Is)) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
         return GetValC<I+1, Is...>(tup) + cuda::std::get<I>(tup)*this->desc_.Stride(I);
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
       }
       else {
         return 0;

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -209,14 +209,14 @@ class tensor_impl_t {
      *   Data type
      */
 // gcc 14.1 incorrectly reports desc as uninitialized in some contexts
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
     template <typename DescriptorType, std::enable_if_t<is_matx_descriptor_v<typename remove_cvref<DescriptorType>::type>, bool> = true>
     __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ tensor_impl_t(T *const ldata,  
                     DescriptorType &&desc)                
         : ldata_(ldata), desc_{std::forward<DescriptorType>(desc)}
     {
     }
-IGNORE_WARNING_POP  
+IGNORE_WARNING_POP_GCC
 
     /**
      * Constructor for creating a view with only a descriptor
@@ -654,9 +654,9 @@ IGNORE_WARNING_POP
     template <int I = 0, typename ...Is>
     __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ stride_type GetVal([[maybe_unused]] cuda::std::tuple<Is...> tup)  {
       if constexpr (I < sizeof...(Is)) {
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
         return GetVal<I+1, Is...>(tup) + cuda::std::get<I>(tup)*this->desc_.Stride(I);
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
       }
       else {
         return 0;
@@ -666,9 +666,9 @@ IGNORE_WARNING_POP
     template <int I = 0, typename ...Is>
     __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ stride_type GetValC([[maybe_unused]] const cuda::std::tuple<Is...> tup) const {
       if constexpr (I < sizeof...(Is)) {
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
         return GetValC<I+1, Is...>(tup) + cuda::std::get<I>(tup)*this->desc_.Stride(I);
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
       }
       else {
         return 0;

--- a/include/matx/generators/range.h
+++ b/include/matx/generators/range.h
@@ -55,14 +55,14 @@ namespace matx
         __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ T operator()(index_t idx) const
         {
           if constexpr (is_matx_half_v<T>) {
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
             return first_ + T(static_cast<T>((float)idx) * step_);
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
           }
           else {
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
             return first_ + T(static_cast<T>(idx) * step_);
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
           }
         }
     };

--- a/include/matx/generators/range.h
+++ b/include/matx/generators/range.h
@@ -55,16 +55,14 @@ namespace matx
         __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ T operator()(index_t idx) const
         {
           if constexpr (is_matx_half_v<T>) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
             return first_ + T(static_cast<T>((float)idx) * step_);
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
           }
           else {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
             return first_ + T(static_cast<T>(idx) * step_);
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
           }
         }
     };

--- a/include/matx/operators/clone.h
+++ b/include/matx/operators/clone.h
@@ -69,10 +69,9 @@ namespace matx
                 sizes_[i] = op_.Size(d);
                 // gcc incorrectly shows an invalid access to array element [1] in a unit test here. This is not
                 // possible based on runtime checks we have. Disable the warning temporarily.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
+IGNORE_WARNING_PUSH("-Warray-bounds")                
                 dims_[d++] = i;
-#pragma GCC diagnostic pop                
+IGNORE_WARNING_POP           
               } else {
                 sizes_[i] = shape[i];
               }
@@ -91,11 +90,10 @@ namespace matx
         {
 
           // convert variadic type to tuple so we can read/update
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"          
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")        
           cuda::std::array<index_t, Rank()> sind{indices...};
           cuda::std::array<index_t, T::Rank()> gind;
-#pragma GCC diagnostic pop       
+IGNORE_WARNING_POP
 
           // gather indices
           for(int i = 0; i < T::Rank(); i++) {
@@ -111,11 +109,10 @@ namespace matx
         {
 
           // convert variadic type to tuple so we can read/update
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"          
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")         
           cuda::std::array<index_t, Rank()> sind{indices...};
           cuda::std::array<index_t, T::Rank()> gind;
-#pragma GCC diagnostic pop 
+IGNORE_WARNING_POP
 
           // gather indices
           for(int i = 0; i < T::Rank(); i++) {

--- a/include/matx/operators/clone.h
+++ b/include/matx/operators/clone.h
@@ -91,8 +91,11 @@ namespace matx
         {
 
           // convert variadic type to tuple so we can read/update
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"          
           cuda::std::array<index_t, Rank()> sind{indices...};
           cuda::std::array<index_t, T::Rank()> gind;
+#pragma GCC diagnostic pop       
 
           // gather indices
           for(int i = 0; i < T::Rank(); i++) {
@@ -108,8 +111,11 @@ namespace matx
         {
 
           // convert variadic type to tuple so we can read/update
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"          
           cuda::std::array<index_t, Rank()> sind{indices...};
           cuda::std::array<index_t, T::Rank()> gind;
+#pragma GCC diagnostic pop 
 
           // gather indices
           for(int i = 0; i < T::Rank(); i++) {

--- a/include/matx/operators/clone.h
+++ b/include/matx/operators/clone.h
@@ -69,9 +69,9 @@ namespace matx
                 sizes_[i] = op_.Size(d);
                 // gcc incorrectly shows an invalid access to array element [1] in a unit test here. This is not
                 // possible based on runtime checks we have. Disable the warning temporarily.
-IGNORE_WARNING_PUSH("-Warray-bounds")                
+IGNORE_WARNING_PUSH_GCC("-Warray-bounds")                
                 dims_[d++] = i;
-IGNORE_WARNING_POP           
+IGNORE_WARNING_POP_GCC           
               } else {
                 sizes_[i] = shape[i];
               }
@@ -90,10 +90,10 @@ IGNORE_WARNING_POP
         {
 
           // convert variadic type to tuple so we can read/update
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")        
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")        
           cuda::std::array<index_t, Rank()> sind{indices...};
           cuda::std::array<index_t, T::Rank()> gind;
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
 
           // gather indices
           for(int i = 0; i < T::Rank(); i++) {
@@ -109,10 +109,10 @@ IGNORE_WARNING_POP
         {
 
           // convert variadic type to tuple so we can read/update
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")         
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")         
           cuda::std::array<index_t, Rank()> sind{indices...};
           cuda::std::array<index_t, T::Rank()> gind;
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
 
           // gather indices
           for(int i = 0; i < T::Rank(); i++) {

--- a/include/matx/operators/diag.h
+++ b/include/matx/operators/diag.h
@@ -84,18 +84,16 @@ namespace matx
               if (k_ < 0) {
                 auto tup = cuda::std::make_tuple(indices..., static_cast<tt>(0));
                 cuda::std::get<RANK - 1>(tup) = pp_get<RANK-2>(indices...) ;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
                 cuda::std::get<RANK - 2>(tup) = cuda::std::get<RANK - 2>(tup) - k_;
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
                 return cuda::std::apply(op_, tup);
               }
               else {
                 auto tup = cuda::std::make_tuple(indices..., static_cast<tt>(0));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
                 cuda::std::get<RANK - 1>(tup) = pp_get<RANK-2>(indices...) + k_;
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
                 return cuda::std::apply(op_, tup);                
               }
             }

--- a/include/matx/operators/diag.h
+++ b/include/matx/operators/diag.h
@@ -84,16 +84,16 @@ namespace matx
               if (k_ < 0) {
                 auto tup = cuda::std::make_tuple(indices..., static_cast<tt>(0));
                 cuda::std::get<RANK - 1>(tup) = pp_get<RANK-2>(indices...) ;
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
                 cuda::std::get<RANK - 2>(tup) = cuda::std::get<RANK - 2>(tup) - k_;
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
                 return cuda::std::apply(op_, tup);
               }
               else {
                 auto tup = cuda::std::make_tuple(indices..., static_cast<tt>(0));
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
                 cuda::std::get<RANK - 1>(tup) = pp_get<RANK-2>(indices...) + k_;
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
                 return cuda::std::apply(op_, tup);                
               }
             }

--- a/include/matx/operators/isclose.h
+++ b/include/matx/operators/isclose.h
@@ -46,8 +46,9 @@ namespace matx
     {
       public:
         using matxop = bool;
-        using value_type = typename remove_cvref_t<Op2>::value_type;
-        using inner_type = typename inner_op_type_t<value_type>::type;
+        using value_type = int;
+        using op_type = typename remove_cvref_t<Op2>::value_type;
+        using inner_type = typename inner_op_type_t<op_type>::type;
 
         __MATX_INLINE__ std::string str() const { return "isclose()"; }
 

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -85,10 +85,9 @@ namespace matx
 
             // convert variadic type to tuple so we can read/update
             cuda::std::array<index_t, Rank()> inds{indices...};
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
             cuda::std::array<index_t, Rank()> ind;
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
             //cuda::std::array<index_t, T::Rank()> ind{indices...};
 
 #if 0
@@ -122,10 +121,9 @@ namespace matx
             // convert variadic type to tuple so we can read/update
             cuda::std::array<index_t, Rank()> inds{indices...};
             //cuda::std::array<index_t, T::Rank()> ind{indices...};
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
             cuda::std::array<index_t, Rank()> ind;
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
 
 #if 0
 	    //This causes register spills but might be faster if Rank is large

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -85,9 +85,9 @@ namespace matx
 
             // convert variadic type to tuple so we can read/update
             cuda::std::array<index_t, Rank()> inds{indices...};
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
             cuda::std::array<index_t, Rank()> ind;
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
             //cuda::std::array<index_t, T::Rank()> ind{indices...};
 
 #if 0
@@ -121,9 +121,9 @@ IGNORE_WARNING_POP
             // convert variadic type to tuple so we can read/update
             cuda::std::array<index_t, Rank()> inds{indices...};
             //cuda::std::array<index_t, T::Rank()> ind{indices...};
-IGNORE_WARNING_PUSH("-Wmaybe-uninitialized")
+IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
             cuda::std::array<index_t, Rank()> ind;
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
 
 #if 0
 	    //This causes register spills but might be faster if Rank is large

--- a/include/matx/transforms/eig/eig_lapack.h
+++ b/include/matx/transforms/eig/eig_lapack.h
@@ -231,8 +231,7 @@ private:
             const lapack_int_t* liwork_in, lapack_int_t* info)
   {
     // TODO: remove warning suppression once syevd is optimized in NVPL LAPACK
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+IGNORE_WARNING_PUSH("-Wdeprecated-declarations")
     if constexpr (std::is_same_v<AType, float>) {
       LAPACK_CALL(ssyevd)(jobz, uplo, n, a, lda, w, work_in, lwork_in, iwork_in, liwork_in, info);
     } else if constexpr (std::is_same_v<AType, double>) {
@@ -242,7 +241,7 @@ private:
     } else if constexpr (std::is_same_v<AType, cuda::std::complex<double>>) {
       LAPACK_CALL(zheevd)(jobz, uplo, n, a, lda, w, work_in, lwork_in, rwork_in, lrwork_in, iwork_in, liwork_in, info);
     }
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
   }
 
   std::vector<T2 *> batch_w_ptrs;

--- a/include/matx/transforms/eig/eig_lapack.h
+++ b/include/matx/transforms/eig/eig_lapack.h
@@ -231,7 +231,7 @@ private:
             const lapack_int_t* liwork_in, lapack_int_t* info)
   {
     // TODO: remove warning suppression once syevd is optimized in NVPL LAPACK
-IGNORE_WARNING_PUSH("-Wdeprecated-declarations")
+IGNORE_WARNING_PUSH_GCC("-Wdeprecated-declarations")
     if constexpr (std::is_same_v<AType, float>) {
       LAPACK_CALL(ssyevd)(jobz, uplo, n, a, lda, w, work_in, lwork_in, iwork_in, liwork_in, info);
     } else if constexpr (std::is_same_v<AType, double>) {
@@ -241,7 +241,7 @@ IGNORE_WARNING_PUSH("-Wdeprecated-declarations")
     } else if constexpr (std::is_same_v<AType, cuda::std::complex<double>>) {
       LAPACK_CALL(zheevd)(jobz, uplo, n, a, lda, w, work_in, lwork_in, rwork_in, lrwork_in, iwork_in, liwork_in, info);
     }
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
   }
 
   std::vector<T2 *> batch_w_ptrs;

--- a/include/matx/transforms/reduce.h
+++ b/include/matx/transforms/reduce.h
@@ -2339,13 +2339,13 @@ void __MATX_INLINE__ any_impl(OutType dest, const InType &in, [[maybe_unused]] c
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
       *lout = std::any_of(lin, lin + TotalSize(in), [](typename InType::value_type vin) {
-          return vin != 0;
+          return vin != static_cast<typename InType::value_type>(0);
         });
     }
     else {
       for (index_t b = 0; b < lin.Size(0); b++) {
         lout[b] = std::any_of(lin + lbegin[b], lin + lend[b], [](typename InType::value_type vin) {
-          return vin != 0;
+          return vin != static_cast<typename InType::value_type>(0);
         });
       }
     }
@@ -2412,13 +2412,13 @@ void __MATX_INLINE__ all_impl(OutType dest, const InType &in, [[maybe_unused]] c
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
       *lout = std::all_of(lin, lin + TotalSize(in), [](typename InType::value_type vin) {
-          return vin != 0;
+          return vin != static_cast<typename InType::value_type>(0);
         });
     }
     else {
       for (index_t b = 0; b < lin.Size(0); b++) {
         lout[b] = std::all_of(lin + lbegin[b], lin + lend[b], [](typename InType::value_type vin) {
-          return vin != 0;
+          return vin != static_cast<typename InType::value_type>(0);
         });
       }
     }

--- a/include/matx/transforms/svd/svd_lapack.h
+++ b/include/matx/transforms/svd/svd_lapack.h
@@ -300,8 +300,7 @@ private:
                       const lapack_int_t *lwork_in, [[maybe_unused]] T3 *rwork_in, lapack_int_t *info)
   {
     // TODO: remove warning suppression once gesvd is optimized in NVPL LAPACK
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+IGNORE_WARNING_PUSH("-Wdeprecated-declarations")
     if constexpr (std::is_same_v<T1, float>) {
       LAPACK_CALL(sgesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, info);
     } else if constexpr (std::is_same_v<T1, double>) {
@@ -311,7 +310,7 @@ private:
     } else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
       LAPACK_CALL(zgesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, rwork_in, info);
     }
-#pragma GCC diagnostic pop
+IGNORE_WARNING_POP
   }
 
   /**

--- a/include/matx/transforms/svd/svd_lapack.h
+++ b/include/matx/transforms/svd/svd_lapack.h
@@ -300,7 +300,7 @@ private:
                       const lapack_int_t *lwork_in, [[maybe_unused]] T3 *rwork_in, lapack_int_t *info)
   {
     // TODO: remove warning suppression once gesvd is optimized in NVPL LAPACK
-IGNORE_WARNING_PUSH("-Wdeprecated-declarations")
+IGNORE_WARNING_PUSH_GCC("-Wdeprecated-declarations")
     if constexpr (std::is_same_v<T1, float>) {
       LAPACK_CALL(sgesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, info);
     } else if constexpr (std::is_same_v<T1, double>) {
@@ -310,7 +310,7 @@ IGNORE_WARNING_PUSH("-Wdeprecated-declarations")
     } else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
       LAPACK_CALL(zgesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, rwork_in, info);
     }
-IGNORE_WARNING_POP
+IGNORE_WARNING_POP_GCC
   }
 
   /**


### PR DESCRIPTION
gcc14.1 has several erroneous error messages that are not correct related to uninitialized variables. We disable these warnings on specific lines of code for now.