### PR TITLE
Implement the () operator on sparse tensors

### DIFF
--- a/include/matx/core/sparse_tensor.h
+++ b/include/matx/core/sparse_tensor.h
@@ -109,6 +109,82 @@ public:
   index_t crdSize(int l) const { return coordinates_[l].size() / sizeof(CRD); }
   index_t posSize(int l) const { return positions_[l].size() / sizeof(POS); }
 
+  // Locates position of an element at given indices, or returns -1 when not
+  // found.
+  template <int L = 0>
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t
+  GetPos(index_t *lvlsz, index_t *lvl, index_t pos) const {
+    if constexpr (L < LVL) {
+      using ftype = std::tuple_element_t<L, typename TF::LVLSPECS>;
+      if constexpr (ftype::lvltype == LvlType::Dense) {
+        // Dense level: pos * size + i.
+        // TODO: see below, use a constexpr GetLvlSize(L) instead?
+        const index_t dpos = pos * lvlsz[L] + lvl[L];
+        if constexpr (L + 1 < LVL) {
+          return GetPos<L + 1>(lvlsz, lvl, dpos);
+        } else {
+          return dpos;
+        }
+      } else if constexpr (ftype::lvltype == LvlType::Singleton) {
+        // Singleton level: pos if crd[pos] == i and next levels match.
+        if (this->CRDData(L)[pos] == lvl[L]) {
+          if constexpr (L + 1 < LVL) {
+            return GetPos<L + 1>(lvlsz, lvl, pos);
+          } else {
+            return pos;
+          }
+        }
+      } else if constexpr (ftype::lvltype == LvlType::Compressed ||
+                           ftype::lvltype == LvlType::CompressedNonUnique) {
+        // Compressed level: scan for match on i and test next levels.
+        const CRD *c = this->CRDData(L);
+        const POS *p = this->POSData(L);
+        for (index_t pp = p[pos], hi = p[pos + 1]; pp < hi; pp++) {
+          if (c[pp] == lvl[L]) {
+            if constexpr (L + 1 < LVL) {
+              const index_t cpos = GetPos<L + 1>(lvlsz, lvl, pp);
+              if constexpr (ftype::lvltype == LvlType::Compressed) {
+                return cpos; // always end scan (unique)
+              } else if (cpos != -1) {
+                return cpos; // only end scan on success (non-unique)
+              }
+            } else {
+              return pp;
+            }
+          }
+        }
+      }
+    }
+    return -1; // not found
+  }
+
+  // Element getter (viz. "lhs = Acoo(0,0);"). Note that due to the compact
+  // nature of sparse data structures, these storage formats do not provide
+  // cheap random access to their elements. Instead, the implementation will
+  // search for a stored element at the given position (which involves a scan
+  // at each compressed level). The implicit value zero is returned when the
+  // element cannot be found. So, although functional for testing, clients
+  // should avoid using getters inside performance critial regions, since
+  // the implementation is far worse than O(1).
+  template <typename... Is>
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ VAL
+  operator()(Is... indices) const noexcept {
+    static_assert(
+        sizeof...(Is) == DIM,
+        "Number of indices of operator() must match rank of sparse tensor");
+    cuda::std::array<index_t, DIM> dim{indices...};
+    cuda::std::array<index_t, LVL> lvl;
+    cuda::std::array<index_t, LVL> lvlsz;
+    TF::dim2lvl(dim.data(), lvl.data(), /*asSize=*/false);
+    // TODO: only compute once and provide a constexpr LvlSize(l) instead?
+    TF::dim2lvl(this->Shape().data(), lvlsz.data(), /*asSize=*/true);
+    const index_t pos = GetPos(lvlsz.data(), lvl.data(), 0);
+    if (pos != -1) {
+      return this->Data()[pos];
+    }
+    return static_cast<VAL>(0); // implicit zero
+  }
+
 private:
   // Primary storage of sparse tensor (explicitly stored element values).
   StorageV values_;

--- a/include/matx/core/sparse_tensor_format.h
+++ b/include/matx/core/sparse_tensor_format.h
@@ -255,42 +255,48 @@ public:
   template <typename CRD, int L = 0>
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static void
   dim2lvl(const CRD *dims, CRD *lvls, bool asSize) {
-    using ftype = std::tuple_element_t<L, LVLSPECS>;
-    if constexpr (ftype::expr::op == LvlOp::Id) {
-      lvls[L] = dims[ftype::expr::di];
-    } else if constexpr (ftype::expr::op == LvlOp::Div) {
-      lvls[L] = dims[ftype::expr::di] / ftype::expr::cj;
-    } else if constexpr (ftype::expr::op == LvlOp::Mod) {
-      lvls[L] =
-          asSize ? ftype::expr::cj : (dims[ftype::expr::di] % ftype::expr::cj);
-    }
-    if constexpr (L + 1 < LVL) {
-      dim2lvl<CRD, L + 1>(dims, lvls, asSize);
+    if constexpr (L < LVL) {
+      using ftype = std::tuple_element_t<L, LVLSPECS>;
+      if constexpr (ftype::expr::op == LvlOp::Id) {
+        lvls[L] = dims[ftype::expr::di];
+      } else if constexpr (ftype::expr::op == LvlOp::Div) {
+        lvls[L] = dims[ftype::expr::di] / ftype::expr::cj;
+      } else if constexpr (ftype::expr::op == LvlOp::Mod) {
+        lvls[L] = asSize ? ftype::expr::cj
+                         : (dims[ftype::expr::di] % ftype::expr::cj);
+      }
+      if constexpr (L + 1 < LVL) {
+        dim2lvl<CRD, L + 1>(dims, lvls, asSize);
+      }
     }
   }
 
   template <typename CRD, int L = 0>
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static void
   lvl2dim(const CRD *lvls, CRD *dims) {
-    using ftype = std::tuple_element_t<L, LVLSPECS>;
-    if constexpr (ftype::expr::op == LvlOp::Id) {
-      dims[ftype::expr::di] = lvls[L];
-    } else if constexpr (ftype::expr::op == LvlOp::Div) {
-      dims[ftype::expr::di] = lvls[L] * ftype::expr::cj;
-    } else if constexpr (ftype::expr::op == LvlOp::Mod) {
-      dims[ftype::expr::di] += lvls[L]; // update (seen second)
-    }
-    if constexpr (L + 1 < LVL) {
-      lvl2dim<CRD, L + 1>(lvls, dims);
+    if constexpr (L < LVL) {
+      using ftype = std::tuple_element_t<L, LVLSPECS>;
+      if constexpr (ftype::expr::op == LvlOp::Id) {
+        dims[ftype::expr::di] = lvls[L];
+      } else if constexpr (ftype::expr::op == LvlOp::Div) {
+        dims[ftype::expr::di] = lvls[L] * ftype::expr::cj;
+      } else if constexpr (ftype::expr::op == LvlOp::Mod) {
+        dims[ftype::expr::di] += lvls[L]; // update (seen second)
+      }
+      if constexpr (L + 1 < LVL) {
+        lvl2dim<CRD, L + 1>(lvls, dims);
+      }
     }
   }
 
   template <int L = 0> static void printLevel() {
-    using ftype = std::tuple_element_t<L, LVLSPECS>;
-    std::cout << " " << ftype::toString();
-    if constexpr (L + 1 < LVL) {
-      std::cout << ",";
-      printLevel<L + 1>();
+    if constexpr (L < LVL) {
+      using ftype = std::tuple_element_t<L, LVLSPECS>;
+      std::cout << " " << ftype::toString();
+      if constexpr (L + 1 < LVL) {
+        std::cout << ",";
+        printLevel<L + 1>();
+      }
     }
   }
 

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -637,7 +637,8 @@ MATX_IGNORE_WARNING_POP_GCC
      * @return
      *    A shape of the data with the appropriate dimensions set
      */
-    __MATX_INLINE__ auto Shape() const noexcept { return this->desc_.Shape(); }
+    __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__
+    auto Shape() const noexcept { return this->desc_.Shape(); }
 
     /**
      * Get the strides the tensor from the underlying data


### PR DESCRIPTION
Note that is a fully functional "locator" for the () operator that works for *all* versatile sparse tensors. Currently, the operator is defined at sparse_tensor level, but it should be moved into tensor_impl after this. Also, clients should always be aware that the () operator for compressed levels are *not* random-access, but involve a search to find if the element is stored.