### PR TITLE
Fix initializer list order

### DIFF
--- a/include/matx/file_io/tiff.h
+++ b/include/matx/file_io/tiff.h
@@ -51,7 +51,7 @@ namespace matx {
     {
       public:
         Tiff(cudaStream_t stream=0, int NUM_DECODERS=1)
-          : stream_(stream), NUM_DECODERS_(NUM_DECODERS), decoder_idx(0)
+          : NUM_DECODERS_(NUM_DECODERS), decoder_idx(0), stream_(stream)
         {
           events.resize(NUM_DECODERS_);
           tiff_streams.resize(NUM_DECODERS_);


### PR DESCRIPTION
When matx.h is included in a .cpp file and libnvtiff is present on the system, there is an initializer list ordering error during compilation:

```
In file included from /build/_deps/matx-src/include/matx/file_io/file_io.h:50,
                 from /build/_deps/matx-src/include/matx.h:44,
                 from /workspace/src/test.cpp:2:
/build/_deps/matx-src/include/matx/file_io/tiff.h: In constructor 'matx::io::Tiff::Tiff(cudaStream_t, int)':
/build/_deps/matx-src/include/matx/file_io/tiff.h:135:22: error: 'matx::io::Tiff::stream_' will be initialized after [-Werror=reorder]
  135 |         cudaStream_t stream_;
      |                      ^~~~~~~
/build/_deps/matx-src/include/matx/file_io/tiff.h:133:13: error:   'int matx::io::Tiff::NUM_DECODERS_' [-Werror=reorder]
  133 |         int NUM_DECODERS_;
      |             ^~~~~~~~~~~~~
/build/_deps/matx-src/include/matx/file_io/tiff.h:53:9: error:   when initialized here [-Werror=reorder]
   53 |         Tiff(cudaStream_t stream=0, int NUM_DECODERS=1)
      |         ^~~~
```

This PR fixes the issue