### PR TITLE
introduce a versatile sparse tensor type to MatX (experimental)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,7 @@ set(examples
     mvdr_beamformer
     pwelch
     resample_poly_bench
+    sparse_tensor
     spectrogram
     spectrogram_graph
     spherical_harmonics

--- a/include/matx/core/make_sparse_tensor.h
+++ b/include/matx/core/make_sparse_tensor.h
@@ -1,0 +1,104 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx/core/sparse_tensor.h"
+
+namespace matx {
+namespace experimental {
+
+//
+// MatX uses a single versatile sparse tensor type that uses a tensor format
+// DSL (Domain Specific Language) to describe a vast space of storage formats.
+// This file provides a number of convenience factory methods that construct
+// sparse tensors in well-known storage formats, like COO, CSR, and CSC,
+// directly from the constituent buffers. More factory methods can easily be
+// added as the need arises.
+//
+
+// Constructs a sparse matrix in COO format directly from the values and
+// the two coordinates vectors. The entries should be sorted by row, then
+// column. Duplicate entries should not occur. Explicit zeros may be stored.
+template <typename ValTensor, typename CrdTensor>
+auto make_tensor_coo(ValTensor &val, CrdTensor &row, CrdTensor &col,
+                     const index_t (&shape)[2], bool owning = false) {
+  static_assert(ValTensor::Rank() == 1 && CrdTensor::Rank() == 1);
+  using VAL = typename ValTensor::value_type;
+  using CRD = typename CrdTensor::value_type;
+  using POS = int; // no positions, although some forms use [0,nse]
+  raw_pointer_buffer<POS, matx_allocator<POS>> emptyp{nullptr, 0, owning};
+  basic_storage<decltype(emptyp)> ep{std::move(emptyp)};
+  return sparse_tensor_t<VAL, CRD, POS, COO>(
+      shape, val.GetStorage(), {row.GetStorage(), col.GetStorage()}, {ep, ep});
+}
+
+// Constructs a sparse matrix in CSR format directly from the values, the row
+// positions, and column coordinates vectors. The entries should be sorted by
+// row, then column. Explicit zeros may be stored.
+template <typename ValTensor, typename PosTensor, typename CrdTensor>
+auto make_tensor_csr(ValTensor &val, PosTensor &rowp, CrdTensor &col,
+                     const index_t (&shape)[2], bool owning = false) {
+  static_assert(ValTensor::Rank() == 1 && CrdTensor::Rank() == 1 &&
+                PosTensor::Rank() == 1);
+  using VAL = typename ValTensor::value_type;
+  using CRD = typename CrdTensor::value_type;
+  using POS = typename PosTensor::value_type;
+  raw_pointer_buffer<CRD, matx_allocator<CRD>> emptyc{nullptr, 0, owning};
+  basic_storage<decltype(emptyc)> ec{std::move(emptyc)};
+  raw_pointer_buffer<POS, matx_allocator<POS>> emptyp{nullptr, 0, owning};
+  basic_storage<decltype(emptyp)> ep{std::move(emptyp)};
+  return sparse_tensor_t<VAL, CRD, POS, CSR>(
+      shape, val.GetStorage(), {ec, col.GetStorage()}, {ep, rowp.GetStorage()});
+}
+
+// Constructs a sparse matrix in CSC format directly from the values,
+// the row coordinates, and column position vectors. The entries should
+// be sorted by column, then row. Explicit zeros may be stored.
+template <typename ValTensor, typename PosTensor, typename CrdTensor>
+auto make_tensor_csc(ValTensor &val, CrdTensor &row, PosTensor &colp,
+                     const index_t (&shape)[2], bool owning = false) {
+  static_assert(ValTensor::Rank() == 1 && CrdTensor::Rank() == 1 &&
+                PosTensor::Rank() == 1);
+  using VAL = typename ValTensor::value_type;
+  using CRD = typename CrdTensor::value_type;
+  using POS = typename PosTensor::value_type;
+  raw_pointer_buffer<CRD, matx_allocator<CRD>> emptyc{nullptr, 0, owning};
+  basic_storage<decltype(emptyc)> ec{std::move(emptyc)};
+  raw_pointer_buffer<POS, matx_allocator<POS>> emptyp{nullptr, 0, owning};
+  basic_storage<decltype(emptyp)> ep{std::move(emptyp)};
+  return sparse_tensor_t<VAL, CRD, POS, CSC>(
+      shape, val.GetStorage(), {ec, row.GetStorage()}, {ep, colp.GetStorage()});
+}
+
+} // namespace experimental
+} // namespace matx

--- a/include/matx/core/print.h
+++ b/include/matx/core/print.h
@@ -136,11 +136,17 @@ namespace matx {
 
     template <typename Op>
     void PrintShapeImpl(const Op& op, FILE *fp) {
-      if (is_tensor_view_v<Op>) {
-        fprintf(fp, "%s: ",op.str().c_str());
+      if constexpr (is_tensor_view_v<Op>) {
+        fprintf(fp, "%s: ", op.str().c_str());
       }
 
-      std::string type = (is_tensor_view_v<Op>) ? "Tensor" : "Operator";
+      std::string type;
+      if constexpr (is_sparse_tensor_v<Op>)
+        type = "SparseTensor";
+      else if constexpr (is_tensor_view_v<Op>)
+        type = "Tensor";
+      else
+        type = "Operator";
       fprintf(fp, "%s{%s} Rank: %d, Sizes:[", type.c_str(), detail::GetTensorTypeString<typename Op::value_type>().c_str(), op.Rank());
       for (index_t dimIdx = 0; dimIdx < op.Rank(); dimIdx++)
       {
@@ -149,7 +155,25 @@ namespace matx {
           fprintf(fp, ", ");
       }
 
-      if constexpr (is_tensor_view_v<Op>)
+      if constexpr (is_sparse_tensor_v<Op>)
+      {
+        // A sparse tensor has no strides, so show the level sizes instead.
+        // These are obtained by translating dims to levels using the format.
+        index_t dims[Op::Format::DIM];
+        index_t lvls[Op::Format::LVL];
+        for (int dimIdx = 0; dimIdx < Op::Format::DIM; dimIdx++) {
+          dims[dimIdx] = op.Size(dimIdx);
+        }
+	Op::Format::dim2lvl(dims, lvls, /*asSize=*/true);
+        fprintf(fp, "], Levels:[");
+        for (int lvlIdx = 0; lvlIdx < Op::Format::LVL; lvlIdx++) {
+          fprintf(fp, "%" MATX_INDEX_T_FMT, lvls[lvlIdx]);
+          if (lvlIdx < (Op::Format::LVL - 1)) {
+            fprintf(fp, ", ");
+          }
+        }
+      }
+      else if constexpr (is_tensor_view_v<Op>)
       {
         fprintf(fp, "], Strides:[");
         if constexpr (Op::Rank() > 0)
@@ -543,7 +567,37 @@ namespace matx {
 
     #ifdef __CUDACC__
       cudaDeviceSynchronize();
-      if constexpr (is_tensor_view_v<Op>) {
+      if constexpr (is_sparse_tensor_v<Op>) {
+        using Format = typename Op::Format;
+	index_t nse = op.Nse();
+        fprintf(fp, "nse    = %" MATX_INDEX_T_FMT "\n", nse);
+        fprintf(fp, "format = ");
+	Format::print();
+        for (int lvlIdx = 0; lvlIdx < Format::LVL; lvlIdx++) {
+	  if (op.POSData(lvlIdx)) {
+            const index_t pend = op.posSize(lvlIdx);
+            fprintf(fp, "pos[%d] = (", lvlIdx);
+            for (index_t i = 0; i < pend; i++) {
+              PrintVal(fp, op.POSData(lvlIdx)[i]);
+            }
+            fprintf(fp, ")\n");
+          }
+          if (op.CRDData(lvlIdx)) {
+            const index_t cend = op.crdSize(lvlIdx);
+            fprintf(fp, "crd[%d] = (", lvlIdx);
+            for (index_t i = 0; i < cend; i++) {
+              PrintVal(fp, op.CRDData(lvlIdx)[i]);
+            }
+            fprintf(fp, ")\n");
+          }
+        }
+        fprintf(fp, "values = (");
+        for (index_t i = 0; i < nse; i++) {
+          PrintVal(fp, op.Data()[i]);
+        }
+        fprintf(fp, ")\nspace  = %s\n", SpaceString(GetPointerKind(op.Data())).c_str());
+      }
+      else if constexpr (is_tensor_view_v<Op>) {
         // If the user is printing a tensor with a const pointer underlying the data, we need to do the lookup
         // as if it's not const. This is because the ownership decision is done at runtime instead of compile-time,
         // so even though the lookup will never be done, the compilation path happens.

--- a/include/matx/core/sparse_tensor.h
+++ b/include/matx/core/sparse_tensor.h
@@ -1,0 +1,125 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <string>
+
+#include "matx/core/sparse_tensor_format.h"
+#include "matx/core/tensor_impl.h"
+
+namespace matx {
+namespace experimental {
+
+//
+// Sparse tensors
+//   VAL : data type of stored elements
+//   CRD : data type of coordinates
+//   POS : data type of positions
+//   TF  : tensor format
+//
+template <typename VAL, typename CRD, typename POS, typename TF,
+          typename StorageV = DefaultStorage<VAL>,
+          typename StorageC = DefaultStorage<CRD>,
+          typename StorageP = DefaultStorage<POS>,
+          typename DimDesc = DefaultDescriptor<TF::DIM>>
+class sparse_tensor_t : public detail::tensor_impl_t<
+                            VAL, TF::DIM, DimDesc,
+                            detail::SparseTensorData<VAL, CRD, POS, TF::LVL>> {
+public:
+  using sparse_tensor = bool;
+  static constexpr int DIM = TF::DIM;
+  static constexpr int LVL = TF::LVL;
+  using Format = TF;
+
+  //
+  // Constructs a sparse tensor with given shape and contents.
+  //
+  // The storage format is defined through the template. The contents
+  // consist of a buffer for the values (primary storage), and LVL times
+  // a buffer with the coordinates and LVL times a buffer with the positions
+  // (secondary storage). The semantics of these contents depend on the
+  // used storage format.
+  //
+  // Most users should *not* use this constructor directly, since it depends
+  // on intricate knowledge of the storage formats. Instead, users should
+  // use the "make_sparse_tensor" methods that provide factory methods in
+  // terms of storage formats that are more familiar (COO, CSR, etc).
+  //
+  __MATX_INLINE__
+  sparse_tensor_t(const typename DimDesc::shape_type (&shape)[DIM],
+                  StorageV &&vals, StorageC (&&crd)[LVL], StorageP (&&pos)[LVL])
+      : detail::tensor_impl_t<VAL, DIM, DimDesc,
+                              detail::SparseTensorData<VAL, CRD, POS, LVL>>(
+            shape) {
+    // Initialize primary and secondary storage.
+    values_ = std::move(vals);
+    for (int l = 0; l < LVL; l++) {
+      coordinates_[l] = std::move(crd[l]);
+      positions_[l] = std::move(pos[l]);
+    }
+    // Set the sparse data in tensor_impl.
+    VAL *v = values_.data();
+    CRD *c[LVL];
+    POS *p[LVL];
+    for (int l = 0; l < LVL; l++) {
+      c[l] = coordinates_[l].data();
+      p[l] = positions_[l].data();
+      // All non-null data resides in same space.
+      assert(!c[l] || GetPointerKind(c[l]) == GetPointerKind(v));
+      assert(!p[l] || GetPointerKind(p[l]) == GetPointerKind(v));
+    }
+    this->SetSparseData(v, c, p);
+  }
+
+  // Default destructor.
+  __MATX_INLINE__ ~sparse_tensor_t() = default;
+
+  // Size getters.
+  index_t Nse() const { return values_.size() / sizeof(VAL); }
+  index_t crdSize(int l) const { return coordinates_[l].size() / sizeof(CRD); }
+  index_t posSize(int l) const { return positions_[l].size() / sizeof(POS); }
+
+private:
+  // Primary storage of sparse tensor (explicitly stored element values).
+  StorageV values_;
+
+  // Secondary storage of sparse tensor (coordinates and positions).
+  // There is potentially one for each level, although some of these
+  // may remain empty. The secondary storage is essential to determine
+  // where in the original tensor the explicitly stored elements reside.
+  StorageC coordinates_[LVL];
+  StorageP positions_[LVL];
+};
+
+} // end namespace experimental
+} // end namespace matx

--- a/include/matx/core/sparse_tensor_format.h
+++ b/include/matx/core/sparse_tensor_format.h
@@ -1,0 +1,443 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <string>
+
+namespace matx {
+namespace experimental {
+
+//
+// MatX uses a single versatile sparse tensor type that uses a tensor format
+// DSL (Domain Specific Language) to describe a vast space of storage formats.
+// Although the tensor format can easily define many common storage formats
+// (such as Dense, CSR, CSC, BSR), it can also define many less common storage
+// formats. In addition, the tensor format DSL can be extended to include even
+// more storage formats in the future.
+//
+// In the tensor format, the term **dimension** is used to refer to the axes of
+// the semantic tensor (as seen by the user), and the term **level** to refer to
+// the axes of the actual storage format (how it eventually resides in memory).
+//
+// The tensor format contains a map that provides the following:
+//
+// (1) An ordered sequence of dimension specifications, each of which includes:
+//
+//     (*) a dimension-expression, which provides a reference to each dimension
+//
+// (2) An ordered sequence of level specifications, each of which includes:
+//
+//     (*) a level expression, which defines what is stored in each level
+//     (*) a required level type, which defines how the level is stored,
+//     including:
+//         (+) a required level format
+//         (+) a collection of level properties
+//
+// Currently, the following level formats are supported:
+//
+// (1) dense: level is dense, entries along the level are stored and linearized
+// (2) compressed: level is sparse, only nonzeros along the level are stored
+//     with the compact positions and coordinates encoding
+// (3) singleton: a variant of the compressed format, for when coordinates have
+//     no siblings
+//
+// All level formats have the following level properties:
+//
+// (1) non/unique (are duplicates allowed at that level),
+// (2) un/ordered (are coordinates sorted at that level).
+//
+// Matrix Examples (dimension == 2, level >= dimension)
+//
+// COO:
+//     map = (i, j) -> ( i : compressed(non-unique), j : singleton )
+//
+// CSR:
+//     map = (i, j) -> ( i : dense, j : compressed )
+//
+// DCSR:
+//     map = (i, j) -> ( i : compressed, j : compressed )
+//
+// CSC:
+//     map = (i, j) -> ( j : dense, i : compressed )
+//
+// BSR with 2x3 blocks:
+//      map = ( i, j ) -> ( i floordiv 2 : dense,
+//                          j floordiv 3 : compressed,
+//                          i mod 2      : dense,
+//                          j mod 3      : dense )
+//
+// Tensor Examples (dimension > 2, level >= dimension)
+//
+// COO3:
+//     map = (i, j, k) -> ( i : compressed(non-unique),
+//                          j : singleton,
+//                          k : singleton )
+//
+// CSF3:
+//     map = (i, j, k) -> ( i : compressed,
+//                          j : compressed,
+//                          k : compressed )
+//
+// The idea of a single versatile sparse tensor type has its roots in
+// sparse compilers, first pioneered for sparse linear algebra in [Bik96]
+// and formalized to sparse tensor algebra in [Kjolstad20]. The generalization
+// to higher-dimensional levels was introduced in [MLIR22].
+//
+// [Bik96] Aart J.C. Bik. Compiler Support for Sparse Matrix Computations.
+//         PhD thesis, Leiden University, May 1996.
+// [Kjolstad20] Fredrik Berg Kjolstad. Sparse Tensor Algebra Compilation.
+//              PhD thesis, MIT, February, 2020.
+// [MLIR22] Aart J.C. Bik, Penporn Koanantakool, Tatiana Shpeisman,
+//        Nicolas Vasilache, Bixia Zheng, and Fredrik Kjolstad.
+//        Compiler Support for Sparse Tensor Computations in MLIR.
+//        ACM Transactions on Architecture and Code Optimization, June, 2022.
+//
+
+//
+// A level type consists of a level format together with a set of
+// level properties (ordered and unique by default).
+//
+// TODO: split out format and properties, generalize into class
+//
+enum class LvlType { Dense, Singleton, Compressed, CompressedNonUnique };
+
+//
+// A level expression consists of an expression in terms of dimension
+// variables. Currently, the following expressions are supported:
+//
+// (1) di
+// (2) di div 2
+// (3) di mod 2
+//
+enum class LvlOp { Id, Div, Mod };
+template <LvlOp o, int d, int c> class LvlExpr {
+public:
+  static constexpr LvlOp op = o;
+  static constexpr int di = d;
+  static constexpr int cj = c;
+
+  static std::string toString() {
+    if constexpr (op == LvlOp::Id) {
+      return "d" + std::to_string(di);
+    } else if constexpr (op == LvlOp::Div) {
+      return "d" + std::to_string(di) + " div " + std::to_string(cj);
+    } else if constexpr (op == LvlOp::Mod) {
+      return "d" + std::to_string(di) + " mod " + std::to_string(cj);
+    }
+  }
+};
+
+//
+// A level specification consists of a level expression and a level type.
+//
+template <typename Expr, LvlType ltype> class LvlSpec {
+public:
+  using expr = Expr;
+  static constexpr LvlType lvltype = ltype;
+
+  static std::string toString() {
+    return Expr::toString() + " : " + LvlTypeToString();
+  }
+
+  // TODO: move to LvlType when that class evolves
+  static inline std::string LvlTypeToString() {
+    if constexpr (ltype == LvlType::Dense) {
+      return "dense";
+    } else if constexpr (ltype == LvlType::Singleton) {
+      return "singleton";
+    } else if constexpr (ltype == LvlType::Compressed) {
+      return "compressed";
+    } else if constexpr (ltype == LvlType::CompressedNonUnique) {
+      return "compressed(non-unique)";
+    }
+  }
+};
+
+//
+// A tensor format consists of an implicit ordered sequence of dimension
+// specifications (d0, d1, etc.) and an explicit ordered sequence of level
+// specifications (e.g. d0 : Dense, d1 : Compressed).
+//
+template <int D, typename... LvlSpecs> class SparseTensorFormat {
+public:
+  static constexpr int DIM = D;
+  static constexpr int LVL = sizeof...(LvlSpecs);
+
+  static_assert(DIM <= LVL);
+
+  static constexpr bool isScalar() { return LVL == 0; }
+
+  static constexpr bool isDnVec() {
+    if constexpr (LVL == 1) {
+      using first_type = std::tuple_element_t<0, std::tuple<LvlSpecs...>>;
+      return first_type::lvltype == LvlType::Dense &&
+             first_type::expr::op == LvlOp::Id && first_type::expr::di == 0;
+    }
+    return false;
+  }
+
+  static constexpr bool isSpVec() {
+    if constexpr (LVL == 1) {
+      using first_type = std::tuple_element_t<0, std::tuple<LvlSpecs...>>;
+      return first_type::lvltype == LvlType::Compressed &&
+             first_type::expr::op == LvlOp::Id && first_type::expr::di == 0;
+    }
+    return false;
+  }
+
+  static constexpr bool isCOO() {
+    if constexpr (LVL == 2) {
+      using first_type = std::tuple_element_t<0, std::tuple<LvlSpecs...>>;
+      using second_type = std::tuple_element_t<1, std::tuple<LvlSpecs...>>;
+      return first_type::lvltype == LvlType::CompressedNonUnique &&
+             first_type::expr::op == LvlOp::Id && first_type::expr::di == 0 &&
+             second_type::lvltype == LvlType::Singleton &&
+             second_type::expr::op == LvlOp::Id && second_type::expr::di == 1;
+    }
+    return false;
+  }
+
+  static constexpr bool isCSR() {
+    if constexpr (LVL == 2) {
+      using first_type = std::tuple_element_t<0, std::tuple<LvlSpecs...>>;
+      using second_type = std::tuple_element_t<1, std::tuple<LvlSpecs...>>;
+      return first_type::lvltype == LvlType::Dense &&
+             first_type::expr::op == LvlOp::Id && first_type::expr::di == 0 &&
+             second_type::lvltype == LvlType::Compressed &&
+             second_type::expr::op == LvlOp::Id && second_type::expr::di == 1;
+    }
+    return false;
+  }
+
+  static constexpr bool isCSC() {
+    if constexpr (LVL == 2) {
+      using first_type = std::tuple_element_t<0, std::tuple<LvlSpecs...>>;
+      using second_type = std::tuple_element_t<1, std::tuple<LvlSpecs...>>;
+      return first_type::lvltype == LvlType::Dense &&
+             first_type::expr::op == LvlOp::Id && first_type::expr::di == 1 &&
+             second_type::lvltype == LvlType::Compressed &&
+             second_type::expr::op == LvlOp::Id && second_type::expr::di == 0;
+    }
+    return false;
+  }
+
+  template <typename CRD>
+  static CRD *dim2lvl(const CRD *dims, CRD *lvls, bool asSize) {
+    // Lambda for dim2lvl translation.
+    auto loop_fun = [&dims, &lvls, &asSize](auto ic) {
+      constexpr int idx = decltype(ic)::value;
+      if constexpr (LVL >= (idx + 1)) {
+        using ftype = std::tuple_element_t<idx, std::tuple<LvlSpecs...>>;
+        if constexpr (ftype::expr::op == LvlOp::Id) {
+          lvls[idx] = dims[ftype::expr::di];
+        } else if constexpr (ftype::expr::op == LvlOp::Div) {
+          lvls[idx] = dims[ftype::expr::di] / ftype::expr::cj;
+        } else if constexpr (ftype::expr::op == LvlOp::Mod) {
+          lvls[idx] = asSize ? ftype::expr::cj
+                             : (dims[ftype::expr::di] % ftype::expr::cj);
+        }
+      }
+    };
+    // Assumes LVL <= 5.
+    static_assert(LVL <= 5);
+    loop_fun(std::integral_constant<int, 0>{});
+    loop_fun(std::integral_constant<int, 1>{});
+    loop_fun(std::integral_constant<int, 2>{});
+    loop_fun(std::integral_constant<int, 3>{});
+    loop_fun(std::integral_constant<int, 4>{});
+    return lvls;
+  }
+
+  template <typename CRD> static CRD *lvl2dim(const CRD *lvls, CRD *dims) {
+    // Lambda for lvl2dim translation.
+    auto loop_fun = [&lvls, &dims](auto ic) {
+      constexpr int idx = decltype(ic)::value;
+      if constexpr (LVL >= (idx + 1)) {
+        using ftype = std::tuple_element_t<idx, std::tuple<LvlSpecs...>>;
+        if constexpr (ftype::expr::op == LvlOp::Id) {
+          dims[ftype::expr::di] = lvls[idx];
+        } else if constexpr (ftype::expr::op == LvlOp::Div) {
+          dims[ftype::expr::di] = lvls[idx] * ftype::expr::cj;
+        } else if constexpr (ftype::expr::op == LvlOp::Mod) {
+          dims[ftype::expr::di] += lvls[idx]; // update (seen second)
+        }
+      }
+    };
+    // Assumes LVL <= 5.
+    static_assert(LVL <= 5);
+    loop_fun(std::integral_constant<int, 0>{});
+    loop_fun(std::integral_constant<int, 1>{});
+    loop_fun(std::integral_constant<int, 2>{});
+    loop_fun(std::integral_constant<int, 3>{});
+    loop_fun(std::integral_constant<int, 4>{});
+    return dims;
+  }
+
+  static void print() {
+    std::cout << "(";
+    for (int d = 0; d < DIM; d++) {
+      std::cout << " d" << d;
+      if (d != DIM - 1)
+        std::cout << ",";
+    }
+    std::cout << " ) -> (";
+    // Assumes LVL <= 5.
+    static_assert(LVL <= 5);
+    if constexpr (LVL > 1) {
+      using ftype = std::tuple_element_t<0, std::tuple<LvlSpecs...>>;
+      std::cout << " " << ftype::toString();
+      if constexpr (LVL != 1) {
+        std::cout << ",";
+      }
+    }
+    if constexpr (LVL >= 2) {
+      using ftype = std::tuple_element_t<1, std::tuple<LvlSpecs...>>;
+      std::cout << " " << ftype::toString();
+      if constexpr (LVL > 2) {
+        std::cout << ",";
+      }
+    }
+    if constexpr (LVL >= 3) {
+      using ftype = std::tuple_element_t<2, std::tuple<LvlSpecs...>>;
+      std::cout << " " << ftype::toString();
+      if constexpr (LVL > 3) {
+        std::cout << ",";
+      }
+    }
+    if constexpr (LVL >= 4) {
+      using ftype = std::tuple_element_t<3, std::tuple<LvlSpecs...>>;
+      std::cout << " " << ftype::toString();
+      if constexpr (LVL > 4) {
+        std::cout << ",";
+      }
+    }
+    if constexpr (LVL >= 5) {
+      using ftype = std::tuple_element_t<4, std::tuple<LvlSpecs...>>;
+      std::cout << " " << ftype::toString();
+    }
+    std::cout << " )" << std::endl;
+  };
+};
+
+//
+// Predefined common tensor formats. Note that even though the tensor format
+// was introduced to define a single versatile sparse tensor type, the
+// "all-dense" format also naturally describes dense scalars, vectors,
+// matrices, and tensors, with all d-major format variants.
+//
+
+// Dimension short-cuts (d0, d1, d3, d4).
+using D0 = LvlExpr<LvlOp::Id, 0, 1>;
+using D1 = LvlExpr<LvlOp::Id, 1, 1>;
+using D2 = LvlExpr<LvlOp::Id, 2, 1>;
+using D3 = LvlExpr<LvlOp::Id, 3, 1>;
+using D4 = LvlExpr<LvlOp::Id, 4, 1>;
+
+// Scalars.
+using Scalar = SparseTensorFormat<0>;
+
+// Vectors.
+using DnVec = SparseTensorFormat<1, LvlSpec<D0, LvlType::Dense>>;
+using SpVec = SparseTensorFormat<1, LvlSpec<D1, LvlType::Compressed>>;
+
+// Dense Matrices.
+using DnMat = SparseTensorFormat<2, LvlSpec<D0, LvlType::Dense>,
+                                 LvlSpec<D1, LvlType::Dense>>;
+using DnMatCol = SparseTensorFormat<2, LvlSpec<D1, LvlType::Dense>,
+                                    LvlSpec<D0, LvlType::Dense>>;
+
+// Sparse Matrices.
+using COO = SparseTensorFormat<2, LvlSpec<D0, LvlType::CompressedNonUnique>,
+                               LvlSpec<D1, LvlType::Singleton>>;
+using CSR = SparseTensorFormat<2, LvlSpec<D0, LvlType::Dense>,
+                               LvlSpec<D1, LvlType::Compressed>>;
+using CSC = SparseTensorFormat<2, LvlSpec<D1, LvlType::Dense>,
+                               LvlSpec<D0, LvlType::Compressed>>;
+using DCSR = SparseTensorFormat<2, LvlSpec<D0, LvlType::Compressed>,
+                                LvlSpec<D1, LvlType::Compressed>>;
+using DCSC = SparseTensorFormat<2, LvlSpec<D1, LvlType::Compressed>,
+                                LvlSpec<D0, LvlType::Compressed>>;
+using CROW = SparseTensorFormat<2, LvlSpec<D0, LvlType::Compressed>,
+                                LvlSpec<D1, LvlType::Dense>>;
+using CCOL = SparseTensorFormat<2, LvlSpec<D1, LvlType::Compressed>,
+                                LvlSpec<D0, LvlType::Dense>>;
+
+// Sparse Block Matrices.
+template <int m, int n>
+using BSR =
+    SparseTensorFormat<2, LvlSpec<LvlExpr<LvlOp::Div, 0, m>, LvlType::Dense>,
+                       LvlSpec<LvlExpr<LvlOp::Div, 1, n>, LvlType::Compressed>,
+                       LvlSpec<LvlExpr<LvlOp::Mod, 0, m>, LvlType::Dense>,
+                       LvlSpec<LvlExpr<LvlOp::Mod, 1, n>, LvlType::Dense>>;
+
+// 3-D Tensors.
+using Dn3 = SparseTensorFormat<3, LvlSpec<D0, LvlType::Dense>,
+                               LvlSpec<D1, LvlType::Dense>,
+                               LvlSpec<D2, LvlType::Dense>>;
+using COO3 = SparseTensorFormat<3, LvlSpec<D0, LvlType::CompressedNonUnique>,
+                                LvlSpec<D1, LvlType::Singleton>,
+                                LvlSpec<D2, LvlType::Singleton>>;
+using CSF3 = SparseTensorFormat<3, LvlSpec<D0, LvlType::Compressed>,
+                                LvlSpec<D1, LvlType::Compressed>,
+                                LvlSpec<D2, LvlType::Compressed>>;
+
+// 4-D Tensors.
+using Dn4 =
+    SparseTensorFormat<4, LvlSpec<D0, LvlType::Dense>,
+                       LvlSpec<D1, LvlType::Dense>, LvlSpec<D2, LvlType::Dense>,
+                       LvlSpec<D3, LvlType::Dense>>;
+using COO4 = SparseTensorFormat<4, LvlSpec<D0, LvlType::CompressedNonUnique>,
+                                LvlSpec<D1, LvlType::Singleton>,
+                                LvlSpec<D2, LvlType::Singleton>,
+                                LvlSpec<D3, LvlType::Singleton>>;
+using CSF4 = SparseTensorFormat<
+    4, LvlSpec<D0, LvlType::Compressed>, LvlSpec<D1, LvlType::Compressed>,
+    LvlSpec<D2, LvlType::Compressed>, LvlSpec<D3, LvlType::Compressed>>;
+
+// 5-D Tensors.
+using Dn5 =
+    SparseTensorFormat<5, LvlSpec<D0, LvlType::Dense>,
+                       LvlSpec<D1, LvlType::Dense>, LvlSpec<D2, LvlType::Dense>,
+                       LvlSpec<D3, LvlType::Dense>,
+                       LvlSpec<D4, LvlType::Dense>>;
+using COO5 = SparseTensorFormat<
+    5, LvlSpec<D0, LvlType::CompressedNonUnique>,
+    LvlSpec<D1, LvlType::Singleton>, LvlSpec<D2, LvlType::Singleton>,
+    LvlSpec<D3, LvlType::Singleton>, LvlSpec<D4, LvlType::Singleton>>;
+using CSF5 = SparseTensorFormat<
+    5, LvlSpec<D0, LvlType::Compressed>, LvlSpec<D1, LvlType::Compressed>,
+    LvlSpec<D2, LvlType::Compressed>, LvlSpec<D3, LvlType::Compressed>,
+    LvlSpec<D4, LvlType::Compressed>>;
+
+} // namespace experimental
+} // namespace matx


### PR DESCRIPTION
This PR introduces the implementation of a single versatile sparse tensor type that uses a tensor format DSL (Domain Specific Language) to describe a vast space of storage formats. Although the tensor format can easily define many common storage formats (such as Dense, COO, CSR, CSC, BSR), it can also define many less common storage formats. In addition, the tensor format DSL can be extended to include even more storage formats in the future.

This first PR simply introduces all storage details for the single versatile sparse tensor type, together with some factory methods for constructing COO, CSR, and CSC sparse matrices from MatX buffers. Later PRs will introduce more general ways of constructing sparse tensors (e.g. from file) and actual operations like SpMV and SpMM using cuSPARSE.