### PR TITLE
Fix build error using shape_type in std::conditional_t

### DIFF
--- a/include/matx/operators/collapse.h
+++ b/include/matx/operators/collapse.h
@@ -49,7 +49,6 @@ namespace matx
       public:
         using matxop = bool;
         using value_type = typename T1::value_type;
-        using shape_type = index_t;
         using matxoplvalue = bool;
         using self_type = LCollapseOp<DIM, T1>;
 
@@ -191,7 +190,6 @@ namespace matx
       public:
         using matxop = bool;
         using value_type = typename T1::value_type;
-        using shape_type = index_t;
         using matxlvalue = bool;
         using self_type = RCollapseOp<DIM, T1>;
 

--- a/include/matx/operators/concat.h
+++ b/include/matx/operators/concat.h
@@ -58,7 +58,6 @@ namespace matx
       public:
       using matxop = bool;
       using matxoplvalue = bool;
-      using shape_type = index_t;
 
       // Scalar type of operation
       using value_type = first_value_type;

--- a/include/matx/operators/normalize.h
+++ b/include/matx/operators/normalize.h
@@ -68,7 +68,6 @@ namespace matx
         using matxop = bool;
         using matx_transform_op = bool; 
         using value_type = typename OpA::value_type;
-        using shape_type = index_t;
         using self_type = NormalizeOp<OpA, DIM>;
 
         __MATX_INLINE__ NormalizeOp(const OpA &op, const NORMALIZE_RANGE method): op_(op), normalize_method(method) {

--- a/include/matx/operators/overlap.h
+++ b/include/matx/operators/overlap.h
@@ -47,10 +47,10 @@ namespace matx
     {
       public:
         using value_type = typename T::value_type;
-        using shape_type = index_t;
         using self_type = OverlapOp<DIM, T>;
 
       private:
+        using shape_type = index_t;
         typename detail::base_type_t<T> op_;
         cuda::std::array<int32_t, DIM> dims_;
         cuda::std::array<shape_type, DIM+1> n_;

--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -55,7 +55,6 @@ namespace matx
         using matxoplvalue = bool;
 
         using value_type = typename T::value_type;
-        using shape_type = index_t;
         using index_type = typename IdxType::value_type;
         using self_type = RemapOp<DIM, T, IdxType>;
         static_assert(std::is_integral<index_type>::value, "RemapOp: Type for index operator must be integral");

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -48,10 +48,10 @@ namespace matx
     {
       public: 
         using value_type = typename T::value_type;
-        using shape_type = index_t; 
         using self_type = SliceOp<DIM, T, StrideType>;
 
       private:
+        using shape_type = index_t;
         typename detail::base_type_t<T> op_;
         cuda::std::array<shape_type, DIM> sizes_;
         cuda::std::array<int32_t, DIM> dims_;

--- a/include/matx/operators/stack.h
+++ b/include/matx/operators/stack.h
@@ -57,7 +57,6 @@ namespace matx
       public:
       using matxop = bool;
       using matxoplvalue = bool;
-      using shape_type = index_t;
 
       // Scalar type of operation
       using value_type = first_value_type;

--- a/include/matx/operators/transpose.h
+++ b/include/matx/operators/transpose.h
@@ -54,7 +54,6 @@ namespace detail {
     public:
       using matxop = bool;
       using value_type = typename OpA::value_type;
-      using shape_type = std::conditional_t<has_shape_type_v<OpA>, typename OpA::shape_type, index_t>; 
       using matx_transform_op = bool;
       using matxoplvalue = bool;
       using transpose_xform_op = bool;

--- a/include/matx/transforms/conv.h
+++ b/include/matx/transforms/conv.h
@@ -189,7 +189,6 @@ inline void matxDirectConv1DInternal(OutputType &o, const InType &i,
 
   using strip_input_t = typename InType::value_type;
   using strip_filter_t = typename FilterType::value_type;
-  using shape_type = std::conditional_t<has_shape_type_v<OutputType>, typename OutputType::shape_type, index_t>;
 
   size_t filter_len = filter.Size(filter.Rank()-1);
 
@@ -202,7 +201,7 @@ inline void matxDirectConv1DInternal(OutputType &o, const InType &i,
 
   size_t shmsize = filter_shm + signal_shm;
 
-  shape_type sig_len = i.Size(OutputType::Rank() - 1);
+  const index_t sig_len = i.Size(OutputType::Rank() - 1);
   int work_per_block = CONV1D_ELEMENTS_PER_BLOCK;
   unsigned int num_blocks = (unsigned int)(sig_len + filter.Size(filter.Rank()-1) + work_per_block -1) / work_per_block;
 


### PR DESCRIPTION
Fixes issue GH-953. The conv1d operator uses std::conditional_t<> to define a local shape_type depending on the shape_type trait of the output operator. When combined with an output operator lacking a shape_type trait, this yields a build error.

Relatively few operators include a public shape_type trait, although the tensor_desc_t struct does include shape_type. This commit removes public shape_type traits from current operators that define them, but does allow private shape_type types for internal use. For conv1d, shape_type is replaced by index_t. shape_type is still used in the tensor descriptors.