### PR TITLE
Docs: Fix Sphinx 9 path warning

### DIFF
--- a/docs_input/conf.py.in
+++ b/docs_input/conf.py.in
@@ -13,6 +13,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+from pathlib import Path
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import datetime
@@ -55,7 +56,7 @@ autodoc_default_options = {
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-breathe_projects = { "MatX": "@DOXYXML_DIR@" }
+breathe_projects = { "MatX": Path("@DOXYXML_DIR@") }
 breathe_default_project = "MatX"
 
 # The suffix(es) of source filenames.


### PR DESCRIPTION
Fix the Sphinx9 warning for documentation building.

Appears to make the warning go away when building locally.

Fixes #830 

- [x] I read the contribution guidelines