### PR TITLE
implement basic interp

### DIFF
--- a/docs_input/api/math/misc/interp.rst
+++ b/docs_input/api/math/misc/interp.rst
@@ -3,18 +3,27 @@
 interp1
 =======
 
-Piecewise linear or nearest-neighbor interpolation.
+Piecewise interpolation with various methods (linear, nearest, next, previous, spline).
 
-.. doxygenfunction:: interp1(const OpX &x, const OpV &v, const OpXQ &xq)
+.. doxygenfunction:: interp1(const OpX &x, const OpV &v, const OpXQ &xq, InterpMethod method)
+
+Interpolation Methods
+~~~~~~~~~~~~~~~~~~~~~
+
+.. doxygenenum:: matx::InterpMethod
 
 Examples
 ~~~~~~~~
+
+Linear Interpolation (default):
 
 .. literalinclude:: ../../../../test/00_operators/interp_test.cu
    :language: cpp
    :start-after: example-begin interp-test-1
    :end-before: example-end interp-test-1
    :dedent:
+
+Nearest Neighbor Interpolation:
 
 .. literalinclude:: ../../../../test/00_operators/interp_test.cu
    :language: cpp

--- a/docs_input/api/math/misc/interp.rst
+++ b/docs_input/api/math/misc/interp.rst
@@ -1,0 +1,24 @@
+.. _interp_func:
+
+interp
+=======
+
+Piecewise linear or nearest-neighbor interpolation.
+
+.. doxygenfunction:: interp(const OpX &x, const OpV &v, const OpXQ &xq)
+.. doxygenfunction:: interp(const OpX &x, const OpV &v, const OpXQ &xq, const InterpMethod method)
+
+Examples
+~~~~~~~~
+
+.. literalinclude:: ../../../../test/00_operators/interp_test.cu
+   :language: cpp
+   :start-after: example-begin interp-test-1
+   :end-before: example-end interp-test-1
+   :dedent:
+
+.. literalinclude:: ../../../../test/00_operators/interp_test.cu
+   :language: cpp
+   :start-after: example-begin interp-test-2
+   :end-before: example-end interp-test-2
+   :dedent:

--- a/docs_input/api/math/misc/interp.rst
+++ b/docs_input/api/math/misc/interp.rst
@@ -1,12 +1,11 @@
 .. _interp_func:
 
-interp
+interp1
 =======
 
 Piecewise linear or nearest-neighbor interpolation.
 
-.. doxygenfunction:: interp(const OpX &x, const OpV &v, const OpXQ &xq)
-.. doxygenfunction:: interp(const OpX &x, const OpV &v, const OpXQ &xq, const InterpMethod method)
+.. doxygenfunction:: interp1(const OpX &x, const OpV &v, const OpXQ &xq)
 
 Examples
 ~~~~~~~~

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,7 @@ set(examples
     cgsolve
     eigenExample
     fft_conv
+    interpolate
     resample
     mvdr_beamformer
     pwelch

--- a/examples/interpolate.cu
+++ b/examples/interpolate.cu
@@ -48,18 +48,15 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 
 
   index_t in_count = 10;
-  auto x = make_tensor<float>({in_count});
-  auto v = make_tensor<float>({in_count});
   index_t out_count = 100;
-  auto xq = make_tensor<float>({out_count});
-  auto vq = make_tensor<float>({out_count});
 
-  (x = linspace<0>(x.Shape(), 0.0f, 1.0f)).run(exec);
-  (v = sin(x)).run(exec);
-  (xq = linspace<0>(xq.Shape(), 0.0f, 1.0f)).run(exec);
+  auto x = linspace(0.0f, 1.0f, in_count);
+  auto v = sin(x);
+  auto xq = linspace(0.0f, 1.0f, out_count);
 
   // Execute the interpolation
-  (vq = interp(x, v, xq)).run(exec);
+  auto vq = make_tensor<float>({out_count});
+  (vq = interp1<InterpMethodLinear>(x, v, xq)).run(exec);
   exec.sync();
 
   // Print the results

--- a/examples/interpolate.cu
+++ b/examples/interpolate.cu
@@ -1,0 +1,98 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "matx.h"
+#include <cassert>
+#include <cstdio>
+
+using namespace matx;
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
+{
+  MATX_ENTER_HANDLER();
+
+
+  // Create a CUDA stream and executor
+  cudaStream_t stream;
+  cudaStreamCreate(&stream);
+  cudaExecutor exec{stream};
+
+
+  index_t in_count = 10;
+  auto x = make_tensor<float>({in_count});
+  auto v = make_tensor<float>({in_count});
+  index_t out_count = 100;
+  auto xq = make_tensor<float>({out_count});
+  auto vq = make_tensor<float>({out_count});
+
+  (x = linspace<0>(x.Shape(), 0.0f, 1.0f)).run(exec);
+  (v = sin(x)).run(exec);
+  (xq = linspace<0>(xq.Shape(), 0.0f, 1.0f)).run(exec);
+
+  // Execute the interpolation
+  (vq = interp(x, v, xq)).run(exec);
+  exec.sync();
+
+  // Print the results
+  std::cout << "Interpolation Results:" << std::endl;
+  std::cout << "x values: ";
+  for (int i = 0; i < 5; i++) {
+    std::cout << x(i) << " ";
+  }
+  std::cout << "..." << std::endl;
+
+  std::cout << "v values: ";
+  for (int i = 0; i < 5; i++) {
+    std::cout << v(i) << " ";
+  }
+  std::cout << "..." << std::endl;
+
+  std::cout << "xq values: ";
+  for (int i = 0; i < 5; i++) {
+    std::cout << xq(i) << " ";
+  }
+  std::cout << "..." << std::endl;
+
+  std::cout << "Interpolated values: ";
+  for (int i = 0; i < 5; i++) {
+    std::cout << vq(i) << " ";
+  }
+  std::cout << "..." << std::endl;
+
+  // Clean up
+  cudaStreamDestroy(stream);
+
+  matxPrintMemoryStatistics();
+
+  MATX_CUDA_CHECK_LAST_ERROR();
+  MATX_EXIT_HANDLER();
+}

--- a/examples/interpolate.cu
+++ b/examples/interpolate.cu
@@ -56,7 +56,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 
   // Execute the interpolation
   auto vq = make_tensor<float>({out_count});
-  (vq = interp1<InterpMethodLinear>(x, v, xq)).run(exec);
+  (vq = interp1(x, v, xq, InterpMethod::LINEAR)).run(exec);
   exec.sync();
 
   // Print the results

--- a/include/matx/operators/interp.h
+++ b/include/matx/operators/interp.h
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include <cusparse.h>
+
 #include "matx/core/type_utils.h"
 #include "matx/operators/base_operator.h"
 

--- a/include/matx/operators/interp.h
+++ b/include/matx/operators/interp.h
@@ -65,7 +65,9 @@ namespace matx {
         v_(v),
         xq_(xq),
         method_(method) 
-      {}
+      {
+        MATX_ASSERT_STR(x_.Size(0) == v_.Size(0), matxInvalidSize, "interp: sample points and values must have the same size");
+      }
       
 
       template <typename... Is>

--- a/include/matx/operators/interp.h
+++ b/include/matx/operators/interp.h
@@ -152,7 +152,7 @@ namespace matx {
       mutable value_type *ptr_m_ = nullptr;
 
       template <typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) searchsorted(const domain_type x_query) const
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto searchsorted(const domain_type x_query) const
       {        
         // Binary search to find the interval containing the query point
 

--- a/include/matx/operators/interp.h
+++ b/include/matx/operators/interp.h
@@ -1,0 +1,197 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx/core/type_utils.h"
+#include "matx/operators/base_operator.h"
+
+namespace matx {
+
+  enum class InterpMethod {
+    INTERP_METHOD_LINEAR,
+    INTERP_METHOD_NEAREST,
+    INTERP_METHOD_NEXT,
+    INTERP_METHOD_PREV
+  };
+
+  namespace detail {
+  template <typename OpX, typename OpV, typename OpXQ>
+  class InterpolateOp : public BaseOp<InterpolateOp<OpX, OpV, OpXQ>> {
+    private:
+      typename detail::base_type_t<OpX> x_;    // Sample points
+      typename detail::base_type_t<OpV> v_;    // Values at sample points
+      typename detail::base_type_t<OpXQ> xq_;  // Query points
+
+    public:
+      using matxop = bool;
+      using domain_type = typename OpX::value_type;
+      using value_type = typename OpV::value_type;
+      InterpMethod method_;
+
+      __MATX_INLINE__ std::string str() const { return "interp()"; }
+
+      __MATX_INLINE__ InterpolateOp(const OpX &x, const OpV &v, const OpXQ &xq, InterpMethod method) : 
+        x_(x), 
+        v_(v),
+        xq_(xq),
+        method_(method) 
+      {}
+      
+
+      template <typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
+      {
+        auto x_query = xq_(indices...);
+        
+        index_t idx_low, idx_high, idx_mid;
+        domain_type x_low, x_high, x_mid;
+
+        idx_low = 0;
+        idx_high = x_.Size(0) - 1;
+        x_low = x_(idx_low);
+        if (x_query <= x_low) {
+          value_type v = v_(idx_low);
+          return v;
+        }
+        x_high = x_(idx_high);
+        if (x_query >= x_high) {
+          value_type v = v_(idx_high);
+          return v;
+        }
+
+        // Find the interval containing the query point
+        while (idx_high - idx_low > 1) {
+          idx_mid = (idx_low + idx_high) / 2;
+          x_mid = x_(idx_mid);
+          if (x_query == x_mid) {
+            value_type v = v_(idx_mid);
+            return v;
+          } else if (x_query < x_mid) {
+            idx_high = idx_mid;
+            x_high = x_mid;
+          } else {
+            idx_low = idx_mid;
+            x_low = x_mid;
+          }
+        }
+        if (method_ == InterpMethod::INTERP_METHOD_LINEAR)
+        {
+          value_type v_low = v_(idx_low);
+          value_type v_high = v_(idx_high);
+          return v_low + (x_query - x_low) * (v_high - v_low) / (x_high - x_low);
+        }
+        else if (method_ == InterpMethod::INTERP_METHOD_NEAREST)
+        {
+          if (x_query - x_low < x_high - x_query) {
+            value_type v = v_(idx_low);
+            return v;
+          }
+          else {
+            value_type v = v_(idx_high);
+            return v;
+          }
+        }
+        else if (method_ == InterpMethod::INTERP_METHOD_NEXT)
+        {
+          value_type v = v_(idx_high);
+          return v;
+        }
+        else // if (method_ == InterpMethod::INTERP_METHOD_PREV)
+        {
+          value_type v = v_(idx_low);
+          return v;
+        }
+      }
+
+      static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() 
+      { 
+        return OpXQ::Rank(); 
+      }
+
+      constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
+      {
+        return xq_.Size(dim);
+      }
+    };
+  } // namespace detail
+/**
+ * Linear interpolation operator
+ *
+ * @tparam OpX
+ *   Type of sample points vector
+ * @tparam OpV
+ *   Type of values vector
+ * @tparam OpXQ
+ *   Type of query points
+ * @param x
+ *   Sample points (must be sorted in ascending order)
+ * @param v
+ *   Values at sample points
+ * @param xq
+ *   Query points where to interpolate
+ * @returns Operator that interpolates values at query points
+ */
+template <typename OpX, typename OpV, typename OpXQ>
+auto interp(const OpX &x, const OpV &v, const OpXQ &xq) {
+  static_assert(OpX::Rank() == 1, "interp: sample points must be 1D");
+  static_assert(OpV::Rank() == 1, "interp: values must be 1D");
+  return detail::InterpolateOp<OpX, OpV, OpXQ>(x, v, xq, InterpMethod::INTERP_METHOD_LINEAR);
+}
+
+/**
+ * Linear interpolation operator
+ *
+ * @tparam OpX
+ *   Type of sample points vector
+ * @tparam OpV
+ *   Type of values vector
+ * @tparam OpXQ
+ *   Type of query points
+ * @param x
+ *   Sample points (must be sorted in ascending order)
+ * @param v
+ *   Values at sample points
+ * @param xq
+ *   Query points where to interpolate
+ * @param method
+ *   Interpolation method (INTERP_METHOD_LINEAR, INTERP_METHOD_NEAREST, INTERP_METHOD_NEXT, INTERP_METHOD_PREV)
+ * @returns Operator that interpolates values at query points
+ */
+template <typename OpX, typename OpV, typename OpXQ>
+auto interp(const OpX &x, const OpV &v, const OpXQ &xq, const InterpMethod method) {
+  static_assert(OpX::Rank() == 1, "interp: sample points must be 1D");
+  static_assert(OpV::Rank() == 1, "interp: values must be 1D");
+  return detail::InterpolateOp<OpX, OpV, OpXQ>(x, v, xq, method);
+}
+
+} // namespace matx 

--- a/include/matx/operators/interp.h
+++ b/include/matx/operators/interp.h
@@ -58,27 +58,30 @@ namespace matx {
       O dl_, d_, du_, b_;
       OpX x_;
       OpV v_;
+      using x_val_type = typename OpX::value_type;
+      using v_val_type = typename OpV::value_type;
+
 
     public:
-      InterpSplineTridiagonalFillOp(O dl, O d, O du, O b, OpX x, OpV v)
+      InterpSplineTridiagonalFillOp(const O& dl, const O& d, const O& du, const O& b, const OpX& x, const OpV& v)
           : dl_(dl), d_(d), du_(du), b_(b), x_(x), v_(v)  {}
 
       __device__ inline void operator()(index_t idx) const
       {
       
         if (idx == 0) { // left boundary condition
-          typename OpX::value_type x0 = x_(idx);
-          typename OpX::value_type x1 = x_(idx + 1);
-          typename OpX::value_type x2 = x_(idx + 2);
-          typename OpX::value_type h0 = x1 - x0;
-          typename OpX::value_type h1 = x2 - x1;
+          x_val_type x0 = x_(idx);
+          x_val_type x1 = x_(idx + 1);
+          x_val_type x2 = x_(idx + 2);
+          x_val_type h0 = x1 - x0;
+          x_val_type h1 = x2 - x1;
 
-          typename OpV::value_type v0 = v_(idx);
-          typename OpV::value_type v1 = v_(idx + 1);
-          typename OpV::value_type v2 = v_(idx + 2);
+          v_val_type v0 = v_(idx);
+          v_val_type v1 = v_(idx + 1);
+          v_val_type v2 = v_(idx + 2);
 
-          typename OpV::value_type delta0 = (v1 - v0) / h0;
-          typename OpV::value_type delta1 = (v2 - v1) / h1;
+          v_val_type delta0 = (v1 - v0) / h0;
+          v_val_type delta1 = (v2 - v1) / h1;
 
           dl_(idx) = static_cast<typename O::value_type>(0);
           d_(idx) = h1;
@@ -86,18 +89,18 @@ namespace matx {
           b_(idx) = ((2*h1 + 3*h0)*h1*delta0 + h0*h0*delta1) / (h1 + h0);
         }
         else if (idx == x_.Size(0) - 1) { // right boundary condition
-          typename OpX::value_type x0 = x_(idx - 2);
-          typename OpX::value_type x1 = x_(idx - 1);
-          typename OpX::value_type x2 = x_(idx);
-          typename OpX::value_type h0 = x1 - x0;
-          typename OpX::value_type h1 = x2 - x1;
+          x_val_type x0 = x_(idx - 2);
+          x_val_type x1 = x_(idx - 1);
+          x_val_type x2 = x_(idx);
+          x_val_type h0 = x1 - x0;
+          x_val_type h1 = x2 - x1;
 
-          typename OpV::value_type v0 = v_(idx - 2);
-          typename OpV::value_type v1 = v_(idx - 1);
-          typename OpV::value_type v2 = v_(idx);
+          v_val_type v0 = v_(idx - 2);
+          v_val_type v1 = v_(idx - 1);
+          v_val_type v2 = v_(idx);
 
-          typename OpV::value_type delta0 = (v1 - v0) / h0;
-          typename OpV::value_type delta1 = (v2 - v1) / h1;
+          v_val_type delta0 = (v1 - v0) / h0;
+          v_val_type delta1 = (v2 - v1) / h1;
 
 
           dl_(idx) = h0 + h1;
@@ -106,18 +109,18 @@ namespace matx {
           b_(idx) = ((2*h0 + 3*h1)*h0*delta1 + h1*h1*delta0) / (h0 + h1);
         }
         else { // interior points
-          typename OpX::value_type x0 = x_(idx - 1);
-          typename OpX::value_type x1 = x_(idx);
-          typename OpX::value_type x2 = x_(idx + 1);
-          typename OpX::value_type h0 = x1 - x0;
-          typename OpX::value_type h1 = x2 - x1;
+          x_val_type x0 = x_(idx - 1);
+          x_val_type x1 = x_(idx);
+          x_val_type x2 = x_(idx + 1);
+          x_val_type h0 = x1 - x0;
+          x_val_type h1 = x2 - x1;
 
-          typename OpV::value_type v0 = v_(idx - 1);
-          typename OpV::value_type v1 = v_(idx);
-          typename OpV::value_type v2 = v_(idx + 1);
+          v_val_type v0 = v_(idx - 1);
+          v_val_type v1 = v_(idx);
+          v_val_type v2 = v_(idx + 1);
 
-          typename OpV::value_type delta0 = (v1 - v0) / h0;
-          typename OpV::value_type delta1 = (v2 - v1) / h1;
+          v_val_type delta0 = (v1 - v0) / h0;
+          v_val_type delta1 = (v2 - v1) / h1;
 
           dl_(idx) = h1;
           d_(idx) = 2*(h0 + h1);
@@ -140,7 +143,7 @@ namespace matx {
       using value_type = typename OpV::value_type;
       using method_type = Method;
 
-    protected:
+    private:
       typename detail::base_type_t<OpX> x_;    // Sample points
       typename detail::base_type_t<OpV> v_;    // Values at sample points
       typename detail::base_type_t<OpXQ> xq_;  // Query points

--- a/include/matx/operators/operators.h
+++ b/include/matx/operators/operators.h
@@ -71,6 +71,7 @@
 #include "matx/operators/ifelse.h"
 #include "matx/operators/index.h"
 #include "matx/operators/interleaved.h"
+#include "matx/operators/interp.h"
 #include "matx/operators/isclose.h"
 #include "matx/operators/inverse.h"
 #include "matx/operators/kronecker.h"

--- a/test/00_operators/CMakeLists.txt
+++ b/test/00_operators/CMakeLists.txt
@@ -22,6 +22,7 @@ set(OPERATOR_TEST_FILES
   frexpc_test.cu
   get_string_test.cu
   interleaved_test.cu
+  interp_test.cu
   isclose_test.cu
   isnaninf_test.cu
   legendre_test.cu

--- a/test/00_operators/interp_test.cu
+++ b/test/00_operators/interp_test.cu
@@ -32,7 +32,7 @@ TEST(InterpTests, Interp)
   xq.SetVals({-1.0, 0.0, 0.25, 1.0, 1.5, 5.0});
 
   auto out_linear = make_tensor<TestType>({xq.Size(0)});
-  (out_linear = interp1<InterpMethodLinear>(x, v, xq)).run(exec);
+  (out_linear = interp1(x, v, xq, InterpMethod::LINEAR)).run(exec);
   // example-end interp-test-1
   exec.sync();
 
@@ -45,7 +45,7 @@ TEST(InterpTests, Interp)
 
   // example-begin interp-test-2
   auto out_nearest = make_tensor<TestType>({xq.Size(0)});
-  (out_nearest = interp1<InterpMethodNearest>(x, v, xq)).run(exec);
+  (out_nearest = interp1(x, v, xq, InterpMethod::NEAREST)).run(exec);
   // example-end interp-test-2
   exec.sync();
 
@@ -57,7 +57,7 @@ TEST(InterpTests, Interp)
   ASSERT_EQ(out_nearest(5), 4.0);
 
   auto out_next = make_tensor<TestType>({xq.Size(0)});
-  (out_next = interp1<InterpMethodNext>(x, v, xq)).run(exec);
+  (out_next = interp1(x, v, xq, InterpMethod::NEXT)).run(exec);
   exec.sync();
 
   ASSERT_EQ(out_next(0), 0.0);
@@ -68,7 +68,7 @@ TEST(InterpTests, Interp)
   ASSERT_EQ(out_next(5), 4.0);
 
   auto out_prev = make_tensor<TestType>({xq.Size(0)});
-  (out_prev = interp1<InterpMethodPrev>(x, v, xq)).run(exec);
+  (out_prev = interp1(x, v, xq, InterpMethod::PREV)).run(exec);
   exec.sync();
 
   ASSERT_EQ(out_prev(0), 0.0);
@@ -80,7 +80,7 @@ TEST(InterpTests, Interp)
 
 
   auto out_spline = make_tensor<TestType>({xq.Size(0)});
-  (out_spline = interp1<InterpMethodSpline>(x, v, xq)).run(exec);
+  (out_spline = interp1(x, v, xq, InterpMethod::SPLINE)).run(exec);
   exec.sync();
 
 

--- a/test/00_operators/interp_test.cu
+++ b/test/00_operators/interp_test.cu
@@ -7,12 +7,18 @@ using namespace matx;
 using namespace matx::test;
 
 
-TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Interp)
+//TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, Interp)
+TEST(InterpTests, Interp)
 {
   MATX_ENTER_HANDLER();
-  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  using TestType = float;
+  using ExecType = cudaExecutor;
 
+  if constexpr (!is_cuda_executor_v<ExecType>) {
+    GTEST_SKIP();
+  }
+
+  using inner_type = typename inner_op_type_t<TestType>::type;
   ExecType exec{};
 
   // example-begin interp-test-1
@@ -77,7 +83,13 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Interp)
   (out_spline = interp<InterpMethodSpline>(x, v, xq)).run(exec);
   exec.sync();
 
-  ASSERT_EQ(out_prev(3), 2.0);
+
+  ASSERT_NEAR(out_spline(0), -10.7391, 1e-4);
+  ASSERT_EQ(out_spline(1), 0.0);
+  ASSERT_NEAR(out_spline(2), 1.1121, 1e-4);
+  ASSERT_EQ(out_spline(3), 2.0);
+  ASSERT_NEAR(out_spline(4), 1.3804, 1e-4);
+  ASSERT_NEAR(out_spline(5), -8.1739, 1e-4);
 
 
   MATX_EXIT_HANDLER();

--- a/test/00_operators/interp_test.cu
+++ b/test/00_operators/interp_test.cu
@@ -32,7 +32,7 @@ TEST(InterpTests, Interp)
   xq.SetVals({-1.0, 0.0, 0.25, 1.0, 1.5, 5.0});
 
   auto out_linear = make_tensor<TestType>({xq.Size(0)});
-  (out_linear = interp(x, v, xq)).run(exec);
+  (out_linear = interp1<InterpMethodLinear>(x, v, xq)).run(exec);
   // example-end interp-test-1
   exec.sync();
 
@@ -45,7 +45,7 @@ TEST(InterpTests, Interp)
 
   // example-begin interp-test-2
   auto out_nearest = make_tensor<TestType>({xq.Size(0)});
-  (out_nearest = interp<InterpMethodNearest>(x, v, xq)).run(exec);
+  (out_nearest = interp1<InterpMethodNearest>(x, v, xq)).run(exec);
   // example-end interp-test-2
   exec.sync();
 
@@ -57,7 +57,7 @@ TEST(InterpTests, Interp)
   ASSERT_EQ(out_nearest(5), 4.0);
 
   auto out_next = make_tensor<TestType>({xq.Size(0)});
-  (out_next = interp<InterpMethodNext>(x, v, xq)).run(exec);
+  (out_next = interp1<InterpMethodNext>(x, v, xq)).run(exec);
   exec.sync();
 
   ASSERT_EQ(out_next(0), 0.0);
@@ -68,7 +68,7 @@ TEST(InterpTests, Interp)
   ASSERT_EQ(out_next(5), 4.0);
 
   auto out_prev = make_tensor<TestType>({xq.Size(0)});
-  (out_prev = interp<InterpMethodPrev>(x, v, xq)).run(exec);
+  (out_prev = interp1<InterpMethodPrev>(x, v, xq)).run(exec);
   exec.sync();
 
   ASSERT_EQ(out_prev(0), 0.0);
@@ -80,7 +80,7 @@ TEST(InterpTests, Interp)
 
 
   auto out_spline = make_tensor<TestType>({xq.Size(0)});
-  (out_spline = interp<InterpMethodSpline>(x, v, xq)).run(exec);
+  (out_spline = interp1<InterpMethodSpline>(x, v, xq)).run(exec);
   exec.sync();
 
 

--- a/test/00_operators/interp_test.cu
+++ b/test/00_operators/interp_test.cu
@@ -72,5 +72,13 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Interp)
   ASSERT_EQ(out_prev(4), 2.0);
   ASSERT_EQ(out_prev(5), 4.0);
 
+
+  auto out_spline = make_tensor<TestType>({xq.Size(0)});
+  (out_spline = interp<InterpMethodSpline>(x, v, xq)).run(exec);
+  exec.sync();
+
+  ASSERT_EQ(out_spline(5), 7.0);
+
+
   MATX_EXIT_HANDLER();
 }

--- a/test/00_operators/interp_test.cu
+++ b/test/00_operators/interp_test.cu
@@ -77,7 +77,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Interp)
   (out_spline = interp<InterpMethodSpline>(x, v, xq)).run(exec);
   exec.sync();
 
-  ASSERT_EQ(out_spline(5), 7.0);
+  ASSERT_EQ(out_prev(3), 2.0);
 
 
   MATX_EXIT_HANDLER();

--- a/test/00_operators/interp_test.cu
+++ b/test/00_operators/interp_test.cu
@@ -39,7 +39,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Interp)
 
   // example-begin interp-test-2
   auto out_nearest = make_tensor<TestType>({xq.Size(0)});
-  (out_nearest = interp(x, v, xq, InterpMethod::INTERP_METHOD_NEAREST)).run(exec);
+  (out_nearest = interp<InterpMethodNearest>(x, v, xq)).run(exec);
   // example-end interp-test-2
   exec.sync();
 
@@ -51,7 +51,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Interp)
   ASSERT_EQ(out_nearest(5), 4.0);
 
   auto out_next = make_tensor<TestType>({xq.Size(0)});
-  (out_next = interp(x, v, xq, InterpMethod::INTERP_METHOD_NEXT)).run(exec);
+  (out_next = interp<InterpMethodNext>(x, v, xq)).run(exec);
   exec.sync();
 
   ASSERT_EQ(out_next(0), 0.0);
@@ -62,7 +62,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Interp)
   ASSERT_EQ(out_next(5), 4.0);
 
   auto out_prev = make_tensor<TestType>({xq.Size(0)});
-  (out_prev = interp(x, v, xq, InterpMethod::INTERP_METHOD_PREV)).run(exec);
+  (out_prev = interp<InterpMethodPrev>(x, v, xq)).run(exec);
   exec.sync();
 
   ASSERT_EQ(out_prev(0), 0.0);

--- a/test/00_operators/interp_test.cu
+++ b/test/00_operators/interp_test.cu
@@ -1,0 +1,76 @@
+#include "operator_test_types.hpp"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+
+using namespace matx;
+using namespace matx::test;
+
+
+TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Interp)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  // example-begin interp-test-1
+  auto x = make_tensor<TestType>({5});
+  x.SetVals({0.0, 1.0, 3.0, 3.5, 4.0});
+
+  auto v = make_tensor<TestType>({5});
+  v.SetVals({0.0, 2.0, 1.0, 3.0, 4.0});
+
+  auto xq = make_tensor<TestType>({6});
+  xq.SetVals({-1.0, 0.0, 0.25, 1.0, 1.5, 5.0});
+
+  auto out_linear = make_tensor<TestType>({xq.Size(0)});
+  (out_linear = interp(x, v, xq)).run(exec);
+  // example-end interp-test-1
+  exec.sync();
+
+  ASSERT_EQ(out_linear(0), 0.0);
+  ASSERT_EQ(out_linear(1), 0.0);
+  ASSERT_EQ(out_linear(2), 0.5);
+  ASSERT_EQ(out_linear(3), 2.0);
+  ASSERT_EQ(out_linear(4), 1.75);
+  ASSERT_EQ(out_linear(5), 4.0);
+
+  // example-begin interp-test-2
+  auto out_nearest = make_tensor<TestType>({xq.Size(0)});
+  (out_nearest = interp(x, v, xq, InterpMethod::INTERP_METHOD_NEAREST)).run(exec);
+  // example-end interp-test-2
+  exec.sync();
+
+  ASSERT_EQ(out_nearest(0), 0.0);
+  ASSERT_EQ(out_nearest(1), 0.0);
+  ASSERT_EQ(out_nearest(2), 0.0);
+  ASSERT_EQ(out_nearest(3), 2.0);
+  ASSERT_EQ(out_nearest(4), 2.0);
+  ASSERT_EQ(out_nearest(5), 4.0);
+
+  auto out_next = make_tensor<TestType>({xq.Size(0)});
+  (out_next = interp(x, v, xq, InterpMethod::INTERP_METHOD_NEXT)).run(exec);
+  exec.sync();
+
+  ASSERT_EQ(out_next(0), 0.0);
+  ASSERT_EQ(out_next(1), 0.0);
+  ASSERT_EQ(out_next(2), 2.0);
+  ASSERT_EQ(out_next(3), 2.0);
+  ASSERT_EQ(out_next(4), 1.0);
+  ASSERT_EQ(out_next(5), 4.0);
+
+  auto out_prev = make_tensor<TestType>({xq.Size(0)});
+  (out_prev = interp(x, v, xq, InterpMethod::INTERP_METHOD_PREV)).run(exec);
+  exec.sync();
+
+  ASSERT_EQ(out_prev(0), 0.0);
+  ASSERT_EQ(out_prev(1), 0.0);
+  ASSERT_EQ(out_prev(2), 0.0);
+  ASSERT_EQ(out_prev(3), 2.0);
+  ASSERT_EQ(out_prev(4), 2.0);
+  ASSERT_EQ(out_prev(5), 4.0);
+
+  MATX_EXIT_HANDLER();
+}


### PR DESCRIPTION
Fixes #926 

Implements linear interpolation, as well as piecewise constant (nearest, next, previous).

## Open questions
Some questions it would be good to get some input on:

### How should extrapolation be handled?

At the moment, it just extrapolates the boundary value as piecewise constant. 
- [Matlab](https://www.mathworks.com/help/matlab/ref/double.interp1.html#btwp6lt-1-extrapolation) fills with NaNs by default. 
- We could also support linear extrapolation (from the 2 points closest to the neighbor)
- numpy supports periodic domains.

### Implementation

Currently this is implemented as a regular operator, so each point is interpolated independently. There is probably room to optimize this (though the optimal pattern will probably depend on the sizes of `x` and `xq`). cc @tmartin-gh 

### Special case: equally spaced `x`

I haven't yet implemented the equally-spaced case yet, which would let us avoid the binary search. Ideally we would be able to detect if `x` is a `linspace` operator: is there a way to do this?

Similarly, we could provide a two argument method, where `x` is assumed to be `linspace(0, n-1, n)`

### What methods to support

Currently supports
- piecewise constant (`nearest`, `next`, `previous` in Matlab `interp1`)
- linear (`linear`)
- $C^2$ splines with not-a-knot boundary conditions (`spline`)

Can also add support for $C^1$ splines (`makima` and `pchip`) but I need to understand a bit more about these. Also could use different boundary conditions for splines (e.g. natural cubic splines <=> 2nd derivative equal to 0 at boundary)

### Dimensionality of samples

Currently the sample points and values must be 1d, the query points can be of arbitrary dimensions. 

We could support arbitrary dimensions sample points and values, along with an `Axis` parameter which specifies dimension the interpolation is performed on. The usual broadcasting semantics (i.e. implicit prepending of dimensions) would be compatible with what is currently implemented here.