### PR TITLE
Refactor MATX_CUDA_CHECK to prevent multiple evaluation

### DIFF
--- a/include/matx/core/error.h
+++ b/include/matx/core/error.h
@@ -153,7 +153,7 @@ namespace matx
 
 #define MATX_EXIT_HANDLER()                                     \
   }                                                             \
-  catch (matx::detail::matxException & e)                                     \
+  catch (matx::detail::matxException & e)                       \
   {                                                             \
     fprintf(stderr, "%s\n", e.what());                          \
     fprintf(stderr, "Stack Trace:\n%s", e.stack.str().c_str()); \
@@ -185,10 +185,10 @@ namespace matx
   #define MATX_ASSERT_STR_EXP(a, expected, error, str) \
   {                                    \
     auto tmp = a;                      \
-    if ((tmp != expected))                   \
+    if ((tmp != expected))             \
     {                                  \
       std::cout << #a ": " << str << "(" << tmp << " != " << expected << ")\n";\
-      MATX_THROW(error, "");  \
+      MATX_THROW(error, "");           \
     }                                  \
   }
 
@@ -205,30 +205,33 @@ namespace matx
 
 #define MATX_STATIC_ASSERT_STR(a, error, str) \
   {                                           \
-    static_assert((a), #error ": " #str);       \
+    static_assert((a), #error ": " #str);     \
   }
 
 #define MATX_CUDA_CHECK(e)                                      \
-  if (e != cudaSuccess)                                         \
-  {                                                             \
-    fprintf(stderr, "%s:%d CUDA Error: %s\n", __FILE__,__LINE__, cudaGetErrorString(e)); \
-    MATX_THROW(matx::matxCudaError, cudaGetErrorString(e));           \
-  }
+  do {                                                          \
+    const auto e_ = (e);                                        \
+    if (e_ != cudaSuccess)                                      \
+    {                                                           \
+      fprintf(stderr, "%s:%d CUDA Error: %s (%d)\n", __FILE__,__LINE__, cudaGetErrorString(e_), e_); \
+      MATX_THROW(matx::matxCudaError, cudaGetErrorString(e_));  \
+    }                                                           \
+  } while (0)
 
 // Macro for checking cuda errors following a cuda launch or api call
-#define MATX_CUDA_CHECK_LAST_ERROR()        \
+#define MATX_CUDA_CHECK_LAST_ERROR()   \
   {                                    \
     const auto e = cudaGetLastError(); \
     MATX_CUDA_CHECK(e);                \
   }
 
 // This macro asserts compatible dimensions of current class to an operator.
-#define MATX_ASSERT_COMPATIBLE_OP_SIZES(op)                               \
+#define MATX_ASSERT_COMPATIBLE_OP_SIZES(op)                          \
   if constexpr (Rank() > 0) {                                        \
     bool compatible = true;                                          \
     _Pragma("unroll")                                                \
     for (int32_t i = 0; i < Rank(); i++) {                           \
-      [[maybe_unused]] index_t size = matx::detail::get_expanded_size<Rank()>(op, i);       \
+      [[maybe_unused]] index_t size = matx::detail::get_expanded_size<Rank()>(op, i); \
       compatible = (size == 0 || size == Size(i));                   \
     }                                                                \
     if (!compatible) { \
@@ -248,7 +251,7 @@ namespace matx
       } \
       std::cerr << ")" << std::endl; \
       MATX_THROW(matxInvalidSize, "Incompatible operator sizes"); \
-    }                   \
+    } \
   }
 
 } // end namespace matx


### PR DESCRIPTION
Prevents `MATX_CUDA_CHECK(cudaGetLastError())` from printing 'no error' due to possible multiple evaluation of the input.