### PR TITLE
Disable additional NaN/Inf checks for complex ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ option(MATX_EN_BLIS OFF "Enable BLIS support")
 option(MATX_EN_OPENBLAS OFF "Enable OpenBLAS (BLAS + LAPACK) support")
 option(MATX_DISABLE_CUB_CACHE "Disable caching for CUB allocations" ON)
 option(MATX_EN_COVERAGE OFF "Enable code coverage reporting")
+option(MATX_EN_COMPLEX_OP_NAN_CHECKS "Enable full NaN/Inf handling for complex multiplication and division" OFF)
 
 set(MATX_EN_PYBIND11 OFF CACHE BOOL "Enable pybind11 support")
 
@@ -258,6 +259,10 @@ endif()
 
 if (MATX_DISABLE_CUB_CACHE)
     target_compile_definitions(matx INTERFACE MATX_DISABLE_CUB_CACHE)
+endif()
+
+if (MATX_EN_COMPLEX_OP_NAN_CHECKS)
+    target_compile_definitions(matx INTERFACE MATX_EN_COMPLEX_OP_NAN_CHECKS)
 endif()
 
 if (MATX_EN_COVERAGE)

--- a/include/matx.h
+++ b/include/matx.h
@@ -37,8 +37,9 @@
 #endif
 #include <cuda_runtime_api.h>
 #endif
-#include <cuda/std/ccomplex>
 
+// defines.h should always be included first. Its definitions may impact
+// the behavior of other headers.
 #include "matx/core/defines.h"
 #include "matx/core/error.h"
 #include "matx/file_io/file_io.h"
@@ -59,6 +60,7 @@
 #include "matx/operators/operators.h"
 #include "matx/transforms/transforms.h"
 
+#include <cuda/std/complex>
 namespace matx {
   using fcomplex = cuda::std::complex<float>;
   using dcomplex = cuda::std::complex<double>;

--- a/include/matx/core/defines.h
+++ b/include/matx/core/defines.h
@@ -32,8 +32,9 @@
 
 #pragma once
 
-// This file is intended to contain simple defines that don't rely on any other headers. It must be
-// useable on both host and device compilers
+// This file is intended to contain simple defines that don't rely on any other
+// MatX headers. It must be usable on both host and device compilers
+#include <cuda/std/limits>
 
 namespace matx {
 
@@ -43,6 +44,17 @@ namespace matx {
 #else
     using index_t = long long int;
     #define MATX_INDEX_T_FMT "lld"
+#endif
+
+// By default, MatX opts out of additional handling of NaNs and infinite values
+// in complex multiplication and division. These checks are defined in Annex G
+// as an optional part of the C11 standard, but are not specified in the C++
+// standard. The checks add additional cost beyond a "standard" implementation
+// that computes, for example, complex multiplication via:
+//   (a + bi) * (c + di) = (ac - bd) + (ad + bc)i.
+// Users can opt-in to the additional checks by defining MATX_EN_COMPLEX_OP_NAN_CHECKS.
+#ifndef MATX_EN_COMPLEX_OP_NAN_CHECKS
+#define LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_OPERATIONS
 #endif
 
 #ifdef __CUDACC__
@@ -91,10 +103,10 @@ namespace matx {
 #define MATX_ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
 
 enum {
-  matxKeepDim     = std::numeric_limits<index_t>::max(),
-  matxDropDim     = std::numeric_limits<index_t>::max() - 1,
-  matxEnd         = std::numeric_limits<index_t>::max() - 2,
-  matxKeepStride  = std::numeric_limits<index_t>::max() - 3,
+  matxKeepDim     = cuda::std::numeric_limits<index_t>::max(),
+  matxDropDim     = cuda::std::numeric_limits<index_t>::max() - 1,
+  matxEnd         = cuda::std::numeric_limits<index_t>::max() - 2,
+  matxKeepStride  = cuda::std::numeric_limits<index_t>::max() - 3,
 
   // If adding a new marker adjust this to the last element above
   matxIdxSentinel = matxKeepStride - 1,


### PR DESCRIPTION
By default, libcudacxx includes additional checking for NaN/Inf combinations for complex multiplication and division. This is not required by the C++ Standard and is not the way a typical user would define these operations for themselves. For example, complex multiplication between x and y would typically be implemented as:

    std::complex prod(
        x.real()*y.real() - x.imag()*y.imag(),
        x.real()*y.imag() + x.imag()*y.real());

This implementation does not include any special handling for NaN/Inf values and it will outperform implementations that include such handling.

Thus, MatX now defaults to the "simple" implementation of the operations. If the extra checks (see Annex G of the C11 specification for details) are needed, then the user can enable these checks by defining the MATX_EN_COMPLEX_OP_NAN_CHECKS macro.

For the following test case on Grace-Hopper:

channelize_poly, 128 batches, 64 channels, 16 filter coefs/channel, 4e6 elems

preventing the additional checks yields an uplift of ~10% for fp32 and ~4.5% for fp64.