### PR TITLE
Update linspace for more of a pythonic syntax

### DIFF
--- a/docs_input/api/creation/operators/linspace.rst
+++ b/docs_input/api/creation/operators/linspace.rst
@@ -4,10 +4,11 @@ linspace
 ========
 
 Return a range of linearly-spaced numbers using first and last value. The step size is
-determined by the shape.
+determined by the `count` parameter. `axis` (either 0 or 1) can be used to make the increasing
+sequence along the specified axis.
 
-.. doxygenfunction:: matx::linspace(ShapeType &&s, T first, T last)
-.. doxygenfunction:: matx::linspace(const index_t (&s)[RANK], T first, T last)
+.. doxygenfunction:: matx::linspace(T first, T last, index_t count, int axis = 0)
+.. doxygenfunction:: matx::linspace(const T (&firsts)[NUM_RC], const T (&lasts)[NUM_RC], index_t count, int axis = 0)
 
 Examples
 ~~~~~~~~

--- a/examples/spectrogram.cu
+++ b/examples/spectrogram.cu
@@ -72,9 +72,6 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   constexpr uint32_t num_iterations = 100;
   float time_ms;
 
-  cuda::std::array<index_t, 1> num_samps{N};
-  cuda::std::array<index_t, 1> half_win{nfft / 2 + 1};
-  cuda::std::array<index_t, 1> s_time_shape{(N - noverlap) / nstep};
 
   auto time = make_tensor<float>({N});
   auto modulation = make_tensor<float>({N});
@@ -88,7 +85,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 
   // Set up all static buffers
   // time = np.arange(N) / float(fs)
-  (time = linspace<0>(num_samps, 0.0f, static_cast<float>(N) - 1.0f) / fs)
+  (time = linspace(0.0f, static_cast<float>(N) - 1.0f, N) / fs)
       .run(exec);
   // mod = 500 * np.cos(2*np.pi*0.25*time)
   (modulation = 500.f * cos(2.f * static_cast<typename complex::value_type>(M_PI) * 0.25f * time)).run(exec);
@@ -108,7 +105,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 
     // DFT Sample Frequencies (rfftfreq)
     (freqs = (1.0f / (static_cast<float>(nfft) * 1.f / fs)) *
-               linspace<0>(half_win, 0.0f, static_cast<float>(nfft) / 2.0f))
+               linspace(0.0f, static_cast<float>(nfft) / 2.0f, nfft / 2 + 1))
         .run(exec);
 
     // Create overlapping matrix of segments.
@@ -122,8 +119,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
     auto Sxx = fftStackedMatrix.RealView().Permute({1, 0});
 
     // Spectral time axis
-    (s_time = linspace<0>(s_time_shape, static_cast<float>(nperseg) / 2.0f,
-                           static_cast<float>(N - nperseg) / 2.0f + 1) /
+    (s_time = linspace(static_cast<float>(nperseg) / 2.0f,
+                           static_cast<float>(N - nperseg) / 2.0f + 1, (N - noverlap) / nstep) /
                 fs)
         .run(exec);
 

--- a/include/matx/generators/chirp.h
+++ b/include/matx/generators/chirp.h
@@ -226,8 +226,7 @@ namespace matx
   template <typename TimeType, typename FreqType>
     inline auto chirp(index_t num, TimeType last, FreqType f0, TimeType t1, FreqType f1, ChirpMethod method = ChirpMethod::CHIRP_METHOD_LINEAR)
     {
-      cuda::std::array<index_t, 1> shape = {num};
-      auto space = linspace<0>(std::move(shape), (TimeType)0, last);
+      auto space = linspace((TimeType)0, last, num);
       return chirp(space, f0, t1, f1, method);
     }
     
@@ -263,8 +262,7 @@ namespace matx
   template <typename TimeType, typename FreqType>
     inline auto cchirp(index_t num, TimeType last, FreqType f0, TimeType t1, FreqType f1, ChirpMethod method = ChirpMethod::CHIRP_METHOD_LINEAR)
     {
-      cuda::std::array<index_t, 1> shape = {num};
-      auto space = linspace<0>(std::move(shape), (TimeType)0, last);
+      auto space = linspace((TimeType)0, last, num);
       return cchirp(space, f0, t1, f1, method);
     }
 

--- a/include/matx/generators/linspace.h
+++ b/include/matx/generators/linspace.h
@@ -37,38 +37,127 @@
 namespace matx
 {
   namespace detail {
-    template <class T> class LinspaceOp {
+    template <class T, int NUM_RC> class LinspaceOp : public BaseOp<LinspaceOp<T, NUM_RC>> {
       private:
-        Range<T> range_;
-
+        cuda::std::array<T, NUM_RC> steps_;
+        cuda::std::array<T, NUM_RC> firsts_;
+        int axis_;
+        index_t count_;
       public:
         using value_type = T;
         using matxop = bool;
 
         __MATX_INLINE__ std::string str() const { return "linspace"; }
 
+        static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { return NUM_RC; }  
 
-        inline LinspaceOp(T first, T last, index_t count)
+        inline LinspaceOp(const T (&firsts)[NUM_RC], const T (&lasts)[NUM_RC], index_t count, int axis) 
         {
-#ifdef __CUDA_ARCH__
-          range_ = Range<T>{first, (last - first) / static_cast<T>(count - 1)};
-#else
-          // Host has no support for most half precision operators/intrinsics
-          if constexpr (is_matx_half_v<T>) {
-            range_ = Range<T>{static_cast<float>(first),
-              (static_cast<float>(last) - static_cast<float>(first)) /
-                static_cast<float>(count - 1)};
+          axis_ = axis;
+          count_ = count;
+          for (int i = 0; i < NUM_RC; ++i) {
+            firsts_[i] = firsts[i];
+            steps_[i] = (lasts[i] - firsts[i]) / static_cast<T>(count - 1);
           }
-          else {
-            range_ = Range<T>{first, (last - first) / static_cast<T>(count - 1)};
-          }
-#endif
         }
 
-        __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ T operator()(index_t idx) const { return range_(idx); }
+        template <typename... Is>
+        __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ T operator()(Is... indices) const { 
+          static_assert(sizeof...(indices) == NUM_RC, "Number of indices incorrect in linspace");
+          cuda::std::array idx{indices...};
+          if constexpr (sizeof...(indices) == 1) {
+            return firsts_[0] + steps_[0] * static_cast<T>(idx[0]);
+          } else {
+            if (axis_ == 0) {
+              return firsts_[idx[1]] + steps_[idx[1]] * static_cast<T>(idx[0]);
+            } else {
+              return firsts_[idx[0]] + steps_[idx[0]] * static_cast<T>(idx[1]);
+            }
+          }
+        }
+
+      constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
+      {
+        if constexpr (NUM_RC == 1) {
+          return count_;
+        } else {
+          if (dim != axis_) {
+            return NUM_RC;
+          } else {
+            return count_;
+          }
+        }
+      }        
     };
   }
 
+
+  /**
+   * @brief Create a matrix linearly-spaced range of values
+   *
+   * Creates a set of values using starts and stops that are linearly-
+   * spaced apart over the set of values. Distance is determined
+   * by the count parameter
+   * 
+   * @tparam NUM_RC Number of rows or columns, depending on the axis
+   * @tparam T Type of the values
+   * @param firsts First values
+   * @param lasts Last values
+   * @param count Number of values in a row or column, depending on the axis
+   * @param axis Axis to operate over
+   * @return Operator with linearly-spaced values 
+   */
+  template <int NUM_RC, typename T = float>
+  inline auto linspace(const T (&firsts)[NUM_RC], const T (&lasts)[NUM_RC], index_t count, int axis = 0)
+  {
+    return detail::LinspaceOp<T, NUM_RC>(firsts, lasts, count, axis);
+  }   
+
+  /**
+   * @brief Create a linearly-spaced vector of values
+   *
+   * Creates a set of values using startsand stop that are linearly-
+   * spaced apart over the set of values. Distance is determined
+   * by the count parameter
+   * 
+   * @tparam T Type of the values
+   * @param first First value
+   * @param last Last value
+   * @param count Number of values in a row or column, depending on the axis
+   * @param axis Axis to operate over
+   * @return Operator with linearly-spaced values 
+   */
+  template <typename T = float>
+  inline auto linspace(T first, T last, index_t count, int axis = 0)
+  {
+    const T firsts[] = {first};
+    const T lasts[] = {last};
+    return linspace(firsts, lasts, count, axis);
+  }
+
+  /**
+   * @brief Create a linearly-spaced range of values
+   *
+   * Creates a set of values using a start and end that are linearly-
+   * spaced apart over the set of values. Distance is determined
+   * by the shape and selected dimension.
+   * 
+   * @tparam Dim Dimension to operate over
+   * @tparam NUM_RC Rank of shape
+   * @tparam T Operator type
+   * @param s Array of sizes
+   * @param first First value
+   * @param last Last value
+   * @return Operator with linearly-spaced values 
+   */
+  template <int Dim, int NUM_RC, typename T>
+  [[deprecated("Use matx::linspace(T first, T last, index_t count, int axis = 0) instead.")]]  
+  inline auto linspace([[maybe_unused]]const index_t (&s)[NUM_RC], T first, T last)
+  {
+    const T firsts[] = {first};
+    const T lasts[] = {last};   
+    return linspace(firsts, lasts, NUM_RC, 0);
+  }  
 
   /**
    * @brief Create a linearly-spaced range of values
@@ -87,33 +176,14 @@ namespace matx
    */
   template <int Dim, typename ShapeType, typename T,
            std::enable_if_t<!std::is_array_v<typename remove_cvref<ShapeType>::type>, bool> = true>
-             inline auto linspace(ShapeType &&s, T first, T last)
-             {
-               constexpr int RANK = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
-               static_assert(RANK > Dim);
-               auto count =  *(s.begin() + Dim);
-               detail::LinspaceOp<T> l(first, last, count);
-               return detail::matxGenerator1D_t<detail::LinspaceOp<T>, Dim, ShapeType>(std::forward<ShapeType>(s), l);
-             }
-
-  /**
-   * @brief Create a linearly-spaced range of values
-   *
-   * Creates a set of values using a start and end that are linearly-
-   * spaced apart over the set of values. Distance is determined
-   * by the shape and selected dimension.
-   * 
-   * @tparam Dim Dimension to operate over
-   * @tparam RANK Rank of shape
-   * @tparam T Operator type
-   * @param s Array of sizes
-   * @param first First value
-   * @param last Last value
-   * @return Operator with linearly-spaced values 
-   */
-  template <int Dim, int RANK, typename T>
-    inline auto linspace(const index_t (&s)[RANK], T first, T last)
-    {
-      return linspace<Dim>(detail::to_array(s), first, last);
-    }
+  [[deprecated("Use matx::linspace(T first, T last, index_t count, int axis = 0) instead.")]]           
+  inline auto linspace(ShapeType &&s, T first, T last)
+  {
+    constexpr int NUM_RC = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+    static_assert(NUM_RC > Dim);
+    auto count =  *(s.begin() + Dim);
+    const T firsts[] = {first};
+    const T lasts[] = {last};       
+    return linspace(firsts, lasts, count, 0);
+  }  
 } // end namespace matx

--- a/test/00_operators/legendre_test.cu
+++ b/test/00_operators/legendre_test.cu
@@ -55,7 +55,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Legendre)
     // example-begin legendre-test-1
     auto n = range<0, 1, int>({order}, 0, 1);
     auto m = range<0, 1, int>({order}, 0, 1);
-    auto x = as_type<TestType>(linspace<0>({size}, TestType(0), TestType(1)));
+    auto x = as_type<TestType>(linspace(TestType(0), TestType(1), size));
 
     auto out = make_tensor<TestType>({order, order, size});
 
@@ -80,7 +80,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Legendre)
  
   { // constant for n
     auto m = range<0, 1, int>({order}, 0, 1);
-    auto x = as_type<TestType>(linspace<0>({size}, TestType(0), TestType(1)));
+    auto x = as_type<TestType>(linspace(TestType(0), TestType(1), size));
 
     auto out = make_tensor<TestType>({order, size});
 
@@ -101,7 +101,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Legendre)
   }
 
   { // taking a constant for m and n;
-    auto x = as_type<TestType>(linspace<0>({size}, TestType(0), TestType(1)));
+    auto x = as_type<TestType>(linspace(TestType(0), TestType(1), size));
 
     auto out = make_tensor<TestType>({size});
 
@@ -120,7 +120,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Legendre)
   }
   
   { // taking a rank0 tensor for m and constant for n
-    auto x = as_type<TestType>(linspace<0>({size}, TestType(0), TestType(1)));
+    auto x = as_type<TestType>(linspace(TestType(0), TestType(1), size));
     auto m = make_tensor<int>({});
     auto out = make_tensor<TestType>({size});
     m() = order;

--- a/test/00_operators/overlap_test.cu
+++ b/test/00_operators/overlap_test.cu
@@ -65,7 +65,7 @@ TYPED_TEST(OperatorTestsNumericNonComplexAllExecs, Overlap)
 
   // Test with an operator input
   // example-begin overlap-test-1  
-  auto aop = linspace<0>(a.Shape(), (TestType)0, (TestType)9);
+  auto aop = linspace((TestType)0, (TestType)9, a.Size(0));
   tensor_t<TestType, 2> b4out{{4, 3}};
 
   // Input is {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}

--- a/test/00_operators/slice_and_reduce_test.cu
+++ b/test/00_operators/slice_and_reduce_test.cu
@@ -16,8 +16,8 @@ TYPED_TEST(OperatorTestsNumericAllExecs, SliceAndReduceOp)
 
   tensor_t<TestType, 2> t2t{{20, 10}};
   tensor_t<TestType, 3> t3t{{30, 20, 10}};
-  (t2t = linspace<1>(t2t.Shape(), (inner_type)0, (inner_type)10)).run(exec);
-  (t3t = linspace<2>(t3t.Shape(), (inner_type)0, (inner_type)10)).run(exec);
+  (t2t = clone<2>(linspace((inner_type)0, (inner_type)10, 10), {t2t.Size(0), matxKeepDim})).run(exec);
+  (t3t = clone<3>(linspace((inner_type)0, (inner_type)10, 10), {t3t.Size(0), t3t.Size(1), matxKeepDim})).run(exec);
   exec.sync();
 
   {

--- a/test/00_operators/slice_and_reshape_test.cu
+++ b/test/00_operators/slice_and_reshape_test.cu
@@ -17,7 +17,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, SliceAndReshape)
   {
     // Unit test combining slice with reshape which showed a bug in the past
     auto t = make_tensor<TestType>({100});
-    (t = linspace<0>(t.Shape(), (TestType)0, (TestType)99)).run(exec);
+    (t = linspace((TestType)0, (TestType)99, t.Size(0))).run(exec);
     auto rs = reshape(t, {2, 10, 5});
     auto s = slice(rs, {0, 0, 2}, {matxEnd, matxEnd, matxEnd});
     exec.sync();

--- a/test/00_operators/slice_test.cu
+++ b/test/00_operators/slice_test.cu
@@ -20,9 +20,9 @@ TYPED_TEST(OperatorTestsNumericAllExecs, SliceOp)
   auto t3 = make_tensor<TestType>({30, 20, 10});
   auto t4 = make_tensor<TestType>({40, 30, 20, 10});
 
-  (t2 = linspace<1>(t2.Shape(), (inner_type)0, (inner_type)10)).run(exec);
-  (t3 = linspace<2>(t3.Shape(), (inner_type)0, (inner_type)10)).run(exec);
-  (t4 = linspace<3>(t4.Shape(), (inner_type)0, (inner_type)10)).run(exec);
+  (t2 = clone<2>(linspace((inner_type)0, (inner_type)10, 10), {t2.Size(0), matxKeepDim})).run(exec);
+  (t3 = clone<3>(linspace((inner_type)0, (inner_type)10, 10), {t3.Size(0), t3.Size(1), matxKeepDim})).run(exec);
+  (t4 = clone<4>(linspace((inner_type)0, (inner_type)10, 10), {t4.Size(0), t4.Size(1), t4.Size(2), matxKeepDim})).run(exec);
   exec.sync();
 
   // Slice with different start and end points in each dimension

--- a/test/00_tensor/EinsumTests.cu
+++ b/test/00_tensor/EinsumTests.cu
@@ -113,8 +113,8 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Contraction3D)
   auto b1 = make_tensor<TestType>({24});
   auto c2 = make_tensor<TestType>({5,2});
 
-  (a1 = linspace<0>(a1.Shape(), (TestType)0, static_cast<TestType>(a1.Size(0) - 1))).run(exec);
-  (b1 = linspace<0>(b1.Shape(), (TestType)0, static_cast<TestType>(b1.Size(0) - 1))).run(exec);
+  (a1 = linspace((TestType)0, static_cast<TestType>(a1.Size(0) - 1), a1.Size(0))).run(exec);
+  (b1 = linspace((TestType)0, static_cast<TestType>(b1.Size(0) - 1), b1.Size(0))).run(exec);
   auto a = a1.View({3,4,5});
   auto b = b1.View({4,3,2});
 
@@ -144,8 +144,8 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Contraction3DOperator)
 
   // Perform a 3D tensor contraction
   (c2 = cutensor::einsum("ijk,jil->kl",
-    reshape(linspace<0>(a1.Shape(), (TestType)0, static_cast<TestType>(a1.Size(0) - 1)), {3,4,5}),
-    reshape(linspace<0>(b1.Shape(), (TestType)0, static_cast<TestType>(b1.Size(0) - 1)), {4,3,2}))).run(exec);
+    reshape(linspace((TestType)0, static_cast<TestType>(a1.Size(0) - 1), a1.Size(0)), {3,4,5}),
+    reshape(linspace((TestType)0, static_cast<TestType>(b1.Size(0) - 1), b1.Size(0)), {4,3,2}))).run(exec);
 
   exec.sync();
   MATX_TEST_ASSERT_COMPARE(this->pb, c2, "c_float3d", 0.01);


### PR DESCRIPTION
The old linspace syntax used a template parameter to essentially describe how the 1D vector was cloned. This is not how python does linspace, and is very limited in value since `clone` does the same thing. This change follows the Python syntax by allowing a vector of start/stops such that every row/column can be different.

Closes #929 