### PR TITLE
Guard all DIM/LVL recursion against completely empty format

### DIFF
--- a/examples/sparse_tensor.cu
+++ b/examples/sparse_tensor.cu
@@ -42,6 +42,22 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   cudaExecutor exec{stream};
 
   //
+  // Print some formats that are used for the versatile sparse tensor
+  // type. Note that common formats like COO and CSR have good library
+  // support in e.g. cuSPARSE, but MatX provides a much more general
+  // way to define the sparse tensor storage through a DSL (see doc).
+  //
+  experimental::Scalar::print();   // scalars
+  experimental::SpVec::print();    // sparse vectors
+  experimental::COO::print();      // various sparse matrix formats
+  experimental::CSR::print();
+  experimental::CSC::print();
+  experimental::DCSR::print();
+  experimental::BSR<2,2>::print(); // 2x2 blocks
+  experimental::COO4::print();     // 4-dim tensor in COO
+  experimental::CSF5::print();     // 5-dim tensor in CSF
+
+  //
   // Creates a COO matrix for the following 4x8 dense matrix with 5 nonzero
   // elements, using the factory method that uses MatX tensors for the 1-dim
   // buffers. The sparse matrix resides in the same memory space as its buffer
@@ -71,7 +87,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   //
   // This shows:
   //
-  // tensor_impl_2_f32: Tensor{float} Rank: 2, Sizes:[4, 8], Levels:[4, 8]
+  // tensor_impl_2_f32: SparseTensor{float} Rank: 2, Sizes:[4, 8], Levels:[4, 8]
   // nse    = 5
   // format = ( d0, d1 ) -> ( d0 : compressed(non-unique), d1 : singleton )
   // crd[0] = ( 0  0  3  3  3 )

--- a/include/matx/core/sparse_tensor_format.h
+++ b/include/matx/core/sparse_tensor_format.h
@@ -255,42 +255,48 @@ public:
   template <typename CRD, int L = 0>
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static void
   dim2lvl(const CRD *dims, CRD *lvls, bool asSize) {
-    using ftype = std::tuple_element_t<L, LVLSPECS>;
-    if constexpr (ftype::expr::op == LvlOp::Id) {
-      lvls[L] = dims[ftype::expr::di];
-    } else if constexpr (ftype::expr::op == LvlOp::Div) {
-      lvls[L] = dims[ftype::expr::di] / ftype::expr::cj;
-    } else if constexpr (ftype::expr::op == LvlOp::Mod) {
-      lvls[L] =
-          asSize ? ftype::expr::cj : (dims[ftype::expr::di] % ftype::expr::cj);
-    }
-    if constexpr (L + 1 < LVL) {
-      dim2lvl<CRD, L + 1>(dims, lvls, asSize);
+    if constexpr (L < LVL) {
+      using ftype = std::tuple_element_t<L, LVLSPECS>;
+      if constexpr (ftype::expr::op == LvlOp::Id) {
+        lvls[L] = dims[ftype::expr::di];
+      } else if constexpr (ftype::expr::op == LvlOp::Div) {
+        lvls[L] = dims[ftype::expr::di] / ftype::expr::cj;
+      } else if constexpr (ftype::expr::op == LvlOp::Mod) {
+        lvls[L] = asSize ? ftype::expr::cj
+                         : (dims[ftype::expr::di] % ftype::expr::cj);
+      }
+      if constexpr (L + 1 < LVL) {
+        dim2lvl<CRD, L + 1>(dims, lvls, asSize);
+      }
     }
   }
 
   template <typename CRD, int L = 0>
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static void
   lvl2dim(const CRD *lvls, CRD *dims) {
-    using ftype = std::tuple_element_t<L, LVLSPECS>;
-    if constexpr (ftype::expr::op == LvlOp::Id) {
-      dims[ftype::expr::di] = lvls[L];
-    } else if constexpr (ftype::expr::op == LvlOp::Div) {
-      dims[ftype::expr::di] = lvls[L] * ftype::expr::cj;
-    } else if constexpr (ftype::expr::op == LvlOp::Mod) {
-      dims[ftype::expr::di] += lvls[L]; // update (seen second)
-    }
-    if constexpr (L + 1 < LVL) {
-      lvl2dim<CRD, L + 1>(lvls, dims);
+    if constexpr (L < LVL) {
+      using ftype = std::tuple_element_t<L, LVLSPECS>;
+      if constexpr (ftype::expr::op == LvlOp::Id) {
+        dims[ftype::expr::di] = lvls[L];
+      } else if constexpr (ftype::expr::op == LvlOp::Div) {
+        dims[ftype::expr::di] = lvls[L] * ftype::expr::cj;
+      } else if constexpr (ftype::expr::op == LvlOp::Mod) {
+        dims[ftype::expr::di] += lvls[L]; // update (seen second)
+      }
+      if constexpr (L + 1 < LVL) {
+        lvl2dim<CRD, L + 1>(lvls, dims);
+      }
     }
   }
 
   template <int L = 0> static void printLevel() {
-    using ftype = std::tuple_element_t<L, LVLSPECS>;
-    std::cout << " " << ftype::toString();
-    if constexpr (L + 1 < LVL) {
-      std::cout << ",";
-      printLevel<L + 1>();
+    if constexpr (L < LVL) {
+      using ftype = std::tuple_element_t<L, LVLSPECS>;
+      std::cout << " " << ftype::toString();
+      if constexpr (L + 1 < LVL) {
+        std::cout << ",";
+        printLevel<L + 1>();
+      }
     }
   }
 


### PR DESCRIPTION
Although unlikely to be useful, the "Scalar" form is a valid storage format in the full space of storage formats that can be described by the DSL. This minor change ensures those cases do not result in compile-time errors.