### PR TITLE
Cleanup cmake usage when MatX is a dependent project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,10 @@ endif()
 if(NOT DEFINED rapids-cmake-dir)
   include(FetchContent)
   # Tell FetchContent to just use the local copy of rapids-cmake:
-  set(FETCHCONTENT_SOURCE_DIR_RAPIDS_CMAKE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/rapids-cmake")
-  FetchContent_Declare(rapids-cmake URL https://github.com/rapidsai/rapids-cmake/archive/refs/heads/branch-24.12.zip)
+  FetchContent_Declare(rapids-cmake SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/rapids-cmake")
+
+  # Tell FetchContent to download remote copy of rapids-cmake:
+  #FetchContent_Declare(rapids-cmake URL https://github.com/rapidsai/rapids-cmake/archive/refs/heads/branch-24.12.zip)
   FetchContent_MakeAvailable(rapids-cmake)
 else()
   # The include() commands below search the module path for the corresponding .cmake files

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,7 @@ set (test_sources
 )
 
 # Some of <00_io> tests need csv files and binaries which all
-# are located under 'CMAKE_SOURCE_DIR/test/00_io'. When calling the test
+# are located under 'CMAKE_CURRENT_SOURCE_DIR/00_io'. When calling the test
 # executable <matx_test> from its location in 'CMAKE_BINARY_DIR/test' the
 # search paths according <FileIOTests.cu> are
 # '../test/00_io/small_csv_comma_nh.csv' and
@@ -49,19 +49,19 @@ set (test_sources
 # they must be copied to the correct location:
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/test/00_io)
 file(COPY
-	${CMAKE_SOURCE_DIR}/test/00_io/small_csv_comma_nh.csv
+	${CMAKE_CURRENT_SOURCE_DIR}/00_io/small_csv_comma_nh.csv
 	DESTINATION ${CMAKE_BINARY_DIR}/test/00_io
 )
 file(COPY
-	${CMAKE_SOURCE_DIR}/test/00_io/small_csv_complex_comma_nh.csv
+	${CMAKE_CURRENT_SOURCE_DIR}/00_io/small_csv_complex_comma_nh.csv
 	DESTINATION ${CMAKE_BINARY_DIR}/test/00_io
 )
 file(COPY
-	${CMAKE_SOURCE_DIR}/test/00_io/test.mat
+	${CMAKE_CURRENT_SOURCE_DIR}/00_io/test.mat
 	DESTINATION ${CMAKE_BINARY_DIR}/test/00_io
 )
 file(COPY
-	${CMAKE_SOURCE_DIR}/test/00_io/test.npy
+	${CMAKE_CURRENT_SOURCE_DIR}/00_io/test.npy
 	DESTINATION ${CMAKE_BINARY_DIR}/test/00_io
 )
 
@@ -72,7 +72,7 @@ foreach (ptest ${proprietary_sources})
     list(APPEND proprietary_inc_list ${incdir}/../examples)
 endforeach()
 
-set(target_inc ${CMAKE_SOURCE_DIR}/test/include ${CMAKE_SOURCE_DIR}/examples/ ${proprietary_inc_list})
+set(target_inc ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/../examples/ ${proprietary_inc_list})
 set(system_inc ${CUTLASS_INC} ${GTEST_INC_DIRS} ${pybind11_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS})
 
 set(all_test_srcs ${test_sources} ${proprietary_sources})


### PR DESCRIPTION
Couple minor items:
1. Use FetchContent_Declare's SOURCE_DIR feature instead of directly setting a variable
2. Use CMAKE_CURRENT_SOURCE_DIR relative path to test vectors, allowing MatX tests to be built when MatX is not the top level project