### PR TITLE
Major refactoring of the code to better handle tensor_t usage

### DIFF
--- a/docs_input/api/casting/as_complex_double.rst
+++ b/docs_input/api/casting/as_complex_double.rst
@@ -5,8 +5,8 @@ as_complex_double
 
 Cast an operator to cuda::std::complex<double>
 
-.. doxygenfunction:: matx::as_complex_double(T t)
-.. doxygenfunction:: matx::as_complex_double(T1 t1, T2 t2)
+.. doxygenfunction:: matx::as_complex_double(const T &t)
+.. doxygenfunction:: matx::as_complex_double(const T1 &t1, const T2 &t2)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/casting/as_complex_float.rst
+++ b/docs_input/api/casting/as_complex_float.rst
@@ -5,8 +5,8 @@ as_complex_float
 
 Cast an operator to cuda::std::complex<float>
 
-.. doxygenfunction:: matx::as_complex_float(T t)
-.. doxygenfunction:: matx::as_complex_float(T1 t1, T2 t2)
+.. doxygenfunction:: matx::as_complex_float(const T &t)
+.. doxygenfunction:: matx::as_complex_float(const T1 &t1, const T2 &t2)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/creation/operators/diag.rst
+++ b/docs_input/api/creation/operators/diag.rst
@@ -8,7 +8,7 @@ tensor with a given value or a 1D input operator, while the operator pulls diago
 
 Operator
 ________
-.. doxygenfunction:: diag(T1 t, index_t k = 0)
+.. doxygenfunction:: diag(const T1 &t, index_t k = 0)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/creation/tensors/make.rst
+++ b/docs_input/api/creation/tensors/make.rst
@@ -35,5 +35,4 @@ Return by Pointer
 ~~~~~~~~~~~~~~~~~
 .. doxygenfunction:: make_tensor_p( const index_t (&shape)[RANK],  matxMemorySpace_t space = MATX_MANAGED_MEMORY, cudaStream_t stream = 0)
 .. doxygenfunction:: make_tensor_p( ShapeType &&shape, matxMemorySpace_t space = MATX_MANAGED_MEMORY, cudaStream_t stream = 0)
-.. doxygenfunction:: make_tensor_p( TensorType &tensor, typename TensorType::shape_container &&shape, matxMemorySpace_t space = MATX_MANAGED_MEMORY, cudaStream_t stream = 0)
 .. doxygenfunction:: make_tensor_p( T *const data, ShapeType &&shape, bool owning = false)

--- a/docs_input/api/dft/fft/fft.rst
+++ b/docs_input/api/dft/fft/fft.rst
@@ -6,8 +6,8 @@ fft
 Perform a 1D FFT. Batching is supported for any tensor with a rank higher than 1.
 
 
-.. doxygenfunction:: fft(OpA &&a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
-.. doxygenfunction:: fft(OpA &&a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
+.. doxygenfunction:: fft(const OpA &a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
+.. doxygenfunction:: fft(const OpA &a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/dft/fft/fft2d.rst
+++ b/docs_input/api/dft/fft/fft2d.rst
@@ -6,8 +6,8 @@ fft2
 Perform a 2D FFT. Batching is supported for any tensor with a rank higher than 2.
 
 
-.. doxygenfunction:: fft2(OpA &&a, FFTNorm norm = FFTNorm::BACKWARD)
-.. doxygenfunction:: fft2(OpA &&a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD)  
+.. doxygenfunction:: fft2(const OpA &a, FFTNorm norm = FFTNorm::BACKWARD)
+.. doxygenfunction:: fft2(const OpA &a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD)  
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/dft/fft/ifft.rst
+++ b/docs_input/api/dft/fft/ifft.rst
@@ -6,8 +6,8 @@ ifft
 Perform a 1D inverse FFT. Batching is supported for any tensor with a rank higher than 1.
 
 
-.. doxygenfunction:: ifft(OpA &&a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
-.. doxygenfunction:: ifft(OpA &&a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
+.. doxygenfunction:: ifft(const OpA &a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
+.. doxygenfunction:: ifft(const OpA &a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/dft/fft/ifft2.rst
+++ b/docs_input/api/dft/fft/ifft2.rst
@@ -6,9 +6,9 @@ ifft2
 Perform a 2D inverse FFT. Batching is supported for any tensor with a rank higher than 2.
 
 
-.. doxygenfunction:: ifft2(OpA &&a, FFTNorm norm = FFTNorm::BACKWARD)
-.. doxygenfunction:: ifft2(OpA &&a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD)  
-
+.. doxygenfunction:: ifft2(const OpA &a, FFTNorm norm = FFTNorm::BACKWARD)
+.. doxygenfunction:: ifft2(const OpA &a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD)
+  
 Examples
 ~~~~~~~~
 .. literalinclude:: ../../../../test/00_transform/FFT.cu

--- a/docs_input/api/dft/fft/r2c.rst
+++ b/docs_input/api/dft/fft/r2c.rst
@@ -5,5 +5,5 @@ r2c
 
 Return the full spectrum from an R2C transform
 
-.. doxygenfunction:: r2c(T1 t, index_t orig)
+.. doxygenfunction:: r2c(const T1 &t, index_t orig)
 

--- a/docs_input/api/linalg/matvec/matmul.rst
+++ b/docs_input/api/linalg/matvec/matmul.rst
@@ -10,8 +10,8 @@ Matrix Multiply (GEMM)
 is supported for any tensor with a rank higher than 2.
 
 
-.. doxygenfunction:: matmul(const OpA A, const OpB B, float alpha = 1.0, float beta = 0.0)
-.. doxygenfunction:: matmul(const OpA A, const OpB B, const int32_t (&axis)[2], float alpha = 1.0, float beta = 0.0)
+.. doxygenfunction:: matmul(const OpA &A, const OpB &B, float alpha = 1.0, float beta = 0.0)
+.. doxygenfunction:: matmul(const OpA &A, const OpB &B, const int32_t (&axis)[2], float alpha = 1.0, float beta = 0.0)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/linalg/other/cgsolve.rst
+++ b/docs_input/api/linalg/other/cgsolve.rst
@@ -5,7 +5,7 @@ cgsolve
 
 Complex gradient solve on square matrix
 
-.. doxygenfunction:: cgsolve(AType A, BType B, double tol=1e-6, int max_iters=4)
+.. doxygenfunction:: cgsolve(const AType &A, const BType &B, double tol=1e-6, int max_iters=4)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/joinrepeat/clone.rst
+++ b/docs_input/api/manipulation/joinrepeat/clone.rst
@@ -5,8 +5,8 @@ clone
 
 Clone one or more dimensions of an operator to a higher rank
 
-.. doxygenfunction:: clone(Op t, const index_t (&shape)[Rank])
-.. doxygenfunction:: clone(Op t, const cuda::std::array<index_t, Rank> &shape)
+.. doxygenfunction:: clone(const Op &t, const index_t (&shape)[Rank])
+.. doxygenfunction:: clone(const Op &t, const cuda::std::array<index_t, Rank> &shape)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/joinrepeat/repmat.rst
+++ b/docs_input/api/manipulation/joinrepeat/repmat.rst
@@ -5,9 +5,9 @@ repmat
 
 Repeat an operator
 
-.. doxygenfunction:: repmat(T1 t, index_t reps)    
-.. doxygenfunction:: repmat(T1 t, const index_t(&reps)[N])
-.. doxygenfunction:: repmat(T1 t, const index_t *reps)
+.. doxygenfunction:: repmat(const T1 &t, index_t reps)    
+.. doxygenfunction:: repmat(const T1 &t, const index_t(&reps)[N])
+.. doxygenfunction:: repmat(const T1 &t, const index_t *reps)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/rearranging/reverse.rst
+++ b/docs_input/api/manipulation/rearranging/reverse.rst
@@ -5,8 +5,8 @@ reverse
 
 Reverse the values of an operator along a single dimension
 
-.. doxygenfunction:: template <int DIM, typename Op> reverse(const Op &t)
-.. doxygenfunction:: template <int DIM1, int DIM2, int... DIMS, typename Op> reverse(const Op &t)
+.. cpp:function:: template <int DIM, typename Op> reverse(const Op &t)
+.. cpp:function:: template <int DIM1, int DIM2, int... DIMS, typename Op> reverse(const Op &t)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/rearranging/reverse.rst
+++ b/docs_input/api/manipulation/rearranging/reverse.rst
@@ -5,8 +5,8 @@ reverse
 
 Reverse the values of an operator along a single dimension
 
-.. doxygenfunction:: reverse(Op t)
-.. doxygenfunction:: reverse(Op_type t)
+.. doxygenfunction:: template <int DIM, typename Op> reverse(const Op &t)
+.. doxygenfunction:: template <int DIM1, int DIM2, int... DIMS, typename Op> reverse(const Op &t)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/rearranging/shift.rst
+++ b/docs_input/api/manipulation/rearranging/shift.rst
@@ -5,8 +5,8 @@ shift
 
 Shift an operator by a given amount either positive or negative along one dimension
 
-.. doxygenfunction:: shift(OpT op, ShiftOpT s)
-.. doxygenfunction:: shift(OpT op, ShiftT s, ShiftsT... shifts)
+.. doxygenfunction:: shift(const OpT &op, ShiftOpT s)
+.. doxygenfunction:: shift(const OpT &op, ShiftT s, ShiftsT... shifts)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/rearranging/transpose.rst
+++ b/docs_input/api/manipulation/rearranging/transpose.rst
@@ -7,7 +7,7 @@ Transpose an operator into a tensor. This is equivalent to permuting the dimensi
 an operator in reverse order. Using `transpose()` potentially allows for higher performance
 than calling `permute()` since it's not lazily evaluated and can use an optimized implementation.
 
-.. doxygenfunction:: transpose(const T op)
+.. doxygenfunction:: transpose(const T &op)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/rearranging/transpose_matrix.rst
+++ b/docs_input/api/manipulation/rearranging/transpose_matrix.rst
@@ -5,7 +5,7 @@ transpose_matrix
 
 Transpose the last two dimensions of an operator
 
-.. doxygenfunction:: transpose_matrix(const T op)
+.. doxygenfunction:: transpose_matrix(const T &op)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/selecting/at.rst
+++ b/docs_input/api/manipulation/selecting/at.rst
@@ -18,7 +18,7 @@ the operation is launched:
 
     (a = at(b, 5)).run();
 
-.. doxygenfunction:: at(const Op op, Is... indices)
+.. doxygenfunction:: at(const Op &op, Is... indices)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/selecting/remap.rst
+++ b/docs_input/api/manipulation/selecting/remap.rst
@@ -5,8 +5,8 @@ remap
 
 Remaps an input operator by selecting items from an input index operator
 
-.. doxygenfunction:: remap(Op t, Ind idx)
-.. doxygenfunction:: remap(Op t, Ind idx, Inds... inds)
+.. doxygenfunction:: remap(const Op &t, Ind idx)
+.. doxygenfunction:: remap(const Op &t, Ind idx, Inds... inds)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/manipulation/selecting/select.rst
+++ b/docs_input/api/manipulation/selecting/select.rst
@@ -6,7 +6,7 @@ select
 Selects value from a tensor based on a 1D index mapping. The 1D index mapping works for any rank tensor.
 Usually the mapping is provided by `find_idx`, but any source with the same mapping will work.
 
-.. doxygenfunction:: select(T t, IdxType idx)
+.. doxygenfunction:: select(const T &t, IdxType idx)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/polynomials/legendre.rst
+++ b/docs_input/api/polynomials/legendre.rst
@@ -5,9 +5,9 @@ legendre
 
 Return Legendre polynomial coefficients at the input operator
 
-.. doxygenfunction:: legendre(T1 n, T2 m, const T3 in)
-.. doxygenfunction:: legendre(T1 n, T2 m, const T3 in, int (&axis)[2])
-.. doxygenfunction:: legendre(T1 n, T2 m, const T3 in, cuda::std::array<int, 2> axis)  
+.. doxygenfunction:: legendre(const T1 &n, const T2 &m, const T3 &in)
+.. doxygenfunction:: legendre(const T1 &n, const T2 &m, const T3 &in, int (&axis)[2])
+.. doxygenfunction:: legendre(const T1 &n, const T2 &m, const T3 &in, cuda::std::array<int, 2> axis)  
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/signalimage/radar/ambgfun.rst
+++ b/docs_input/api/signalimage/radar/ambgfun.rst
@@ -5,8 +5,8 @@ ambgfun
 
 Ambiguity function
 
-.. doxygenfunction:: ambgfun(XTensor &x, YTensor &y, double fs, AMBGFunCutType_t cut, float cut_val = 0.0)
-.. doxygenfunction:: ambgfun(XTensor &x, double fs, AMBGFunCutType_t cut, float cut_val = 0.0)
+.. doxygenfunction:: ambgfun(const XTensor &x, const YTensor &y, double fs, AMBGFunCutType_t cut, float cut_val = 0.0)
+.. doxygenfunction:: ambgfun(const XTensor &x, double fs, AMBGFunCutType_t cut, float cut_val = 0.0)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/stats/corr/cov.rst
+++ b/docs_input/api/stats/corr/cov.rst
@@ -9,7 +9,7 @@ Compute a covariance matrix
    This function is currently not supported with host-based executors (CPU)
 
 
-.. doxygenfunction:: cov(AType a)
+.. doxygenfunction:: cov(const AType &a)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/stats/hist/hist.rst
+++ b/docs_input/api/stats/hist/hist.rst
@@ -3,12 +3,12 @@
 hist
 ====
 
-Compute a histogram of input `a` with bounds specified by `upper` and `lower`
+Compute a histogram of input `a` with bounds specified by `upper` and `lower` and `num_levels` bins
 
 .. note::
    This function is currently not supported with host-based executors (CPU)
 
-.. doxygenfunction:: hist(const InputOperator &a, const typename InputOperator::value_type lower, const typename InputOperator::value_type upper)
+.. doxygenfunction:: hist(const InputOperator &a, const typename InputOperator::value_type lower, const typename InputOperator::value_type upper, int num_levels)
 
 Examples
 ~~~~~~~~

--- a/include/matx/core/allocator.h
+++ b/include/matx/core/allocator.h
@@ -121,6 +121,7 @@ struct MemTracker {
     }
 
     size_t bytes = iter->second.size;
+
     matxMemoryStats.currentBytesAllocated -= bytes;
 
     switch (iter->second.kind) {

--- a/include/matx/core/defines.h
+++ b/include/matx/core/defines.h
@@ -90,4 +90,14 @@ namespace matx {
 // std::ceil is not constexpr until C++23
 #define MATX_ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
 
+enum {
+  matxKeepDim     = std::numeric_limits<index_t>::max(),
+  matxDropDim     = std::numeric_limits<index_t>::max() - 1,
+  matxEnd         = std::numeric_limits<index_t>::max() - 2,
+  matxKeepStride  = std::numeric_limits<index_t>::max() - 3,
+
+  // If adding a new marker adjust this to the last element above
+  matxIdxSentinel = matxKeepStride - 1,
+};
+
 }

--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -1109,7 +1109,12 @@ void print(const Op &op)
 
 template <typename Op, typename Executor>
 auto OpToTensor(Op &&op, [[maybe_unused]] const Executor &exec) {
-  if constexpr (!is_tensor_view_v<Op>) {
+  if constexpr (is_matx_transform_op<Op>()) {
+    // We can assume that if a transform is passed to the input then PreRun has already completed
+    // on the transform and we can use the internal pointer
+    return make_tensor<typename Op::value_type>(op.Data(), Shape(op));
+  }    
+  else if constexpr (!is_tensor_view_v<Op>) {
     if constexpr (is_cuda_executor_v<Executor>) {
       return make_tensor<typename remove_cvref<Op>::value_type>(op.Shape(), MATX_ASYNC_DEVICE_MEMORY, exec.getStream());
     } else {

--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -231,6 +231,34 @@ template <typename T> constexpr bool is_matx_op_lvalue()
 }
 
 namespace detail {
+template <typename T, typename = void> struct is_tensor_t : std::false_type {};
+template <typename T>
+struct is_tensor_t<T, std::void_t<typename T::tensor_t_type>> : std::true_type {};
+}
+
+/**
+ * @brief Determine if a type is a MatX tensor_t
+ * 
+ * @tparam T Type to test
+ */
+template< class T >
+inline constexpr bool is_tensor_t_v = detail::is_tensor_t<typename remove_cvref<T>::type>::value;
+
+namespace detail {
+template <typename T, typename = void> struct is_tensor_impl : std::false_type {};
+template <typename T>
+struct is_tensor_impl<T, std::void_t<typename T::tensor_impl>> : std::true_type {};
+}
+
+/**
+ * @brief Determine if a type is a MatX tensor_impl_t
+ * 
+ * @tparam T Type to test
+ */
+template< class T >
+inline constexpr bool is_tensor_impl_v = detail::is_tensor_impl<typename remove_cvref<T>::type>::value;
+
+namespace detail {
 template <typename T, typename = void> struct is_tensor_view : std::false_type {
 };
 
@@ -781,7 +809,7 @@ struct base_type {
 };
 
 template <typename T> 
-struct base_type<T, typename std::enable_if_t<is_tensor_view_v<T>>> {
+struct base_type<T, typename std::enable_if_t<is_tensor_t_v<T>>> {
   using type = tensor_impl_t<typename T::value_type, T::Rank(), typename T::desc_type>;
 };
 

--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -43,7 +43,7 @@
 #include "cuda_fp16.h"
 #include "matx/core/half.h"
 #include "matx/core/half_complex.h"
-#include "matx/executors/device.h"
+#include "matx/executors/cuda.h"
 
 /**
  * Defines type traits for host and device compilers. This file should be includable by
@@ -707,7 +707,7 @@ struct extract_value_type_impl<T, typename std::enable_if_t<is_matx_op<T>()>> {
  * @tparam T Type to extract from
  */
 template <typename T>
-using extract_value_type_t = typename detail::extract_value_type_impl<T>::value_type;
+using extract_value_type_t = typename detail::extract_value_type_impl<std::remove_cv_t<T>>::value_type;
 
 /**
  * @brief Promote half precision floating point value to fp32, or leave untouched if not half

--- a/include/matx/executors/cuda.h
+++ b/include/matx/executors/cuda.h
@@ -81,7 +81,7 @@ namespace matx
        * @param op value
        **/
       template <typename Op>
-        void Exec(Op &op) const {
+        void Exec(const Op &op) const {
 #ifdef __CUDACC__      
           dim3 threads, blocks;  
 

--- a/include/matx/executors/executors.h
+++ b/include/matx/executors/executors.h
@@ -33,5 +33,5 @@
 #pragma once
 
 #include "matx/executors/support.h"
-#include "matx/executors/device.h"
+#include "matx/executors/cuda.h"
 #include "matx/executors/host.h"

--- a/include/matx/executors/host.h
+++ b/include/matx/executors/host.h
@@ -117,7 +117,7 @@ class HostExecutor {
      * @param op Operator to execute
      */
     template <typename Op>
-    void Exec(Op &op) const noexcept {
+    void Exec(const Op &op) const noexcept {
       if constexpr (Op::Rank() == 0) {
         op();
       } 

--- a/include/matx/operators/all.h
+++ b/include/matx/operators/all.h
@@ -50,7 +50,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr;     
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;     
 
     public:
       using matxop = bool;
@@ -59,11 +59,17 @@ namespace detail {
       using all_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "all(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ AllOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ AllOp(const OpA &a) : a_(a) { 
         for (int r = 0; r < ORank; r++) {
           out_dims_[r] = a_.Size(r);
         }
       };
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~AllOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif        
+      }      
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {

--- a/include/matx/operators/all.h
+++ b/include/matx/operators/all.h
@@ -47,7 +47,7 @@ namespace detail {
   class AllOp : public BaseOp<AllOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;     
@@ -65,11 +65,7 @@ namespace detail {
         }
       };
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~AllOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }      
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr); 
       }      
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/ambgfun.h
+++ b/include/matx/operators/ambgfun.h
@@ -44,6 +44,7 @@ namespace matx
     class AmbgFunOp : public BaseOp<AmbgFunOp<OpX, OpY>>
     {
       private:
+        // Make these base_type once we get rid of std::optional
         mutable OpX x_;
         mutable OpY y_;
         double fs_;
@@ -89,11 +90,7 @@ namespace matx
           }
         }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~AmbgFunOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }            
+        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }   
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -149,6 +146,8 @@ namespace matx
           if constexpr (is_matx_op<OpY>()) {
             y_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
+
+          matxFree(ptr); 
         }            
     };
   }
@@ -186,7 +185,7 @@ namespace matx
  */
 template <typename XTensor, typename YTensor>
 __MATX_INLINE__ auto ambgfun(const XTensor &x,
-                    YTensor &y, double fs, AMBGFunCutType_t cut,
+                    const YTensor &y, double fs, AMBGFunCutType_t cut,
                     float cut_val = 0.0)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)

--- a/include/matx/operators/any.h
+++ b/include/matx/operators/any.h
@@ -63,13 +63,9 @@ namespace detail {
         for (int r = 0; r < ORank; r++) {
           out_dims_[r] = a_.Size(r);
         }        
-      };
+      }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~AnyOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }         
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr); 
       }          
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/any.h
+++ b/include/matx/operators/any.h
@@ -50,7 +50,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
     public:
       using matxop = bool;
@@ -59,11 +59,17 @@ namespace detail {
       using any_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "any(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ AnyOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ AnyOp(const OpA &a) : a_(a) { 
         for (int r = 0; r < ORank; r++) {
           out_dims_[r] = a_.Size(r);
         }        
       };
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~AnyOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif        
+      }         
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {

--- a/include/matx/operators/argmax.h
+++ b/include/matx/operators/argmax.h
@@ -47,7 +47,7 @@ namespace detail {
   class ArgMaxOp : public BaseOp<ArgMaxOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
 
     public:
       using matxop = bool;
@@ -77,7 +77,9 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "argmax() must only be called with a single assignment since it has multiple return types");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/argmax.h
+++ b/include/matx/operators/argmax.h
@@ -56,7 +56,7 @@ namespace detail {
       using argmax_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "argmax(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ ArgMaxOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ ArgMaxOp(const OpA &a) : a_(a) { 
      
       };
 

--- a/include/matx/operators/argmin.h
+++ b/include/matx/operators/argmin.h
@@ -56,7 +56,7 @@ namespace detail {
       using argmin_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "argmin(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ ArgMinOp(OpA a) : a_(a) {
+      __MATX_INLINE__ ArgMinOp(const OpA &a) : a_(a) {
      
       };
 

--- a/include/matx/operators/argmin.h
+++ b/include/matx/operators/argmin.h
@@ -47,7 +47,7 @@ namespace detail {
   class ArgMinOp : public BaseOp<ArgMinOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
 
     public:
       using matxop = bool;
@@ -77,7 +77,9 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "argmin() must only be called with a single assignment since it has multiple return types");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/at.h
+++ b/include/matx/operators/at.h
@@ -53,7 +53,7 @@ namespace matx
         using value_type = typename Op::value_type;
 
         __MATX_INLINE__ std::string str() const { return "at()"; }
-        __MATX_INLINE__ AtOp(Op op, Is... is) : op_(op), idx_{is...} {};
+        __MATX_INLINE__ AtOp(const Op &op, Is... is) : op_(op), idx_{is...} {};
 
         template <typename... Is2>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()([[maybe_unused]] Is2... indices) const
@@ -95,7 +95,7 @@ namespace matx
 #else
   template <typename Op, typename... Is>
 #endif
-  __MATX_INLINE__ auto at(const Op op, Is... indices) {
+  __MATX_INLINE__ auto at(const Op &op, Is... indices) {
     return detail::AtOp(op, indices...);
   }
 } // end namespace matx

--- a/include/matx/operators/at.h
+++ b/include/matx/operators/at.h
@@ -45,7 +45,7 @@ namespace matx
     class AtOp : public BaseOp<AtOp<Op, Is...>>
     {
       private:
-        typename base_type<Op>::type op_;
+        typename detail::base_type_t<Op> op_;
         cuda::std::array<index_t, sizeof...(Is)> idx_;
 
       public:

--- a/include/matx/operators/binary_operators.h
+++ b/include/matx/operators/binary_operators.h
@@ -45,8 +45,8 @@
     using I1Type = extract_value_type_t<I1>;                        \
     using I2Type = extract_value_type_t<I2>;                        \
     using Op = TENSOR_OP<I1Type, I2Type>;                            \
-    const typename detail::base_type<I1>::type &base1 = i1;       \
-    const typename detail::base_type<I2>::type &base2 = i2;       \
+    const typename detail::base_type_t<I1> &base1 = i1;       \
+    const typename detail::base_type_t<I2> &base2 = i2;       \
     return detail::matxBinaryOp(base1, base2, Op());              \
   }
 
@@ -94,9 +94,9 @@ namespace matx
       class matxBinaryOp : public BaseOp<matxBinaryOp<I1,I2,Op>>
     {
       private:
-        mutable typename base_type<I1>::type in1_;
-        mutable typename base_type<I2>::type in2_;
-        typename base_type<Op>::type op_;
+        mutable typename detail::base_type_t<I1> in1_;
+        mutable typename detail::base_type_t<I2> in2_;
+        typename detail::base_type_t<Op> op_;
 
       public:
         // dummy type to signal this is a matxop

--- a/include/matx/operators/binary_operators.h
+++ b/include/matx/operators/binary_operators.h
@@ -40,7 +40,7 @@
   template <typename I1, typename I2,                                \
             typename = typename std::enable_if_t<is_matx_op<I1>() or \
                                                  is_matx_op<I2>()>>  \
-  [[nodiscard]] __MATX_INLINE__ auto FUNCTION(I1 i1, I2 i2)                   \
+  [[nodiscard]] __MATX_INLINE__ auto FUNCTION(const I1 &i1, const I2 &i2)                   \
   {                                                                  \
     using I1Type = extract_value_type_t<I1>;                        \
     using I2Type = extract_value_type_t<I2>;                        \
@@ -108,7 +108,7 @@ namespace matx
         return op_.str(get_type_str(in1_), get_type_str(in2_));
       }
 
-        __MATX_INLINE__ matxBinaryOp(I1 in1, I2 in2, Op op) : in1_(in1), in2_(in2), op_(op)
+        __MATX_INLINE__ matxBinaryOp(const I1 &in1, const I2 &in2, const Op &op) : in1_(in1), in2_(in2), op_(op)
       {
         if constexpr (Rank() > 0)
         {

--- a/include/matx/operators/cart2sph.h
+++ b/include/matx/operators/cart2sph.h
@@ -46,9 +46,9 @@ namespace matx
       class Cart2SphOp : public BaseOp<Cart2SphOp<T1, T2, T3, WHICH>>
     {
       private:
-        typename base_type<T1>::type x_;
-        typename base_type<T2>::type y_;
-        typename base_type<T3>::type z_;
+        typename detail::base_type_t<T1> x_;
+        typename detail::base_type_t<T2> y_;
+        typename detail::base_type_t<T3> z_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/cart2sph.h
+++ b/include/matx/operators/cart2sph.h
@@ -57,7 +57,7 @@ namespace matx
         __MATX_INLINE__ std::string str() const { return "cart2sph(" + get_type_str(x_) + 
           "," + get_type_str(y_) + "," + get_type_str(z_) + ")"; }
 
-        __MATX_INLINE__ Cart2SphOp(T1 x, T2 y, T3 z) : x_(x), y_(y), z_(z)
+        __MATX_INLINE__ Cart2SphOp(const T1 &x, const T2 &y, const T3 &z) : x_(x), y_(y), z_(z)
       {
         ASSERT_COMPATIBLE_OP_SIZES(x);
         ASSERT_COMPATIBLE_OP_SIZES(y);
@@ -150,7 +150,7 @@ namespace matx
    *   Tuple of operators for theta, phi, and r.
    */
   template <typename T1, typename T2, typename T3>
-    auto __MATX_INLINE__ cart2sph(T1 x, T2 y, T3 z)
+    auto __MATX_INLINE__ cart2sph(const T1 &x, const T2 &y, const T3 &z)
     {
       return cuda::std::tuple{ 
         detail::Cart2SphOp<T1, T2, T3, 0>(x, y, z),

--- a/include/matx/operators/cast.h
+++ b/include/matx/operators/cast.h
@@ -69,7 +69,7 @@ namespace matx
         using value_type = NewType;
 
 	      __MATX_INLINE__ std::string str() const { return as_type_str<NewType>() + "(" + op_.str() + ")"; }
-        __MATX_INLINE__ CastOp(T op) : op_(op){};  
+        __MATX_INLINE__ CastOp(const T &op) : op_(op){};  
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
@@ -211,7 +211,7 @@ namespace matx
    * @return Operator output casted to NewType (must be complex)
    */
   template <typename NewType, typename T1, typename T2>
-    auto __MATX_INLINE__ as_complex_type(T1 t1, T2 t2)
+    auto __MATX_INLINE__ as_complex_type(const T1 &t1, const T2 &t2)
     {
       return detail::ComplexCastOp<T1, T2, NewType>(t1, t2);
     };
@@ -224,7 +224,7 @@ namespace matx
    * @return Operator output casted to int 
    */
   template <typename T>
-    auto __MATX_INLINE__ as_int(T t)
+    auto __MATX_INLINE__ as_int(const T &t)
     {
       return as_type<int>(t);
     };   
@@ -237,7 +237,7 @@ namespace matx
    * @return Operator output casted to float 
    */
   template <typename T>
-    auto __MATX_INLINE__ as_float(T t)
+    auto __MATX_INLINE__ as_float(const T &t)
     {
       return as_type<float>(t);
     };   
@@ -250,7 +250,7 @@ namespace matx
    * @return Operator output casted to cuda::std::complex<float>
    */
   template <typename T>
-    auto __MATX_INLINE__ as_complex_float(T t)
+    auto __MATX_INLINE__ as_complex_float(const T &t)
     {
       return as_type<cuda::std::complex<float>>(t);
     };
@@ -265,7 +265,7 @@ namespace matx
    * @return Operator output casted to cuda::std::complex<float>
    */
   template <typename T1, typename T2>
-    auto __MATX_INLINE__ as_complex_float(T1 t1, T2 t2)
+    auto __MATX_INLINE__ as_complex_float(const T1 &t1, const T2 &t2)
     {
       return as_complex_type<cuda::std::complex<float>>(t1, t2);
     };
@@ -280,7 +280,7 @@ namespace matx
    * @return Operator output casted to cuda::std::complex<double>
    */
   template <typename T1, typename T2>
-    auto __MATX_INLINE__ as_complex_double(T1 t1, T2 t2)
+    auto __MATX_INLINE__ as_complex_double(const T1 &t1, const T2 &t2)
     {
       return as_complex_type<cuda::std::complex<double>>(t1, t2);
     };
@@ -293,7 +293,7 @@ namespace matx
    * @return Operator output casted to double 
    */
   template <typename T>
-    auto __MATX_INLINE__ as_double(T t)
+    auto __MATX_INLINE__ as_double(const T &t)
     {
       return as_type<double>(t);
     };   
@@ -306,7 +306,7 @@ namespace matx
    * @return Operator output casted to cuda::std::complex<double>
    */
   template <typename T>
-    auto __MATX_INLINE__ as_complex_double(T t)
+    auto __MATX_INLINE__ as_complex_double(const T &t)
     {
       return as_type<cuda::std::complex<double>>(t);
     };
@@ -319,7 +319,7 @@ namespace matx
    * @return Operator output casted to uint32_t 
    */
   template <typename T>
-    auto __MATX_INLINE__ as_uint32(T t)
+    auto __MATX_INLINE__ as_uint32(const T &t)
     {
       return as_type<uint32_t>(t);
     };   
@@ -332,7 +332,7 @@ namespace matx
    * @return Operator output casted to int32_t 
    */
   template <typename T>
-    auto __MATX_INLINE__ as_int32(T t)
+    auto __MATX_INLINE__ as_int32(const T &t)
     {
       return as_type<int32_t>(t);
     }; 
@@ -345,7 +345,7 @@ namespace matx
    * @return Operator output casted to int16_t 
    */
   template <typename T>
-    auto __MATX_INLINE__ as_int16(T t)
+    auto __MATX_INLINE__ as_int16(const T &t)
     {
       return as_type<int16_t>(t);
     }; 
@@ -358,7 +358,7 @@ namespace matx
    * @return Operator output casted to uint16_t 
    */
   template <typename T>
-    auto __MATX_INLINE__ as_uint16(T t)
+    auto __MATX_INLINE__ as_uint16(const T &t)
     {
       return as_type<uint16_t>(t);
     }; 
@@ -371,7 +371,7 @@ namespace matx
    * @return Operator output casted to int8_t 
    */
   template <typename T>
-    auto __MATX_INLINE__ as_int8(T t)
+    auto __MATX_INLINE__ as_int8(const T &t)
     {
       return as_type<int8_t>(t);
     }; 
@@ -384,7 +384,7 @@ namespace matx
    * @return Operator output casted to uint8_t 
    */
   template <typename T>
-    auto __MATX_INLINE__ as_uint8(T t)
+    auto __MATX_INLINE__ as_uint8(const T &t)
     {
       return as_type<uint8_t>(t);
     }; 

--- a/include/matx/operators/cast.h
+++ b/include/matx/operators/cast.h
@@ -62,7 +62,7 @@ namespace matx
       class CastOp : public BaseOp<CastOp<T, NewType>>
     {
       private:
-        typename base_type<T>::type op_;
+        typename detail::base_type_t<T> op_;
 
       public:
         using matxop = bool;
@@ -113,8 +113,8 @@ namespace matx
       class ComplexCastOp : public BaseOp<ComplexCastOp<T1, T2, NewType>>
     {
       private:
-        typename base_type<T1>::type real_op_;
-        typename base_type<T2>::type imag_op_;
+        typename detail::base_type_t<T1> real_op_;
+        typename detail::base_type_t<T2> imag_op_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/cgsolve.h
+++ b/include/matx/operators/cgsolve.h
@@ -50,7 +50,7 @@ namespace matx
         int max_iters_;
         cuda::std::array<index_t, 2> out_dims_;
         mutable detail::tensor_impl_t<typename OpA::value_type, 2> tmp_out_;
-        mutable typename OpA::value_type *ptr;               
+        mutable typename OpA::value_type *ptr = nullptr;               
 
       public:
         using matxop = bool;
@@ -69,6 +69,12 @@ namespace matx
             out_dims_[r] = b_.Size(r);
           }
         }
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~CGSolveOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif        
+      }           
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -143,7 +149,7 @@ namespace matx
    *
    */
   template <typename AType, typename BType>
-    __MATX_INLINE__ auto cgsolve(AType A, BType B, double tol=1e-6, int max_iters=4)
+    __MATX_INLINE__ auto cgsolve(const AType &A, const BType &B, double tol=1e-6, int max_iters=4)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
     

--- a/include/matx/operators/cgsolve.h
+++ b/include/matx/operators/cgsolve.h
@@ -44,8 +44,8 @@ namespace matx
     class CGSolveOp : public BaseOp<CGSolveOp<OpA, OpB>>
     {
       private:
-        OpA a_;
-        OpB b_;
+        typename detail::base_type_t<OpA> a_;
+        typename detail::base_type_t<OpB> b_;
         double tol_;
         int max_iters_;
         cuda::std::array<index_t, 2> out_dims_;
@@ -70,11 +70,7 @@ namespace matx
           }
         }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~CGSolveOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }           
+        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -130,6 +126,8 @@ namespace matx
           if constexpr (is_matx_op<OpB>()) {
             b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           } 
+
+          matxFree(ptr); 
         }           
     };
   }

--- a/include/matx/operators/channelize_poly.h
+++ b/include/matx/operators/channelize_poly.h
@@ -50,7 +50,7 @@ namespace detail {
       // will be cuda::std::complex<double>.
       using out_t = cuda::std::common_type_t<
         complex_from_scalar_t<typename OpA::value_type>, complex_from_scalar_t<typename FilterType::value_type>>;
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       FilterType f_;
       index_t num_channels_;
       index_t decimation_factor_;
@@ -78,11 +78,7 @@ namespace detail {
         out_dims_[Rank() - 1] = num_channels;
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~ChannelizePolyOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }          
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) {
@@ -133,6 +129,8 @@ namespace detail {
         if constexpr (is_matx_op<FilterType>()) {
           f_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         } 
+
+        matxFree(ptr);
       }        
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/chol.h
+++ b/include/matx/operators/chol.h
@@ -46,9 +46,9 @@ namespace detail {
   class CholOp : public BaseOp<CholOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       SolverFillMode uplo_;
-      mutable matx::tensor_t<typename OpA::value_type, OpA::Rank()> tmp_out_;
+      mutable detail::tensor_impl_t<typename OpA::value_type, OpA::Rank()> tmp_out_;
       mutable typename OpA::value_type *ptr = nullptr;      
 
     public:
@@ -58,13 +58,9 @@ namespace detail {
       using chol_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "chol()"; }
-      __MATX_INLINE__ CholOp(const OpA &a, SolverFillMode uplo) : a_(a), uplo_(uplo) { };
+      __MATX_INLINE__ CholOp(const OpA &a, SolverFillMode uplo) : a_(a), uplo_(uplo) { }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~CholOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }          
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       // This should never be called
       template <typename... Is>
@@ -104,6 +100,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr); 
       }        
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/clone.h
+++ b/include/matx/operators/clone.h
@@ -44,7 +44,7 @@ namespace matx
     {
       static_assert(CRank > T::Rank(), "Clone rank must be higher than input rank");
       private:
-        mutable typename base_type<T>::type op_;
+        mutable typename detail::base_type_t<T> op_;
         cuda::std::array<index_t, CRank> sizes_;         // size of each dimension after cloning
         cuda::std::array<index_t, T::Rank()> dims_;      // gather map for computing operator() indices
       public:
@@ -162,26 +162,26 @@ IGNORE_WARNING_POP_GCC
    * @return operator to compute the cloned value
    */
   template <std::size_t Rank, typename Op>
-    auto __MATX_INLINE__ clone(const Op &t, const cuda::std::array<index_t, Rank> &shape)
-    {
-      static_assert(Rank >= Op::Rank(), "Cloning rank must be >= input operator rank");
+  auto __MATX_INLINE__ clone(const Op &t, const cuda::std::array<index_t, Rank> &shape)
+  {
+    static_assert(Rank >= Op::Rank(), "Cloning rank must be >= input operator rank");
 
-      if constexpr (Op::Rank() == Rank) {
-        return t; // No-op to same rank
-      }
-      else if constexpr (is_tensor_view_v<Op>) {
-        return t.template Clone<static_cast<int>(Rank)>(shape);
-      } else {
-        return detail::CloneOp<static_cast<int>(Rank), Op>(t, shape);
+    if constexpr (Op::Rank() == Rank) {
+      return t; // No-op to same rank
+    }
+    else if constexpr (is_tensor_view_v<Op>) {
+      return t.template Clone<static_cast<int>(Rank)>(shape);
+    } else {
+      return detail::CloneOp<static_cast<int>(Rank), Op>(t, shape);
 
-      }
-    };
+    }
+  };
 
   template <int Rank, typename Op>
-    auto __MATX_INLINE__ clone(Op t, const index_t (&shape)[Rank])
-    {
-      return clone<Rank, Op>(t, detail::to_array(shape));
-    };
+  auto __MATX_INLINE__ clone(const Op &t, const index_t (&shape)[Rank])
+  {
+    return clone<Rank, Op>(t, detail::to_array(shape));
+  };
 
 
 } // end namespace matx

--- a/include/matx/operators/clone.h
+++ b/include/matx/operators/clone.h
@@ -54,7 +54,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "clone(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ CloneOp(T op, cuda::std::array<index_t, CRank> shape) : op_(op) {
+        __MATX_INLINE__ CloneOp(const T &op, cuda::std::array<index_t, CRank> shape) : op_(op) {
           static_assert(T::Rank() < CRank, "Cloning rank must be higher than input operator rank");
 
           const index_t num_keep = std::count_if(shape.begin(), shape.end(), [](index_t i) { return i == matxKeepDim; });
@@ -83,7 +83,7 @@ IGNORE_WARNING_POP_GCC
           }
           MATX_ASSERT(d == T::Rank(), matxInvalidDim);
 
-        };
+        }
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -162,7 +162,7 @@ IGNORE_WARNING_POP_GCC
    * @return operator to compute the cloned value
    */
   template <std::size_t Rank, typename Op>
-    auto __MATX_INLINE__ clone(Op t, const cuda::std::array<index_t, Rank> &shape)
+    auto __MATX_INLINE__ clone(const Op &t, const cuda::std::array<index_t, Rank> &shape)
     {
       static_assert(Rank >= Op::Rank(), "Cloning rank must be >= input operator rank");
 

--- a/include/matx/operators/collapse.h
+++ b/include/matx/operators/collapse.h
@@ -43,7 +43,7 @@ namespace matx
       class LCollapseOp : public BaseOp<LCollapseOp<DIM, T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
         index_t size_;  // size of collapsed dim
 
       public:
@@ -198,7 +198,7 @@ namespace matx
       class RCollapseOp : public BaseOp<RCollapseOp<DIM, T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
         index_t size_;  // size of collapsed dim
 
       public:

--- a/include/matx/operators/collapse.h
+++ b/include/matx/operators/collapse.h
@@ -54,7 +54,7 @@ namespace matx
         using self_type = LCollapseOp<DIM, T1>;
 
         __MATX_INLINE__ std::string str() const { return "lcollapse<" + std::to_string(DIM) + ">(" + op_.str() + ")"; }
-        __MATX_INLINE__ LCollapseOp(const T1 op) : op_(op)
+        __MATX_INLINE__ LCollapseOp(const T1 &op) : op_(op)
       {
         static_assert(DIM <= T1::Rank(),  "Collapse DIM must be less than or equal to Rank() of operator");
         static_assert(DIM > 1, "Must collapse multiple dims");
@@ -339,7 +339,7 @@ namespace matx
    *   Operator with collapsed input
    */
   template <int DIM, typename T1>
-    auto __MATX_INLINE__ rcollapse(const T1 a)
+    auto __MATX_INLINE__ rcollapse(const T1 &a)
     {
       if constexpr (DIM <= 1) {
         return a;

--- a/include/matx/operators/comma.h
+++ b/include/matx/operators/comma.h
@@ -48,7 +48,7 @@ namespace matx
     template<class Op1, class Op2>
       class CommaOp : public BaseOp<CommaOp<Op1, Op2>>{
         public:
-          __MATX_HOST__ __MATX_INLINE__  CommaOp(Op1 op1, Op2 op2) : op1_(op1), op2_(op2) {
+          __MATX_HOST__ __MATX_INLINE__  CommaOp(const Op1 &op1, const Op2 &op2) : op1_(op1), op2_(op2) {
             MATX_STATIC_ASSERT_STR(Op1::Rank() == Op2::Rank(), matxInvalidSize, 
                 "Chained expressions using the comma operator must match in rank");
             if constexpr ( Rank() > 0) {
@@ -116,7 +116,7 @@ namespace matx
    * @return Result of comma operator
    */
   template <typename T, typename S, std::enable_if_t<is_matx_op<T>() && is_matx_op<S>(), bool> = true>
-    __MATX_INLINE__ __MATX_HOST__ auto operator,(T l, S r)
+    __MATX_INLINE__ __MATX_HOST__ auto operator,(const T &l, const S &r)
     {
       return detail::CommaOp(l, r);
     }

--- a/include/matx/operators/comma.h
+++ b/include/matx/operators/comma.h
@@ -101,8 +101,8 @@ namespace matx
           }       
                  
         private:
-          typename base_type<Op1>::type op1_;
-          typename base_type<Op2>::type op2_;
+          typename detail::base_type_t<Op1> op1_;
+          typename detail::base_type_t<Op2> op2_;
       };  
   }
 

--- a/include/matx/operators/concat.h
+++ b/include/matx/operators/concat.h
@@ -75,7 +75,7 @@ namespace matx
         return get_str<-1>();
       }
 
-      __MATX_INLINE__ ConcatOp(int axis, Ts... ts) : ops_(ts...), axis_(axis)
+      __MATX_INLINE__ ConcatOp(int axis, const Ts&... ts) : ops_(ts...), axis_(axis)
       {
         static_assert(RANK > 0, "Cannot concatenate rank-0 tensors");
         static_assert(sizeof...(Ts) > 1, "Must have more than one tensor to concatenate");
@@ -243,7 +243,7 @@ namespace matx
    * @return concatenated operator 
    */
   template <typename... Ts>
-    __MATX_INLINE__ __MATX_HOST__  auto concat(int axis, Ts... ts)
+    __MATX_INLINE__ __MATX_HOST__  auto concat(int axis, const Ts&... ts)
     {
       auto first = detail::pp_get<0>(ts...);
 

--- a/include/matx/operators/concat.h
+++ b/include/matx/operators/concat.h
@@ -227,7 +227,7 @@ namespace matx
       }
 
       private:
-      cuda::std::tuple<typename base_type<Ts>::type ...> ops_;
+      cuda::std::tuple<typename detail::base_type_t<Ts> ...> ops_;
       index_t size_;    
       int axis_;
     }; // end class ConcatOp

--- a/include/matx/operators/conv.h
+++ b/include/matx/operators/conv.h
@@ -54,7 +54,7 @@ namespace matx
         PermDims perm_;
         cuda::std::array<index_t, max_rank> out_dims_;
         mutable detail::tensor_impl_t<out_t, max_rank> tmp_out_;
-        mutable out_t *ptr; 
+        mutable out_t *ptr = nullptr; 
 
         static constexpr int MAX_MIN_DIMENSION_DIRECT = 1024;
 
@@ -67,6 +67,12 @@ namespace matx
         __MATX_INLINE__ std::string str() const { 
           return "conv1d(" + get_type_str(a_) + "," + get_type_str(b_)  + ")";
         }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~Conv1DOp() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif        
+        }          
 
         __MATX_INLINE__ Conv1DOp(const OpA &A, const OpB &B, matxConvCorrMode_t mode, matxConvCorrMethod_t method, PermDims perm) : 
               a_(A), b_(B), mode_(mode), method_(method), perm_(perm) {
@@ -243,7 +249,7 @@ namespace detail {
       PermDims perm_;
       cuda::std::array<index_t, max_rank> out_dims_;
       mutable detail::tensor_impl_t<out_t, max_rank> tmp_out_;
-      mutable out_t *ptr; 
+      mutable out_t *ptr = nullptr; 
 
     public:
       using matxop = bool;

--- a/include/matx/operators/conv.h
+++ b/include/matx/operators/conv.h
@@ -47,8 +47,8 @@ namespace matx
         using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>, 
               typename OpA::value_type, typename OpB::value_type>;
         constexpr static int max_rank = cuda::std::max(OpA::Rank(), OpB::Rank());
-        OpA a_;
-        OpB b_;
+        typename detail::base_type_t<OpA> a_;
+        typename detail::base_type_t<OpB> b_;
         matxConvCorrMode_t mode_;
         matxConvCorrMethod_t method_;
         PermDims perm_;
@@ -67,12 +67,6 @@ namespace matx
         __MATX_INLINE__ std::string str() const { 
           return "conv1d(" + get_type_str(a_) + "," + get_type_str(b_)  + ")";
         }
-
-        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~Conv1DOp() {
-        #ifndef __CUDA_ARCH__
-          matxFree(ptr);
-        #endif        
-        }          
 
         __MATX_INLINE__ Conv1DOp(const OpA &A, const OpB &B, matxConvCorrMode_t mode, matxConvCorrMethod_t method, PermDims perm) : 
               a_(A), b_(B), mode_(mode), method_(method), perm_(perm) {
@@ -138,6 +132,8 @@ namespace matx
                           "Please switch to FFT convolution using MATX_C_METHOD_FFT");
         }
 
+        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
+
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
@@ -187,6 +183,20 @@ namespace matx
 
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PostRun(ShapeType &&shape, Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<OpA>()) {
+            a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }     
+
+          if constexpr (is_matx_op<OpB>()) {
+            b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          } 
+
+          matxFree(ptr);
+        }  
     };
   }
 
@@ -314,6 +324,8 @@ namespace detail {
         }
       }
 
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
+
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
       {
@@ -362,6 +374,20 @@ namespace detail {
 
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
+
+      template <typename ShapeType, typename Executor>
+      __MATX_INLINE__ void PostRun(ShapeType &&shape, Executor &&ex) const noexcept
+      {
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }     
+
+        if constexpr (is_matx_op<OpB>()) {
+          b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        } 
+
+        matxFree(ptr);
+      }       
     };
   }
 

--- a/include/matx/operators/corr.h
+++ b/include/matx/operators/corr.h
@@ -54,7 +54,7 @@ namespace matx
         PermDims perm_;
         cuda::std::array<index_t, max_rank> out_dims_;
         mutable detail::tensor_impl_t<out_t, max_rank> tmp_out_;
-        mutable out_t *ptr; 
+        mutable out_t *ptr = nullptr; 
 
       public:
         using matxop = bool;
@@ -65,6 +65,12 @@ namespace matx
         __MATX_INLINE__ std::string str() const { 
           return "conv1d(" + get_type_str(a_) + "," + get_type_str(b_)  + ")";
         }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~CorrOp() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif        
+        }          
 
         __MATX_INLINE__ CorrOp(const OpA &A, const OpB &B, matxConvCorrMode_t mode, [[maybe_unused]] matxConvCorrMethod_t method, PermDims perm) : 
               a_(A), b_(B), mode_(mode), method_(method), perm_(perm) {

--- a/include/matx/operators/cov.h
+++ b/include/matx/operators/cov.h
@@ -44,7 +44,7 @@ namespace matx
     class CovOp : public BaseOp<CovOp<OpA>>
     {
       private:
-        OpA a_;
+        typename detail::base_type_t<OpA> a_;
         cuda::std::array<index_t, 2> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
         mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
@@ -67,11 +67,7 @@ namespace matx
           }
         }
 
-        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~CovOp() {
-        #ifndef __CUDA_ARCH__
-          matxFree(ptr);
-        #endif        
-        }           
+        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -118,6 +114,8 @@ namespace matx
           if constexpr (is_matx_op<OpA>()) {
             a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
+
+          matxFree(ptr);
         }          
     };
   }

--- a/include/matx/operators/cov.h
+++ b/include/matx/operators/cov.h
@@ -47,7 +47,7 @@ namespace matx
         OpA a_;
         cuda::std::array<index_t, 2> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
       public:
         using matxop = bool;
@@ -66,6 +66,12 @@ namespace matx
             out_dims_[r] = a_.Size(r);
           }
         }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~CovOp() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif        
+        }           
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -133,7 +139,7 @@ namespace matx
  *   Covariance operator input view
  */
   template <typename AType>
-    __MATX_INLINE__ auto cov(AType a)
+    __MATX_INLINE__ auto cov(const AType &a)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
     

--- a/include/matx/operators/cumsum.h
+++ b/include/matx/operators/cumsum.h
@@ -49,7 +49,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr;  
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;  
 
     public:
       using matxop = bool;
@@ -58,11 +58,17 @@ namespace detail {
       using cumsum_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "cumsum()"; }
-      __MATX_INLINE__ CumSumOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ CumSumOp(const OpA &a) : a_(a) { 
         for (int r = 0; r < Rank(); r++) {
           out_dims_[r] = a_.Size(r);
         }
       };
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~CumSumOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif        
+      }         
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {

--- a/include/matx/operators/det.h
+++ b/include/matx/operators/det.h
@@ -45,7 +45,7 @@ namespace detail {
     private:
       OpA a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
     public:
       using matxop = bool;
@@ -54,7 +54,13 @@ namespace detail {
       using det_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "det()"; }
-      __MATX_INLINE__ DetOp(OpA a) : a_(a) { };
+      __MATX_INLINE__ DetOp(const OpA &a) : a_(a) { };
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~DetOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif        
+      }           
 
       // This should never be called
       template <typename... Is>

--- a/include/matx/operators/det.h
+++ b/include/matx/operators/det.h
@@ -43,7 +43,7 @@ namespace detail {
   class DetOp : public BaseOp<DetOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
@@ -54,13 +54,9 @@ namespace detail {
       using det_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "det()"; }
-      __MATX_INLINE__ DetOp(const OpA &a) : a_(a) { };
+      __MATX_INLINE__ DetOp(const OpA &a) : a_(a) { }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~DetOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }           
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       // This should never be called
       template <typename... Is>
@@ -100,6 +96,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }        
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/diag.h
+++ b/include/matx/operators/diag.h
@@ -60,7 +60,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "diag(" + op_.str() + ")"; }
  
-        __MATX_INLINE__ DiagOp(T1 op, index_t k) : op_(op), k_(k) { }
+        __MATX_INLINE__ DiagOp(const T1 &op, index_t k) : op_(op), k_(k) { }
 
         template <typename... Is>
           __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
@@ -162,7 +162,7 @@ IGNORE_WARNING_POP_GCC
    *   Diagonal to pull (0 is the main diagonal). Only used for 2D tensors and above
    */
 #ifdef DOXYGEN_ONLY
-  auto __MATX_INLINE__ diag(T1 t, index_t k = 0) { 
+  auto __MATX_INLINE__ diag(const T1 &t, index_t k = 0) { 
 #else
   template <typename T1, std::enable_if_t<is_matx_op<T1>(), bool> = true>
     auto __MATX_INLINE__ diag(T1 t, index_t k = 0) { 

--- a/include/matx/operators/diag.h
+++ b/include/matx/operators/diag.h
@@ -51,7 +51,7 @@ namespace matx
       class DiagOp : public BaseOp<DiagOp<T1, RANK>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
         index_t k_;
 
       public:

--- a/include/matx/operators/eig.h
+++ b/include/matx/operators/eig.h
@@ -60,7 +60,7 @@ namespace detail {
       using eig_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "eig()"; }
-      __MATX_INLINE__ EigOp(OpA a, EigenMode jobz, SolverFillMode uplo) : a_(a), jobz_(jobz), uplo_(uplo) { };
+      __MATX_INLINE__ EigOp(const OpA &a, EigenMode jobz, SolverFillMode uplo) : a_(a), jobz_(jobz), uplo_(uplo) { };
 
       // This should never be called
       template <typename... Is>

--- a/include/matx/operators/eig.h
+++ b/include/matx/operators/eig.h
@@ -49,7 +49,7 @@ namespace detail {
   class EigOp : public BaseOp<EigOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       EigenMode jobz_;
       SolverFillMode uplo_;
 
@@ -81,7 +81,9 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "eig() must only be called with a single assignment since it has multiple return types");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       // Size is not relevant in eig() since there are multiple return values and it

--- a/include/matx/operators/einsum.h
+++ b/include/matx/operators/einsum.h
@@ -58,7 +58,7 @@ namespace detail {
       using einsum_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "einsum()"; }
-      __MATX_INLINE__ EinsumOp(const std::string &subscripts, OpA... ops) : subscripts_(subscripts), a_(cuda::std::make_tuple(ops...)) { };
+      __MATX_INLINE__ EinsumOp(const std::string &subscripts, const OpA&... ops) : subscripts_(subscripts), a_(cuda::std::make_tuple(ops...)) { };
 
       // This should never be called
       template <typename... Is>
@@ -121,7 +121,7 @@ namespace cutensor {
    * @param ops List of input operators
    */
   template <typename... InT>
-  __MATX_INLINE__ auto einsum(const std::string &subscripts, InT... ops) {
+  __MATX_INLINE__ auto einsum(const std::string &subscripts, const InT&... ops) {
     return detail::EinsumOp(subscripts, ops...);
   }
 }

--- a/include/matx/operators/fft.h
+++ b/include/matx/operators/fft.h
@@ -58,7 +58,7 @@ namespace matx
                                           typename scalar_to_complex<typename OpA::value_type>::ctype>;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in fft
         mutable matx::tensor_t<ttype, OpA::Rank()> tmp_out_;
-        mutable ttype *ptr;                                           
+        mutable ttype *ptr = nullptr;                                           
 
       public:
         using matxop = bool;
@@ -77,7 +77,7 @@ namespace matx
           }
         }
 
-        __MATX_INLINE__ FFTOp(OpA a, uint64_t size, PermDims perm, FFTType t, FFTNorm norm) : 
+        __MATX_INLINE__ FFTOp(const OpA &a, uint64_t size, PermDims perm, FFTType t, FFTNorm norm) : 
             a_(a), fft_size_(size),  perm_(perm), type_(t), norm_(norm) {
           for (int r = 0; r < Rank(); r++) {
             out_dims_[r] = a_.Size(r);
@@ -127,6 +127,12 @@ namespace matx
             }
           }
         }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~FFTOp() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif        
+        }                    
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -211,7 +217,7 @@ namespace matx
    *   Normalization to apply to FFT
    */
   template<typename OpA>
-  __MATX_INLINE__ auto fft(OpA &&a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD) {
+  __MATX_INLINE__ auto fft(const OpA &a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD) {
     return detail::FFTOp(a, fft_size, detail::no_permute_t{}, detail::fft_t{}, norm);
   }
 
@@ -236,7 +242,7 @@ namespace matx
    *   Normalization to apply to FFT
    */
   template<typename OpA>
-  __MATX_INLINE__ auto fft(OpA &&a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD) {
+  __MATX_INLINE__ auto fft(const OpA &a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD) {
 
     auto perm = detail::getPermuteDims<remove_cvref_t<OpA>::Rank()>(axis);  
     return detail::FFTOp(a, fft_size, perm, detail::fft_t{}, norm);
@@ -262,7 +268,7 @@ namespace matx
    *   Normalization to apply to IFFT
    */
   template<typename OpA>
-  __MATX_INLINE__ auto ifft(OpA &&a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD) {
+  __MATX_INLINE__ auto ifft(const OpA &a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD) {
     return detail::FFTOp(a, fft_size, detail::no_permute_t{}, detail::ifft_t{}, norm);
   }
 
@@ -287,7 +293,7 @@ namespace matx
    *   Normalization to apply to IFFT
    */
   template<typename OpA>
-  __MATX_INLINE__ auto ifft(OpA &&a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD) {
+  __MATX_INLINE__ auto ifft(const OpA &a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD) {
     auto perm = detail::getPermuteDims<remove_cvref_t<OpA>::Rank()>(axis);  
     return detail::FFTOp(a, fft_size, perm, detail::ifft_t{}, norm);
   }  
@@ -308,7 +314,7 @@ namespace matx
                                           typename scalar_to_complex<typename OpA::value_type>::ctype>;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in fft
         mutable matx::tensor_t<ttype, OpA::Rank()> tmp_out_; 
-        mutable ttype *ptr;                                                
+        mutable ttype *ptr = nullptr;                                                
 
       public:
         using matxop = bool;
@@ -325,7 +331,7 @@ namespace matx
           }
         }
 
-        __MATX_INLINE__ FFT2Op(OpA a, PermDims perm, FFTType t, FFTNorm norm) : a_(a),  perm_(perm), type_(t), norm_(norm) {
+        __MATX_INLINE__ FFT2Op(const OpA &a, PermDims perm, FFTType t, FFTNorm norm) : a_(a),  perm_(perm), type_(t), norm_(norm) {
           for (int r = 0; r < Rank(); r++) {
             out_dims_[r] = a_.Size(r);
           }
@@ -341,6 +347,12 @@ namespace matx
             }
           }  
         }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~FFT2Op() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif        
+        }            
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -410,7 +422,7 @@ namespace matx
  *   Normalization to apply to FFT
  */
   template<typename OpA>
-  __MATX_INLINE__ auto fft2(OpA &&a, FFTNorm norm = FFTNorm::BACKWARD) {
+  __MATX_INLINE__ auto fft2(const OpA &a, FFTNorm norm = FFTNorm::BACKWARD) {
     return detail::FFT2Op(a, detail::no_permute_t{}, detail::fft_t{}, norm);
   }
 
@@ -431,7 +443,7 @@ namespace matx
  *   Normalization to apply to FFT
  */
   template<typename OpA>
-  __MATX_INLINE__ auto fft2(OpA &&a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD) {
+  __MATX_INLINE__ auto fft2(const OpA &a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD) {
 
     auto perm = detail::getPermuteDims<remove_cvref_t<OpA>::Rank()>(axis);  
     return detail::FFT2Op(a, perm, detail::fft_t{}, norm);
@@ -452,7 +464,7 @@ namespace matx
  *   Normalization to apply to IFFT
  */
   template<typename OpA>
-  __MATX_INLINE__ auto ifft2(OpA &&a, FFTNorm norm = FFTNorm::BACKWARD) {
+  __MATX_INLINE__ auto ifft2(const OpA &a, FFTNorm norm = FFTNorm::BACKWARD) {
     return detail::FFT2Op(a, detail::no_permute_t{}, detail::ifft_t{}, norm);
   }
 
@@ -473,7 +485,7 @@ namespace matx
  *   Normalization to apply to IFFT
  */
   template<typename OpA>
-  __MATX_INLINE__ auto ifft2(OpA &&a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD) {
+  __MATX_INLINE__ auto ifft2(const OpA &a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD) {
     auto perm = detail::getPermuteDims<remove_cvref_t<OpA>::Rank()>(axis);  
     return detail::FFT2Op(a, perm, detail::ifft_t{}, norm);
   }  

--- a/include/matx/operators/fftshift.h
+++ b/include/matx/operators/fftshift.h
@@ -51,7 +51,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "fftshift(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ FFTShift1DOp(T1 op) : op_(op){
+        __MATX_INLINE__ FFTShift1DOp(const T1 &op) : op_(op){
           static_assert(Rank() >= 1, "1D FFT shift must have a rank 1 operator or higher");
         };
 
@@ -116,7 +116,7 @@ namespace matx
    *
    */
   template <typename T1>
-    auto fftshift1D(T1 t) { return detail::FFTShift1DOp<T1>(t); }
+    auto fftshift1D(const T1 &t) { return detail::FFTShift1DOp<T1>(t); }
 
 
   namespace detail {
@@ -130,7 +130,7 @@ namespace matx
         using matxop = bool;
         using value_type = typename T1::value_type;
 
-        __MATX_INLINE__ FFTShift2DOp(T1 op) : op_(op){
+        __MATX_INLINE__ FFTShift2DOp(const T1 &op) : op_(op){
           static_assert(Rank() >= 2, "2D FFT shift must have a rank 2 operator or higher");
         };
 
@@ -201,7 +201,7 @@ namespace matx
         using matxop = bool;
         using value_type = typename T1::value_type;
 
-        __MATX_INLINE__ IFFTShift1DOp(T1 op) : op_(op) {
+        __MATX_INLINE__ IFFTShift1DOp(const T1 &op) : op_(op) {
           static_assert(Rank() >= 1, "1D IFFT shift must have a rank 1 operator or higher");
         };
 
@@ -271,7 +271,7 @@ namespace matx
         using matxop = bool;
         using value_type = typename T1::value_type;
 
-        __MATX_INLINE__ IFFTShift2DOp(T1 op) : op_(op) {
+        __MATX_INLINE__ IFFTShift2DOp(const T1 &op) : op_(op) {
           static_assert(Rank() >= 2, "2D IFFT shift must have a rank 2 operator or higher");
         };
 
@@ -329,5 +329,5 @@ namespace matx
    *
    */
   template <typename T1>
-    auto ifftshift2D(T1 t) { return detail::IFFTShift2DOp<T1>(t); }
+    auto ifftshift2D(const T1 &t) { return detail::IFFTShift2DOp<T1>(t); }
 } // end namespace matx

--- a/include/matx/operators/fftshift.h
+++ b/include/matx/operators/fftshift.h
@@ -43,7 +43,7 @@ namespace matx
       class FFTShift1DOp : public BaseOp<FFTShift1DOp<T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
 
       public:
         using matxop = bool;
@@ -124,7 +124,7 @@ namespace matx
       class FFTShift2DOp : public BaseOp<FFTShift2DOp<T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
 
       public:
         using matxop = bool;
@@ -195,7 +195,7 @@ namespace matx
       class IFFTShift1DOp : public BaseOp<IFFTShift1DOp<T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
 
       public:
         using matxop = bool;
@@ -265,7 +265,7 @@ namespace matx
       class IFFTShift2DOp : public BaseOp<IFFTShift2DOp<T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/filter.h
+++ b/include/matx/operators/filter.h
@@ -46,7 +46,7 @@ namespace detail {
   class FilterOp : public BaseOp<FilterOp<OpA, FilterType, NR, NNR>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       cuda::std::array<FilterType, NR> h_rec_;
       cuda::std::array<FilterType, NNR> h_nonrec_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
@@ -67,13 +67,9 @@ namespace detail {
         for (int r = 0; r < Rank(); r++) {
           out_dims_[r] = a_.Size(r);
         }              
-      };
+      }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~FilterOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }        
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       // This should never be called
       template <typename... Is>
@@ -117,6 +113,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }        
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/find.h
+++ b/include/matx/operators/find.h
@@ -46,7 +46,7 @@ namespace detail {
   class FindOp : public BaseOp<FindOp<OpA, SelectType>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       SelectType sel_;
 
     public:
@@ -77,7 +77,9 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "find() must only be called with a single assignment since it has multiple return types");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       // Size is not relevant in find() since there are multiple return values and it

--- a/include/matx/operators/find.h
+++ b/include/matx/operators/find.h
@@ -56,7 +56,7 @@ namespace detail {
       using find_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "find()"; }
-      __MATX_INLINE__ FindOp(OpA a, SelectType sel) : a_(a), sel_(sel) { };
+      __MATX_INLINE__ FindOp(const OpA &a, SelectType sel) : a_(a), sel_(sel) { };
 
       // This should never be called
       template <typename... Is>

--- a/include/matx/operators/find_idx.h
+++ b/include/matx/operators/find_idx.h
@@ -56,7 +56,7 @@ namespace detail {
       using find_idx_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "find_idx()"; }
-      __MATX_INLINE__ FindIdxOp(OpA a, SelectType sel) : a_(a), sel_(sel) { };
+      __MATX_INLINE__ FindIdxOp(const OpA &a, SelectType sel) : a_(a), sel_(sel) { };
 
       // This should never be called
       template <typename... Is>

--- a/include/matx/operators/find_idx.h
+++ b/include/matx/operators/find_idx.h
@@ -46,7 +46,7 @@ namespace detail {
   class FindIdxOp : public BaseOp<FindIdxOp<OpA, SelectType>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       SelectType sel_;
 
     public:
@@ -77,7 +77,9 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "find_idx() must only be called with a single assignment since it has multiple return types");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       // Size is not relevant in find_idx() since there are multiple return values and it

--- a/include/matx/operators/flatten.h
+++ b/include/matx/operators/flatten.h
@@ -44,7 +44,7 @@ namespace matx
       class FlattenOp : public BaseOp<FlattenOp<T1>>
     {
       private:
-        typename base_type<T1>::type op1_;
+        typename detail::base_type_t<T1> op1_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/frexp.h
+++ b/include/matx/operators/frexp.h
@@ -43,7 +43,7 @@ namespace detail {
   class FrexpOp : public BaseOp<FrexpOp<OpA, WHICH>>
   {
     private:
-      typename base_type<OpA>::type a_;
+      typename detail::base_type_t<OpA> a_;
 
     public:
       using matxop = bool;

--- a/include/matx/operators/frexp.h
+++ b/include/matx/operators/frexp.h
@@ -50,7 +50,7 @@ namespace detail {
       using value_type = typename OpA::value_type;
 
       __MATX_INLINE__ std::string str() const { return "frexp()"; }
-      __MATX_INLINE__ FrexpOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ FrexpOp(const OpA &a) : a_(a) { 
         static_assert(std::is_floating_point_v<value_type> ||
                       is_cuda_complex_v<value_type>, "frexp() must take a floating point input");
 

--- a/include/matx/operators/hermitian.h
+++ b/include/matx/operators/hermitian.h
@@ -56,7 +56,7 @@ namespace matx
         using value_type = typename T1::value_type;
 
 	__MATX_INLINE__ std::string str() const { return "hermitian(" + op_.str() + ")"; }
-        __MATX_INLINE__ HermitianTransOp(T1 op) : op_(op) {
+        __MATX_INLINE__ HermitianTransOp(const T1 &op) : op_(op) {
           static_assert(Rank() >= 2, "Hermitian operation needs input with rank >= 2");
         }
 
@@ -102,7 +102,7 @@ namespace matx
    * Helper function for creating a hermitian transpose from an operator/View
    */
   template <typename T1>
-    auto __MATX_INLINE__ hermitianT(T1 t)
+    auto __MATX_INLINE__ hermitianT(const T1 &t)
     {
       return detail::HermitianTransOp<T1, T1::Rank()>(t);
     }

--- a/include/matx/operators/hermitian.h
+++ b/include/matx/operators/hermitian.h
@@ -49,7 +49,7 @@ namespace matx
       class HermitianTransOp : public BaseOp<HermitianTransOp<T1, DIM>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/hist.h
+++ b/include/matx/operators/hist.h
@@ -46,9 +46,10 @@ namespace detail {
   class HistOp : public BaseOp<HistOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       typename OpA::value_type lower_;
       typename OpA::value_type upper_;
+      int num_levels_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<int, OpA::Rank()> tmp_out_;
       mutable int *ptr = nullptr;  
@@ -60,17 +61,16 @@ namespace detail {
       using hist_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "hist()"; }
-      __MATX_INLINE__ HistOp(const OpA &a, typename OpA::value_type lower, typename OpA::value_type upper) : a_(a), lower_(lower), upper_(upper) { 
+      __MATX_INLINE__ HistOp(const OpA &a, typename OpA::value_type lower, typename OpA::value_type upper, int num_levels) : 
+          a_(a), lower_(lower), upper_(upper), num_levels_(num_levels) { 
         for (int r = 0; r < Rank(); r++) {
           out_dims_[r] = a_.Size(r);
         }
+
+        out_dims_[out_dims_.size() - 1] = num_levels_ - 1;
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~HistOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }          
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -81,7 +81,7 @@ namespace detail {
       void Exec(Out &&out, Executor &&ex) const {
         static_assert(is_cuda_executor_v<Executor>, "hist() only supports the CUDA executor currently"); 
 
-        hist_impl(cuda::std::get<0>(out), a_, lower_, upper_, ex.getStream());
+        hist_impl(cuda::std::get<0>(out), a_, lower_, upper_, num_levels_, ex.getStream());
       }
 
       static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
@@ -113,6 +113,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }        
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
@@ -127,10 +129,10 @@ namespace detail {
  * Compute a histogram of rows in a tensor
  *
  * Computes a histogram with the given number of levels and upper/lower limits.
- * The number of levels is one greater than the number of bins generated, and is
- * determined by the size of the last dimension of the output tensor. Each bin
- * contains elements falling within idx*(upper-lower)/a.out.Lsize(). In other
- * words, each bin is as large as the difference between the upper and lower
+ * The number of levels is explicitly passed in, and the output must be large
+ * enough to hold all levels.
+ * Each bin contains elements falling within idx*(upper-lower)/a.out.Lsize(). In 
+ * other words, each bin is as large as the difference between the upper and lower
  * bounds and the number of bins
  *
  * @tparam InputOperator
@@ -141,12 +143,15 @@ namespace detail {
  *   Lower limit
  * @param upper
  *   Upper limit
+ * @param num_levels
+ *   Number of levels
  */
 template <typename InputOperator>
 __MATX_INLINE__ auto hist(const InputOperator &a,
           const typename InputOperator::value_type lower,
-          const typename InputOperator::value_type upper) {
-  return detail::HistOp(a, lower, upper);
+          const typename InputOperator::value_type upper,
+          int num_levels) {
+  return detail::HistOp(a, lower, upper, num_levels);
 }
 
 }

--- a/include/matx/operators/if.h
+++ b/include/matx/operators/if.h
@@ -67,7 +67,7 @@ namespace matx
        * @param cond Condition to perform the IF/ELSE on
        * @param op Operator if conditional branch is true
        */    
-      __MATX_INLINE__ IFOP(T1 cond, T2 op) : cond_(cond), op_(op)
+      __MATX_INLINE__ IFOP(const T1 &cond, const T2 &op) : cond_(cond), op_(op)
     {
       static_assert((!is_tensor_view_v<T2>),
           "Only operator emmitters are allowed in IF. Tensor views are "

--- a/include/matx/operators/if.h
+++ b/include/matx/operators/if.h
@@ -53,8 +53,8 @@ namespace matx
     class IFOP : public BaseOp<IFOP<T1, T2>>
   {
     private:
-      typename detail::base_type<T1>::type cond_;
-      typename detail::base_type<T2>::type op_;
+      typename detail::base_type_t<T1> cond_;
+      typename detail::base_type_t<T2> op_;
       cuda::std::array<index_t, detail::matx_max(detail::get_rank<T1>(), detail::get_rank<T2>())> size_;
 
     public:

--- a/include/matx/operators/ifelse.h
+++ b/include/matx/operators/ifelse.h
@@ -54,9 +54,9 @@ namespace matx
     class IFELSE : public BaseOp<IFELSE<C1, T1, T2>>
   {
     private:
-      typename detail::base_type<C1>::type cond_;
-      typename detail::base_type<T1>::type op1_;
-      typename detail::base_type<T2>::type op2_;    
+      typename detail::base_type_t<C1> cond_;
+      typename detail::base_type_t<T1> op1_;
+      typename detail::base_type_t<T2> op2_;    
       cuda::std::array<index_t, detail::matx_max(detail::get_rank<C1>(), detail::get_rank<T1>(), detail::get_rank<T2>())> size_;
 
     public:

--- a/include/matx/operators/ifelse.h
+++ b/include/matx/operators/ifelse.h
@@ -62,7 +62,9 @@ namespace matx
     public:
       using value_type = void; ///< Scalar type for type extraction
 
-      __MATX_INLINE__ std::string str() const { return  "if(" + detail::get_type_str(cond_) + ") then {" +  detail::get_type_str(op1_) + "} else {" + detail::get_type_str(op2_) + "}"; }
+      __MATX_INLINE__ std::string str() const { 
+        return  "if(" + detail::get_type_str(cond_) + ") then {" +  detail::get_type_str(op1_) + "} else {" + detail::get_type_str(op2_) + "}"; 
+      }
 
       /**
        * @brief Constructor for an IFELSE statement
@@ -71,7 +73,8 @@ namespace matx
        * @param op1 Operator if conditional branch is true
        * @param op2 Operator if conditional branch is false
        */
-      __MATX_INLINE__ IFELSE(C1 cond, T1 op1, T2 op2) : cond_(cond), op1_(op1), op2_(op2)
+      __MATX_INLINE__ IFELSE(const C1 &cond, const T1 &op1, const T2 &op2) : 
+                              cond_(cond), op1_(op1), op2_(op2)
     {
       static_assert((!is_tensor_view_v<T1> && !is_tensor_view_v<T2>),
           "Only operator emmitters are allowed in IFELSE. Tensor views "

--- a/include/matx/operators/interleaved.h
+++ b/include/matx/operators/interleaved.h
@@ -43,7 +43,7 @@ namespace matx
       class ComplexInterleavedOp : public BaseOp<ComplexInterleavedOp<T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/interleaved.h
+++ b/include/matx/operators/interleaved.h
@@ -54,7 +54,7 @@ namespace matx
               cuda::std::complex<value_type>>;
         __MATX_INLINE__ std::string str() const { return "interleaved(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ ComplexInterleavedOp(T1 op) : op_(op) {
+        __MATX_INLINE__ ComplexInterleavedOp(const T1 &op) : op_(op) {
           static_assert(!is_complex_v<extract_value_type_t<T1>>, "Complex interleaved op only works on scalar input types");
           static_assert(Rank() > 0);
         };
@@ -137,7 +137,7 @@ namespace matx
    *
    */
   template <typename T1>
-    auto interleaved(T1 t)
+    auto interleaved(const T1 &t)
     {
       static_assert(!is_complex_v<extract_value_type_t<T1>>, "Input to interleaved operator must be real-valued");
       return detail::ComplexInterleavedOp<T1>(t);

--- a/include/matx/operators/inverse.h
+++ b/include/matx/operators/inverse.h
@@ -45,7 +45,7 @@ namespace detail {
   class InvOp : public BaseOp<InvOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
@@ -58,11 +58,7 @@ namespace detail {
       __MATX_INLINE__ std::string str() const { return "inv()"; }
       __MATX_INLINE__ InvOp(const OpA &a) : a_(a) {};
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~InvOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
-      }      
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -96,7 +92,7 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
+        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), a_.Shape(), &ptr);
 
@@ -108,7 +104,9 @@ namespace detail {
       {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        }        
+        }  
+
+        matxFree(ptr);
       }
   };
 }

--- a/include/matx/operators/inverse.h
+++ b/include/matx/operators/inverse.h
@@ -47,7 +47,7 @@ namespace detail {
     private:
       OpA a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
     public:
       using matxop = bool;
@@ -56,7 +56,13 @@ namespace detail {
       using inv_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "inv()"; }
-      __MATX_INLINE__ InvOp(OpA a) : a_(a) {};
+      __MATX_INLINE__ InvOp(const OpA &a) : a_(a) {};
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~InvOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif        
+      }      
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const

--- a/include/matx/operators/isclose.h
+++ b/include/matx/operators/isclose.h
@@ -52,7 +52,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "isclose()"; }
 
-        __MATX_INLINE__ IsCloseOp(Op1 op1, Op2 op2, double rtol, double atol) : 
+        __MATX_INLINE__ IsCloseOp(const Op1 &op1, const Op2 &op2, double rtol, double atol) : 
           op1_(op1), op2_(op2), rtol_(static_cast<inner_type>(rtol)), atol_(static_cast<inner_type>(atol)) 
         {
           static_assert(op1.Rank() == op2.Rank(), "Operator ranks must match in isclose()");
@@ -128,7 +128,7 @@ namespace matx
    * @return IsClose operator
    */
   template <typename Op1, typename Op2>
-  __MATX_INLINE__ auto isclose(Op1 op1, Op2 op2, double rtol = 1e-5, double atol = 1e-8) {
+  __MATX_INLINE__ auto isclose(const Op1 &op1, const Op2 &op2, double rtol = 1e-5, double atol = 1e-8) {
     return detail::IsCloseOp<Op1, Op2>(op1, op2, rtol, atol);
   }
 } // end namespace matx

--- a/include/matx/operators/isclose.h
+++ b/include/matx/operators/isclose.h
@@ -61,12 +61,12 @@ namespace matx
         }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ int operator()([[maybe_unused]] Is... indices) const 
-          {
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ int operator()([[maybe_unused]] Is... indices) const 
+        {
 
-            return static_cast<int>(detail::_internal_abs(op1_(indices...) - op2_(indices...)) <= 
-               static_cast<inner_type>(atol_) + static_cast<inner_type>(rtol_) * detail::_internal_abs(op2_(indices...)));
-          }
+          return static_cast<int>(detail::_internal_abs(op1_(indices...) - op2_(indices...)) <= 
+              static_cast<inner_type>(atol_) + static_cast<inner_type>(rtol_) * detail::_internal_abs(op2_(indices...)));
+        }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {
@@ -105,8 +105,8 @@ namespace matx
         }          
 
       private:
-        Op1 op1_;
-        Op2 op2_;
+        typename detail::base_type_t<Op1> op1_;
+        typename detail::base_type_t<Op2> op2_;
         inner_type rtol_;
         inner_type atol_;
 

--- a/include/matx/operators/kronecker.h
+++ b/include/matx/operators/kronecker.h
@@ -59,7 +59,7 @@ namespace matx
 
       __MATX_INLINE__ std::string str() const { return "kron(" + op1_.str() + "," + op2_.str() + ")"; }
 
-        __MATX_INLINE__ KronOp(T1 op1, T2 op2) : op1_(op1), op2_(op2)
+        __MATX_INLINE__ KronOp(const T1 &op1, const T2 &op2) : op1_(op1), op2_(op2)
       {
         static_assert(RankGTE(Rank(), 2), "Kronecker product must be used on tensors with rank 2 or higher");
       }
@@ -147,7 +147,7 @@ namespace matx
    *   New operator of the kronecker product
    */
   template <typename T1, typename T2>
-    auto __MATX_INLINE__ kron(T1 a, T2 b)
+    auto __MATX_INLINE__ kron(const T1 &a, const T2 &b)
     {
       return detail::KronOp<T1, T2, T1::Rank()>(a, b);
     };

--- a/include/matx/operators/kronecker.h
+++ b/include/matx/operators/kronecker.h
@@ -50,8 +50,8 @@ namespace matx
       class KronOp : public BaseOp<KronOp<T1, T2, DIM>>
     {
       private:
-        typename base_type<T1>::type op1_;
-        typename base_type<T2>::type op2_;
+        typename detail::base_type_t<T1> op1_;
+        typename detail::base_type_t<T2> op2_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/legendre.h
+++ b/include/matx/operators/legendre.h
@@ -94,7 +94,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "legendre(" + get_type_str(n_) + "," + get_type_str(m_) + "," + get_type_str(in_) + ")"; }
 
-        __MATX_INLINE__ LegendreOp(T1 n, T2 m, const T3 in, cuda::std::array<int,2> axis) : n_(n), m_(m), in_(in), axis_(axis) {
+        __MATX_INLINE__ LegendreOp(const T1 &n, const T2 &m, const T3 &in, cuda::std::array<int,2> axis) : n_(n), m_(m), in_(in), axis_(axis) {
           static_assert(get_rank<T1>() <= 1, "legendre op:  n must be a scalar, rank 0 or 1 operator");
           static_assert(get_rank<T2>() <= 1, "legendre op:  m must be a scalar, rank 0 or 1 operator");
         }
@@ -221,7 +221,7 @@ namespace matx
    *   New operator with Rank+1 and size of last dimension = order.
    */
   template <typename T1, typename T2, typename T3>
-    auto __MATX_INLINE__ legendre(T1 n, T2 m, const T3 in)
+    auto __MATX_INLINE__ legendre(const T1 &n, const T2 &m, const T3 &in)
     {
       int axis[2] = {0,1};
       return detail::LegendreOp<T1,T2,T3>(n, m, in, detail::to_array(axis));
@@ -248,14 +248,15 @@ namespace matx
    *   New operator with Rank+1 and size of last dimension = order.
    */
   template <typename T1, typename T2, typename T3>
-    auto __MATX_INLINE__ legendre(T1 n, T2 m, const T3 in, cuda::std::array<int, 2> axis)
-    {
-      return detail::LegendreOp<T1,T2,T3>(n, m, in, axis);
-    };
+  auto __MATX_INLINE__ legendre(const T1 &n, const T2 &m, const T3 &in, cuda::std::array<int, 2> axis)
+  {
+    return detail::LegendreOp<T1,T2,T3>(n, m, in, axis);
+  };
+
   template <typename T1, typename T2, typename T3>
-    auto __MATX_INLINE__ legendre(T1 n, T2 m, const T3 in, int (&axis)[2])
-    {
-      return detail::LegendreOp<T1,T2,T3>(n, m, in, detail::to_array(axis));
-    };
+  auto __MATX_INLINE__ legendre(const T1 &n, const T2 &m, const T3 &in, int (&axis)[2])
+  {
+    return detail::LegendreOp<T1,T2,T3>(n, m, in, detail::to_array(axis));
+  };
 
 } // end namespace matx

--- a/include/matx/operators/legendre.h
+++ b/include/matx/operators/legendre.h
@@ -49,9 +49,9 @@ namespace matx
       class LegendreOp : public BaseOp<LegendreOp<T1,T2,T3>>
     {
       private:
-        T1 n_;
-        T2 m_;
-        T3 in_;
+        typename detail::base_type_t<T1> n_;
+        typename detail::base_type_t<T2> m_;
+        typename detail::base_type_t<T3> in_;
 
         cuda::std::array<int,2> axis_;
 

--- a/include/matx/operators/lu.h
+++ b/include/matx/operators/lu.h
@@ -49,7 +49,7 @@ namespace detail {
     private:
       OpA a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
     public:
       using matxop = bool;
@@ -58,7 +58,13 @@ namespace detail {
       using lu_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "lu()"; }
-      __MATX_INLINE__ LUOp(OpA a) : a_(a) { };
+      __MATX_INLINE__ LUOp(const OpA &a) : a_(a) { };
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~LUOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif        
+      }        
 
       // This should never be called
       template <typename... Is>

--- a/include/matx/operators/matmul.h
+++ b/include/matx/operators/matmul.h
@@ -56,7 +56,7 @@ namespace matx
         cuda::std::array<index_t, out_rank> out_dims_;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in matmul
         mutable matx::tensor_t<typename remove_cvref_t<OpA>::value_type, out_rank> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
       public:
         using matxop = bool;
@@ -68,7 +68,7 @@ namespace matx
             return "matmul(" + get_type_str(a_) + "," + get_type_str(b_) + ")";
         }
 
-        __MATX_INLINE__ MatMulOp(OpA a, OpB b, float alpha, float beta, PermDims perm) : 
+        __MATX_INLINE__ MatMulOp(const OpA &a, const OpB &b, float alpha, float beta, PermDims perm) : 
               a_(a), b_(b), alpha_(alpha), beta_(beta), perm_(perm) {
           if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
             for (int r = 0; r < Rank(); r++) {
@@ -92,6 +92,12 @@ namespace matx
             out_dims_[Rank() - 1] = b_.Size(OpB::Rank() - 1);
           }
         }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MatMulOp() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif        
+        }           
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -183,7 +189,7 @@ namespace matx
    *   Operator that produces the output tensor C of shape `... x m x n`
    */
   template<typename OpA, typename OpB>
-  __MATX_INLINE__ auto matmul(const OpA A, const OpB B, float alpha = 1.0, float beta = 0.0) {
+  __MATX_INLINE__ auto matmul(const OpA &A, const OpB &B, float alpha = 1.0, float beta = 0.0) {
     return detail::MatMulOp(A, B, alpha, beta, detail::no_permute_t{});
   }
 
@@ -216,7 +222,7 @@ namespace matx
    *   Operator that produces the output tensor C of shape `... x m x n`
    */
   template<typename OpA, typename OpB>
-  __MATX_INLINE__ auto matmul(const OpA A, const OpB B, const int32_t (&axis)[2], float alpha = 1.0, float beta = 0.0) {
+  __MATX_INLINE__ auto matmul(const OpA &A, const OpB &B, const int32_t (&axis)[2], float alpha = 1.0, float beta = 0.0) {
     MATX_STATIC_ASSERT(OpA::Rank() == OpB::Rank(), "matmul: inputs must have same rank to use matmul with axis parameter");
     MATX_STATIC_ASSERT(OpA::Rank() == OpB::Rank(), "matmul: inputs and outputs must have same rank to use matmul with axis parameter");
 

--- a/include/matx/operators/matvec.h
+++ b/include/matx/operators/matvec.h
@@ -44,8 +44,8 @@ namespace matx
     class MatVecOp : public BaseOp<MatVecOp<OpA, OpB>>
     {
       private:
-        OpA a_;
-        OpB b_;
+        typename detail::base_type_t<OpA> a_;
+        typename detail::base_type_t<OpB> b_;
         float alpha_;
         float beta_;
         static constexpr int RANK = remove_cvref_t<OpB>::Rank();
@@ -71,11 +71,7 @@ namespace matx
           }
         }
 
-        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MatVecOp() {
-        #ifndef __CUDA_ARCH__
-          matxFree(ptr);
-        #endif        
-        }             
+        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -130,6 +126,8 @@ namespace matx
           if constexpr (is_matx_op<OpB>()) {
             b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           } 
+
+          matxFree(ptr);
         }           
     };
   }
@@ -166,7 +164,6 @@ namespace matx
               float alpha = 1.0, float beta = 0.0)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-    
     return detail::MatVecOp(A, B, alpha, beta);
   }
 

--- a/include/matx/operators/matvec.h
+++ b/include/matx/operators/matvec.h
@@ -51,7 +51,7 @@ namespace matx
         static constexpr int RANK = remove_cvref_t<OpB>::Rank();
         cuda::std::array<index_t, RANK> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, RANK> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
       public:
         using matxop = bool;
@@ -70,6 +70,12 @@ namespace matx
             out_dims_[r] = a_.Size(r);
           }
         }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MatVecOp() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif        
+        }             
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -140,23 +146,23 @@ namespace matx
    * decide if a plan is cached, it may be able to reused plans for different
    * A/B/C matrices as long as they were configured with the same dimensions.
    *
-   * @tparam TensorTypeA
-   *    Data type of A tensor or operator
-   * @tparam TensorTypeB
-   *    Data type of B tensor or operator
+   * @tparam OpA
+   *    Data type of A operator
+   * @tparam OpB
+   *    Data type of B operator
    *
    * @param A
-   *   A input tensor or operator
+   *   A input operator
    * @param B
-   *   B input tensor or operator
+   *   B input operator
    * @param alpha
    *   Scalar multiplier to apply to operator A
    * @param beta
    *   Scalar multiplier to apply to operator C on input
    *
    */
-  template <typename TensorTypeA, typename TensorTypeB>
-  __MATX_INLINE__ auto matvec(const TensorTypeA A, const TensorTypeB B,
+  template <typename OpA, typename OpB>
+  __MATX_INLINE__ auto matvec(const OpA &A, const OpB &B,
               float alpha = 1.0, float beta = 0.0)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)

--- a/include/matx/operators/max.h
+++ b/include/matx/operators/max.h
@@ -47,7 +47,7 @@ namespace detail {
   class MaxOp : public BaseOp<MaxOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;    
@@ -65,16 +65,12 @@ namespace detail {
         }        
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MaxOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
-      };
+      }
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }       
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/mean.h
+++ b/include/matx/operators/mean.h
@@ -47,7 +47,7 @@ namespace detail {
   class MeanOp : public BaseOp<MeanOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;     
@@ -65,11 +65,7 @@ namespace detail {
         }            
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MeanOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }      
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }             
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/mean.h
+++ b/include/matx/operators/mean.h
@@ -50,7 +50,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr;     
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;     
 
     public:
       using matxop = bool;
@@ -59,16 +59,22 @@ namespace detail {
       using mean_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "mean(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ MeanOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ MeanOp(const OpA &a) : a_(a) { 
         for (int r = 0; r < ORank; r++) {
           out_dims_[r] = a_.Size(r);
         }            
-      };
+      }
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MeanOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif
+      }      
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
-      };
+      }
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/median.h
+++ b/include/matx/operators/median.h
@@ -50,7 +50,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
     public:
       using matxop = bool;
@@ -59,16 +59,22 @@ namespace detail {
       using median_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "median(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ MedianOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ MedianOp(const OpA &a) : a_(a) { 
         for (int r = 0; r < ORank; r++) {
           out_dims_[r] = a_.Size(r);
         }            
-      };
+      }
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MedianOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif
+      }       
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
-      };
+      }
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/median.h
+++ b/include/matx/operators/median.h
@@ -47,7 +47,7 @@ namespace detail {
   class MedianOp : public BaseOp<MedianOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
@@ -65,11 +65,7 @@ namespace detail {
         }            
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MedianOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }       
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }             
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/min.h
+++ b/include/matx/operators/min.h
@@ -47,7 +47,7 @@ namespace detail {
   class MinOp : public BaseOp<MinOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;     
@@ -65,11 +65,7 @@ namespace detail {
         }        
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MinOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }      
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       } 
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/min.h
+++ b/include/matx/operators/min.h
@@ -50,7 +50,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr;     
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;     
 
     public:
       using matxop = bool;
@@ -59,16 +59,22 @@ namespace detail {
       using min_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "min(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ MinOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ MinOp(const OpA &a) : a_(a) { 
         for (int r = 0; r < ORank; r++) {
           out_dims_[r] = a_.Size(r);
         }        
-      };
+      }
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~MinOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif
+      }      
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
-      };
+      }
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/norm.h
+++ b/include/matx/operators/norm.h
@@ -50,7 +50,7 @@ namespace matx
         static constexpr int ORank = std::is_same_v<NormType, detail::NormTypeVector> ? OpA::Rank() - 1 : OpA::Rank() - 2;
         cuda::std::array<index_t, ORank> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
       public:
         using matxop = bool;
@@ -78,6 +78,11 @@ namespace matx
         }
       }
 
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~NormOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif
+      }        
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {

--- a/include/matx/operators/overlap.h
+++ b/include/matx/operators/overlap.h
@@ -51,7 +51,7 @@ namespace matx
         using self_type = OverlapOp<DIM, T>;
 
       private:
-        typename base_type<T>::type op_;
+        typename detail::base_type_t<T> op_;
         cuda::std::array<int32_t, DIM> dims_;
         cuda::std::array<shape_type, DIM+1> n_;
         cuda::std::array<shape_type, DIM+1> s_;

--- a/include/matx/operators/overlap.h
+++ b/include/matx/operators/overlap.h
@@ -63,7 +63,7 @@ namespace matx
         static_assert(DIM == 1, "overlap() only supports input rank 1 currently");
 
         __MATX_INLINE__ std::string str() const { return "overlap(" + op_.str() + ")"; }
-        __MATX_INLINE__ OverlapOp(T op, const cuda::std::array<shape_type, DIM> &windows,
+        __MATX_INLINE__ OverlapOp(const T &op, const cuda::std::array<shape_type, DIM> &windows,
                                       const cuda::std::array<shape_type, DIM> &strides) : op_(op) {
 
           // This only works for 1D tensors going to 2D at the moment. Generalize to

--- a/include/matx/operators/percentile.h
+++ b/include/matx/operators/percentile.h
@@ -45,7 +45,7 @@ namespace detail {
   class PercentileOp : public BaseOp<PercentileOp<OpA,ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       uint32_t q_;
       PercentileMethod method_;
       cuda::std::array<index_t, ORank> out_dims_; 
@@ -65,11 +65,7 @@ namespace detail {
         }
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~PercentileOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }         
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }             
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -66,7 +66,7 @@ namespace matx
 
         static_assert(Rank() > 0, "PermuteOp: Rank of operator must be greater than 0.");
 
-	      __MATX_INLINE__ PermuteOp(T op, const cuda::std::array<int32_t, T::Rank()> &dims) : op_(op) {
+	      __MATX_INLINE__ PermuteOp(const T &op, const cuda::std::array<int32_t, T::Rank()> &dims) : op_(op) {
 
           for(int32_t i = 0; i < Rank(); i++) {
             [[maybe_unused]] int32_t dim = dims[i];

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -50,7 +50,7 @@ namespace matx
         using self_type = PermuteOp<T>;
 
       private:
-        typename base_type<T>::type op_;
+        typename detail::base_type_t<T> op_;
         cuda::std::array<int32_t, T::Rank()> dims_;
 
       public:

--- a/include/matx/operators/pinv.h
+++ b/include/matx/operators/pinv.h
@@ -47,7 +47,7 @@ namespace detail {
       float rcond_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
     public:
       using matxop = bool;
@@ -56,7 +56,7 @@ namespace detail {
       using pinv_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "pinv()"; }
-      __MATX_INLINE__ PinvOp(OpA a, float rcond) : a_(a), rcond_(rcond) {
+      __MATX_INLINE__ PinvOp(const OpA &a, float rcond) : a_(a), rcond_(rcond) {
         for (int r = 0; r < Rank(); r++) {
           if (r >= Rank() - 2) {
             out_dims_[r] = (r == Rank() - 1) ? a_.Size(Rank() - 2) : a_.Size(Rank() - 1);
@@ -65,7 +65,13 @@ namespace detail {
             out_dims_[r] = a_.Size(r);
           }
         } 
-      };
+      }
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~PinvOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif
+      }        
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const

--- a/include/matx/operators/pinv.h
+++ b/include/matx/operators/pinv.h
@@ -43,7 +43,7 @@ namespace detail {
   class PinvOp : public BaseOp<PinvOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       float rcond_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
@@ -67,11 +67,7 @@ namespace detail {
         } 
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~PinvOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }        
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -86,7 +82,7 @@ namespace detail {
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
       {
-        return out_dims_.Size(dim);
+        return out_dims_[dim];
       }
 
       template <typename Out, typename Executor>
@@ -118,6 +114,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }
 
   };

--- a/include/matx/operators/planar.h
+++ b/include/matx/operators/planar.h
@@ -51,7 +51,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "planar(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ ComplexPlanarOp(T1 op) : op_(op) {
+        __MATX_INLINE__ ComplexPlanarOp(const T1 &op) : op_(op) {
           static_assert(is_complex_v<extract_value_type_t<T1>>, "Complex planar op only works on complex types");
           static_assert(Rank() > 0);
         };
@@ -133,7 +133,7 @@ namespace matx
    *
    */
   template <typename T1>
-    auto planar(T1 t)
+    auto planar(const T1 &t)
     {
       static_assert(is_complex_v<extract_value_type_t<T1>>, "Input to interleaved operator must be complex-valued");
       return detail::ComplexPlanarOp<T1>(t);

--- a/include/matx/operators/planar.h
+++ b/include/matx/operators/planar.h
@@ -43,7 +43,7 @@ namespace matx
       class ComplexPlanarOp : public BaseOp<ComplexPlanarOp<T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/polyval.h
+++ b/include/matx/operators/polyval.h
@@ -47,7 +47,7 @@ namespace matx
     class PolyvalOp : public BaseOp<PolyvalOp<Op, Coeffs>>
     {
       private:
-        Op op_;
+        typename detail::base_type_t<Op> op_;
         Coeffs coeffs_;
 
       public:

--- a/include/matx/operators/prod.h
+++ b/include/matx/operators/prod.h
@@ -50,7 +50,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
     public:
       using matxop = bool;
@@ -59,16 +59,22 @@ namespace detail {
       using prod_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "prod(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ ProdOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ ProdOp(const OpA &a) : a_(a) { 
         for (int r = 0; r < ORank; r++) {
           out_dims_[r] = a_.Size(r);
         }                    
-      };
+      }
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~ProdOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif
+      }         
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
-      };
+      }
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/prod.h
+++ b/include/matx/operators/prod.h
@@ -47,7 +47,7 @@ namespace detail {
   class ProdOp : public BaseOp<ProdOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
@@ -65,11 +65,7 @@ namespace detail {
         }                    
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~ProdOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }         
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }             
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/pwelch.h
+++ b/include/matx/operators/pwelch.h
@@ -44,8 +44,8 @@ namespace matx
     class PWelchOp : public BaseOp<PWelchOp<OpX,OpW>>
     {
       private:
-        OpX x_;
-        OpW w_;
+        typename detail::base_type_t<OpX> x_;
+        typename detail::base_type_t<OpW> w_;
 
         index_t nperseg_;
         index_t noverlap_;
@@ -60,6 +60,8 @@ namespace matx
         using matx_transform_op = bool;
         using pwelch_xform_op = bool;
 
+        static_assert(is_complex_v<typename OpX::value_type>, "pwelch() must have a complex input type");
+
         __MATX_INLINE__ std::string str() const {
           return "pwelch(" + get_type_str(x_) + "," + get_type_str(w_) + ")";
         }
@@ -69,15 +71,11 @@ namespace matx
 
           MATX_STATIC_ASSERT_STR(OpX::Rank() == 1, matxInvalidDim, "pwelch:  Only input rank of 1 is supported presently");
           for (int r = 0; r < OpX::Rank(); r++) {
-            out_dims_[r] = x_.Size(r);
+            out_dims_[r] = nfft_;
           }
         }
 
-        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~PWelchOp() {
-        #ifndef __CUDA_ARCH__
-          matxFree(ptr);
-        #endif
-        }         
+        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -124,7 +122,7 @@ namespace matx
         }
 
         template <typename ShapeType, typename Executor>
-        __MATX_INLINE__ void PostRun(ShapeType &&shape, Executor &&ex) const noexcept
+        __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
           if constexpr (is_matx_op<OpX>()) {
             x_.PostRun(Shape(x_), std::forward<Executor>(ex));
@@ -133,6 +131,8 @@ namespace matx
           if constexpr (is_matx_op<OpW>()) {
             w_.PostRun(Shape(w_), std::forward<Executor>(ex));
           }
+
+          matxFree(ptr);
         }               
     };
   }

--- a/include/matx/operators/pwelch.h
+++ b/include/matx/operators/pwelch.h
@@ -52,7 +52,7 @@ namespace matx
         index_t nfft_;
         cuda::std::array<index_t, 1> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpX>::value_type, 1> tmp_out_;
-        mutable typename remove_cvref_t<OpX>::value_type *ptr; 
+        mutable typename remove_cvref_t<OpX>::value_type *ptr = nullptr; 
 
       public:
         using matxop = bool;
@@ -72,6 +72,12 @@ namespace matx
             out_dims_[r] = x_.Size(r);
           }
         }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~PWelchOp() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif
+        }         
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const

--- a/include/matx/operators/qr.h
+++ b/include/matx/operators/qr.h
@@ -56,7 +56,7 @@ namespace detail {
       using qr_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "qr(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ QROp(OpA a) : a_(a) { };
+      __MATX_INLINE__ QROp(const OpA &a) : a_(a) { };
 
       // This should never be called
       template <typename... Is>
@@ -105,7 +105,7 @@ namespace detail {
  * @returns Operator to generate Q/R outputs
  */
 template<typename AType>
-__MATX_INLINE__ auto qr(AType A) {
+__MATX_INLINE__ auto qr(const AType &A) {
   return detail::QROp(A);
 }
 
@@ -125,7 +125,7 @@ namespace detail {
       using qr_solver_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "qr_solver()"; }
-      __MATX_INLINE__ SolverQROp(OpA a) : a_(a) { };
+      __MATX_INLINE__ SolverQROp(const OpA &a) : a_(a) { }    
 
       // This should never be called
       template <typename... Is>

--- a/include/matx/operators/qr.h
+++ b/include/matx/operators/qr.h
@@ -47,7 +47,7 @@ namespace detail {
   class QROp : public BaseOp<QROp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
 
     public:
       using matxop = bool;
@@ -78,7 +78,9 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "qr() must only be called with a single assignment");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       // Size is not relevant in qr() since there are multiple return values and it
@@ -115,8 +117,7 @@ namespace detail {
   class SolverQROp : public BaseOp<SolverQROp<OpA>>
   {
     private:
-      OpA a_;
-      matx::tensor_t<typename OpA::value_type, OpA::Rank()> tmp_out_;
+      typename detail::base_type_t<OpA> a_;
 
     public:
       using matxop = bool;
@@ -146,7 +147,9 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "qr_solver() must only be called with a single assignment since it has multiple return types");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       // Size is not relevant in qr_solver() since there are multiple return values and it

--- a/include/matx/operators/r2c.h
+++ b/include/matx/operators/r2c.h
@@ -43,7 +43,7 @@ namespace matx
       class R2COp : public BaseOp<R2COp<T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
         index_t orig_size_;
 
       public:

--- a/include/matx/operators/r2c.h
+++ b/include/matx/operators/r2c.h
@@ -52,7 +52,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "r2c(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ R2COp(T1 op, index_t orig) : op_(op), orig_size_(orig) {
+        __MATX_INLINE__ R2COp(const T1 &op, index_t orig) : op_(op), orig_size_(orig) {
           static_assert(Rank() >= 1, "R2COp must have a rank 1 operator or higher");
         };
 
@@ -134,6 +134,6 @@ namespace matx
    *
    */
   template <typename T1>
-    auto r2c(T1 t, index_t orig) { return detail::R2COp<T1>(t, orig); }
+    auto r2c(const T1 &t, index_t orig) { return detail::R2COp<T1>(t, orig); }
 
 } // end namespace matx

--- a/include/matx/operators/reduce.h
+++ b/include/matx/operators/reduce.h
@@ -51,7 +51,7 @@ namespace matx
         bool init_;
         cuda::std::array<index_t, ORank> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
       public:
         using matxop = bool;
@@ -68,6 +68,12 @@ namespace matx
           for (int r = 0; r < ORank; r++) {
             out_dims_[r] = a_.Size(r);
           }
+        }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~ReduceOp() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif
         }
 
         template <typename... Is>

--- a/include/matx/operators/reduce.h
+++ b/include/matx/operators/reduce.h
@@ -45,7 +45,7 @@ namespace matx
     {
       private:
         static constexpr int ORank = permute_rank<OpA, PermDims, ReductionOp>::rank;
-        OpA a_;
+        typename detail::base_type_t<OpA> a_;
         PermDims perm_;
         ReductionOp reduction_op_;
         bool init_;
@@ -70,11 +70,7 @@ namespace matx
           }
         }
 
-        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~ReduceOp() {
-        #ifndef __CUDA_ARCH__
-          matxFree(ptr);
-        #endif
-        }
+        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -127,6 +123,8 @@ namespace matx
           if constexpr (is_matx_op<OpA>()) {
             a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
+
+          matxFree(ptr);
         }               
     };
   }

--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -64,7 +64,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "remap(" + op_.str() + ")"; }
 
-	__MATX_INLINE__ RemapOp(T op, IdxType idx) : op_(op), idx_(idx) {};
+	__MATX_INLINE__ RemapOp(const T &op, IdxType idx) : op_(op), idx_(idx) {};
 
         template <typename... Is>
           __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
@@ -176,7 +176,7 @@ namespace matx
    * @return Value in t from each location in idx
    */
   template <int DIM, typename Op, typename Ind>
-    auto __MATX_INLINE__ remap(Op t, Ind idx)
+    auto __MATX_INLINE__ remap(const Op &t, Ind idx)
     {
       return detail::RemapOp<DIM, Op, Ind>(t, idx);
     };   
@@ -206,7 +206,7 @@ namespace matx
    * @return Value in t from each location in idx
    */
   template <int DIM, int... DIMS, typename Op, typename Ind, typename... Inds>
-    auto __MATX_INLINE__ remap(Op t, Ind idx, Inds... inds)
+    auto __MATX_INLINE__ remap(const Op &t, Ind idx, Inds... inds)
     {
       static_assert(sizeof...(DIMS) == sizeof...(Inds), "remap number of DIMs must match number of index arrays");
 

--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -46,9 +46,9 @@ namespace matx
       class RemapOp : public BaseOp<RemapOp<DIM, T, IdxType>>
     {
       private:
-        //mutable typename base_type<T>::type op_;
-        typename base_type<T>::type op_;
-        typename base_type<IdxType>::type idx_;
+        //mutable typename detail::base_type_t<T> op_;
+        typename detail::base_type_t<T> op_;
+        typename detail::base_type_t<IdxType> idx_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/repmat.h
+++ b/include/matx/operators/repmat.h
@@ -52,7 +52,7 @@ namespace matx
       class RepMatOp : public BaseOp<RepMatOp<T1, DIM>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
         index_t reps_[T1::Rank()];
 
       public:

--- a/include/matx/operators/repmat.h
+++ b/include/matx/operators/repmat.h
@@ -61,7 +61,7 @@ namespace matx
 
 	    __MATX_INLINE__ std::string str() const { return "repmat(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ RepMatOp(T1 op, index_t reps) : op_(op)
+        __MATX_INLINE__ RepMatOp(const T1 &op, index_t reps) : op_(op)
       {
         for (int dim = 0; dim < DIM; dim++)
         {
@@ -69,7 +69,7 @@ namespace matx
         }
       }
 
-      __MATX_INLINE__ RepMatOp(T1 op, const cuda::std::array<index_t, DIM> reps) : op_(op)
+      __MATX_INLINE__ RepMatOp(const T1 &op, const cuda::std::array<index_t, DIM> reps) : op_(op)
       {
         for (int dim = 0; dim < DIM; dim++)
         {
@@ -77,7 +77,7 @@ namespace matx
         }
       }
 
-      __MATX_INLINE__ RepMatOp(T1 op, const index_t *reps) : op_(op)
+      __MATX_INLINE__ RepMatOp(const T1 &op, const index_t *reps) : op_(op)
       {
         for (int dim = 0; dim < DIM; dim++)
         {
@@ -162,7 +162,7 @@ namespace matx
    *   New operator with repeated data
    */
   template <typename T1>
-    auto __MATX_INLINE__ repmat(T1 t, index_t reps)
+    auto __MATX_INLINE__ repmat(const T1 &t, index_t reps)
     {
       return detail::RepMatOp<T1, T1::Rank()>(t, reps);
     };
@@ -181,7 +181,7 @@ namespace matx
    *   New operator with repeated data
    */
   template <typename T1, int N>
-    auto __MATX_INLINE__ repmat(T1 t, const index_t (&reps)[N])
+    auto __MATX_INLINE__ repmat(const T1 &t, const index_t (&reps)[N])
     {
       return detail::RepMatOp<T1, T1::Rank()>(t, detail::to_array(reps));
     };
@@ -200,7 +200,7 @@ namespace matx
    *   New operator with repeated data
    */
   template <typename T1>
-    auto __MATX_INLINE__ repmat(T1 t, const index_t *reps)
+    auto __MATX_INLINE__ repmat(const T1 &t, const index_t *reps)
     {
       return detail::RepMatOp<T1, T1::Rank()>(t, reps);
     };

--- a/include/matx/operators/reshape.h
+++ b/include/matx/operators/reshape.h
@@ -50,7 +50,7 @@ namespace matx
         using value_type = typename T::value_type;
 	
       private:
-        typename base_type<T>::type op_;
+        typename detail::base_type_t<T> op_;
 	      ShapeType sizes_;
 
       public:

--- a/include/matx/operators/reverse.h
+++ b/include/matx/operators/reverse.h
@@ -51,7 +51,7 @@ namespace matx
       class ReverseOp : public BaseOp<ReverseOp<DIM, T1>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
 
       public:
         using matxop = bool;
@@ -141,10 +141,10 @@ namespace matx
    * @param t Input operator
    */
   template <int DIM, typename Op>
-    auto __MATX_INLINE__ reverse(const Op &t)
-    {
-      return detail::ReverseOp<DIM, Op>(t);
-    };
+  auto __MATX_INLINE__ reverse(const Op &t)
+  {
+    return detail::ReverseOp<DIM, Op>(t);
+  };
 
   /**
    * @brief Operator to logically reverse elements of an operator.
@@ -156,41 +156,41 @@ namespace matx
    * @tparam Op Input operator/tensor type
    * @param t Input operator
    */
-  template <int DIM1, int DIM2, int... DIMS, typename Op>
+    template <int DIM1, int DIM2, int... DIMS, typename Op>
     auto __MATX_INLINE__ reverse(const Op &t)
-    {
-      // recursively call remap on remaining bits
-      auto op = reverse<DIM2, DIMS...>(t);
+  {
+    // recursively call remap on remaining bits
+    auto op = reverse<DIM2, DIMS...>(t);
 
-      // construct remap op
-      return detail::ReverseOp<DIM1, decltype(op)>(op);
-    };
+    // construct remap op
+    return detail::ReverseOp<DIM1, decltype(op)>(op);
+  };
 
   /**
    * Flip the vertical axis of a tensor.
    */
   template <typename T1>
-    auto __MATX_INLINE__ flipud(const T1 &t)
+  auto __MATX_INLINE__ flipud(const T1 &t)
+  {
+    if constexpr (T1::Rank() == 1)
     {
-      if constexpr (T1::Rank() == 1)
-      {
-        return detail::ReverseOp<T1::Rank() - 1 , T1>(t);
-      }
+      return detail::ReverseOp<T1::Rank() - 1 , T1>(t);
+    }
 
-      return detail::ReverseOp<T1::Rank() - 2, T1>(t);
-    };
+    return detail::ReverseOp<T1::Rank() - 2, T1>(t);
+  };
 
   /**
    * Flip the horizontal axis of a tensor.
    */
   template <typename T1>
-    auto __MATX_INLINE__ fliplr(const T1 &t)
+  auto __MATX_INLINE__ fliplr(const T1 &t)
+  {
+    if constexpr (T1::Rank() == 1)
     {
-      if constexpr (T1::Rank() == 1)
-      {
-        return detail::ReverseOp<T1::Rank() - 1, T1>(t);
-      }
-
       return detail::ReverseOp<T1::Rank() - 1, T1>(t);
-    };
+    }
+
+    return detail::ReverseOp<T1::Rank() - 1, T1>(t);
+  };
 } // end namespace matx

--- a/include/matx/operators/reverse.h
+++ b/include/matx/operators/reverse.h
@@ -61,7 +61,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "reverse(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ ReverseOp(T1 op) : op_(op){};
+        __MATX_INLINE__ ReverseOp(const T1 &op) : op_(op){};
 
 
         template <typename... Is>
@@ -141,7 +141,7 @@ namespace matx
    * @param t Input operator
    */
   template <int DIM, typename Op>
-    auto __MATX_INLINE__ reverse(Op t)
+    auto __MATX_INLINE__ reverse(const Op &t)
     {
       return detail::ReverseOp<DIM, Op>(t);
     };
@@ -156,8 +156,8 @@ namespace matx
    * @tparam Op Input operator/tensor type
    * @param t Input operator
    */
-  template <int DIM1, int DIM2, int... DIMS, typename Op_type>
-    auto __MATX_INLINE__ reverse(Op_type t)
+  template <int DIM1, int DIM2, int... DIMS, typename Op>
+    auto __MATX_INLINE__ reverse(const Op &t)
     {
       // recursively call remap on remaining bits
       auto op = reverse<DIM2, DIMS...>(t);
@@ -170,7 +170,7 @@ namespace matx
    * Flip the vertical axis of a tensor.
    */
   template <typename T1>
-    auto __MATX_INLINE__ flipud(T1 t)
+    auto __MATX_INLINE__ flipud(const T1 &t)
     {
       if constexpr (T1::Rank() == 1)
       {
@@ -184,7 +184,7 @@ namespace matx
    * Flip the horizontal axis of a tensor.
    */
   template <typename T1>
-    auto __MATX_INLINE__ fliplr(T1 t)
+    auto __MATX_INLINE__ fliplr(const T1 &t)
     {
       if constexpr (T1::Rank() == 1)
       {

--- a/include/matx/operators/select.h
+++ b/include/matx/operators/select.h
@@ -57,7 +57,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "select(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ SelectOp(T op, IdxType idx) : op_(op), idx_(idx) {};  
+        __MATX_INLINE__ SelectOp(const T &op, IdxType idx) : op_(op), idx_(idx) {};  
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(index_t i) const 
@@ -122,7 +122,7 @@ namespace matx
    * @return Value in t from each location in idx
    */
   template <typename T, typename IdxType>
-    auto __MATX_INLINE__ select(T t, IdxType idx)
+    auto __MATX_INLINE__ select(const T &t, IdxType idx)
     {
       return detail::SelectOp<T, IdxType>(t, idx);
     };   

--- a/include/matx/operators/select.h
+++ b/include/matx/operators/select.h
@@ -47,8 +47,8 @@ namespace matx
       class SelectOp : public BaseOp<SelectOp<T, IdxType>>
     {
       private:
-        typename base_type<T>::type op_;
-        typename base_type<IdxType>::type idx_;
+        typename detail::base_type_t<T> op_;
+        typename detail::base_type_t<IdxType> idx_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/self.h
+++ b/include/matx/operators/self.h
@@ -57,7 +57,7 @@ namespace matx
         
         __MATX_INLINE__ std::string str() const { return "self(" + op_.str() + ")"; }
         
-	__MATX_INLINE__ SelfOp(T1 op) : op_(op) {}
+	      __MATX_INLINE__ SelfOp(const T1 &op) : op_(op) {}
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
@@ -112,5 +112,5 @@ namespace matx
    *   Operator of input
    */
   template <typename T1>
-    auto self(T1 t) { return detail::SelfOp<T1, T1::Rank()>(t); };
+    auto self(const T1 &t) { return detail::SelfOp<T1, T1::Rank()>(t); };
 } // end namespace matx

--- a/include/matx/operators/self.h
+++ b/include/matx/operators/self.h
@@ -49,7 +49,7 @@ namespace matx
       class SelfOp : public BaseOp<SelfOp<T1, DIM>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/set.h
+++ b/include/matx/operators/set.h
@@ -93,7 +93,7 @@ public:
    * @param op
    *   Input operator
    */
-  inline set(T &out, const Op op) : out_(out), op_(op)
+  inline set(T &out, const Op &op) : out_(out), op_(op)
   {
     static_assert(is_matx_op_lvalue<T>() == true, "Invalid operator on LHS of set/operator=");
     static_assert(!is_matx_transform_op<T>(), "Cannot use transform operator on LHS of assignment");

--- a/include/matx/operators/shift.h
+++ b/include/matx/operators/shift.h
@@ -54,7 +54,7 @@ namespace matx
       class ShiftOp : public BaseOp<ShiftOp<DIM, T1, T2>>
     {
       private:
-        typename base_type<T1>::type op_;
+        typename detail::base_type_t<T1> op_;
         T2 shift_;
 
       public:

--- a/include/matx/operators/shift.h
+++ b/include/matx/operators/shift.h
@@ -65,7 +65,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "shift(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ ShiftOp(T1 op, T2 shift) : op_(op), shift_(shift)
+        __MATX_INLINE__ ShiftOp(const T1 &op, T2 shift) : op_(op), shift_(shift)
       {
         static_assert(DIM < Rank(), "Dimension to shift must be less than rank of tensor");
         ASSERT_COMPATIBLE_OP_SIZES(shift_); 
@@ -171,7 +171,7 @@ namespace matx
    *   New operator with shifted indices
    */
   template <int DIM, typename OpT, typename ShiftOpT>
-    auto __MATX_INLINE__ shift(OpT op, ShiftOpT s)
+    auto __MATX_INLINE__ shift(const OpT &op, ShiftOpT s)
     {
       return detail::ShiftOp<DIM, OpT, ShiftOpT>(op, s);
     };
@@ -205,7 +205,7 @@ namespace matx
    *   New operator with shifted indices
    */
   template <int DIM, int... DIMS,  typename OpT, typename ShiftT,  typename... ShiftsT>
-    auto __MATX_INLINE__ shift(OpT op, ShiftT s, ShiftsT... shifts)
+    auto __MATX_INLINE__ shift(const OpT &op, ShiftT s, ShiftsT... shifts)
     {
       static_assert(sizeof...(DIMS) == sizeof...(shifts), "shift: number of DIMs must match number of shifts");
 

--- a/include/matx/operators/sign.h
+++ b/include/matx/operators/sign.h
@@ -47,7 +47,7 @@ namespace matx
       class SignOp : public BaseOp<SignOp<T>>
     {
       private:
-        typename base_type<T>::type op_;
+        typename detail::base_type_t<T> op_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/sign.h
+++ b/include/matx/operators/sign.h
@@ -56,7 +56,7 @@ namespace matx
         value_type zval_; 
 
         __MATX_INLINE__ std::string str() const { return "sign(" + get_type_str(op_) + ")"; }
-        __MATX_INLINE__ SignOp(T op, value_type zval) : op_(op), zval_(zval) {};  
+        __MATX_INLINE__ SignOp(const T &op, value_type zval) : op_(op), zval_(zval) {};  
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
@@ -106,7 +106,7 @@ namespace matx
   } // end namespace detail   
 
   template <typename T>
-  __MATX_INLINE__ auto sign(T op, typename T::value_type zval=0) {
+  __MATX_INLINE__ auto sign(const T &op, typename T::value_type zval=0) {
     return detail::SignOp(op,zval);
   }
 

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -52,7 +52,7 @@ namespace matx
         using self_type = SliceOp<DIM, T, StrideType>;
 
       private:
-        typename base_type<T>::type op_;
+        typename detail::base_type_t<T> op_;
         cuda::std::array<shape_type, DIM> sizes_;
         cuda::std::array<int32_t, DIM> dims_;
         cuda::std::array<shape_type, T::Rank()> starts_;
@@ -114,24 +114,10 @@ namespace matx
           {
             static_assert(sizeof...(Is)==Rank());
             static_assert((std::is_convertible_v<Is, index_t> && ... ));
-
-#if 0
-            cuda::std::array<index_t, Rank()> inds{indices...};
-            cuda::std::array<index_t, T::Rank()> ind{indices...};
-
-#pragma unroll 
-            for(int32_t i = 0; i < T::Rank(); i++) {
-              ind[i] = starts_[i];
-            }
-
-#pragma unroll 
-            for(int32_t i = 0; i < Rank(); i++) {
-              ind[dims_[i]] += inds[i] * strides_[i]; 
-            }
-#else            
+       
             // convert variadic type to tuple so we can read/update
-            cuda::std::array<index_t, T::Rank()> ind;
-            cuda::std::array<index_t, Rank()> inds{indices...};
+            cuda::std::array<index_t, T::Rank()> ind = starts_;
+            cuda::std::array<index_t, Rank()> inds{indices...};   
 
             #pragma unroll            
             for (int32_t i = 0; i < T::Rank(); i++) {
@@ -145,14 +131,9 @@ namespace matx
                     ind[i] = starts_[j] + inds[j];
                   }
                 }
-                else {
-                  ind[i] = starts_[i];
-                }
               }
             }       
-#endif                   
-
-            //return op_(ind);
+               
             return cuda::std::apply(op_, ind);
           }
 
@@ -161,23 +142,9 @@ namespace matx
           {
             static_assert(sizeof...(Is)==Rank());
             static_assert((std::is_convertible_v<Is, index_t> && ... ));
-
-#if 0
-            cuda::std::array<index_t, Rank()> inds{indices...};
-            cuda::std::array<index_t, T::Rank()> ind{indices...};
-
-#pragma unroll 
-            for(int32_t i = 0; i < T::Rank(); i++) {
-              ind[i] = starts_[i];
-            }
-
-#pragma unroll 
-            for(int32_t i = 0; i < Rank(); i++) {
-              ind[dims_[i]] += inds[i] * strides_[i]; 
-            }
-#else            
+          
             // convert variadic type to tuple so we can read/update
-            cuda::std::array<index_t, T::Rank()> ind;
+            cuda::std::array<index_t, T::Rank()> ind = starts_;
             cuda::std::array<index_t, Rank()> inds{indices...};
 
             #pragma unroll            
@@ -192,14 +159,9 @@ namespace matx
                     ind[i] = starts_[j] + inds[j];
                   }
                 }
-                else {
-                  ind[i] = starts_[i];
-                }
               }
-            }        
-#endif       
+            }              
 
-            //return op_(ind);
             return cuda::std::apply(op_, ind);
           }
 

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -67,7 +67,7 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "slice(" + op_.str() + ")"; }
 
-        __MATX_INLINE__ SliceOp(T op, const cuda::std::array<shape_type, T::Rank()> &starts,
+        __MATX_INLINE__ SliceOp(const T &op, const cuda::std::array<shape_type, T::Rank()> &starts,
                                       const cuda::std::array<shape_type, T::Rank()> &ends,
                                       StrideType strides) : op_(op) {
           int32_t d = 0;

--- a/include/matx/operators/softmax.h
+++ b/include/matx/operators/softmax.h
@@ -48,7 +48,7 @@ namespace matx
         PermDims perm_;
         cuda::std::array<index_t, OpA::Rank()> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
 
       public:
         using matxop = bool;
@@ -66,6 +66,12 @@ namespace matx
             out_dims_[r] = a_.Size(r);
           }          
         }
+
+        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~SoftmaxOp() {
+        #ifndef __CUDA_ARCH__
+          matxFree(ptr);
+        #endif
+        }         
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const

--- a/include/matx/operators/softmax.h
+++ b/include/matx/operators/softmax.h
@@ -44,7 +44,7 @@ namespace matx
     class SoftmaxOp : public BaseOp<SoftmaxOp<OpA, PermDims>>
     {
       private:
-        OpA a_;
+        typename detail::base_type_t<OpA> a_;
         PermDims perm_;
         cuda::std::array<index_t, OpA::Rank()> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
@@ -67,11 +67,7 @@ namespace matx
           }          
         }
 
-        __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~SoftmaxOp() {
-        #ifndef __CUDA_ARCH__
-          matxFree(ptr);
-        #endif
-        }         
+        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
@@ -124,7 +120,9 @@ namespace matx
           if constexpr (is_matx_op<OpA>()) {
             a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
-        }        
+
+          matxFree(ptr);
+        }   
     };
   }
 

--- a/include/matx/operators/sort.h
+++ b/include/matx/operators/sort.h
@@ -46,7 +46,7 @@ namespace detail {
   class SortOp : public BaseOp<SortOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       SortDirection_t dir_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
@@ -63,18 +63,14 @@ namespace detail {
         for (int r = 0; r < Rank(); r++) {
           out_dims_[r] = a_.Size(r);
         }
-      };
+      }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~SortOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }      
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
-      };
+      }
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }      
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/sph2cart.h
+++ b/include/matx/operators/sph2cart.h
@@ -57,7 +57,7 @@ namespace matx
         __MATX_INLINE__ std::string str() const { return "sph2cart(" + get_type_str(theta_) + 
           "," + get_type_str(phi_) + "," + get_type_str(r_) + ")"; }
 
-        __MATX_INLINE__ Sph2CartOp(T1 theta, T2 phi, T3 r) : theta_(theta), phi_(phi), r_(r)
+        __MATX_INLINE__ Sph2CartOp(const T1 &theta, const T2 &phi, const T3 &r) : theta_(theta), phi_(phi), r_(r)
       {
         ASSERT_COMPATIBLE_OP_SIZES(theta);
         ASSERT_COMPATIBLE_OP_SIZES(phi);
@@ -151,7 +151,7 @@ namespace matx
    *   Tuple of operators for x, y, and z.
    */
   template <typename T1, typename T2, typename T3>
-    auto __MATX_INLINE__ sph2cart(T1 theta, T2 phi, T3 r)
+    auto __MATX_INLINE__ sph2cart(const T1 &theta, const T2 &phi, const T3 &r)
     {
       return cuda::std::tuple{ 
         detail::Sph2CartOp<T1,T2,T3,0>(theta, phi, r),

--- a/include/matx/operators/sph2cart.h
+++ b/include/matx/operators/sph2cart.h
@@ -46,9 +46,9 @@ namespace matx
       class Sph2CartOp : public BaseOp<Sph2CartOp<T1, T2, T3, WHICH>>
     {
       private:
-        typename base_type<T1>::type theta_;
-        typename base_type<T2>::type phi_;
-        typename base_type<T3>::type r_;
+        typename detail::base_type_t<T1> theta_;
+        typename detail::base_type_t<T2> phi_;
+        typename detail::base_type_t<T3> r_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/stack.h
+++ b/include/matx/operators/stack.h
@@ -199,7 +199,7 @@ namespace matx
       }
 
       private:
-      cuda::std::tuple<typename base_type<Ts>::type ...> ops_;
+      cuda::std::tuple<typename detail::base_type_t<Ts> ...> ops_;
       index_t size_;    
       int axis_;
     }; // end class StackOp

--- a/include/matx/operators/stack.h
+++ b/include/matx/operators/stack.h
@@ -74,7 +74,7 @@ namespace matx
         return get_str<-1>();
       }
 
-      __MATX_INLINE__ StackOp(int axis, Ts... ts) : ops_(ts...), axis_(axis)
+      __MATX_INLINE__ StackOp(int axis, const Ts&... ts) : ops_(ts...), axis_(axis)
       {
         static_assert(sizeof...(Ts) > 1, "Must have more than one tensor to stack");
         static_assert((... && (RANK == ts.Rank())), "stacked ops must have the same rank");
@@ -214,11 +214,11 @@ namespace matx
    * @return stacked operator 
    */
   template <typename... Ts>
-    __MATX_INLINE__ __MATX_HOST__  auto stack(int axis, Ts... ts)
+    __MATX_INLINE__ __MATX_HOST__  auto stack(int axis, const Ts&... ts)
     {
       auto first = detail::pp_get<0>(ts...);
 
-      MATX_ASSERT_STR(axis <= first.Rank(),matxInvalidDim, "concat must take an axis less than or equal to the the rank of the operators");
+      MATX_ASSERT_STR(axis <= first.Rank(),matxInvalidDim, "stack must take an axis less than or equal to the the rank of the operators");
       return detail::StackOp<Ts...>{axis, ts...};
     }  
 } // end namespace matx

--- a/include/matx/operators/stdd.h
+++ b/include/matx/operators/stdd.h
@@ -47,7 +47,7 @@ namespace detail {
   class StddOp : public BaseOp<StddOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;   
@@ -65,11 +65,7 @@ namespace detail {
         }
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~StddOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }        
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/stdd.h
+++ b/include/matx/operators/stdd.h
@@ -50,7 +50,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr;   
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;   
 
     public:
       using matxop = bool;
@@ -59,16 +59,22 @@ namespace detail {
       using stdd_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "stdd(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ StddOp(OpA a) : a_(a) { 
+      __MATX_INLINE__ StddOp(const OpA &a) : a_(a) { 
         for (int r = 0; r < ORank; r++) {
           out_dims_[r] = a_.Size(r);
         }
-      };
+      }
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~StddOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif
+      }        
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
-      };
+      }
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/sum.h
+++ b/include/matx/operators/sum.h
@@ -50,7 +50,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr;
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
 
     public:
       using matxop = bool;
@@ -64,6 +64,12 @@ namespace detail {
           out_dims_[r] = a_.Size(r);
         }        
       };
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~SumOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif        
+      }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {

--- a/include/matx/operators/sum.h
+++ b/include/matx/operators/sum.h
@@ -47,7 +47,7 @@ namespace detail {
   class SumOp : public BaseOp<SumOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
@@ -63,18 +63,14 @@ namespace detail {
         for (int r = 0; r < ORank; r++) {
           out_dims_[r] = a_.Size(r);
         }        
-      };
-
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~SumOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif        
       }
+
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
-      };
+      }
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
@@ -110,6 +106,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/svd.h
+++ b/include/matx/operators/svd.h
@@ -59,7 +59,7 @@ namespace detail {
       using svd_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "svd(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ SVDOp(OpA a, const SVDMode jobz, const SVDHostAlgo algo) : a_(a), jobz_(jobz), algo_(algo) { };
+      __MATX_INLINE__ SVDOp(const OpA &a, const SVDMode jobz, const SVDHostAlgo algo) : a_(a), jobz_(jobz), algo_(algo) { };
 
       // This should never be called
       template <typename... Is>
@@ -209,7 +209,7 @@ namespace detail {
  *    The number of singular values to find.  Default is all singular values: min(m,n).
  */
 template<typename AType, typename X0Type>
-__MATX_INLINE__ auto svdpi(AType &A, X0Type &x0, int iterations, index_t k=-1) {
+__MATX_INLINE__ auto svdpi(const AType &A, const X0Type &x0, int iterations, index_t k=-1) {
   return detail::SVDPIOp(A, x0, iterations, k);
 }
 
@@ -283,7 +283,7 @@ namespace detail {
  *   The termination tolerance for the QR iteration. Setting this to 0 will skip the tolerance check.
  */
 template<typename AType>
-__MATX_INLINE__ auto svdbpi(AType &A, int max_iters=10, float tol=0.0f) {
+__MATX_INLINE__ auto svdbpi(const AType &A, int max_iters=10, float tol=0.0f) {
   return detail::SVDBPIOp(A, max_iters, tol);
 }
 

--- a/include/matx/operators/svd.h
+++ b/include/matx/operators/svd.h
@@ -48,7 +48,7 @@ namespace detail {
   class SVDOp : public BaseOp<SVDOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       SVDMode jobz_;
       SVDHostAlgo algo_;
 
@@ -84,7 +84,9 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "svd() must only be called with a single assignment");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       // Size is not relevant in svd() since there are multiple return values and it
@@ -143,8 +145,8 @@ namespace detail {
   class SVDPIOp : public BaseOp<SVDPIOp<OpA,OpX>>
   {
     private:
-      OpA a_;
-      OpX x_;
+      typename detail::base_type_t<OpA> a_;
+      typename detail::base_type_t<OpX> x_;
       int iterations_;
       index_t k_;
 
@@ -176,9 +178,11 @@ namespace detail {
       }
 
       template <typename ShapeType, typename Executor>
-      __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) noexcept
+      __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "svdpi() must only be called with a single assignment");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
@@ -221,7 +225,7 @@ namespace detail {
   class SVDBPIOp : public BaseOp<SVDBPIOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       int max_iters_;
       float tol_;
 
@@ -253,9 +257,11 @@ namespace detail {
       }
 
       template <typename ShapeType, typename Executor>
-      __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) noexcept
+      __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "svdbpi() must only be called with a single assignment");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/toeplitz.h
+++ b/include/matx/operators/toeplitz.h
@@ -46,8 +46,8 @@ namespace matx
       class TopelitzOp : public BaseOp<TopelitzOp<T1, T2>>
     {
       private:
-        typename base_type<T1>::type op1_;
-        typename base_type<T2>::type op2_;
+        typename detail::base_type_t<T1> op1_;
+        typename detail::base_type_t<T2> op2_;
 
       public:
         using matxop = bool;

--- a/include/matx/operators/toeplitz.h
+++ b/include/matx/operators/toeplitz.h
@@ -73,7 +73,7 @@ namespace matx
         return "toeplitz(" + top1 + "," + top2 + ")"; 
       }
 
-        __MATX_INLINE__ TopelitzOp(T1 op1, T2 op2) : op1_(op1), op2_(op2)
+        __MATX_INLINE__ TopelitzOp(const T1 &op1, const T2 &op2) : op1_(op1), op2_(op2)
       {
         if constexpr (is_matx_op<T1>()) {
           static_assert(T1::Rank() == 1, "toeplitz() operator input rank must be 1");

--- a/include/matx/operators/trace.h
+++ b/include/matx/operators/trace.h
@@ -46,7 +46,7 @@ namespace detail {
   class TraceOp : public BaseOp<TraceOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, 0> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
 
@@ -57,14 +57,9 @@ namespace detail {
       using trace_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "trace()"; }
-      __MATX_INLINE__ TraceOp(const OpA &a) : a_(a) { 
-      }
+      __MATX_INLINE__ TraceOp(const OpA &a) : a_(a) {}
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~TraceOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }           
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -105,6 +100,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/trace.h
+++ b/include/matx/operators/trace.h
@@ -48,7 +48,7 @@ namespace detail {
     private:
       OpA a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, 0> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr;
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
 
     public:
       using matxop = bool;
@@ -57,13 +57,19 @@ namespace detail {
       using trace_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "trace()"; }
-      __MATX_INLINE__ TraceOp(OpA a) : a_(a) { 
-      };
+      __MATX_INLINE__ TraceOp(const OpA &a) : a_(a) { 
+      }
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~TraceOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif
+      }           
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
         return tmp_out_(indices...);
-      };
+      }
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {

--- a/include/matx/operators/transpose.h
+++ b/include/matx/operators/transpose.h
@@ -49,6 +49,7 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable matx::tensor_t<typename OpA::value_type, OpA::Rank()> tmp_out_;
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
 
     public:
       using matxop = bool;
@@ -60,7 +61,7 @@ namespace detail {
       using self_type = TransposeMatrixOp<OpA>;
 
       __MATX_INLINE__ std::string str() const { return "transpose_matrix(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ TransposeMatrixOp(OpA a) : a_(a) {
+      __MATX_INLINE__ TransposeMatrixOp(const OpA &a) : a_(a) {
         for (int r = 0; r < Rank(); r++) {
           if (r >= Rank() - 2) {
             out_dims_[r] = (r == Rank() - 1) ? a_.Size(Rank() - 2) : a_.Size(Rank() - 1);
@@ -70,6 +71,12 @@ namespace detail {
           }
         }        
       }
+
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~TransposeMatrixOp() {
+      #ifndef __CUDA_ARCH__
+        matxFree(ptr);
+      #endif
+      }       
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -99,12 +106,7 @@ namespace detail {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }     
 
-        if constexpr (is_cuda_executor_v<Executor>) {
-          make_tensor(tmp_out_, out_dims_, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
-        }
-        else {
-          make_tensor(tmp_out_, out_dims_, MATX_HOST_MEMORY);
-        }
+        detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
@@ -122,7 +124,6 @@ namespace detail {
         return out_dims_[dim];
       }
 
-      ~TransposeMatrixOp() = default;
       TransposeMatrixOp(const TransposeMatrixOp &rhs) = default;
       __MATX_INLINE__ auto operator=(const self_type &rhs) { 
         return set(*this, rhs); 
@@ -154,7 +155,7 @@ namespace detail {
   * @return transposed operator
   */
   template <typename T>
-  __MATX_INLINE__ auto transpose(const T op) {
+  __MATX_INLINE__ auto transpose(const T &op) {
   
     static_assert(T::Rank() >= 2, "transpose operator must be on rank 2 or greater");
     int32_t dims[T::Rank()];
@@ -178,7 +179,7 @@ namespace detail {
    * @return permuted operator
    */
   template <typename T>
-  __MATX_INLINE__ auto transpose_matrix(const T op) {
+  __MATX_INLINE__ auto transpose_matrix(const T &op) {
     static_assert(T::Rank() >= 2, "transpose operator must be on rank 2 or greater");
 
     int32_t dims[T::Rank()];

--- a/include/matx/operators/unary_operators.h
+++ b/include/matx/operators/unary_operators.h
@@ -40,7 +40,7 @@
 #define DEFINE_UNARY_OP(FUNCTION, TENSOR_OP)                        \
   template <typename I1,                                            \
             typename = typename std::enable_if_t<is_matx_op<I1>()>> \
-  [[nodiscard]] __MATX_INLINE__ auto FUNCTION(I1 i1)                         \
+  [[nodiscard]] __MATX_INLINE__ auto FUNCTION(const I1 &i1)                         \
   {                                                                 \
     using I1Type = extract_value_type_t<I1>;                       \
     using Op = TENSOR_OP<I1Type>;                                   \
@@ -71,7 +71,7 @@ namespace matx
       return op_.str() + "(" + get_type_str(in1_) + ")";
     }
 
-    __MATX_INLINE__ matxUnaryOp(I1 in1, Op op) : in1_(in1), op_(op) {
+    __MATX_INLINE__ matxUnaryOp(const I1 &in1, const Op &op) : in1_(in1), op_(op) {
       if constexpr (Rank() > 0) {
         for (int32_t i = 0; i < Rank(); i++) {
           size_[i] = get_size(in1_, i);

--- a/include/matx/operators/unary_operators.h
+++ b/include/matx/operators/unary_operators.h
@@ -44,7 +44,7 @@
   {                                                                 \
     using I1Type = extract_value_type_t<I1>;                       \
     using Op = TENSOR_OP<I1Type>;                                   \
-    const typename detail::base_type<I1>::type &base = i1;          \
+    const typename detail::base_type_t<I1> &base = i1;          \
     return detail::matxUnaryOp(base, Op());                           \
   }
 
@@ -57,8 +57,8 @@ namespace matx
   class matxUnaryOp :  public BaseOp<matxUnaryOp<I1,Op>>
   {
   private:
-    typename base_type<I1>::type in1_;
-    typename base_type<Op>::type op_;
+    typename detail::base_type_t<I1> in1_;
+    typename detail::base_type_t<Op> op_;
     cuda::std::array<index_t, detail::get_rank<I1>()> size_;
 
   public:
@@ -387,7 +387,7 @@ namespace matx
     using I1Type = extract_value_type_t<I1>;
     if constexpr (is_complex_v<I1Type>) {
       using Op = detail::ConjOp<I1Type>;
-      const typename detail::base_type<I1>::type &base = i1;
+      const typename detail::base_type_t<I1> &base = i1;
       return detail::matxUnaryOp(base, Op());
     } else {
       // real type conj is a no-op so return original op.
@@ -424,7 +424,7 @@ namespace matx
     using I1Type = extract_value_type_t<I1>;
     if constexpr (is_complex_v<I1Type>) {
       using Op = detail::RealOp<I1Type>;
-      const typename detail::base_type<I1>::type &base = i1;
+      const typename detail::base_type_t<I1> &base = i1;
       return detail::matxUnaryOp(base, Op());
     } else {
       // already real just return i1

--- a/include/matx/operators/unique.h
+++ b/include/matx/operators/unique.h
@@ -55,7 +55,7 @@ namespace detail {
       using unique_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "unique()"; }
-      __MATX_INLINE__ UniqueOp(OpA a) : a_(a) { };
+      __MATX_INLINE__ UniqueOp(const OpA &a) : a_(a) { };
 
       // This should never be called
       template <typename... Is>

--- a/include/matx/operators/unique.h
+++ b/include/matx/operators/unique.h
@@ -46,7 +46,7 @@ namespace detail {
   class UniqueOp : public BaseOp<UniqueOp<OpA>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
 
     public:
       using matxop = bool;
@@ -76,7 +76,9 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        MATX_ASSERT_STR(false, matxNotSupported, "unique() must only be called with a single assignment since it has multiple return types");
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
       }
 
       template <typename ShapeType, typename Executor>

--- a/include/matx/operators/updownsample.h
+++ b/include/matx/operators/updownsample.h
@@ -46,7 +46,7 @@ namespace matx
       class UpsampleOp : public BaseOp<UpsampleOp<T>>
     {
       private:
-        typename base_type<T>::type op_;
+        typename detail::base_type_t<T> op_;
         int32_t dim_;
         index_t n_;
 

--- a/include/matx/operators/var.h
+++ b/include/matx/operators/var.h
@@ -47,7 +47,7 @@ namespace detail {
   class VarOp : public BaseOp<VarOp<OpA, ORank>>
   {
     private:
-      OpA a_;
+      typename detail::base_type_t<OpA> a_;
       int ddof_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
@@ -66,11 +66,7 @@ namespace detail {
         }        
       }
 
-      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ ~VarOp() {
-      #ifndef __CUDA_ARCH__
-        matxFree(ptr);
-      #endif
-      }       
+      __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
@@ -111,6 +107,8 @@ namespace detail {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
+
+        matxFree(ptr);
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/transforms/conv.h
+++ b/include/matx/transforms/conv.h
@@ -278,9 +278,9 @@ inline void conv1d_impl_internal(OutputType &o, const In1Type &i1, const In2Type
 
   const int Rank = In1Type::Rank();
   //detail::tensor_impl_t<typename OutputType::value_type, OutputType::Rank(), typename OutputType::desc_type> &o_base = o;
-  typename detail::base_type<OutputType>::type &o_base = o;
-  const typename detail::base_type<In1Type>::type &in1_base = i1;
-  const typename detail::base_type<In2Type>::type &in2_base = i2;
+  typename detail::base_type_t<OutputType> &o_base = o;
+  const typename detail::base_type_t<In1Type> &in1_base = i1;
+  const typename detail::base_type_t<In2Type> &in2_base = i2;
 
   if (i1.Size(Rank-1) < i2.Size(Rank-1)) {
     if (method == MATX_C_METHOD_DIRECT) {

--- a/include/matx/transforms/eig/eig_cuda.h
+++ b/include/matx/transforms/eig/eig_cuda.h
@@ -290,7 +290,7 @@ void eig_impl(OutputTensor &&out, WTensor &&w,
   auto w_new = OpToTensor(w, exec);
   auto a_new = OpToTensor(a, exec);
 
-  if(!a_new.isSameView(a)) {
+  if(!is_matx_transform_op<ATensor>() && !a_new.isSameView(a)) {
     (a_new = a).run(exec);
   }
 

--- a/include/matx/transforms/eig/eig_lapack.h
+++ b/include/matx/transforms/eig/eig_lapack.h
@@ -324,7 +324,7 @@ void eig_impl([[maybe_unused]] OutputTensor &&out,
   auto w_new = OpToTensor(w, exec);
   auto a_new = OpToTensor(a, exec);
 
-  if(!a_new.isSameView(a)) {
+  if(!is_matx_transform_op<ATensor>() && !a_new.isSameView(a)) {
     (a_new = a).run(exec);
   }
 

--- a/include/matx/transforms/lu/lu_cuda.h
+++ b/include/matx/transforms/lu/lu_cuda.h
@@ -267,7 +267,7 @@ void lu_impl(OutputTensor &&out, PivotTensor &&piv,
   auto piv_new = OpToTensor(piv, exec);
   auto a_new = OpToTensor(a, exec);
 
-  if(!a_new.isSameView(a)) {
+  if(!is_matx_transform_op<ATensor>() && !a_new.isSameView(a)) {
     (a_new = a).run(exec);
   }
 

--- a/include/matx/transforms/lu/lu_lapack.h
+++ b/include/matx/transforms/lu/lu_lapack.h
@@ -234,7 +234,7 @@ void lu_impl([[maybe_unused]] OutputTensor &&out,
   auto piv_new = OpToTensor(piv, exec);
   auto a_new = OpToTensor(a, exec);
 
-  if(!a_new.isSameView(a)) {
+  if(!is_matx_transform_op<ATensor>() && !a_new.isSameView(a)) {
     (a_new = a).run(exec);
   }
 

--- a/include/matx/transforms/matmul/matmul_cblas.h
+++ b/include/matx/transforms/matmul/matmul_cblas.h
@@ -519,11 +519,11 @@ void matmul_impl([[maybe_unused]] TensorTypeC C,
   typedef decltype(a) atype;
   typedef decltype(b) btype;
 
-  if (!a.isSameView(A_)) {
+  if (!is_matx_transform_op<TensorTypeA>() && !a.isSameView(A_)) {
     (a = A_).run(exec);
   }
 
-  if (!b.isSameView(B_)) {
+  if (!is_matx_transform_op<TensorTypeB>() && !b.isSameView(B_)) {
     (b = B_).run(exec);
   }
 

--- a/include/matx/transforms/matmul/matmul_cuda.h
+++ b/include/matx/transforms/matmul/matmul_cuda.h
@@ -198,10 +198,10 @@ public:
         MATX_ASSERT(b.Size(i) == c.Size(i), matxInvalidSize);
       }
     }
-
+ 
     // This must come before the things below to properly set class parameters
     params_ = GetGemmParams(c, a, b);
-
+ 
     if constexpr (PROV == PROVIDER_TYPE_CUBLASLT) {
       // The recommended cublas workspace size is 4 MiB for pre-Hopper and 32 MiB for Hopper+:
       // https://docs.nvidia.com/cuda/cublas/#cublassetworkspace
@@ -215,6 +215,7 @@ public:
 
       ConfigureCublasLt();
     }
+    
   }
 
   template <typename InputType>
@@ -493,6 +494,7 @@ public:
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
     // Reorder C/A to match cutlass API
+    
     MatMulDispatchA(a, b, c, stream, alpha, beta);
   }
 
@@ -523,18 +525,19 @@ private:
 
   void ConfigureCublasLt()
   {
+    
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
     ret = cublasLtCreate(&ltHandle);
     MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxMatMulError);
-
+  
     ret = cublasLtMatmulPreferenceCreate(&preference);
     MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxMatMulError);
-
+  
     ret = cublasLtMatmulDescCreate(
                     &operationDesc, MatXTypeToCudaComputeType<T1>(),
                     MatXTypeToCudaType<T1>());
     MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxMatMulError);
-
+  
     ret = cublasLtMatmulPreferenceSetAttribute(
                     preference, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
                     &workspaceSize,
@@ -584,7 +587,7 @@ private:
                     params_.a_cols, params_.lda);
     MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxMatMulError);
 
-    ret =cublasLtMatrixLayoutCreate(
+    ret = cublasLtMatrixLayoutCreate(
                     &Bdesc, MatXTypeToCudaType<T3>(), params_.b_rows,
                     params_.b_cols, params_.ldb);
     MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxMatMulError);
@@ -1098,30 +1101,22 @@ using gemm_cuda_cache_t = std::unordered_map<MatMulCUDAParams_t, std::any,  MatM
 
 template <typename Op>
 __MATX_INLINE__ auto getCublasSupportedTensor( const Op &in, cudaStream_t stream) {
-  constexpr int RANK=Op::Rank();
-
-  if constexpr ( !(is_tensor_view_v<Op>)) {
-    return make_tensor<typename Op::value_type>(in.Shape(), MATX_ASYNC_DEVICE_MEMORY, stream);
-  } else {
-    bool supported = true;
-
-    if(
-
-      // either RANK-1 or RANK-2 stride must equal one in cublasLt
-      (in.Stride(RANK-1) != (index_t)1 && in.Stride(RANK-2) != (index_t)1) ||
-      // cublas allows 0 strides, but verify that the corresponding size is 1
-      (in.Stride(RANK-1) == (index_t)0 && in.Size(RANK-1) != (index_t)1) ||
-      (in.Stride(RANK-2) == (index_t)0 && in.Size(RANK-2) != (index_t)1)
-      ) {
-      supported = false;
+  // This would be better as a templated lambda, but we don't have those in C++17 yet
+  const auto support_func = [&in]() {
+    if constexpr (is_tensor_view_v<Op>) {
+      return !(
+        (in.Stride(Op::Rank()-1) != (index_t)1 && in.Stride(Op::Rank()-2) != (index_t)1) ||
+        // cublas allows 0 strides, but verify that the corresponding size is 1
+        (in.Stride(Op::Rank()-1) == (index_t)0 && in.Size(Op::Rank()-1) != (index_t)1) ||
+        (in.Stride(Op::Rank()-2) == (index_t)0 && in.Size(Op::Rank()-2) != (index_t)1)
+      );
     }
-
-    if(supported) {
-      return in;
-    } else {
-      return make_tensor<typename Op::value_type>(in.Shape(), MATX_ASYNC_DEVICE_MEMORY, stream);
+    else {
+      return true;
     }
-  }
+  };
+  
+  return GetSupportedTensor(in, support_func, MATX_ASYNC_DEVICE_MEMORY, stream);
 }
 
 /**
@@ -1188,18 +1183,19 @@ void matmul_impl(TensorTypeC C, const TensorTypeA A,
   typedef decltype(c) ctype;
   typedef decltype(a) atype;
   typedef decltype(b) btype;
-
-  if(!a.isSameView(A_)) {
+  cudaDeviceSynchronize();
+  if(!is_matx_transform_op<TensorTypeA>() && !a.isSameView(A_)) {
     (a = A_).run(stream);
   }
-
-  if(!b.isSameView(B_)) {
+  cudaDeviceSynchronize();
+  if(!is_matx_transform_op<TensorTypeB>() && !b.isSameView(B_)) {
     (b = B_).run(stream);
   }
-
+  cudaDeviceSynchronize();
   if(beta != 0 && !c.isSameView(C)) {
     (c = C).run(stream);
   }
+  cudaDeviceSynchronize();
 
 #ifndef MATX_ENABLE_CUTLASS
   // cublasLt does not allow transpose modes on C.  Thus we need to make sure that the right most dimension has a stride of 1.

--- a/include/matx/transforms/matmul/matmul_cuda.h
+++ b/include/matx/transforms/matmul/matmul_cuda.h
@@ -1183,19 +1183,18 @@ void matmul_impl(TensorTypeC C, const TensorTypeA A,
   typedef decltype(c) ctype;
   typedef decltype(a) atype;
   typedef decltype(b) btype;
-  cudaDeviceSynchronize();
+  
   if(!is_matx_transform_op<TensorTypeA>() && !a.isSameView(A_)) {
     (a = A_).run(stream);
   }
-  cudaDeviceSynchronize();
+  
   if(!is_matx_transform_op<TensorTypeB>() && !b.isSameView(B_)) {
     (b = B_).run(stream);
   }
-  cudaDeviceSynchronize();
+  
   if(beta != 0 && !c.isSameView(C)) {
     (c = C).run(stream);
   }
-  cudaDeviceSynchronize();
 
 #ifndef MATX_ENABLE_CUTLASS
   // cublasLt does not allow transpose modes on C.  Thus we need to make sure that the right most dimension has a stride of 1.

--- a/include/matx/transforms/matvec.h
+++ b/include/matx/transforms/matvec.h
@@ -85,7 +85,7 @@ __MATX_INLINE__ void matvec_impl(TensorTypeC C, const TensorTypeA A,
     shape[i] = matxKeepDim;
   }
   // clone last dim by 1 to create an Nx1 matrix
-  shape[TensorTypeC::Rank()]=1;
+  shape[TensorTypeC::Rank()] = 1;
 
   auto c = clone<TensorTypeC::Rank()+1>(C, shape);
   auto b = clone<TensorTypeB::Rank()+1>(B, shape);

--- a/include/matx/transforms/qr/qr_cuda.h
+++ b/include/matx/transforms/qr/qr_cuda.h
@@ -448,7 +448,7 @@ void qr_solver_impl(OutTensor &&out, TauTensor &&tau,
   auto tau_new = OpToTensor(tau, exec);
   auto a_new = OpToTensor(a, exec);
 
-  if(!a_new.isSameView(a)) {
+  if(!is_matx_transform_op<ATensor>() && !a_new.isSameView(a)) {
     (a_new = a).run(exec);
   }
 

--- a/include/matx/transforms/qr/qr_lapack.h
+++ b/include/matx/transforms/qr/qr_lapack.h
@@ -278,7 +278,7 @@ void qr_solver_impl([[maybe_unused]] OutTensor &&out,
   auto tau_new = OpToTensor(tau, exec);
   auto a_new = OpToTensor(a, exec);
 
-  if(!a_new.isSameView(a)) {
+  if(!is_matx_transform_op<ATensor>() && !a_new.isSameView(a)) {
     (a_new = a).run(exec);
   }
 

--- a/include/matx/transforms/solver_common.h
+++ b/include/matx/transforms/solver_common.h
@@ -121,13 +121,8 @@ template <typename Op, typename Executor>
 __MATX_INLINE__ auto getSolverSupportedTensor(const Op &in, const Executor &exec) {
   constexpr int RANK = Op::Rank();
 
-  bool supported = true;
-  if constexpr (is_matx_transform_op<Op>()) {
-    // We can assume that if a transform is passed to the input then PreRun has already completed
-    // on the transform and we can use the internal pointer
-    return make_tensor<typename Op::value_type>(in.Data(), Shape(in));
-  }  
-  else if constexpr (!(is_tensor_view_v<Op>)) {
+  bool supported = true; 
+  if constexpr (!(is_tensor_view_v<Op>)) {
     supported = false;
   } else {
 

--- a/test/00_solver/Inverse.cu
+++ b/test/00_solver/Inverse.cu
@@ -144,7 +144,6 @@ TYPED_TEST(InvSolverTestFloatTypes, Inv4x4Batched)
   // Repeat the test using in-place transforms
   (A = inv(A)).run(this->exec);
   this->exec.sync();
-  cudaDeviceSynchronize();
 
   for (index_t b = 0; b < A.Size(0); b++) {
     for (index_t i = 0; i < A.Size(1); i++) {

--- a/test/00_tensor/CUBTests.cu
+++ b/test/00_tensor/CUBTests.cu
@@ -120,7 +120,7 @@ TEST(TensorStats, Hist)
   cudaExecutor exec{};
 
   // example-begin hist-test-1
-  (outv = hist(inv, 0.0f, 12.0f)).run(exec);
+  (outv = hist(inv, 0.0f, 12.0f, levels)).run(exec);
   // example-end hist-test-1
   exec.sync();
 

--- a/test/00_transform/FFT.cu
+++ b/test/00_transform/FFT.cu
@@ -454,6 +454,29 @@ TYPED_TEST(FFTTestComplexTypes, IFFT1D1024C2C)
   MATX_EXIT_HANDLER();
 }
 
+// TYPED_TEST(FFTTestComplexTypes, IRFFT1D1024C2C)
+// {
+//   MATX_ENTER_HANDLER();
+//   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+//   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+//   if constexpr (!detail::CheckFFTSupport<ExecType, TestType>()) {
+//     GTEST_SKIP();
+//   } else {
+//     const index_t fft_dim = 1024;
+//     this->pb->template InitAndRunTVGenerator<TestType>(
+//         "00_transforms", "fft_operators", "irfft_1d", {fft_dim, fft_dim});
+//     tensor_t<TestType, 1> av{{fft_dim / 2 + 1}};
+//     tensor_t<TestType, 1> avo{{fft_dim}};
+//     this->pb->NumpyToTensorView(av, "a_in");
+
+//     (avo = irfft(av)).run(this->exec);
+//     this->exec.sync();
+
+//     MATX_TEST_ASSERT_COMPARE(this->pb, avo, "a_out", this->thresh);
+//   }
+//   MATX_EXIT_HANDLER();
+// }
+
 TYPED_TEST(FFTTestComplexTypes, IFFT1DORTHO1024C2C)
 {
   MATX_ENTER_HANDLER();
@@ -663,21 +686,22 @@ TYPED_TEST(FFTTestComplexNonHalfTypesAllExecs, FFT1DSizeChecks)
     this->exec.sync();
   }, matx::detail::matxException);
 
-  // C2R, output size smaller than N
-  ASSERT_THROW({
-    auto tcs = slice(tc, {0}, {N/2+1});
-    auto t2 = make_tensor<RealType>({N-1});
-    (t2 = fft(tcs)).run(this->exec);
-    this->exec.sync();
-  }, matx::detail::matxException);
+  // Enable once C2R is supported
+//   // C2R, output size smaller than N
+//   ASSERT_THROW({
+//     auto tcs = slice(tc, {0}, {N/2+1});
+//     auto t2 = make_tensor<RealType>({N-1});
+//     (t2 = fft(tcs)).run(this->exec);
+//     this->exec.sync();
+//   }, matx::detail::matxException);
 
-  // C2R, output size too large
- ASSERT_THROW({
-    auto tcs = slice(tc, {0}, {N/2+1});
-    auto t2 = make_tensor<RealType>({N+2});
-    (t2 = fft(tcs)).run(this->exec);
-    this->exec.sync();
- }, matx::detail::matxException);
+//   // C2R, output size too large
+//  ASSERT_THROW({
+//     auto tcs = slice(tc, {0}, {N/2+1});
+//     auto t2 = make_tensor<RealType>({N+2});
+//     (t2 = fft(tcs)).run(this->exec);
+//     this->exec.sync();
+//  }, matx::detail::matxException);
 
   MATX_EXIT_HANDLER();
 }
@@ -891,7 +915,8 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, FFT2D16x32R2C)
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, IFFT2D16C2R)
+// Enable once C2R is supported
+TYPED_TEST(FFTTestComplexNonHalfTypes, DISABLED_IFFT2D16C2R)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
@@ -911,7 +936,7 @@ TYPED_TEST(FFTTestComplexNonHalfTypes, IFFT2D16C2R)
   MATX_EXIT_HANDLER();
 }
 
-TYPED_TEST(FFTTestComplexNonHalfTypes, IFFT2D16x32C2R)
+TYPED_TEST(FFTTestComplexNonHalfTypes, DISABLED_IFFT2D16x32C2R)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;

--- a/test/include/test_types.h
+++ b/test/include/test_types.h
@@ -32,7 +32,7 @@
 #pragma once
 
 #include <cuda/std/ccomplex>
-#include "matx/executors/device.h"
+#include "matx/executors/cuda.h"
 #include "matx/executors/host.h"
 #include "gtest/gtest.h"
 #include "matx.h"


### PR DESCRIPTION
Major changes are:

1. Changed all operators to take const & inputs
2. Removed all possible paths where a tensor_t could sneak onto the device. This has caused countless bugs in the past where it would silently free and we'd have corruption, but also has caused compiler errors we've ignored in the past by incorrectly marking tensor_t functions host/device. Now every operator converts to tensor_impl_t on input. This should also fix all the bad any_cast issues 
3. Fixed two bugs that somehow only popped up after all these changes. For some reason the unit tests were passing before
4. Removed mtie when it's a direct transform (tensor = transform(x)).run();. Now it does the same path as normal set types by going through set() and just taking a shortcut by transforming directly into that tensor
5. Fixed a ton of either early frees and/or not freeing, as mentioned [here](https://nvidia.slack.com/archives/C051ULYTE48/p1728412061470939). This also caused multiple incorrect async allocs and frees which lead to performance degradation. Now even the most complex expressions should allocate and free in the correct places as quickly as possible. The only things you should see not freed are cached items, which we've discussed at length
6. Moved Slice/Clone/OverlapView into tensor_impl_t . The tensor_t version just calls the helper function from the impl class now and they share a common source. This allows tensor_impl_t to to be used in expressions like clone()
7. Cleaned up BaseOp to have a single dispatch function since there was redundant code
8. Cleaned up the "SupportedTensor" functions to use a single common function that takes a lambda for each transform type to make it unique
9. Fixed hist since it was incorrectly assuming a certain size of output. Now it takes an explicit number of levels