### PR TITLE
Create temp contiguous tensors if needed for sort

### DIFF
--- a/include/matx/operators/concat.h
+++ b/include/matx/operators/concat.h
@@ -245,9 +245,9 @@ namespace matx
   template <typename... Ts>
     __MATX_INLINE__ __MATX_HOST__  auto concat(int axis, Ts... ts)
     {
-      auto first = detail::pp_get<0>(ts...);
-
+      [[maybe_unused]] const auto first = detail::pp_get<0>(ts...);
       MATX_ASSERT_STR(axis <= first.Rank(),matxInvalidDim, "concat must take an axis less than the rank of the operators");
+
       return detail::ConcatOp<Ts...>{axis, ts...};
     }  
 } // end namespace matx

--- a/test/00_operators/ReductionTests.cu
+++ b/test/00_operators/ReductionTests.cu
@@ -784,6 +784,8 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, Median)
     tensor_t<TestType, 2> t2e{{2, 4}};
     tensor_t<TestType, 2> t2o{{2, 5}};
     tensor_t<TestType, 1> t1out{{2}};
+    tensor_t<TestType, 1> t4out{{4}};
+    tensor_t<TestType, 1> t5out{{5}};
 
     t1e.SetVals({1, 3, 8, 2, 9, 6, 7, 4, 5, 0});
     t1o.SetVals({1, 3, 8, 2, 9, 6, 7, 4, 5, 0, 10});
@@ -806,10 +808,25 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, Median)
     EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1out(0), (TestType)(2.5f)));
     EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1out(1), (TestType)(2.5f)));
 
+    (t4out = median(t2e, {0})).run(exec);
+    exec.sync();
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t4out(0), (TestType)(2.5f)));
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t4out(1), (TestType)(2.5f)));
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t4out(2), (TestType)(1.5f)));
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t4out(3), (TestType)(3.5f)));
+
     (t1out = median(t2o, {1})).run(exec);
     exec.sync();
     EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1out(0), (TestType)(3.0f)));
     EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1out(1), (TestType)(3.0f)));
+
+    (t5out = median(t2o, {0})).run(exec);
+    exec.sync();
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t5out(0), (TestType)(2.5f)));
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t5out(1), (TestType)(2.5f)));
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t5out(2), (TestType)(3.0f)));
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t5out(3), (TestType)(2.5f)));
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t5out(4), (TestType)(4.5f)));
   }
 
   MATX_EXIT_HANDLER();

--- a/test/00_tensor/CUBTests.cu
+++ b/test/00_tensor/CUBTests.cu
@@ -212,6 +212,16 @@ TYPED_TEST(CUBTestsNumericNonComplexAllExecs, Sort)
     ASSERT_TRUE(tmpv(i) < tmpv(i - 1));
   }
 
+  // operator input test
+  const auto L = tmpv.Lsize();
+  (tmpv = matx::sort(matx::concat(0,
+    static_cast<TestType>(2.0) * matx::ones<TestType>({1}), matx::ones<TestType>({L-1})), SORT_DIR_ASC)).run(this->exec);
+  this->exec.sync();
+  ASSERT_TRUE(tmpv(L-1) == static_cast<TestType>(2.0));
+  for (index_t i = 0; i < L-1; i++) {
+    ASSERT_TRUE(tmpv(i) == static_cast<TestType>(1.0));
+  }
+
   // 2D tests
   auto tmpv2 = make_tensor<TestType>(this->t2.Shape());
 
@@ -228,6 +238,15 @@ TYPED_TEST(CUBTestsNumericNonComplexAllExecs, Sort)
     for (index_t j = 1; j < tmpv2.Size(1); j++) {
       ASSERT_TRUE(tmpv2(i, j) > tmpv2(i, j - 1));
     }
+  }
+
+  // Sort the first column of t2
+  auto tmpslice = make_tensor<TestType>({this->t2.Size(0)});
+  (tmpslice = matx::sort(matx::slice<1>(this->t2, {0, 0}, {matx::matxEnd, matx::matxDropDim}), SORT_DIR_ASC)).run(this->exec);
+  this->exec.sync();
+
+  for (index_t i = 1; i < this->t2.Size(0); i++) {
+    ASSERT_TRUE(tmpslice(i) > tmpslice(i-1));
   }
 
   // Descending


### PR DESCRIPTION
The sort implementation currently requires contiguous tensor view inputs. The run-time check for that requirement is currently disabled for release builds and thus those builds can produce incorrect results for non-contiguous tensors.

This change creates temporary contiguous allocations and copies the input when necessary to support sort(). This has the side effect of adding some operator input support for sort() because the operator will execute to populate the temporary tensor.