### PR TITLE
Remove MATX_ROOT macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,7 +310,6 @@ if (MATX_EN_FILEIO OR MATX_EN_VISUALIZATION OR MATX_EN_PYBIND11 OR MATX_BUILD_EX
     set(MATX_EN_PYBIND11 ON)
     target_compile_definitions(matx INTERFACE MATX_ENABLE_PYBIND11)
     target_compile_definitions(matx INTERFACE MATX_ENABLE_FILEIO)
-    target_compile_options(matx INTERFACE -DMATX_ROOT="${PROJECT_SOURCE_DIR}")
 
     include(cmake/GetPyBind11.cmake)
     find_package(Python3  REQUIRED COMPONENTS Interpreter Development)

--- a/include/matx/core/pybind.h
+++ b/include/matx/core/pybind.h
@@ -39,6 +39,9 @@
 #include <pybind11/embed.h>
 #include <pybind11/numpy.h>
 #include <optional>
+#include <filesystem>
+
+namespace fs = std::filesystem;
 
 namespace matx {
 
@@ -94,7 +97,8 @@ public:
       }
     }
 
-    AddPath(std::string(MATX_ROOT) + GENERATORS_PATH);
+    const auto current_dir = fs::path(__FILE__).parent_path();
+    AddPath((current_dir.string() + "/../../..") + GENERATORS_PATH);
   }
 
   void AddPath(const std::string &path)


### PR DESCRIPTION
The MATX_ROOT macro is another thing that has been around since the beginning, but really just adds an extra dependency for running the tests that's not needed. This PR removes it to make it a relative path instead.