### PR TITLE
Remove dense "testers" from the sparse tensor format type

### DIFF
--- a/include/matx/core/sparse_tensor_format.h
+++ b/include/matx/core/sparse_tensor_format.h
@@ -196,17 +196,6 @@ public:
 
   static_assert(DIM <= LVL);
 
-  static constexpr bool isScalar() { return LVL == 0; }
-
-  static constexpr bool isDnVec() {
-    if constexpr (LVL == 1) {
-      using first_type = std::tuple_element_t<0, LVLSPECS>;
-      return first_type::lvltype == LvlType::Dense &&
-             first_type::expr::op == LvlOp::Id && first_type::expr::di == 0;
-    }
-    return false;
-  }
-
   static constexpr bool isSpVec() {
     if constexpr (LVL == 1) {
       using first_type = std::tuple_element_t<0, LVLSPECS>;


### PR DESCRIPTION
Rationale:
Even though the versatile sparse tensor is able to define tensor storage as well, we will not use that feature inside the MatX library. So the testers will never be used.