### PR TITLE
Add configurable Pwelch scaling and improve performance

### DIFF
--- a/docs_input/api/signalimage/general/pwelch.rst
+++ b/docs_input/api/signalimage/general/pwelch.rst
@@ -5,8 +5,8 @@ pwelch
 
 Estimate the power spectral density of a signal using Welch's method [1]_
 
-.. doxygenfunction:: pwelch(const xType& x, const wType& w, index_t nperseg, index_t noverlap, index_t nfft)
-.. doxygenfunction:: pwelch(const xType& x, index_t nperseg, index_t noverlap, index_t nfft)
+.. doxygenfunction:: pwelch(const xType& x, const wType& w, index_t nperseg, index_t noverlap, index_t nfft, PwelchOutputScaleMode output_scale_mode, typename xType::value_type::value_type fs)
+.. doxygenfunction:: pwelch(const xType& x, index_t nperseg, index_t noverlap, index_t nfft, PwelchOutputScaleMode output_scale_mode, typename xType::value_type::value_type fs)
 
 Examples
 ~~~~~~~~

--- a/docs_input/api/signalimage/general/pwelch.rst
+++ b/docs_input/api/signalimage/general/pwelch.rst
@@ -5,8 +5,8 @@ pwelch
 
 Estimate the power spectral density of a signal using Welch's method [1]_
 
-.. doxygenfunction:: pwelch(const xType& x, const wType& w, index_t nperseg, index_t noverlap, index_t nfft, PwelchOutputScaleMode output_scale_mode, typename xType::value_type::value_type fs)
-.. doxygenfunction:: pwelch(const xType& x, index_t nperseg, index_t noverlap, index_t nfft, PwelchOutputScaleMode output_scale_mode, typename xType::value_type::value_type fs)
+.. doxygenfunction:: pwelch(const xType& x, const wType& w, index_t nperseg, index_t noverlap, index_t nfft, PwelchOutputScaleMode output_scale_mode, fsType fs)
+.. doxygenfunction:: pwelch(const xType& x, index_t nperseg, index_t noverlap, index_t nfft, PwelchOutputScaleMode output_scale_mode, fsType fs)
 
 Examples
 ~~~~~~~~

--- a/examples/pwelch.cu
+++ b/examples/pwelch.cu
@@ -69,7 +69,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   (x = tmp_x).run(exec); // pre-compute x, tmp_x is otherwise lazily evaluated
 
   // Create window
-  auto w = make_tensor<complex>({nperseg});
+  auto w = make_tensor<float>({nperseg});
   (w = flattop<0>({nperseg})).run(exec);
 
   // Create output tensor

--- a/examples/pwelch.cu
+++ b/examples/pwelch.cu
@@ -50,18 +50,15 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   MATX_ENTER_HANDLER();
   using complex = cuda::std::complex<float>;
 
-  float exec_time_ms;
-  const int num_iterations = 100;
-  index_t signal_size = 256;
-  index_t nperseg = 32;
-  index_t nfft = nperseg;
-  index_t noverlap = 8;
-  float ftone = 3.0;
+  const int num_iterations = 500;
+  index_t signal_size = 256000;
+  index_t nperseg = 512;
+  index_t noverlap = 256;
+  index_t nfft = 65536;
+
+  float ftone = 2048.0;
   cudaStream_t stream;
   cudaStreamCreate(&stream);
-  cudaEvent_t start, stop;
-  cudaEventCreate(&start);
-  cudaEventCreate(&stop);
   cudaExecutor exec{stream};
 
   // Create input signal as a complex exponential
@@ -71,31 +68,30 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   auto x = make_tensor<complex>({signal_size});
   (x = tmp_x).run(exec); // pre-compute x, tmp_x is otherwise lazily evaluated
 
+  // Create window
+  auto w = make_tensor<complex>({nperseg});
+  (w = flattop<0>({nperseg})).run(exec);
+
   // Create output tensor
   auto Pxx  = make_tensor<typename complex::value_type>({nfft});
 
   // Run one time to pre-cache the FFT plan
-  (Pxx = pwelch(x, nperseg, noverlap, nfft)).run(exec);
+  (Pxx = pwelch(x, w, nperseg, noverlap, nfft)).run(exec);
   exec.sync();
 
   // Start the timing
-  cudaEventRecord(start, stream);
-
-  // Start the timing
-  cudaEventRecord(start, stream);
+  exec.start_timer();
 
   for (int iteration = 0; iteration < num_iterations; iteration++) {
     // Use the PWelch operator
-    (Pxx = pwelch(x, nperseg, noverlap, nfft)).run(exec);
+    (Pxx = pwelch(x, w, nperseg, noverlap, nfft)).run(exec);
   }
-
-  cudaEventRecord(stop, stream);
   exec.sync();
-  cudaEventElapsedTime(&exec_time_ms, start, stop);
+  exec.stop_timer();
 
-  printf("Output Pxx:\n");
-  print(Pxx);
-  printf("PWelchOp avg runtime = %.3f ms\n", exec_time_ms / num_iterations);
+  printf("Pxx(0) = %f\n", Pxx(0));
+  printf("Pxx(ftone) = %f\n", Pxx(2048));
+  printf("PWelchOp avg runtime = %.3f ms\n", exec.get_time_ms() / num_iterations);
 
   MATX_CUDA_CHECK_LAST_ERROR();
   MATX_EXIT_HANDLER();

--- a/include/matx/kernels/pwelch.cuh
+++ b/include/matx/kernels/pwelch.cuh
@@ -1,0 +1,101 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace matx {
+
+  enum PwelchOutputScaleMode {
+    PwelchOutputScaleMode_Spectrum,
+    PwelchOutputScaleMode_Density,
+    PwelchOutputScaleMode_Spectrum_dB,
+    PwelchOutputScaleMode_Density_dB
+  };
+
+  namespace detail {
+
+#ifdef __CUDACC__
+    template<PwelchOutputScaleMode OUTPUT_SCALE_MODE, typename T_IN, typename T_OUT, typename fsType>
+    __global__ void pwelch_kernel(const T_IN t_in, T_OUT t_out, fsType fs)
+    {
+      const index_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+      const index_t batches = t_in.Shape()[0];
+      const index_t nfft = t_in.Shape()[1];
+
+      if (tid < nfft)
+      {
+        typename T_OUT::value_type pxx = 0;
+        constexpr typename T_OUT::value_type ten = 10;
+
+        for (index_t batch = 0; batch < batches; batch++)
+        {
+          pxx += cuda::std::norm(t_in(batch, tid));
+        }
+
+        if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Spectrum)
+        {
+          t_out(tid) = pxx / batches;
+        }
+        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Density)
+        {
+          t_out(tid) = pxx / (batches * fs);
+        }
+        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Spectrum_dB)
+        {
+          pxx /= batches;
+          if (pxx != 0)
+          {
+            t_out(tid) = ten * cuda::std::log10(pxx);
+          }
+          else
+          {
+            t_out(tid) = cuda::std::numeric_limits<typename T_OUT::value_type>::lowest();
+          }
+        }
+        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Density_dB)
+        {
+          pxx /= (batches * fs);
+          if (pxx != 0)
+          {
+            t_out(tid) = ten * cuda::std::log10(pxx);
+          }
+          else
+          {
+            t_out(tid) = cuda::std::numeric_limits<typename T_OUT::value_type>::lowest();
+          }
+        }
+      }
+    }
+#endif
+
+  };
+};

--- a/include/matx/kernels/pwelch.cuh
+++ b/include/matx/kernels/pwelch.cuh
@@ -61,35 +61,27 @@ namespace matx {
           pxx += cuda::std::norm(t_in(batch, tid));
         }
 
-        if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Spectrum)
-        {
+        if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Spectrum) {
           t_out(tid) = pxx / batches;
         }
-        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Density)
-        {
+        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Density) {
           t_out(tid) = pxx / (batches * fs);
         }
-        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Spectrum_dB)
-        {
+        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Spectrum_dB) {
           pxx /= batches;
-          if (pxx != 0)
-          {
+          if (pxx != 0) {
             t_out(tid) = ten * cuda::std::log10(pxx);
           }
-          else
-          {
+          else {
             t_out(tid) = cuda::std::numeric_limits<typename T_OUT::value_type>::lowest();
           }
         }
-        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Density_dB)
-        {
+        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Density_dB) {
           pxx /= (batches * fs);
-          if (pxx != 0)
-          {
+          if (pxx != 0) {
             t_out(tid) = ten * cuda::std::log10(pxx);
           }
-          else
-          {
+          else {
             t_out(tid) = cuda::std::numeric_limits<typename T_OUT::value_type>::lowest();
           }
         }

--- a/include/matx/transforms/pwelch.h
+++ b/include/matx/transforms/pwelch.h
@@ -55,32 +55,26 @@ namespace matx
       index_t batches = x_with_overlaps.Shape()[0];
       auto X_with_overlaps = make_tensor<cuda::std::complex<typename PxxType::value_type>>({batches,static_cast<index_t>(nfft)},MATX_ASYNC_DEVICE_MEMORY,stream);
 
-      if constexpr (std::is_same_v<wType, std::nullopt_t>)
-      {
+      if constexpr (std::is_same_v<wType, std::nullopt_t>) {
         (X_with_overlaps = fft(x_with_overlaps,nfft)).run(stream);
       }
-      else
-      {
+      else {
         (X_with_overlaps = fft(x_with_overlaps * w,nfft)).run(stream);
       }
 
       int tpb = 512;
       int bpk = (static_cast<int>(nfft) + tpb - 1) / tpb;
 
-      if (output_scale_mode == PwelchOutputScaleMode_Spectrum)
-      {
+      if (output_scale_mode == PwelchOutputScaleMode_Spectrum) {
         detail::pwelch_kernel<PwelchOutputScaleMode_Spectrum><<<bpk, tpb, 0, stream>>>(X_with_overlaps, Pxx, fs);
       }
-      else if (output_scale_mode == PwelchOutputScaleMode_Density)
-      {
+      else if (output_scale_mode == PwelchOutputScaleMode_Density) {
         detail::pwelch_kernel<PwelchOutputScaleMode_Density><<<bpk, tpb, 0, stream>>>(X_with_overlaps, Pxx, fs);
       }
-      else if (output_scale_mode == PwelchOutputScaleMode_Spectrum_dB)
-      {
+      else if (output_scale_mode == PwelchOutputScaleMode_Spectrum_dB) {
         detail::pwelch_kernel<PwelchOutputScaleMode_Spectrum_dB><<<bpk, tpb, 0, stream>>>(X_with_overlaps, Pxx, fs);
       }
-      else //if (output_scale_mode == PwelchOutputScaleMode_Density_dB)
-      {
+      else { //if (output_scale_mode == PwelchOutputScaleMode_Density_dB)
         detail::pwelch_kernel<PwelchOutputScaleMode_Density_dB><<<bpk, tpb, 0, stream>>>(X_with_overlaps, Pxx, fs);
       }
     #endif

--- a/include/matx/transforms/pwelch.h
+++ b/include/matx/transforms/pwelch.h
@@ -32,74 +32,16 @@
 
 #pragma once
 
+#include "matx/kernels/pwelch.cuh"
+
 namespace matx
 {
-
-  enum PwelchOutputScaleMode {
-    PwelchOutputScaleMode_Spectrum,
-    PwelchOutputScaleMode_Density,
-    PwelchOutputScaleMode_Spectrum_dB,
-    PwelchOutputScaleMode_Density_dB
-  };
-
-  namespace detail {
-    template<PwelchOutputScaleMode OUTPUT_SCALE_MODE, typename T_IN, typename T_OUT>
-    __global__ void pwelch_kernel(const T_IN t_in, T_OUT t_out, typename T_OUT::value_type fs)
-    {
-      const index_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-      const index_t batches = t_in.Shape()[0];
-      const index_t nfft = t_in.Shape()[1];
-
-      if (tid < nfft)
-      {
-        typename T_OUT::value_type pxx = 0;
-        constexpr typename T_OUT::value_type ten = 10;
-
-        for (index_t batch = 0; batch < batches; batch++)
-        {
-          pxx += cuda::std::norm(t_in(batch, tid));
-        }
-
-        if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Spectrum)
-        {
-          t_out(tid) = pxx / batches;
-        }
-        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Density)
-        {
-          t_out(tid) = pxx / (batches * fs);
-        }
-        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Spectrum_dB)
-        {
-          pxx /= batches;
-          if (pxx != 0)
-          {
-            t_out(tid) = ten * cuda::std::log10(pxx);
-          }
-          else
-          {
-            t_out(tid) = cuda::std::numeric_limits<typename T_OUT::value_type>::lowest();
-          }
-        }
-        else if constexpr (OUTPUT_SCALE_MODE == PwelchOutputScaleMode_Density_dB)
-        {
-          pxx /= (batches * fs);
-          if (pxx != 0)
-          {
-            t_out(tid) = ten * cuda::std::log10(pxx);
-          }
-          else
-          {
-            t_out(tid) = cuda::std::numeric_limits<typename T_OUT::value_type>::lowest();
-          }
-        }
-      }
-    }
-  };
-
-  extern int g_pwelch_alg_mode;
-  template <typename PxxType, typename xType, typename wType>
-    __MATX_INLINE__ void pwelch_impl(PxxType Pxx, const xType& x, const wType& w, index_t nperseg, index_t noverlap, index_t nfft, PwelchOutputScaleMode output_scale_mode, typename PxxType::value_type fs, cudaStream_t stream=0)
-    {
+  template <typename PxxType, typename xType, typename wType, typename fsType>
+    __MATX_INLINE__ void pwelch_impl(PxxType Pxx, const xType& x, const wType& w, index_t nperseg, index_t noverlap, index_t nfft, PwelchOutputScaleMode output_scale_mode, fsType fs, cudaStream_t stream=0)
+  {
+    #ifndef __CUDACC__
+      MATX_THROW(matxNotSupported, "pwelch not supported on host");
+    #else
       MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
       MATX_ASSERT_STR(Pxx.Rank() == x.Rank(), matxInvalidDim, "pwelch:  Pxx rank must be the same as x rank");
@@ -141,6 +83,6 @@ namespace matx
       {
         detail::pwelch_kernel<PwelchOutputScaleMode_Density_dB><<<bpk, tpb, 0, stream>>>(X_with_overlaps, Pxx, fs);
       }
-    }
-
+    #endif
+  }
 } // end namespace matx


### PR DESCRIPTION
This PR addresses concerns in issue #887:

* Configurable scaling is supported.  Density and Spectrum modes, similar to Matlab or scipy.signal, as well as fused dB modes frequently needed for spectrum-analyzer-like plotting

* Custom reduction kernel is used instead of MatX sum() using CUB DeviceSegmentedReduce (DSR).

Three reasons why the custom reduction kernel is preferred:

1. In the nominal case where the input signal is a memory backed complex-valued tensor and the output power spectrum is a memory backed real-valued tensor, the intermediate overlapping signal is a 2D tensor {batches, nfft}.  This is an optimal memory layout for the FFTs, but a very suboptimal layout for CUB DSR which would the permuted layout {nfft, batches} as CUB DSR uses one block of threads to read all the 'batches' of a single fft bin.  To improve CUB performance, we'd either need to have the batched FFTs directly write to a permuted tensor (about 4x slower for the scenario considered) or permute the intermediate tensor after the FFT (extra round trip through global memory). 

2. CUB currently needs begin/end indexes for each data segment, the generation of which takes around 50% longer than the custom reduction (ignoring the permutation issue)

3. The custom reduction allows for configurable scaling, such as fusing a dB conversion.