### PR TITLE
Fix solver interfaces to use executor in cache

### DIFF
--- a/examples/fft_conv.cu
+++ b/examples/fft_conv.cu
@@ -73,7 +73,6 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 {
   MATX_ENTER_HANDLER();
   using complex = cuda::std::complex<float>;
-  cudaExecutor exec{};
 
   index_t signal_size = 1ULL << 16;
   index_t filter_size = 16;
@@ -87,6 +86,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   cudaEvent_t start, stop;
   cudaEventCreate(&start);
   cudaEventCreate(&stop);  
+  cudaExecutor exec{stream};  
 
   // Create time domain buffers
   auto sig_time  = make_tensor<complex>({batches, signal_size});

--- a/include/matx/core/cache.h
+++ b/include/matx/core/cache.h
@@ -36,6 +36,7 @@
 #include <functional>
 #include <optional>
 #include <any>
+#include <shared_mutex>
 #include <unordered_map>
 #include <cuda/atomic>
 
@@ -50,6 +51,7 @@ using CacheId = uint64_t;
 __attribute__ ((visibility ("default")))
 #endif
 inline cuda::std::atomic<CacheId> CacheIdCounter{0};
+inline std::shared_mutex cache_mtx; ///< Mutex protecting updates from map
 
 template<typename CacheType>
 __attribute__ ((visibility ("default")))
@@ -83,6 +85,8 @@ public:
    */
   template <typename CacheType>
   void Clear(const CacheId &id) {
+    [[maybe_unused]] std::unique_lock lck(cache_mtx);
+
     auto el = cache.find(id);
     MATX_ASSERT_STR(el != cache.end(), matxInvalidType, "Cache type not found");
 
@@ -91,6 +95,8 @@ public:
 
   template <typename CacheType, typename InParams, typename MakeFun, typename ExecFun>
   void LookupAndExec(const CacheId &id, const InParams &params, const MakeFun &mfun, const ExecFun &efun) {
+    [[maybe_unused]] std::unique_lock lck(cache_mtx);
+
     // Create named cache if it doesn't exist
     auto el = cache.find(id);
     if (el == cache.end()) {

--- a/include/matx/transforms/eig/eig_lapack.h
+++ b/include/matx/transforms/eig/eig_lapack.h
@@ -115,7 +115,7 @@ public:
 
     params = GetEigParams(w, a, jobz, uplo);
     this->GetWorkspaceSize();
-    this->AllocateWorkspace(params.batch_size, false);
+    this->AllocateWorkspace(params.batch_size);
   }
 
   void GetWorkspaceSize() override

--- a/include/matx/transforms/lu/lu_cuda.h
+++ b/include/matx/transforms/lu/lu_cuda.h
@@ -59,6 +59,7 @@ struct DnLUCUDAParams_t {
   void *piv;
   size_t batch_size;
   MatXDataType_t dtype;
+  cudaExecutor exec;
 };
 
 template <typename OutputTensor, typename PivotTensor, typename ATensor>
@@ -91,7 +92,8 @@ public:
    *
    */
   matxDnLUCUDAPlan_t(PivotTensor &piv,
-                       const ATensor &a)
+                       const ATensor &a,
+                       const cudaExecutor &exec)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
@@ -105,8 +107,9 @@ public:
     MATX_STATIC_ASSERT_STR((std::is_same_v<T2, int64_t>), matxInavlidType, "Pivot tensor type must be int64_t");
 
     params = GetLUParams(piv, a);
+    params.exec = exec;
     this->GetWorkspaceSize();
-    this->AllocateWorkspace(params.batch_size, false);
+    this->AllocateWorkspace(params.batch_size, false, exec);
   }
 
   void GetWorkspaceSize() override
@@ -212,7 +215,7 @@ struct DnLUCUDAParamsKeyHash {
   std::size_t operator()(const DnLUCUDAParams_t &k) const noexcept
   {
     return (std::hash<uint64_t>()(k.m)) + (std::hash<uint64_t>()(k.n)) +
-           (std::hash<uint64_t>()(k.batch_size));
+           (std::hash<uint64_t>()(k.batch_size)) + (std::hash<uint64_t>()((uint64_t)(k.exec.getStream())));
   }
 };
 
@@ -223,7 +226,7 @@ struct DnLUCUDAParamsKeyEq {
   bool operator()(const DnLUCUDAParams_t &l, const DnLUCUDAParams_t &t) const noexcept
   {
     return l.n == t.n && l.m == t.m && l.batch_size == t.batch_size &&
-           l.dtype == t.dtype;
+           l.dtype == t.dtype && l.exec.getStream() == t.exec.getStream();
   }
 };
 
@@ -292,7 +295,7 @@ void lu_impl(OutputTensor &&out, PivotTensor &&piv,
     detail::GetCacheIdFromType<detail::lu_cuda_cache_t>(),
     params,
     [&]() {
-      return std::make_shared<cache_val_type>(piv_new, tvt);
+      return std::make_shared<cache_val_type>(piv_new, tvt, exec);
     },
     [&](std::shared_ptr<cache_val_type> ctype) {
       ctype->Exec(tvt, piv_new, tvt, exec);

--- a/include/matx/transforms/qr/qr_cuda.h
+++ b/include/matx/transforms/qr/qr_cuda.h
@@ -295,8 +295,7 @@ public:
     MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
     MATX_STATIC_ASSERT_STR((std::is_same_v<T1, T2>), matxInavlidType, "A and Tau types must match");
 
-    params = GetQRParams(tau, a);
-    params.exec = exec;
+    params = GetQRParams(tau, a, exec);
     this->GetWorkspaceSize();
     this->AllocateWorkspace(params.batch_size, false, exec);
   }
@@ -311,7 +310,8 @@ public:
   }
 
   static DnQRCUDAParams_t GetQRParams(TauTensor &tau,
-                                  const ATensor &a)
+                                  const ATensor &a,
+                                  const cudaExecutor &exec)
   {
     DnQRCUDAParams_t params;
 
@@ -321,7 +321,7 @@ public:
     params.A = a.Data();
     params.tau = tau.Data();
     params.dtype = TypeToInt<T1>();
-
+    params.exec = exec;
     return params;
   }
 
@@ -468,7 +468,7 @@ void qr_solver_impl(OutTensor &&out, TauTensor &&tau,
   auto tvt = tv.PermuteMatrix();
 
   // Get parameters required by these tensors
-  auto params = detail::matxDnQRCUDAPlan_t<OutTensor, decltype(tau_new), decltype(a_new)>::GetQRParams(tau_new, tvt);
+  auto params = detail::matxDnQRCUDAPlan_t<OutTensor, decltype(tau_new), decltype(a_new)>::GetQRParams(tau_new, tvt, exec);
 
   // Get cache or new QR plan if it doesn't exist
   using cache_val_type = detail::matxDnQRCUDAPlan_t<OutTensor, decltype(tau_new), decltype(a_new)>;

--- a/include/matx/transforms/qr/qr_lapack.h
+++ b/include/matx/transforms/qr/qr_lapack.h
@@ -110,7 +110,7 @@ public:
 
     params = GetQRParams(tau, a);
     this->GetWorkspaceSize();
-    this->AllocateWorkspace(params.batch_size, false);
+    this->AllocateWorkspace(params.batch_size);
   }
 
   void GetWorkspaceSize() override

--- a/include/matx/transforms/solver_common.h
+++ b/include/matx/transforms/solver_common.h
@@ -255,38 +255,35 @@ public:
     cusolverDnDestroy(handle);
   }
 
-  void AllocateWorkspace([[maybe_unused]] size_t batches, [[maybe_unused]] bool batched_api)
+  void AllocateWorkspace([[maybe_unused]] size_t batches, [[maybe_unused]] bool batched_api, const cudaExecutor &exec)
   {
-#if CUSOLVER_VERSION > 11701 || ( CUSOLVER_VERSION == 11701 && CUSOLVER_VER_BUILD >=2)   
+    const auto stream = exec.getStream();
     if (batched_api) {
       // Newer cuSolver
       if (dspace > 0) {
-        matxAlloc(&d_workspace, dspace, MATX_DEVICE_MEMORY);
+        matxAlloc(&d_workspace, dspace, MATX_ASYNC_DEVICE_MEMORY, stream);
       }
 
       // cuSolver has a bug where the workspace needs to be zeroed before using it when the type is complex. 
       // Zero it out for all types for now.
-      cudaMemset(d_workspace, 0, dspace);
-      matxAlloc((void **)&d_info, sizeof(*d_info) * batches, MATX_DEVICE_MEMORY);
+      cudaMemsetAsync(d_workspace, 0, dspace, stream);
+      matxAlloc((void **)&d_info, sizeof(*d_info) * batches, MATX_ASYNC_DEVICE_MEMORY, stream);
 
       if (hspace > 0) {
         matxAlloc(&h_workspace, hspace, MATX_HOST_MEMORY);
       }
     }
     else {
-#endif 
       if (dspace > 0) {
-        matxAlloc(&d_workspace, batches * dspace, MATX_DEVICE_MEMORY);
+        matxAlloc(&d_workspace, batches * dspace, MATX_ASYNC_DEVICE_MEMORY, stream);
       }
 
-      matxAlloc((void **)&d_info, batches * sizeof(*d_info), MATX_DEVICE_MEMORY);
+      matxAlloc((void **)&d_info, batches * sizeof(*d_info), MATX_ASYNC_DEVICE_MEMORY, stream);
 
       if (hspace > 0) {
         matxAlloc(&h_workspace, batches * hspace, MATX_HOST_MEMORY);
       } 
-#if CUSOLVER_VERSION > 11701 || ( CUSOLVER_VERSION == 11701 && CUSOLVER_VER_BUILD >=2)         
     }
-#endif
   }
 
   virtual void GetWorkspaceSize() = 0;
@@ -328,7 +325,7 @@ public:
     matxFree(iwork);
   }
 
-  void AllocateWorkspace([[maybe_unused]] size_t batches, [[maybe_unused]] bool batched_api)
+  void AllocateWorkspace([[maybe_unused]] size_t batches)
   {
     if (lwork > 0) {
       matxAlloc(&work, lwork * sizeof(ValueType), MATX_HOST_MALLOC_MEMORY);

--- a/include/matx/transforms/svd/svd_cuda.h
+++ b/include/matx/transforms/svd/svd_cuda.h
@@ -543,6 +543,7 @@ struct DnSVDCUDAParams_t {
   size_t batch_size;
   MatXDataType_t dtype;
   SVDMethod method;
+  cudaExecutor exec;
 };
 
 template <typename ATensor>
@@ -626,6 +627,7 @@ public:
                         VtTensor &vt,
                         const ATensor &a,
                         SVDMethod method,
+                        const cudaExecutor &exec,
                         const char jobz = 'A')
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
@@ -642,7 +644,8 @@ public:
     MATX_STATIC_ASSERT_STR(!is_complex_v<T3>, matxInvalidType, "S type must be real");
     MATX_STATIC_ASSERT_STR((std::is_same_v<typename inner_op_type_t<T1>::type, T3>), matxInvalidType, "A and S inner types must match");
 
-    params = GetSVDParams(u, s, vt, a, jobz);
+    params        = GetSVDParams(u, s, vt, a, jobz);
+    params.exec   = exec;
     params.method = method;
 
     if (params.method == SVDMethod::GESVDJ_BATCHED) {
@@ -658,7 +661,7 @@ public:
     }
 
     this->GetWorkspaceSize();
-    this->AllocateWorkspace(params.batch_size, params.method == SVDMethod::GESVDJ_BATCHED);
+    this->AllocateWorkspace(params.batch_size, params.method == SVDMethod::GESVDJ_BATCHED, exec);
   }
 
   void GetWorkspaceSize() override
@@ -882,7 +885,7 @@ struct DnSVDCUDAParamsKeyHash {
   std::size_t operator()(const DnSVDCUDAParams_t &k) const noexcept
   {
     return (std::hash<uint64_t>()(k.m)) + (std::hash<uint64_t>()(k.n)) +
-           (std::hash<uint64_t>()(k.batch_size));
+           (std::hash<uint64_t>()(k.batch_size)) + (std::hash<uint64_t>()((uint64_t)(k.exec.getStream())));
   }
 };
 
@@ -892,7 +895,11 @@ struct DnSVDCUDAParamsKeyHash {
 struct DnSVDCUDAParamsKeyEq {
   bool operator()(const DnSVDCUDAParams_t &l, const DnSVDCUDAParams_t &t) const noexcept
   {
-    return l.n == t.n && l.m == t.m && l.batch_size == t.batch_size && l.dtype == t.dtype;
+    return  l.n == t.n && 
+            l.m == t.m && 
+            l.batch_size == t.batch_size && 
+            l.dtype == t.dtype && 
+            l.exec.getStream() == t.exec.getStream();
   }
 };
 
@@ -998,7 +1005,7 @@ void svd_impl(UTensor &&u, STensor &&s,
       detail::GetCacheIdFromType<detail::svd_cuda_cache_t>(),
       params,
       [&]() {
-        return std::make_shared<cache_val_type>(u_in, s_new, vt_in, at_col_maj, method, job_cusolver);
+        return std::make_shared<cache_val_type>(u_in, s_new, vt_in, at_col_maj, method, exec, job_cusolver);
       },
       [&](std::shared_ptr<cache_val_type> ctype) {
         ctype->Exec(u_in, s_new, vt_in, at_col_maj, exec, job_cusolver);
@@ -1035,7 +1042,7 @@ void svd_impl(UTensor &&u, STensor &&s,
       detail::GetCacheIdFromType<detail::svd_cuda_cache_t>(),
       params,
       [&]() {
-        return std::make_shared<cache_val_type>(u_col_maj, s_new, vt_col_maj, tvt, method, job_cusolver);
+        return std::make_shared<cache_val_type>(u_col_maj, s_new, vt_col_maj, tvt, method, stream, job_cusolver);
       },
       [&](std::shared_ptr<cache_val_type> ctype) {
         ctype->Exec(u_col_maj, s_new, vt_col_maj, tvt, exec, job_cusolver);

--- a/include/matx/transforms/svd/svd_lapack.h
+++ b/include/matx/transforms/svd/svd_lapack.h
@@ -132,7 +132,7 @@ public:
 
     params = GetSVDParams(u, s, vt, a, jobz, algo);
     this->GetWorkspaceSize();
-    this->AllocateWorkspace(params.batch_size, false);
+    this->AllocateWorkspace(params.batch_size);
   }
 
   void GetWorkspaceSize() override


### PR DESCRIPTION
- Add executor to solver params so allocations can happen asynchronously and can be compared for the cache.
- Add mutex around cache for multiple threads