### PR TITLE
Improve tensor format types

### DIFF
--- a/include/matx/core/sparse_tensor_format.h
+++ b/include/matx/core/sparse_tensor_format.h
@@ -7,8 +7,8 @@
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 //
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
 //
 // 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
@@ -20,14 +20,15 @@
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 /////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
@@ -39,19 +40,52 @@ namespace experimental {
 
 //
 // A level type consists of a level format together with a set of
-// level properties (ordered and unique by default).
+// level properties (unique and ordered by default).
 //
-// TODO: split out format and properties, generalize into class
-//
-enum class LvlType { Dense, Singleton, Compressed, CompressedNonUnique };
+enum class LvlFormat { Dense, Compressed, Singleton };
+template <LvlFormat f, bool u = true, bool o = true> class LvlType {
+public:
+  static constexpr LvlFormat format = f;
+  static constexpr bool unique = u;
+  static constexpr bool ordered = o;
+
+  static_assert(ordered);
+
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static constexpr bool
+  isDense() {
+    return format == LvlFormat::Dense;
+  }
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static constexpr bool
+  isCompressed() {
+    return format == LvlFormat::Compressed && unique;
+  }
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static constexpr bool
+  isCompressedNU() {
+    return format == LvlFormat::Compressed && !unique;
+  }
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static constexpr bool
+  isSingleton() {
+    return format == LvlFormat::Singleton;
+  }
+
+  static std::string toString() {
+    if constexpr (isDense()) {
+      return "dense";
+    } else if constexpr (isCompressed()) {
+      return "compressed";
+    } else if constexpr (isCompressedNU()) {
+      return "compressed(non-unique)";
+    } else if constexpr (isSingleton()) {
+      return "singleton";
+    } else { // Should not happen
+      return "?";
+    }
+  }
+};
 
 //
 // A level expression consists of an expression in terms of dimension
-// variables. Currently, the following expressions are supported:
-//
-// (1) di
-// (2) di div 2
-// (3) di mod 2
+// variables (e.g. di, di div 2, or di mod 2).
 //
 enum class LvlOp { Id, Div, Mod };
 template <LvlOp o, int d, int c> class LvlExpr {
@@ -59,6 +93,8 @@ public:
   static constexpr LvlOp op = o;
   static constexpr int di = d;
   static constexpr int cj = c;
+
+  static constexpr bool isId(int i) { return op == LvlOp::Id && di == i; }
 
   static std::string toString() {
     if constexpr (op == LvlOp::Id) {
@@ -68,36 +104,21 @@ public:
     } else if constexpr (op == LvlOp::Mod) {
       return "d" + std::to_string(di) + " mod " + std::to_string(cj);
     } else { // Should not happen
-      return "";
-    }     
+      return "?";
+    }
   }
 };
 
 //
 // A level specification consists of a level expression and a level type.
 //
-template <typename Expr, LvlType ltype> class LvlSpec {
+template <typename E, typename T> class LvlSpec {
 public:
-  using expr = Expr;
-  static constexpr LvlType lvltype = ltype;
+  using Expr = E;
+  using Type = T;
 
   static std::string toString() {
-    return Expr::toString() + " : " + LvlTypeToString();
-  }
-
-  // TODO: move to LvlType when that class evolves
-  static inline std::string LvlTypeToString() {
-    if constexpr (ltype == LvlType::Dense) {
-      return "dense";
-    } else if constexpr (ltype == LvlType::Singleton) {
-      return "singleton";
-    } else if constexpr (ltype == LvlType::Compressed) {
-      return "compressed";
-    } else if constexpr (ltype == LvlType::CompressedNonUnique) {
-      return "compressed(non-unique)";
-    } else { // Should not happen
-      return "";
-    } 
+    return Expr::toString() + " : " + Type::toString();
   }
 };
 
@@ -106,55 +127,48 @@ public:
 // specifications (d0, d1, etc.) and an explicit ordered sequence of level
 // specifications (e.g. d0 : Dense, d1 : Compressed).
 //
-template <int D, typename... LvlSpecs> class SparseTensorFormat {
+template <int D, typename... S> class SparseTensorFormat {
 public:
-  using LVLSPECS = std::tuple<LvlSpecs...>;
+  using LvlSpecs = std::tuple<S...>;
   static constexpr int DIM = D;
-  static constexpr int LVL = sizeof...(LvlSpecs);
+  static constexpr int LVL = sizeof...(S);
 
   static_assert(DIM <= LVL);
 
   static constexpr bool isSpVec() {
     if constexpr (LVL == 1) {
-      using first_type = std::tuple_element_t<0, LVLSPECS>;
-      return first_type::lvltype == LvlType::Compressed &&
-             first_type::expr::op == LvlOp::Id && first_type::expr::di == 0;
+      using type0 = std::tuple_element_t<0, LvlSpecs>;
+      return type0::Expr::isId(0) && type0::Type::isCompressed();
     }
     return false;
   }
 
   static constexpr bool isCOO() {
     if constexpr (LVL == 2) {
-      using first_type = std::tuple_element_t<0, LVLSPECS>;
-      using second_type = std::tuple_element_t<1, LVLSPECS>;
-      return first_type::lvltype == LvlType::CompressedNonUnique &&
-             first_type::expr::op == LvlOp::Id && first_type::expr::di == 0 &&
-             second_type::lvltype == LvlType::Singleton &&
-             second_type::expr::op == LvlOp::Id && second_type::expr::di == 1;
+      using type0 = std::tuple_element_t<0, LvlSpecs>;
+      using type1 = std::tuple_element_t<1, LvlSpecs>;
+      return type0::Expr::isId(0) && type0::Type::isCompressedNU() &&
+             type1::Expr::isId(1) && type1::Type::isSingleton();
     }
     return false;
   }
 
   static constexpr bool isCSR() {
     if constexpr (LVL == 2) {
-      using first_type = std::tuple_element_t<0, LVLSPECS>;
-      using second_type = std::tuple_element_t<1, LVLSPECS>;
-      return first_type::lvltype == LvlType::Dense &&
-             first_type::expr::op == LvlOp::Id && first_type::expr::di == 0 &&
-             second_type::lvltype == LvlType::Compressed &&
-             second_type::expr::op == LvlOp::Id && second_type::expr::di == 1;
+      using type0 = std::tuple_element_t<0, LvlSpecs>;
+      using type1 = std::tuple_element_t<1, LvlSpecs>;
+      return type0::Expr::isId(0) && type0::Type::isDense() &&
+             type1::Expr::isId(1) && type1::Type::isCompressed();
     }
     return false;
   }
 
   static constexpr bool isCSC() {
     if constexpr (LVL == 2) {
-      using first_type = std::tuple_element_t<0, LVLSPECS>;
-      using second_type = std::tuple_element_t<1, LVLSPECS>;
-      return first_type::lvltype == LvlType::Dense &&
-             first_type::expr::op == LvlOp::Id && first_type::expr::di == 1 &&
-             second_type::lvltype == LvlType::Compressed &&
-             second_type::expr::op == LvlOp::Id && second_type::expr::di == 0;
+      using type0 = std::tuple_element_t<0, LvlSpecs>;
+      using type1 = std::tuple_element_t<1, LvlSpecs>;
+      return type0::Expr::isId(1) && type0::Type::isDense() &&
+             type1::Expr::isId(0) && type1::Type::isCompressed();
     }
     return false;
   }
@@ -163,14 +177,15 @@ public:
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static void
   dim2lvl(const CRD *dims, CRD *lvls, bool asSize) {
     if constexpr (L < LVL) {
-      using ftype = std::tuple_element_t<L, LVLSPECS>;
-      if constexpr (ftype::expr::op == LvlOp::Id) {
-        lvls[L] = dims[ftype::expr::di];
-      } else if constexpr (ftype::expr::op == LvlOp::Div) {
-        lvls[L] = dims[ftype::expr::di] / ftype::expr::cj;
-      } else if constexpr (ftype::expr::op == LvlOp::Mod) {
-        lvls[L] = asSize ? ftype::expr::cj
-                         : (dims[ftype::expr::di] % ftype::expr::cj);
+      using ftype = std::tuple_element_t<L, LvlSpecs>;
+      if constexpr (ftype::Expr::op == LvlOp::Id) {
+        lvls[L] = dims[ftype::Expr::di];
+      } else if constexpr (ftype::Expr::op == LvlOp::Div) {
+        lvls[L] = dims[ftype::Expr::di] / ftype::expr::cj;
+      } else if constexpr (ftype::Expr::op == LvlOp::Mod && asSize) {
+        lvls[L] = ftype::Expr::cj;
+      } else if constexpr (ftype::Expr::op == LvlOp::Mod && !asSize) {
+        lvls[L] = dims[ftype::Expr::di] % ftype::Expr::cj;
       }
       if constexpr (L + 1 < LVL) {
         dim2lvl<CRD, L + 1>(dims, lvls, asSize);
@@ -182,13 +197,13 @@ public:
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ static void
   lvl2dim(const CRD *lvls, CRD *dims) {
     if constexpr (L < LVL) {
-      using ftype = std::tuple_element_t<L, LVLSPECS>;
-      if constexpr (ftype::expr::op == LvlOp::Id) {
-        dims[ftype::expr::di] = lvls[L];
-      } else if constexpr (ftype::expr::op == LvlOp::Div) {
-        dims[ftype::expr::di] = lvls[L] * ftype::expr::cj;
-      } else if constexpr (ftype::expr::op == LvlOp::Mod) {
-        dims[ftype::expr::di] += lvls[L]; // update (seen second)
+      using ftype = std::tuple_element_t<L, LvlSpecs>;
+      if constexpr (ftype::Expr::op == LvlOp::Id) {
+        dims[ftype::Expr::di] = lvls[L];
+      } else if constexpr (ftype::Expr::op == LvlOp::Div) {
+        dims[ftype::Expr::di] = lvls[L] * ftype::expr::cj;
+      } else if constexpr (ftype::Expr::op == LvlOp::Mod) {
+        dims[ftype::Expr::di] += lvls[L]; // update (seen second)
       }
       if constexpr (L + 1 < LVL) {
         lvl2dim<CRD, L + 1>(lvls, dims);
@@ -198,7 +213,7 @@ public:
 
   template <int L = 0> static void printLevel() {
     if constexpr (L < LVL) {
-      using ftype = std::tuple_element_t<L, LVLSPECS>;
+      using ftype = std::tuple_element_t<L, LvlSpecs>;
       std::cout << " " << ftype::toString();
       if constexpr (L + 1 < LVL) {
         std::cout << ",";
@@ -234,81 +249,72 @@ using D2 = LvlExpr<LvlOp::Id, 2, 1>;
 using D3 = LvlExpr<LvlOp::Id, 3, 1>;
 using D4 = LvlExpr<LvlOp::Id, 4, 1>;
 
+// Level type short-cuts.
+using dense = LvlType<LvlFormat::Dense>;
+using compressed = LvlType<LvlFormat::Compressed>;
+using compressedNU = LvlType<LvlFormat::Compressed, false>;
+using singleton = LvlType<LvlFormat::Singleton>;
+
 // Scalars.
 using Scalar = SparseTensorFormat<0>;
 
 // Vectors.
-using DnVec = SparseTensorFormat<1, LvlSpec<D0, LvlType::Dense>>;
-using SpVec = SparseTensorFormat<1, LvlSpec<D1, LvlType::Compressed>>;
+using DnVec = SparseTensorFormat<1, LvlSpec<D0, dense>>;
+using SpVec = SparseTensorFormat<1, LvlSpec<D0, compressed>>;
 
-// Dense Matrices.
-using DnMat = SparseTensorFormat<2, LvlSpec<D0, LvlType::Dense>,
-                                 LvlSpec<D1, LvlType::Dense>>;
-using DnMatCol = SparseTensorFormat<2, LvlSpec<D1, LvlType::Dense>,
-                                    LvlSpec<D0, LvlType::Dense>>;
+// dense Matrices.
+using DnMat = SparseTensorFormat<2, LvlSpec<D0, dense>, LvlSpec<D1, dense>>;
+using DnMatCol = SparseTensorFormat<2, LvlSpec<D1, dense>, LvlSpec<D0, dense>>;
 
 // Sparse Matrices.
-using COO = SparseTensorFormat<2, LvlSpec<D0, LvlType::CompressedNonUnique>,
-                               LvlSpec<D1, LvlType::Singleton>>;
-using CSR = SparseTensorFormat<2, LvlSpec<D0, LvlType::Dense>,
-                               LvlSpec<D1, LvlType::Compressed>>;
-using CSC = SparseTensorFormat<2, LvlSpec<D1, LvlType::Dense>,
-                               LvlSpec<D0, LvlType::Compressed>>;
-using DCSR = SparseTensorFormat<2, LvlSpec<D0, LvlType::Compressed>,
-                                LvlSpec<D1, LvlType::Compressed>>;
-using DCSC = SparseTensorFormat<2, LvlSpec<D1, LvlType::Compressed>,
-                                LvlSpec<D0, LvlType::Compressed>>;
-using CROW = SparseTensorFormat<2, LvlSpec<D0, LvlType::Compressed>,
-                                LvlSpec<D1, LvlType::Dense>>;
-using CCOL = SparseTensorFormat<2, LvlSpec<D1, LvlType::Compressed>,
-                                LvlSpec<D0, LvlType::Dense>>;
+using COO =
+    SparseTensorFormat<2, LvlSpec<D0, compressedNU>, LvlSpec<D1, singleton>>;
+using CSR = SparseTensorFormat<2, LvlSpec<D0, dense>, LvlSpec<D1, compressed>>;
+using CSC = SparseTensorFormat<2, LvlSpec<D1, dense>, LvlSpec<D0, compressed>>;
+using DCSR =
+    SparseTensorFormat<2, LvlSpec<D0, compressed>, LvlSpec<D1, compressed>>;
+using DCSC =
+    SparseTensorFormat<2, LvlSpec<D1, compressed>, LvlSpec<D0, compressed>>;
+using CROW = SparseTensorFormat<2, LvlSpec<D0, compressed>, LvlSpec<D1, dense>>;
+using CCOL = SparseTensorFormat<2, LvlSpec<D1, compressed>, LvlSpec<D0, dense>>;
 
 // Sparse Block Matrices.
 template <int m, int n>
-using BSR =
-    SparseTensorFormat<2, LvlSpec<LvlExpr<LvlOp::Div, 0, m>, LvlType::Dense>,
-                       LvlSpec<LvlExpr<LvlOp::Div, 1, n>, LvlType::Compressed>,
-                       LvlSpec<LvlExpr<LvlOp::Mod, 0, m>, LvlType::Dense>,
-                       LvlSpec<LvlExpr<LvlOp::Mod, 1, n>, LvlType::Dense>>;
+using BSR = SparseTensorFormat<2, LvlSpec<LvlExpr<LvlOp::Div, 0, m>, dense>,
+                               LvlSpec<LvlExpr<LvlOp::Div, 1, n>, compressed>,
+                               LvlSpec<LvlExpr<LvlOp::Mod, 0, m>, dense>,
+                               LvlSpec<LvlExpr<LvlOp::Mod, 1, n>, dense>>;
 
 // 3-D Tensors.
-using Dn3 = SparseTensorFormat<3, LvlSpec<D0, LvlType::Dense>,
-                               LvlSpec<D1, LvlType::Dense>,
-                               LvlSpec<D2, LvlType::Dense>>;
-using COO3 = SparseTensorFormat<3, LvlSpec<D0, LvlType::CompressedNonUnique>,
-                                LvlSpec<D1, LvlType::Singleton>,
-                                LvlSpec<D2, LvlType::Singleton>>;
-using CSF3 = SparseTensorFormat<3, LvlSpec<D0, LvlType::Compressed>,
-                                LvlSpec<D1, LvlType::Compressed>,
-                                LvlSpec<D2, LvlType::Compressed>>;
+using Dn3 = SparseTensorFormat<3, LvlSpec<D0, dense>, LvlSpec<D1, dense>,
+                               LvlSpec<D2, dense>>;
+using COO3 = SparseTensorFormat<3, LvlSpec<D0, compressedNU>,
+                                LvlSpec<D1, singleton>, LvlSpec<D2, singleton>>;
+using CSF3 =
+    SparseTensorFormat<3, LvlSpec<D0, compressed>, LvlSpec<D1, compressed>,
+                       LvlSpec<D2, compressed>>;
 
 // 4-D Tensors.
-using Dn4 =
-    SparseTensorFormat<4, LvlSpec<D0, LvlType::Dense>,
-                       LvlSpec<D1, LvlType::Dense>, LvlSpec<D2, LvlType::Dense>,
-                       LvlSpec<D3, LvlType::Dense>>;
-using COO4 = SparseTensorFormat<4, LvlSpec<D0, LvlType::CompressedNonUnique>,
-                                LvlSpec<D1, LvlType::Singleton>,
-                                LvlSpec<D2, LvlType::Singleton>,
-                                LvlSpec<D3, LvlType::Singleton>>;
-using CSF4 = SparseTensorFormat<
-    4, LvlSpec<D0, LvlType::Compressed>, LvlSpec<D1, LvlType::Compressed>,
-    LvlSpec<D2, LvlType::Compressed>, LvlSpec<D3, LvlType::Compressed>>;
+using Dn4 = SparseTensorFormat<4, LvlSpec<D0, dense>, LvlSpec<D1, dense>,
+                               LvlSpec<D2, dense>, LvlSpec<D3, dense>>;
+using COO4 =
+    SparseTensorFormat<4, LvlSpec<D0, compressedNU>, LvlSpec<D1, singleton>,
+                       LvlSpec<D2, singleton>, LvlSpec<D3, singleton>>;
+using CSF4 =
+    SparseTensorFormat<4, LvlSpec<D0, compressed>, LvlSpec<D1, compressed>,
+                       LvlSpec<D2, compressed>, LvlSpec<D3, compressed>>;
 
 // 5-D Tensors.
-using Dn5 =
-    SparseTensorFormat<5, LvlSpec<D0, LvlType::Dense>,
-                       LvlSpec<D1, LvlType::Dense>, LvlSpec<D2, LvlType::Dense>,
-                       LvlSpec<D3, LvlType::Dense>,
-                       LvlSpec<D4, LvlType::Dense>>;
-using COO5 = SparseTensorFormat<
-    5, LvlSpec<D0, LvlType::CompressedNonUnique>,
-    LvlSpec<D1, LvlType::Singleton>, LvlSpec<D2, LvlType::Singleton>,
-    LvlSpec<D3, LvlType::Singleton>, LvlSpec<D4, LvlType::Singleton>>;
-using CSF5 = SparseTensorFormat<
-    5, LvlSpec<D0, LvlType::Compressed>, LvlSpec<D1, LvlType::Compressed>,
-    LvlSpec<D2, LvlType::Compressed>, LvlSpec<D3, LvlType::Compressed>,
-    LvlSpec<D4, LvlType::Compressed>>;
+using Dn5 = SparseTensorFormat<5, LvlSpec<D0, dense>, LvlSpec<D1, dense>,
+                               LvlSpec<D2, dense>, LvlSpec<D3, dense>,
+                               LvlSpec<D4, dense>>;
+using COO5 = SparseTensorFormat<5, LvlSpec<D0, compressedNU>,
+                                LvlSpec<D1, singleton>, LvlSpec<D2, singleton>,
+                                LvlSpec<D3, singleton>, LvlSpec<D4, singleton>>;
+using CSF5 =
+    SparseTensorFormat<5, LvlSpec<D0, compressed>, LvlSpec<D1, compressed>,
+                       LvlSpec<D2, compressed>, LvlSpec<D3, compressed>,
+                       LvlSpec<D4, compressed>>;
 
 } // namespace experimental
 } // namespace matx


### PR DESCRIPTION
 (1) finishes TODO on lvl type to include properties
 (2) adds more constexpr test methods and shortcuts
 (3) improves readability to format decls and testers