### PR TITLE
Add print function with nonzero dim args

### DIFF
--- a/include/matx/core/print.h
+++ b/include/matx/core/print.h
@@ -737,9 +737,10 @@ namespace matx {
   }
 
   /**
-   * @brief Print all a tensor's values to stdout
+   * @brief Print all of a tensor's values to stdout
    *
-   * This form of `print()` is a specialization for 1D+ tensors.
+   * This form of `print()` is a specialization for 1D+ tensors. A size of zero in
+   * dimension prints all elements in that dimension.
    *
    * @tparam Op Operator input type
    * @param op Operator input

--- a/include/matx/core/print.h
+++ b/include/matx/core/print.h
@@ -737,6 +737,20 @@ namespace matx {
   }
 
   /**
+   * @brief Print all a tensor's values to stdout
+   *
+   * This form of `print()` is a specialization for 1D+ tensors.
+   *
+   * @tparam Op Operator input type
+   * @param op Operator input
+   */
+  template <typename Op, typename... Args,
+            std::enable_if_t<(Op::Rank() > 0 && sizeof...(Args) > 0), bool> = true>
+  void print(const Op &op, [[maybe_unused]] Args... dims) {
+    fprint(stdout, op, dims...);
+  }
+
+  /**
    * @brief Print a tensor's all values to stdout
    *
    * This form of `print()` is a specialization for 0D tensors.

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -4749,7 +4749,7 @@ TYPED_TEST(OperatorTestsFloatAllExecs, Print)
   auto r1 = ones<TestType>(t1.Shape());
   print(r1);
 
-  auto t3 = matx::make_tensor<double>({3, 2, 20});
+  auto t3 = matx::make_tensor<TestType>({3, 2, 20});
   print(matx::ones(t3.Shape()), 1, 0, 2);
 
   MATX_EXIT_HANDLER();

--- a/test/00_operators/OperatorTests.cu
+++ b/test/00_operators/OperatorTests.cu
@@ -4745,9 +4745,12 @@ TYPED_TEST(OperatorTestsFloatAllExecs, Print)
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
 
-  auto t = make_tensor<TestType>({3});
-  auto r = ones<TestType>(t.Shape());
+  auto t1 = make_tensor<TestType>({3});
+  auto r1 = ones<TestType>(t1.Shape());
+  print(r1);
 
-  print(r);
+  auto t3 = matx::make_tensor<double>({3, 2, 20});
+  print(matx::ones(t3.Shape()), 1, 0, 2);
+
   MATX_EXIT_HANDLER();
 }  


### PR DESCRIPTION
Add a new matx::print() implementation that accepts one or more arguments to specify the number of elements to print in the given dimension. This uses the pre-existing matx::fprint(stdout, ...) function.