### PR TITLE
feat: added economic QR

### DIFF
--- a/docs_input/api/linalg/decomp/qr.rst
+++ b/docs_input/api/linalg/decomp/qr.rst
@@ -8,7 +8,9 @@ Perform a QR decomposition.
 .. doxygenfunction:: qr
 
 .. note::
-   This function is currently not supported with host-based executors (CPU)
+   This function is currently not supported with host-based executors (CPU), and performs a full QR 
+   decomposition of a tensor `A` with shape `... x m x n`, where `Q` is shaped `... x m x m` and `R`
+   is shaped `... x m x n`.
 
 Examples
 ~~~~~~~~
@@ -19,13 +21,12 @@ Examples
    :end-before: example-end qr-test-1
    :dedent:
 
-
 .. doxygenfunction:: qr_econ
 
 .. note::
-   This function returns an economic QR decomposition, where `Q/R` are shaped `m x k` and `k x n` respectively,
-   where `k = min(m, n)`. 
-   This function is currently not supported with host-based executors (CPU)
+   This function is currently not supported with host-based executors (CPU). It returns an economic 
+   QR decomposition, where `Q/R` are shaped `m x k` and `k x n` respectively, where `k = min(m, n)`. 
+   This is useful when `m >> n` to save memory and computation time.
 
 Examples
 ~~~~~~~~
@@ -40,7 +41,7 @@ Examples
 
 .. note::
    This function does not return `Q` explicitly as it only runs :literal:`geqrf` from LAPACK/cuSolver.
-   For full `Q/R`, use :literal:`qr_solver` on a CUDA executor.
+   For full or economic `Q/R`, use :literal:`qr` or :literal:`qr_econ` on a CUDA executor.
 
 Examples
 ~~~~~~~~
@@ -50,3 +51,4 @@ Examples
    :start-after: example-begin qr_solver-test-1
    :end-before: example-end qr_solver-test-1
    :dedent:
+

--- a/docs_input/api/linalg/decomp/qr.rst
+++ b/docs_input/api/linalg/decomp/qr.rst
@@ -20,6 +20,22 @@ Examples
    :dedent:
 
 
+.. doxygenfunction:: qr_econ
+
+.. note::
+   This function returns an economic QR decomposition, where `Q/R` are shaped `m x k` and `k x n` respectively,
+   where `k = min(m, n)`. 
+   This function is currently not supported with host-based executors (CPU)
+
+Examples
+~~~~~~~~
+
+.. literalinclude:: ../../../../test/00_solver/QREcon.cu
+   :language: cpp
+   :start-after: example-begin qr-econ-test-1
+   :end-before: example-end qr-econ-test-1
+   :dedent:
+
 .. doxygenfunction:: qr_solver
 
 .. note::

--- a/include/matx/operators/qr.h
+++ b/include/matx/operators/qr.h
@@ -236,7 +236,7 @@ namespace detail {
 }
 
 /**
- * Perform a QR decomposition on a matrix using cuSolver or a LAPACK host library.
+ * Perform an economic QR decomposition on a matrix using cuSolver.
  * 
  * If rank > 2, operations are batched.
  * 
@@ -247,10 +247,9 @@ namespace detail {
  *   Input tensor or operator of shape `... x m x n`
  * 
  * @return
- *   Operator that produces R/householder vectors and tau tensor outputs.
- *   - **Out** - Of shape `... x m x n`. The householder vectors are returned in the
- *               bottom half and *R* is returned in the top half.
- *   - **Tau** - The scalar factors *tau* of shape `... x min(m, n)`.
+ *   Operator that produces QR outputs.
+ *   - **Q** - Of shape `... x m x min(m, n)`, the reduced orthonormal basis for the span of A.
+ *   - **R** - Upper triangular matrix of shape  `... x min(m, n) x n`.
  */
 template<typename OpA>
 __MATX_INLINE__ auto qr_econ(const OpA &a) {

--- a/include/matx/transforms/qr/qr_cuda.h
+++ b/include/matx/transforms/qr/qr_cuda.h
@@ -238,6 +238,7 @@ namespace detail {
  * factorizations mostly by the data pointer in A
  */
 struct DnQRCUDAParams_t {
+  int64_t rank;
   int64_t m;
   int64_t n;
   void *A;
@@ -313,7 +314,7 @@ public:
                                   const cudaExecutor &exec)
   {
     DnQRCUDAParams_t params;
-
+    params.rank = RANK;
     params.batch_size = GetNumBatches(a);
     params.m = a.Size(RANK - 2);
     params.n = a.Size(RANK - 1);
@@ -397,7 +398,7 @@ private:
 struct DnQRCUDAParamsKeyHash {
   std::size_t operator()(const DnQRCUDAParams_t &k) const noexcept
   {
-    return (std::hash<uint64_t>()(k.m)) + (std::hash<uint64_t>()(k.n)) +
+    return (std::hash<uint64_t>()(k.rank)) + (std::hash<uint64_t>()(k.m)) + (std::hash<uint64_t>()(k.n)) +
            (std::hash<uint64_t>()(k.batch_size)) + (std::hash<uint64_t>()((uint64_t)(k.exec.getStream())));
   }
 };
@@ -409,7 +410,8 @@ struct DnQRCUDAParamsKeyEq {
   bool operator()(const DnQRCUDAParams_t &l, const DnQRCUDAParams_t &t) const noexcept
   {
     return l.n == t.n && l.m == t.m && l.batch_size == t.batch_size &&
-           l.dtype == t.dtype && l.exec.getStream() == t.exec.getStream();
+           l.dtype == t.dtype && l.exec.getStream() == t.exec.getStream() &&
+           l.rank == t.rank;
   }
 };
 
@@ -485,6 +487,379 @@ void qr_solver_impl(OutTensor &&out, TauTensor &&tau,
   /* Temporary WAR
    * Copy and free async buffer for transpose */
   matx::copy(out, tv.PermuteMatrix(), exec);
+  matxFree(tp);
+}
+
+/********************************************** Economic QR
+ * *********************************************/
+
+namespace detail {
+
+template<class>
+inline constexpr bool always_false_v = false;
+
+template <typename OutTensor, typename RTensor, typename TauTensor, typename ATensor>
+class matxDnEconQRCUDAPlan_t : matxDnCUDASolver_t {
+  using OutTensor_t = remove_cvref_t<OutTensor>;
+  using RTensor_t = remove_cvref_t<RTensor>;
+  using T1 = typename ATensor::value_type;
+  using T2 = typename TauTensor::value_type;
+  static constexpr int RANK = OutTensor_t::Rank();
+  static_assert(RANK >= 2, "Input/Output tensor must be rank 2 or higher");
+
+public:
+  /**
+   * Plan for factoring A such that \f$\textbf{A} = \textbf{Q} * \textbf{R}\f$
+   *
+   * Creates a handle for factoring matrix A into the format above. QR
+   * decomposition in cuBLAS/cuSolver does not return the Q matrix directly, and
+   * it must be computed separately used the Householder reflections in the tau
+   * output, along with the overwritten A matrix input. The input and output
+   * parameters may be the same tensor. In that case, the input is destroyed and
+   * the output is stored in-place.
+   *
+   * @tparam T1
+   *  Data type of A matrix
+   * @tparam T2
+   *  Data type of Tau vector
+   * @tparam RANK
+   *  Rank of A matrix
+   *
+   * @param tau
+   *   Scaling factors for reflections
+   * @param a
+   *   Input tensor view
+   *
+   */
+  matxDnEconQRCUDAPlan_t(TauTensor &tau,
+                       const ATensor &a,
+                       const cudaExecutor &exec)
+  {
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    // Dim checks
+    MATX_STATIC_ASSERT_STR(RANK-1 == TauTensor::Rank(), matxInvalidDim, "Tau tensor must be one rank less than output tensor");
+    MATX_STATIC_ASSERT_STR(RANK == ATensor::Rank(), matxInvalidDim, "Output tensor must match A tensor rank in QR");
+    MATX_STATIC_ASSERT_STR(RANK == RTensor_t::Rank(), matxInvalidDim, "Output tensor R must match A tensor rank in QR");
+
+    // Type checks
+    MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "QR solver does not support half precision");
+    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename RTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, T2>), matxInavlidType, "A and Tau types must match");
+
+    params = GetQRParams(tau, a, exec);
+    this->GetWorkspaceSize();
+    this->AllocateWorkspace(params.batch_size, false, exec);
+  }
+
+  void GetWorkspaceSize() override
+  {
+    [[maybe_unused]] cusolverStatus_t ret = cusolverDnXgeqrf_bufferSize(
+            this->handle, this->dn_params, params.m, params.n, MatXTypeToCudaType<T1>(),
+            params.A, params.m, MatXTypeToCudaType<T2>(), params.tau,
+            MatXTypeToCudaType<T1>(), &this->dspace, &this->hspace);
+    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+    int dspace_orgqr;
+
+    ret = orgqr_bufferSize_dispatch(
+      params.m, params.n, std::min(params.m, params.n),
+      params.A, params.m, params.tau, &dspace_orgqr);
+    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+
+    this->dspace = std::max(this->dspace, static_cast<size_t>(dspace_orgqr));
+
+  }
+
+  static DnQRCUDAParams_t GetQRParams(TauTensor &tau,
+                                  const ATensor &a,
+                                  const cudaExecutor &exec)
+  {
+    DnQRCUDAParams_t params;
+    params.rank = RANK;
+    params.batch_size = GetNumBatches(a);
+    params.m = a.Size(RANK - 2);
+    params.n = a.Size(RANK - 1);
+    params.A = a.Data();
+    params.tau = tau.Data();
+    params.dtype = TypeToInt<T1>();
+    params.exec = exec;
+    return params;
+  }
+
+  void Exec(OutTensor &out, RTensor &out_r, TauTensor &tau,
+            const ATensor &a, const cudaExecutor &exec)
+  {
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    // Batch size checks
+    for(int i = 0 ; i < RANK-2; i++) {
+      MATX_ASSERT_STR(out.Size(i) == a.Size(i), matxInvalidDim, "Out and A must have the same batch sizes");
+      MATX_ASSERT_STR(tau.Size(i) == a.Size(i), matxInvalidDim, "Tau and A must have the same batch sizes");
+      MATX_ASSERT_STR(out.Size(i) == out_r.Size(i), matxInvalidDim, "Out and R must have the same batch sizes");
+    }
+
+    // Inner size checks
+    MATX_ASSERT_STR((out.Size(RANK-2) == params.m) && (out.Size(RANK-1) == params.n), matxInvalidSize, "Out and A shapes do not match");
+    MATX_ASSERT_STR(tau.Size(RANK-2) == cuda::std::min(params.m, params.n), matxInvalidSize, "Tau must be ... x min(m,n)");
+    MATX_ASSERT_STR((out_r.Size(RANK-2) == cuda::std::min(params.m, params.n)) && (out.Size(RANK-1) == params.n), matxInvalidSize, "R and out shapes are not compatible");
+
+    SetBatchPointers<BatchType::MATRIX>(out, this->batch_a_ptrs);
+    SetBatchPointers<BatchType::VECTOR>(tau, this->batch_tau_ptrs);
+
+    if (out.Data() != a.Data()) {
+      (out = a).run(exec);
+    }
+
+    const auto stream = exec.getStream();
+    cusolverDnSetStream(this->handle, stream);
+
+    // At this time cuSolver does not have a batched 64-bit LU interface. Change
+    // this to use the batched version once available.
+    for (size_t i = 0; i < this->batch_a_ptrs.size(); i++) {
+      [[maybe_unused]] auto ret = cusolverDnXgeqrf(
+          this->handle, this->dn_params, params.m, params.n, MatXTypeToCudaType<T1>(),
+          this->batch_a_ptrs[i], params.m, MatXTypeToCudaType<T2>(),
+          this->batch_tau_ptrs[i], MatXTypeToCudaType<T1>(),
+          reinterpret_cast<uint8_t *>(this->d_workspace) + i * this->dspace, this->dspace,
+          reinterpret_cast<uint8_t *>(this->h_workspace) + i * this->hspace, this->hspace,
+          this->d_info + i);
+
+      MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+
+      
+    }
+
+    std::vector<int> h_info(this->batch_a_ptrs.size());
+    cudaMemcpyAsync(h_info.data(), this->d_info, sizeof(int) * this->batch_a_ptrs.size(), cudaMemcpyDeviceToHost, stream);
+
+    // This will block. Figure this out later
+    cudaStreamSynchronize(stream);
+
+    for ([[maybe_unused]] const auto& info : h_info) {
+      MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+        ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xgeqrf").c_str());
+    }
+
+    // at this point, R is stored in the upper triangular part of out
+    // so copy it out into memory assigned by user.
+    // Per the cuSolver documentation (quoted):
+    // The matrix R is overwritten in upper triangular part of A, 
+    // including diagonal elements
+    cuda::std::array<index_t, RANK> rSliceB, rSliceE;   
+    rSliceB.fill(0); rSliceE.fill(matxEnd);
+    rSliceE[RANK-2] = matxDropDim;
+    rSliceE[RANK-1] = params.n; // taking upper triangular portion of out    
+
+    for (int i = 0; i < std::min(params.m, params.n); i++){
+      rSliceB[RANK-2] = i;
+      (slice<RANK-1>(out_r, rSliceB, rSliceE) = (index(RANK-2) >= i)*slice<RANK-1>(out, rSliceB, rSliceE)).run(exec);
+    }
+
+    // Intentionally looping AGAIN, so we can reuse h_info and d_info without 
+    // having to copy to host with each iteration of the loop
+    for (size_t i = 0; i < this->batch_a_ptrs.size(); i++) {
+      [[maybe_unused]] auto ret = orgqr_dispatch(
+            params.m, std::min(params.m, params.n), std::min(params.m, params.n),
+            this->batch_a_ptrs[i], params.m, this->batch_tau_ptrs[i],
+            this->d_workspace, this->dspace, this->d_info + this->batch_a_ptrs.size() + i);
+        MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+    }
+
+    cudaMemcpyAsync(h_info.data(), this->d_info, sizeof(int) * this->batch_a_ptrs.size(), cudaMemcpyDeviceToHost, stream);
+
+    // This will block. Figure this out later
+    cudaStreamSynchronize(stream);
+
+    for ([[maybe_unused]] const auto& info : h_info) {
+      MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+        ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xorgqr").c_str());
+    }
+
+  }
+
+  /**
+   * QR solver handle destructor
+   *
+   * Destroys any helper data used for provider type and any workspace memory
+   * created
+   *
+   */
+  ~matxDnEconQRCUDAPlan_t() {}
+
+private:
+  
+  cusolverStatus_t orgqr_bufferSize_dispatch(
+    int64_t m64, int64_t n64, int64_t k64,
+    void* A, int64_t lda64,
+    void* tau,
+    int* lwork){
+    
+    int m = static_cast<int>(m64);
+    int n = static_cast<int>(n64);
+    int k = static_cast<int>(k64);
+    int lda = static_cast<int>(lda64);
+
+    if constexpr (std::is_same_v<T1, float>) {
+      return cusolverDnSorgqr_bufferSize(handle, m, n, k, 
+              reinterpret_cast<T1*>(A), lda, 
+              reinterpret_cast<T1*>(tau), 
+              lwork);
+    } 
+    else if constexpr (std::is_same_v<T1, double>) {
+      return cusolverDnDorgqr_bufferSize(handle, m, n, k, 
+        reinterpret_cast<T1*>(A), lda, 
+        reinterpret_cast<T1*>(tau), 
+              lwork);
+    } 
+    else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+      return cusolverDnCungqr_bufferSize(handle, m, n, k, 
+              reinterpret_cast<cuComplex*>(A), lda, 
+              reinterpret_cast<cuComplex*>(tau), 
+              lwork);
+    } 
+    else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+      return cusolverDnZungqr_bufferSize(handle, m, n, k, 
+        reinterpret_cast<cuDoubleComplex*>(A), lda, 
+        reinterpret_cast<cuDoubleComplex*>(tau), 
+              lwork);
+    }
+    else{
+      // should never reach here
+      static_assert(always_false_v<T1>, "Unsupported type for economic QR");
+    }
+  }
+
+  cusolverStatus_t orgqr_dispatch(
+    int64_t m64, int64_t n64, int64_t k64,
+    void* A, int64_t lda64,
+    void* tau,
+    void* work, int64_t lwork64,
+    int* info)
+  {
+    int m = static_cast<int>(m64);
+    int n = static_cast<int>(n64);
+    int k = static_cast<int>(k64);
+    int lda = static_cast<int>(lda64);
+    int lwork = static_cast<int>(lwork64);
+
+    if constexpr (std::is_same_v<T1, float>) {
+      return cusolverDnSorgqr(handle, m, n, k, 
+              reinterpret_cast<T1*>(A), lda, 
+              reinterpret_cast<T1*>(tau), 
+              reinterpret_cast<T1*>(work), lwork, info);
+    } 
+    else if constexpr (std::is_same_v<T1, double>) {
+      return cusolverDnDorgqr(handle, m, n, k, 
+              reinterpret_cast<T1*>(A), lda, 
+              reinterpret_cast<T1*>(tau), 
+              reinterpret_cast<T1*>(work), lwork, info);
+    } 
+    else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+      return cusolverDnCungqr(handle, m, n, k, 
+              reinterpret_cast<cuComplex*>(A), lda, 
+              reinterpret_cast<cuComplex*>(tau), 
+              reinterpret_cast<cuComplex*>(work), lwork, info);
+    } 
+    else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+      return cusolverDnZungqr(handle, m, n, k, 
+              reinterpret_cast<cuDoubleComplex*>(A), lda, 
+              reinterpret_cast<cuDoubleComplex*>(tau), 
+              reinterpret_cast<cuDoubleComplex*>(work), lwork, info);
+    }
+    else{
+      // should never reach here
+      static_assert(always_false_v<T1>, "Unsupported type for economic QR");
+    }
+  }
+
+  std::vector<T2 *> batch_tau_ptrs;
+  DnQRCUDAParams_t params;
+};
+
+
+} // end namespace detail
+
+/**
+ * Perform a QR decomposition using a cached plan
+ *
+ * See documentation of matxDnQRCUDAPlan_t for a description of how the
+ * algorithm works. This function provides a simple interface to the cuSolver
+ * library by deducing all parameters needed to perform a QR decomposition from
+ * only the matrix A. The input and output parameters may be the same tensor. In
+ * that case, the input is destroyed and the output is stored in-place.
+ *
+ * @tparam T1
+ *   Data type of matrix A
+ * @tparam RANK
+ *   Rank of matrix A
+ *
+ * @param out
+ *   Orthogonal matrix Q
+ * @param out_r
+ *   Upper triangular output matrix R
+ * @param a
+ *   Input tensor A
+ * @param exec
+ *   CUDA executor
+ */
+template <typename OutTensor, typename RTensor, typename ATensor>
+void qr_econ_impl(OutTensor &&out, RTensor &&out_r,
+        const ATensor &a, const cudaExecutor &exec)
+{
+  MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+  using T1 = typename remove_cvref_t<OutTensor>::value_type;
+  const int RANK = ATensor::Rank();
+
+  cuda::std::array<index_t, RANK-1> tau_shape;
+  for(int i = 0; i < RANK-2; i++) {
+    tau_shape[i] = a.Size(i);
+  }
+  tau_shape[RANK-2] = cuda::std::min(a.Size(RANK-1), a.Size(RANK-2));
+
+  auto tau_new = make_tensor<T1>(tau_shape);
+  //auto tau_new = OpToTensor(tau, exec);
+  auto a_new = OpToTensor(a, exec);
+  
+  if(!is_matx_transform_op<ATensor>() && !a_new.isSameView(a)) {
+    (a_new = a).run(exec);
+  }
+
+  /* Temporary WAR
+     cuSolver doesn't support row-major layouts. Since we want to make the
+     library appear as though everything is row-major, we take a performance hit
+     to transpose in and out of the function. Eventually this may be fixed in
+     cuSolver.
+  */
+  T1 *tp;
+  matxAlloc(reinterpret_cast<void **>(&tp), a_new.Bytes(), MATX_ASYNC_DEVICE_MEMORY,
+            exec.getStream());
+  auto tv = TransposeCopy(tp, a_new, exec);
+  auto tvt = tv.PermuteMatrix();
+
+  // Get parameters required by these tensors
+  auto params = detail::matxDnEconQRCUDAPlan_t<OutTensor, RTensor, decltype(tau_new), decltype(a_new)>::GetQRParams(tau_new, tvt, exec);
+
+  // Get cache or new QR plan if it doesn't exist
+  using cache_val_type = detail::matxDnEconQRCUDAPlan_t<OutTensor, RTensor, decltype(tau_new), decltype(a_new)>;
+  detail::GetCache().LookupAndExec<detail::qr_cuda_cache_t>(
+    detail::GetCacheIdFromType<detail::qr_cuda_cache_t>(),
+    params,
+    [&]() {
+      return std::make_shared<cache_val_type>(tau_new, tvt, exec);
+    },
+    [&](std::shared_ptr<cache_val_type> ctype) {
+      ctype->Exec(tvt, out_r, tau_new, tvt, exec);
+    }
+  );
+
+  /* Temporary WAR
+   * Copy and free async buffer for transpose */
+  cuda::std::array<index_t, RANK> rSliceB, rSliceE;   
+  rSliceB.fill(0); rSliceE.fill(matxEnd);
+  rSliceE[RANK-2] = params.m;
+  rSliceE[RANK-1] = std::min(params.m, params.n);
+  matx::copy(out, slice(tv.PermuteMatrix(), rSliceB, rSliceE), exec);
   matxFree(tp);
 }
 

--- a/include/matx/transforms/qr/qr_cuda.h
+++ b/include/matx/transforms/qr/qr_cuda.h
@@ -600,9 +600,9 @@ public:
     }
 
     // Inner size checks
-    MATX_ASSERT_STR((out.Size(RANK-2) == params.m) && (out.Size(RANK-1) == params.n), matxInvalidSize, "Out and A shapes do not match");
+    MATX_ASSERT_STR((out.Size(RANK-2) == params.m) && (out.Size(RANK-1) == cuda::std::min(params.m, params.n)), matxInvalidSize, "Out and A shapes are not compatible");
     MATX_ASSERT_STR(tau.Size(RANK-2) == cuda::std::min(params.m, params.n), matxInvalidSize, "Tau must be ... x min(m,n)");
-    MATX_ASSERT_STR((out_r.Size(RANK-2) == cuda::std::min(params.m, params.n)) && (out.Size(RANK-1) == params.n), matxInvalidSize, "R and out shapes are not compatible");
+    MATX_ASSERT_STR((out_r.Size(RANK-2) == cuda::std::min(params.m, params.n)) && (out_r.Size(RANK-1) == params.n), matxInvalidSize, "R and out shapes are not compatible");
 
     SetBatchPointers<BatchType::MATRIX>(out, this->batch_a_ptrs);
     SetBatchPointers<BatchType::VECTOR>(tau, this->batch_tau_ptrs);
@@ -818,7 +818,6 @@ void qr_econ_impl(OutTensor &&out, RTensor &&out_r,
   tau_shape[RANK-2] = cuda::std::min(a.Size(RANK-1), a.Size(RANK-2));
 
   auto tau_new = make_tensor<T1>(tau_shape);
-  //auto tau_new = OpToTensor(tau, exec);
   auto a_new = OpToTensor(a, exec);
   
   if(!is_matx_transform_op<ATensor>() && !a_new.isSameView(a)) {

--- a/include/matx/transforms/qr/qr_cuda.h
+++ b/include/matx/transforms/qr/qr_cuda.h
@@ -600,7 +600,7 @@ public:
     }
 
     // Inner size checks
-    MATX_ASSERT_STR((out.Size(RANK-2) == params.m) && (out.Size(RANK-1) == cuda::std::min(params.m, params.n)), matxInvalidSize, "Out and A shapes are not compatible");
+    MATX_ASSERT_STR((out.Size(RANK-2) == params.m) && (out.Size(RANK-1) == params.n), matxInvalidSize, "Out and A shapes do not match");
     MATX_ASSERT_STR(tau.Size(RANK-2) == cuda::std::min(params.m, params.n), matxInvalidSize, "Tau must be ... x min(m,n)");
     MATX_ASSERT_STR((out_r.Size(RANK-2) == cuda::std::min(params.m, params.n)) && (out_r.Size(RANK-1) == params.n), matxInvalidSize, "R and out shapes are not compatible");
 

--- a/include/matx/transforms/svd/svd_cuda.h
+++ b/include/matx/transforms/svd/svd_cuda.h
@@ -713,7 +713,7 @@ public:
         MATX_THROW(matxInvalidType, "Invalid data type passed to svd()");
       }
 
-      this->dspace = i_dspace;
+      this->dspace = sizeof(T1) * i_dspace;
       this->hspace = 0;
     }
 

--- a/test/00_solver/QREcon.cu
+++ b/test/00_solver/QREcon.cu
@@ -1,0 +1,134 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "assert.h"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+#include "gtest/gtest.h"
+
+using namespace matx;
+
+template <typename TensorType>
+class QREconSolverTestNonHalfTypes : public ::testing::Test{
+};
+
+TYPED_TEST_SUITE(QREconSolverTestNonHalfTypes,
+  MatXFloatNonHalfTypesCUDAExec);
+
+template <typename TestType, int RANK>
+void qr_econ_test( const index_t (&AshapeA)[RANK]) { 
+  using AType = TestType;
+  using SType = typename inner_op_type_t<AType>::type;
+  
+  cudaStream_t stream = 0;
+  cudaExecutor exec{stream};
+
+  cuda::std::array<index_t, RANK> Ashape = detail::to_array(AshapeA);
+  cuda::std::array<index_t, RANK> Qshape = Ashape;
+  cuda::std::array<index_t, RANK> Rshape = Ashape;
+
+  index_t m = Ashape[RANK-2];
+  index_t n = Ashape[RANK-1];
+  index_t k = cuda::std::min(m, n);
+  Qshape[RANK-2] = m;
+  Qshape[RANK-1] = k;
+
+  Rshape[RANK-2] = k;
+  Rshape[RANK-1] = n;
+
+  auto A = make_tensor<AType>(Ashape);
+  auto Q = make_tensor<AType>(Qshape);
+  auto R = make_tensor<AType>(Rshape);
+  
+  (A = random<AType>(Ashape, NORMAL)).run(exec);
+  
+  // example-begin qr-econ-test-1
+  (mtie(Q, R) = qr_econ(A)).run(exec);
+  // example-end qr-econ-test-1
+
+  auto mdiffQTQ = make_tensor<SType>({});
+  auto mdiffQR = make_tensor<SType>({});
+
+  {
+    // QTQ == Identity
+    cuda::std::array<index_t, RANK> QTQshape = Qshape;
+    QTQshape[RANK-1] = k;
+    QTQshape[RANK-2] = k;
+
+    auto QTQ = make_tensor<AType>(QTQshape);
+    (QTQ = matmul(conj(transpose_matrix(Q)), Q)).run(exec);
+    auto e = eye<AType>({k, k});
+
+    auto eShape = QTQshape;
+    eShape[RANK-1] = matxKeepDim;
+    eShape[RANK-2] = matxKeepDim;
+    auto I = clone<RANK>(e, eShape);
+  
+    (mdiffQTQ = max(abs(QTQ-I))).run(exec);
+
+  }
+
+  {
+    // Q*R == A
+    auto QR = make_tensor<AType>(Ashape);
+    (QR = matmul(Q, R)).run(exec);
+    
+    (mdiffQR = max(abs(A-QR))).run(exec);
+  }
+
+  exec.sync();
+
+  ASSERT_NEAR( mdiffQTQ(), SType(0), .00001);
+  ASSERT_NEAR( mdiffQR(), SType(0), .00001);
+}
+
+TYPED_TEST(QREconSolverTestNonHalfTypes, QREcon)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;  
+  
+  qr_econ_test<TestType>({4,4});
+  qr_econ_test<TestType>({4,16});
+  
+  qr_econ_test<TestType>({16,4});
+
+  qr_econ_test<TestType>({25,4,4});
+  qr_econ_test<TestType>({25,4,16});
+  qr_econ_test<TestType>({25,16,4});
+
+  qr_econ_test<TestType>({5,5,4,4});
+  qr_econ_test<TestType>({5,5,4,16});
+  qr_econ_test<TestType>({5,5,16,4});
+  
+  MATX_EXIT_HANDLER();
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set (test_sources
     00_solver/LU.cu
     00_solver/QR.cu
     00_solver/QR2.cu
+    00_solver/QREcon.cu
     00_solver/SVD.cu
     00_solver/Eigen.cu
     00_solver/Det.cu


### PR DESCRIPTION
Added an economic qr calling the cusolver orgqr methods based on appropriate type of the input. Did not replace `qr_solver` so as to keep existing functionality, but expanded on it. Modifying the existing `qr` transform to perform an economic QR seems to lead to numeric instability, and `QH * Q` is not near identity in that case, and `Q*R` is not near the input operator.  The` static_cast`s to `int` in the `orgqr_dispatch` functions prevent narrowing errors at compilation.

To catch an edge case error, I modified the hashing function slightly to use the rank of the input as part of the hash to prevent `bad any_cast` when using a cached plan. Previously an error was thrown if one firsts performs a batched economic QR on a tensor of shape` {b, m, n}` with `b = 1`, then run a plan on a tensor with shape `{m, n}` with no specified batch size. Not sure when anyone would do that except me when testing, but it is a simple error to prevent. 