### PR TITLE
Cleaning up non-const operator() to avoid code duplication

### DIFF
--- a/include/matx/operators/clone.h
+++ b/include/matx/operators/clone.h
@@ -107,20 +107,7 @@ IGNORE_WARNING_POP_GCC
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-
-          // convert variadic type to tuple so we can read/update
-IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")         
-          cuda::std::array<index_t, Rank()> sind{indices...};
-          cuda::std::array<index_t, T::Rank()> gind;
-IGNORE_WARNING_POP_GCC
-
-          // gather indices
-          for(int i = 0; i < T::Rank(); i++) {
-            auto idx = dims_[i];
-            gind[i] = sind[idx];
-          }
-
-          return cuda::std::apply(op_, gind);
+          return std::as_const(*this).template operator()(indices...);
         }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()

--- a/include/matx/operators/collapse.h
+++ b/include/matx/operators/collapse.h
@@ -55,70 +55,51 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "lcollapse<" + std::to_string(DIM) + ">(" + op_.str() + ")"; }
         __MATX_INLINE__ LCollapseOp(const T1 &op) : op_(op)
-      {
-        static_assert(DIM <= T1::Rank(),  "Collapse DIM must be less than or equal to Rank() of operator");
-        static_assert(DIM > 1, "Must collapse multiple dims");
-        static_assert(T1::Rank() >= 2, "Collapse must be called on operators with rank >= 2");
+        {
+          static_assert(DIM <= T1::Rank(),  "Collapse DIM must be less than or equal to Rank() of operator");
+          static_assert(DIM > 1, "Must collapse multiple dims");
+          static_assert(T1::Rank() >= 2, "Collapse must be called on operators with rank >= 2");
 
-        // comptue size of collapsed dimension
-        size_ = 1;
+          // comptue size of collapsed dimension
+          size_ = 1;
 
-        // Collapse left-most dims
-#pragma unroll
-        for(int i = 0 ; i < DIM; i++) {
-          size_ *= op_.Size(i);
+          // Collapse left-most dims
+  #pragma unroll
+          for(int i = 0 ; i < DIM; i++) {
+            size_ *= op_.Size(i);
+          }
         }
-      }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
-          {
-            // indices coming in
-            cuda::std::array<index_t, Rank()> in{indices...};  // index coming in
-            cuda::std::array<index_t, T1::Rank()> out;         // index going out
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
+        {
+          // indices coming in
+          cuda::std::array<index_t, Rank()> in{indices...};  // index coming in
+          cuda::std::array<index_t, T1::Rank()> out;         // index going out
 
 #pragma unroll
-            for(int i = 1; i < Rank(); i++) {
-              // copy all but first input index into out array
-              out[DIM + i - 1] = in[i];
-            }
+          for(int i = 1; i < Rank(); i++) {
+            // copy all but first input index into out array
+            out[DIM + i - 1] = in[i];
+          }
 
-            // expand first input index into DIM indices
-            auto ind = in[0];
+          // expand first input index into DIM indices
+          auto ind = in[0];
 #pragma unroll
-            for(int i = 0; i < DIM; i++) {
-              int d = DIM - i - 1;
-              out[d] = ind % op_.Size(d);
-              ind /= op_.Size(d);
-            }
+          for(int i = 0; i < DIM; i++) {
+            int d = DIM - i - 1;
+            out[d] = ind % op_.Size(d);
+            ind /= op_.Size(d);
+          }
 
-            return cuda::std::apply(op_, out);
-          }    
+          return cuda::std::apply(op_, out);
+        }    
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
-          {
-            // indices coming in
-            cuda::std::array<index_t, Rank()> in{indices...};  // index coming in
-            cuda::std::array<index_t, T1::Rank()> out;         // index going out
-
-#pragma unroll
-            for(int i = 1; i < Rank(); i++) {
-              // copy all but first input index into out array
-              out[DIM + i - 1] = in[i];
-            }
-
-            // expand first input index into DIM indices
-            auto ind = in[0];
-#pragma unroll
-            for(int i = 0; i < DIM; i++) {
-              int d = DIM - i - 1;
-              out[d] = ind % op_.Size(d);
-              ind /= op_.Size(d);
-            }
-
-            return cuda::std::apply(op_, out);
-          }    
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
+        {
+          return std::as_const(*this).template operator()(indices...);
+        }   
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {
@@ -211,70 +192,51 @@ namespace matx
         __MATX_INLINE__ std::string str() const { return "rcollapse<" + std::to_string(DIM) + ">(" + op_.str() + ")"; }
 
         __MATX_INLINE__ RCollapseOp(const T1 op) : op_(op)
-      {
-        static_assert(DIM <= T1::Rank(),  "Collapse DIM must be less than or equal to Rank() of operator");
-        static_assert(DIM > 1, "Collapse DIM must have be greater than 1");
-        static_assert(T1::Rank() >= 2, "Collapse must be called on operators with rank >= 2");
+        {
+          static_assert(DIM <= T1::Rank(),  "Collapse DIM must be less than or equal to Rank() of operator");
+          static_assert(DIM > 1, "Collapse DIM must have be greater than 1");
+          static_assert(T1::Rank() >= 2, "Collapse must be called on operators with rank >= 2");
 
-        // comptue size of collapsed dimension
-        size_ = 1;
+          // comptue size of collapsed dimension
+          size_ = 1;
 
-        // Collapse right-most dims
-#pragma unroll
-        for(int i = 0 ; i < DIM; i++) {
-          size_ *= op_.Size(T1::Rank() - 1 - i);
+          // Collapse right-most dims
+  #pragma unroll
+          for(int i = 0 ; i < DIM; i++) {
+            size_ *= op_.Size(T1::Rank() - 1 - i);
+          }
         }
-      }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
-          {
-            // indices coming in
-            cuda::std::array<index_t, Rank()> in{indices...};  // index coming in
-            cuda::std::array<index_t, T1::Rank()> out;         // index going out
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
+        {
+          // indices coming in
+          cuda::std::array<index_t, Rank()> in{indices...};  // index coming in
+          cuda::std::array<index_t, T1::Rank()> out;         // index going out
 
 #pragma unroll
-            for(int i = 0 ; i < Rank() - 1; i++) {
-              // copy all but last index into out array
-              out[i] = in[i];
-            }
+          for(int i = 0 ; i < Rank() - 1; i++) {
+            // copy all but last index into out array
+            out[i] = in[i];
+          }
 
-            // expand last index into DIM indices
-            auto ind = in[Rank() - 1];
+          // expand last index into DIM indices
+          auto ind = in[Rank() - 1];
 #pragma unroll
-            for(int i = 0; i < DIM; i++) {
-              int d = T1::Rank() - 1 - i;
-              out[d] = ind % op_.Size(d);
-              ind /= op_.Size(d);
-            }
+          for(int i = 0; i < DIM; i++) {
+            int d = T1::Rank() - 1 - i;
+            out[d] = ind % op_.Size(d);
+            ind /= op_.Size(d);
+          }
 
-            return cuda::std::apply(op_, out);
-          }    
+          return cuda::std::apply(op_, out);
+        }    
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
-          {
-            // indices coming in
-            cuda::std::array<index_t, Rank()> in{indices...};  // index coming in
-            cuda::std::array<index_t, T1::Rank()> out;         // index going out
-
-#pragma unroll
-            for(int i = 0 ; i < Rank() - 1; i++) {
-              // copy all but last index into out array
-              out[i] = in[i];
-            }
-
-            // expand last index into DIM indices
-            auto ind = in[Rank() - 1];
-#pragma unroll
-            for(int i = 0; i < DIM; i++) {
-              int d = T1::Rank() - 1 - i;
-              out[d] = ind % op_.Size(d);
-              ind /= op_.Size(d);
-            }
-
-            return cuda::std::apply(op_, out);
-          }    
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
+        {
+          return std::as_const(*this).template operator()(indices...);
+        }   
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {

--- a/include/matx/operators/fftshift.h
+++ b/include/matx/operators/fftshift.h
@@ -64,13 +64,10 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-          auto tup = cuda::std::make_tuple(indices...);
-          cuda::std::get<Rank()-1>(tup) = (cuda::std::get<Rank()-1>(tup) + (Size(Rank()-1) + 1) / 2) % Size(Rank()-1);
-          return cuda::std::apply(op_, tup);
+          return std::as_const(*this).template operator()(indices...);
         }
-
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {

--- a/include/matx/operators/hermitian.h
+++ b/include/matx/operators/hermitian.h
@@ -61,14 +61,14 @@ namespace matx
         }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
-          {
-            auto tup = cuda::std::make_tuple(indices...);
-            auto stl = cuda::std::get<Rank()-2>(tup);
-            cuda::std::get<Rank()-2>(tup) = cuda::std::get<Rank()-1>(tup);
-            cuda::std::get<Rank()-1>(tup) = stl;      
-            return conj(cuda::std::apply(op_, tup));
-          }
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
+        {
+          auto tup = cuda::std::make_tuple(indices...);
+          auto stl = cuda::std::get<Rank()-2>(tup);
+          cuda::std::get<Rank()-2>(tup) = cuda::std::get<Rank()-1>(tup);
+          cuda::std::get<Rank()-1>(tup) = stl;      
+          return conj(cuda::std::apply(op_, tup));
+        }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {

--- a/include/matx/operators/interleaved.h
+++ b/include/matx/operators/interleaved.h
@@ -73,16 +73,9 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ complex_type operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-          auto real = op_(indices...);
-
-          constexpr size_t rank_idx = (Rank() == 1) ? 0 : (Rank() - 2);
-          auto tup = cuda::std::make_tuple(indices...);
-          cuda::std::get<rank_idx>(tup) += op_.Size(rank_idx) / 2;
-
-          auto imag = cuda::std::apply(op_, tup);
-          return complex_type{real, imag};
+          return std::as_const(*this).template operator()(indices...);
         }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()

--- a/include/matx/operators/kronecker.h
+++ b/include/matx/operators/kronecker.h
@@ -81,15 +81,7 @@ namespace matx
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-          auto tup1 = cuda::std::make_tuple(indices...);
-          auto tup2 = cuda::std::make_tuple(indices...);
-          cuda::std::get<Rank() - 2>(tup2) = pp_get<Rank() - 2>(indices...) % op2_.Size(Rank() - 2);
-          cuda::std::get<Rank() - 1>(tup2) = pp_get<Rank() - 1>(indices...) % op2_.Size(Rank() - 1);
-
-          cuda::std::get<Rank() - 2>(tup1) = pp_get<Rank() - 2>(indices...) / op2_.Size(Rank() - 2);
-          cuda::std::get<Rank() - 1>(tup1) = pp_get<Rank() - 1>(indices...) / op2_.Size(Rank() - 1);
-
-          return cuda::std::apply(op2_, tup2) * cuda::std::apply(op1_, tup1);
+          return std::as_const(*this).template operator()(indices...);
         }
 
         template <typename ShapeType, typename Executor>

--- a/include/matx/operators/planar.h
+++ b/include/matx/operators/planar.h
@@ -70,16 +70,9 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-          constexpr size_t rank_idx = (Rank() == 1) ? 0 : (Rank() - 2);
-          auto tup = cuda::std::make_tuple(indices...);
-          if (cuda::std::get<rank_idx>(tup) >= op_.Size(rank_idx)) {      
-            cuda::std::get<rank_idx>(tup) -= op_.Size(rank_idx);    
-            return cuda::std::apply(op_, tup).imag();
-          }
-
-          return op_(indices...).real();
+          return std::as_const(*this).template operator()(indices...);
         }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()

--- a/include/matx/operators/r2c.h
+++ b/include/matx/operators/r2c.h
@@ -73,18 +73,10 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-          auto tup = cuda::std::make_tuple(indices...);
-
-          // If we're on the upper part of the spectrum, return the conjugate of the first half
-          if (cuda::std::get<Rank()-1>(tup) >= op_.Size(Rank()-1)) {
-            cuda::std::get<Rank()-1>(tup) = orig_size_ - cuda::std::get<Rank()-1>(tup);
-            return conj(cuda::std::apply(op_, tup));
-          }
-
-          return cuda::std::apply(op_, tup);
-        }        
+          return std::as_const(*this).template operator()(indices...);
+        }      
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {

--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -67,42 +67,29 @@ namespace matx
 	__MATX_INLINE__ RemapOp(const T &op, IdxType idx) : op_(op), idx_(idx) {};
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
-          {
-            static_assert(sizeof...(Is)==Rank());
-            static_assert((std::is_convertible_v<Is, index_t> && ... ));
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
+        {
+          static_assert(sizeof...(Is)==Rank());
+          static_assert((std::is_convertible_v<Is, index_t> && ... ));
 
-            // convert variadic type to tuple so we can read/update
-            cuda::std::array<index_t, Rank()> ind{indices...};
+          // convert variadic type to tuple so we can read/update
+          cuda::std::array<index_t, Rank()> ind{indices...};
 
-            // remap current index for dim
-            if constexpr (IdxType::Rank() == 0) {
-              ind[DIM] = idx_();
-            } else {
-              ind[DIM] = idx_(ind[DIM]);
-            }
-            //return op_(ind);
-            return cuda::std::apply(op_, ind);
+          // remap current index for dim
+          if constexpr (IdxType::Rank() == 0) {
+            ind[DIM] = idx_();
+          } else {
+            ind[DIM] = idx_(ind[DIM]);
           }
+          //return op_(ind);
+          return cuda::std::apply(op_, ind);
+        }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
-          {
-            static_assert(sizeof...(Is)==Rank());
-            static_assert((std::is_convertible_v<Is, index_t> && ... ));
-
-            // convert variadic type to tuple so we can read/update
-            cuda::std::array<index_t, Rank()> ind{indices...};
-
-            // remap current index for dim
-            if constexpr (IdxType::Rank() == 0) {
-              ind[DIM] = idx_();
-            } else {
-              ind[DIM] = idx_(ind[DIM]);
-            }
-            //return op_(ind);
-            return cuda::std::apply(op_, ind);
-          }
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
+        {
+          return std::as_const(*this).template operator()(indices...);
+        }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {

--- a/include/matx/operators/repmat.h
+++ b/include/matx/operators/repmat.h
@@ -110,14 +110,7 @@ namespace matx
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-          if constexpr (Rank() == 0) {
-            return op_();
-          }
-          else {
-            auto tup = cuda::std::make_tuple(indices...);
-            UpdateIndex(tup);
-            return cuda::std::apply(op_, tup);
-          }
+          return std::as_const(*this).template operator()(indices...);
         }
 
         template <typename ShapeType, typename Executor>

--- a/include/matx/operators/reshape.h
+++ b/include/matx/operators/reshape.h
@@ -108,27 +108,7 @@ namespace matx
         template <typename... Is>
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-          cuda::std::array<index_t, Rank()> inds{indices...};
-          cuda::std::array<index_t, T::Rank()> ninds;
-
-          index_t idx = 0;
-          index_t stride = 1;
-
-          // linearlize incoming index
-#pragma unroll
-          for(int i = Rank() - 1 ; i >= 0 ; i--) {
-            idx += stride * inds[i];
-            stride *= Size(i);
-          }
-
-          // extract new indices
-#pragma unroll
-          for(int i = T::Rank() - 1; i >= 0; i--) {
-            ninds[i] = idx % op_.Size(i);
-            idx /= op_.Size(i);
-          }
-
-          return cuda::std::apply(op_, ninds);
+          return std::as_const(*this).template operator()(indices...);
         }
 
         constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int32_t dim) const

--- a/include/matx/operators/reverse.h
+++ b/include/matx/operators/reverse.h
@@ -78,16 +78,9 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-          if constexpr (Rank() == 0) {
-            return op_();
-          } 
-          else {
-            auto tup = cuda::std::make_tuple(indices...);
-            cuda::std::get<DIM>(tup) = Size(DIM) - cuda::std::get<DIM>(tup) - 1;
-            return cuda::std::apply(op_, tup);
-          }
+          return std::as_const(*this).template operator()(indices...);
         }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()

--- a/include/matx/operators/select.h
+++ b/include/matx/operators/select.h
@@ -67,10 +67,9 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(index_t i) 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(index_t i)
         {
-          auto arrs = detail::GetIdxFromAbs(op_, idx_(i));
-          return op_(arrs);
+          return std::as_const(*this).template operator()(i);
         }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()

--- a/include/matx/operators/self.h
+++ b/include/matx/operators/self.h
@@ -66,9 +66,9 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)  
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
-          return op_(indices...);
+          return std::as_const(*this).template operator()(indices...);
         }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()

--- a/include/matx/operators/shift.h
+++ b/include/matx/operators/shift.h
@@ -66,43 +66,33 @@ namespace matx
         __MATX_INLINE__ std::string str() const { return "shift(" + op_.str() + ")"; }
 
         __MATX_INLINE__ ShiftOp(const T1 &op, T2 shift) : op_(op), shift_(shift)
-      {
-        static_assert(DIM < Rank(), "Dimension to shift must be less than rank of tensor");
-        ASSERT_COMPATIBLE_OP_SIZES(shift_); 
-        ASSERT_COMPATIBLE_OP_SIZES(op_); 
-      }
+        {
+          static_assert(DIM < Rank(), "Dimension to shift must be less than rank of tensor");
+          ASSERT_COMPATIBLE_OP_SIZES(shift_); 
+          ASSERT_COMPATIBLE_OP_SIZES(op_); 
+        }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
-          {
-            auto tup = cuda::std::make_tuple(indices...);
-            index_t shift = -get_value(shift_, indices...);
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
+        {
+          auto tup = cuda::std::make_tuple(indices...);
+          index_t shift = -get_value(shift_, indices...);
 
 
-            shift = (shift + cuda::std::get<DIM>(tup)) % Size(DIM);
+          shift = (shift + cuda::std::get<DIM>(tup)) % Size(DIM);
 
-            if(shift<0) shift += Size(DIM);
+          if(shift<0) shift += Size(DIM);
 
-            cuda::std::get<DIM>(tup) = shift;
+          cuda::std::get<DIM>(tup) = shift;
 
-            return cuda::std::apply(op_, tup);
-          }    
+          return cuda::std::apply(op_, tup);
+        }    
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
-          {
-            auto tup = cuda::std::make_tuple(indices...);
-            index_t shift = -get_value(shift_, indices...);
-
-
-            shift = (shift + cuda::std::get<DIM>(tup)) % Size(DIM);
-
-            if(shift<0) shift += Size(DIM);
-
-            cuda::std::get<DIM>(tup) = shift;
-
-            return cuda::std::apply(op_, tup);
-          }
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
+        {
+          return std::as_const(*this).template operator()(indices...);
+        }
 
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun(ShapeType &&shape, Executor &&ex) const noexcept

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -110,60 +110,38 @@ namespace matx
         };
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
-          {
-            static_assert(sizeof...(Is)==Rank());
-            static_assert((std::is_convertible_v<Is, index_t> && ... ));
-       
-            // convert variadic type to tuple so we can read/update
-            cuda::std::array<index_t, T::Rank()> ind = starts_;
-            cuda::std::array<index_t, Rank()> inds{indices...};   
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
+        {
+          static_assert(sizeof...(Is)==Rank());
+          static_assert((std::is_convertible_v<Is, index_t> && ... ));
+      
+          // convert variadic type to tuple so we can read/update
+          cuda::std::array<index_t, T::Rank()> ind = starts_;
+          cuda::std::array<index_t, Rank()> inds{indices...};   
 
-            #pragma unroll            
-            for (int32_t i = 0; i < T::Rank(); i++) {
-              #pragma unroll
-              for(int32_t j = 0; j < Rank(); j++) {
-                if(dims_[j] == i) {
-                  if constexpr (!std::is_same_v<NoStride, StrideType>) {
-                    ind[i] = starts_[j] + inds[j] * strides_[i];
-                  }
-                  else {
-                    ind[i] = starts_[j] + inds[j];
-                  }
+          #pragma unroll            
+          for (int32_t i = 0; i < T::Rank(); i++) {
+            #pragma unroll
+            for(int32_t j = 0; j < Rank(); j++) {
+              if(dims_[j] == i) {
+                if constexpr (!std::is_same_v<NoStride, StrideType>) {
+                  ind[i] = starts_[j] + inds[j] * strides_[i];
+                }
+                else {
+                  ind[i] = starts_[j] + inds[j];
                 }
               }
-            }       
-               
-            return cuda::std::apply(op_, ind);
-          }
+            }
+          }       
+              
+          return cuda::std::apply(op_, ind);
+        }
 
         template <typename... Is>
-          __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
-          {
-            static_assert(sizeof...(Is)==Rank());
-            static_assert((std::is_convertible_v<Is, index_t> && ... ));
-          
-            // convert variadic type to tuple so we can read/update
-            cuda::std::array<index_t, T::Rank()> ind = starts_;
-            cuda::std::array<index_t, Rank()> inds{indices...};
-
-            #pragma unroll            
-            for (int32_t i = 0; i < T::Rank(); i++) {
-              #pragma unroll
-              for(int32_t j = 0; j < Rank(); j++) {
-                if(dims_[j] == i) {
-                  if constexpr (!std::is_same_v<NoStride, StrideType>) {
-                    ind[i] = starts_[j] + inds[j] * strides_[i];
-                  }
-                  else {
-                    ind[i] = starts_[j] + inds[j];
-                  }
-                }
-              }
-            }              
-
-            return cuda::std::apply(op_, ind);
-          }
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
+        {
+          return std::as_const(*this).template operator()(indices...);
+        }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {

--- a/include/matx/operators/stack.h
+++ b/include/matx/operators/stack.h
@@ -124,46 +124,31 @@ namespace matx
         }
 
       template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is) const
-        {
-          cuda::std::array<index_t, RANK + 1> indices = {{is...}};
-          cuda::std::array<index_t, RANK> indices_o;
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is) const
+      {
+        cuda::std::array<index_t, RANK + 1> indices = {{is...}};
+        cuda::std::array<index_t, RANK> indices_o;
 
-          // operator index
-          index_t oidx = indices[axis_];
+        // operator index
+        index_t oidx = indices[axis_];
 
-          // removing operator axis from indices
-          for(int i = 0; i < axis_; i++) {
-            indices_o[i] = indices[i];
-          } 
-          
-          for(int i = axis_; i < (int)indices_o.size(); i++) {
-            indices_o[i] = indices[i+1];
-          }
-
-          return GetVal<0, sizeof...(Ts)>(oidx, indices_o);
+        // removing operator axis from indices
+        for(int i = 0; i < axis_; i++) {
+          indices_o[i] = indices[i];
+        } 
+        
+        for(int i = axis_; i < (int)indices_o.size(); i++) {
+          indices_o[i] = indices[i+1];
         }
+
+        return GetVal<0, sizeof...(Ts)>(oidx, indices_o);
+      }
 
       template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is)
-        {
-          cuda::std::array<index_t, RANK + 1> indices = {{is...}};
-          cuda::std::array<index_t, RANK> indices_o;
-
-          // operator index
-          index_t oidx = indices[axis_];
-
-          // removing operator axis from indices
-          for(int i = 0; i < axis_; i++) {
-            indices_o[i] = indices[i];
-          } 
-          
-          for(int i = axis_; i < (int)indices_o.size(); i++) {
-            indices_o[i] = indices[i+1];
-          } 
-
-          return GetVal<0, sizeof...(Ts)>(oidx, indices_o);
-        }
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
+      {
+        return std::as_const(*this).template operator()(indices...);
+      }
 
       static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() noexcept
       {


### PR DESCRIPTION
Hide whitespace when reviewing since I fixed the alignment on a bunch of files too.