### PR TITLE
Add compile-time check for minimum CUDA arch

### DIFF
--- a/include/matx.h
+++ b/include/matx.h
@@ -32,6 +32,9 @@
 
 #pragma once
 #ifdef __CUDACC__
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600
+#error "MatX requires CUDA compute capability 6.0 or newer."
+#endif
 #include <cuda_runtime_api.h>
 #endif
 #include <cuda/std/ccomplex>


### PR DESCRIPTION
MatX requires CUDA compute capability / architecture 6.0 (Pascal) or newer. Building for an older version, such as 5.2 (Maxwell), results in errors due to missing atomic support for some data types. Add an explicit check to the matx.h header to generate an earlier compile-time error that specifies the minimum architecture requirement.