### PR TITLE
refactored permutation (less code dup)

### DIFF
--- a/include/matx/operators/conv.h
+++ b/include/matx/operators/conv.h
@@ -154,12 +154,11 @@ namespace matx
           MATX_ASSERT_STR(!(is_host_executor_v<Executor> && method_ == MATX_C_METHOD_DIRECT), matxNotSupported, "direct conv1d() only supports the CUDA executor currently");
           MATX_STATIC_ASSERT_STR((Rank() == cuda::std::tuple_element_t<0, remove_cvref_t<Out>>::Rank()), 
                 matxInvalidParameter, "conv1d: inputs and outputs must have same rank to use conv1d with axis parameter");
+          auto outop = cuda::std::get<0>(out);
           if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
-            conv1d_impl(permute(cuda::std::get<0>(out), perm_), a_, b_, mode_, method_, ex);
+            outop = permute(outop, perm_);
           }
-          else {
-            conv1d_impl(cuda::std::get<0>(out), a_, b_, mode_, method_, ex);
-          }
+          conv1d_impl(outop, a_, b_, mode_, method_, ex);
         }
 
         template <typename ShapeType, typename Executor>
@@ -344,13 +343,11 @@ namespace detail {
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
         static_assert(is_cuda_executor_v<Executor>, "conv2d() only supports the CUDA executor currently");
-
+        auto outop = cuda::std::get<0>(out);
         if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
-          conv2d_impl(permute(cuda::std::get<0>(out), perm_), a_, b_, mode_, ex.getStream());
+          outop = permute(outop, perm_);
         }
-        else {
-          conv2d_impl(cuda::std::get<0>(out), a_, b_, mode_, ex.getStream());
-        }
+        conv2d_impl(outop, a_, b_, mode_, ex.getStream());
       }
 
       template <typename ShapeType, typename Executor>

--- a/include/matx/operators/corr.h
+++ b/include/matx/operators/corr.h
@@ -140,12 +140,11 @@ namespace matx
           MATX_ASSERT_STR(!(is_host_executor_v<Executor> && method_ == MATX_C_METHOD_DIRECT), matxNotSupported, "direct corr() only supports the CUDA executor currently");
           MATX_STATIC_ASSERT_STR((Rank() == cuda::std::tuple_element_t<0, remove_cvref_t<Out>>::Rank()), 
                 matxInvalidParameter, "corr: inputs and outputs must have same rank to use corr with axis parameter");
+          auto outop = cuda::std::get<0>(out);
           if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
-            corr_impl(permute(cuda::std::get<0>(out), perm_), a_, b_, mode_, method_, ex);
+            outop = permute(outop, perm_);
           }
-          else {
-            corr_impl(cuda::std::get<0>(out), a_, b_, mode_, method_, ex);
-          }
+          corr_impl(outop, a_, b_, mode_, method_, ex);
         }
 
         template <typename ShapeType, typename Executor>

--- a/include/matx/operators/matmul.h
+++ b/include/matx/operators/matmul.h
@@ -113,12 +113,11 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
+          auto outop = cuda::std::get<0>(out);
           if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
-            matmul_impl(permute(cuda::std::get<0>(out), perm_), a_, b_, ex, alpha_, beta_);
+            outop = permute(outop, perm_);
           }
-          else {
-            matmul_impl(cuda::std::get<0>(out), a_, b_, ex, alpha_, beta_);
-          }
+          matmul_impl(outop, a_, b_, ex, alpha_, beta_);
         }
 
         template <typename ShapeType, typename Executor>


### PR DESCRIPTION
this change avoids some of the code duplication
within the permute / no-permute branches by
refactoring output permutation into prefix