### PR TITLE
Guard tests that require CUDSS

### DIFF
--- a/test/00_sparse/Solve.cu
+++ b/test/00_sparse/Solve.cu
@@ -47,6 +47,7 @@ template <typename T> class SolveSparseTestsAll : public SolveSparseTest<T> { };
 
 TYPED_TEST_SUITE(SolveSparseTestsAll, MatXFloatNonHalfTypesCUDAExec);
 
+#ifdef MATX_EN_CUDSS
 TYPED_TEST(SolveSparseTestsAll, SolveCSR) {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
@@ -131,3 +132,4 @@ TYPED_TEST(SolveSparseTestsAll, SolveCSR) {
 
   MATX_EXIT_HANDLER();
 }
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,12 +45,9 @@ set (test_sources
     00_sparse/Convert.cu
     00_sparse/Matmul.cu
     00_sparse/Matvec.cu
+    00_sparse/Solve.cu
     main.cu
 )
-
-if (cudss_DIR)
-    list(test_sources APPEND 00_sparse/Solve.cu)
-endif()
 
 # Some of <00_io> tests need csv files and binaries which all
 # are located under 'CMAKE_CURRENT_SOURCE_DIR/00_io'. When calling the test

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,9 +45,12 @@ set (test_sources
     00_sparse/Convert.cu
     00_sparse/Matmul.cu
     00_sparse/Matvec.cu
-    00_sparse/Solve.cu
     main.cu
 )
+
+if (cudss_DIR)
+    list(test_sources APPEND 00_sparse/Solve.cu)
+endif()
 
 # Some of <00_io> tests need csv files and binaries which all
 # are located under 'CMAKE_CURRENT_SOURCE_DIR/00_io'. When calling the test


### PR DESCRIPTION
00_sparse/Solve.cu requires cuDSS which is not a required dependency.