### PR TITLE
Bump GTest version for CMake 4.0 compatibility.

### DIFF
--- a/cmake/GetGTest.cmake
+++ b/cmake/GetGTest.cmake
@@ -40,7 +40,7 @@ function(find_and_configure_gtest VERSION)
     CPMFindPackage(NAME GTest
         VERSION         ${VERSION}
         GIT_REPOSITORY  https://github.com/google/googletest.git
-        GIT_TAG         release-${VERSION}
+        GIT_TAG         v${VERSION}
         GIT_SHALLOW     TRUE
         OPTIONS         "INSTALL_GTEST ON"
         # googletest >= 1.10.0 provides a cmake config file -- use it if it exists
@@ -66,6 +66,6 @@ function(find_and_configure_gtest VERSION)
     # fix_cmake_global_defaults(GTest::gmock_main)
 endfunction()
 
-set(CUDF_MIN_VERSION_GTest 1.11.0)
+set(CUDF_MIN_VERSION_GTest 1.16.0)
 
 find_and_configure_gtest(${CUDF_MIN_VERSION_GTest})


### PR DESCRIPTION
GTest 1.11.0 specifies a minimum version of CMake 2.8, which triggers a hard error in CMake 4.0 as support for it has been removed. This has been fixed in later versions of GTest.

This was discovered while testing new devcontainers on CCCL: https://github.com/NVIDIA/cccl/actions/runs/14206091102/job/39804067192?pr=4302

```
Call Stack (most recent call first):
  /home/coder/cccl/build/cuda12.8ext-gcc13/matx/build/cmake/CPM_0.40.0.cmake:1074 (FetchContent_Populate)
  /home/coder/cccl/build/cuda12.8ext-gcc13/matx/build/cmake/CPM_0.40.0.cmake:868 (cpm_fetch_package)
  /home/coder/cccl/build/cuda12.8ext-gcc13/matx/build/cmake/CPM_0.40.0.cmake:306 (CPMAddPackage)
  cmake/GetGTest.cmake:40 (CPMFindPackage)
  cmake/GetGTest.cmake:71 (find_and_configure_gtest)
  CMakeLists.txt:402 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /home/coder/cccl/build/cuda12.8ext-gcc13/matx/build/_deps/gtest-src/CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
```