### PR TITLE
Use sincos() rather than separate sin/cos for expj

### DIFF
--- a/include/matx/operators/scalar_ops.h
+++ b/include/matx/operators/scalar_ops.h
@@ -312,7 +312,17 @@ template <typename T> struct ExpjF {
       return matxHalfComplex<T>{_internal_cos(v1), _internal_sin(v1)};
     }
     else {
-      return cuda::std::complex<T>{_internal_cos(v1), _internal_sin(v1)};
+      if constexpr (std::is_same_v<T, double>) {
+        double sinx, cosx;
+        sincos(v1, &sinx, &cosx);
+        return cuda::std::complex<T>{cosx, sinx};
+      } else if constexpr (std::is_same_v<T, float>) {
+        float sinx, cosx;
+        sincosf(v1, &sinx, &cosx);
+        return cuda::std::complex<T>{cosx, sinx};
+      } else {
+        return cuda::std::complex<T>{_internal_cos(v1), _internal_sin(v1)};
+      }
     }
   }
 };

--- a/test/00_operators/operator_func_test.cu
+++ b/test/00_operators/operator_func_test.cu
@@ -52,15 +52,33 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, OperatorFuncsR2C)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
-  ExecType exec{};   
+  ExecType exec{};
+
   auto tiv0 = make_tensor<TestType>({});
   auto tov0 = make_tensor<typename detail::complex_from_scalar_t<TestType>>({});
+  // example-begin expj-test-1
+  // TestType is float, double, bf16, etc.
+  tiv0() = static_cast<TestType>(M_PI/2.0);
+  (tov0 = expj(tiv0)).run(exec);
+  // tov0 is complex with value 0 + 1j
+  // example-end expj-test-1
+
+  exec.sync();
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::complex_from_scalar_t<TestType>(0.0, 1.0)));
+
+  tiv0() = static_cast<TestType>(-1.0 * M_PI);
+  (tov0 = expj(tiv0)).run(exec);
+  exec.sync();
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::complex_from_scalar_t<TestType>(-1.0, 0.0)));
+
+  tiv0() = 0;
+  (tov0 = expj(tiv0)).run(exec);
+  exec.sync();
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tov0(), detail::complex_from_scalar_t<TestType>(1.0, 0.0)));
+
   TestType c = GenerateData<TestType>();
   tiv0() = c;
-
-  // example-begin expj-test-1
   (tov0 = expj(tiv0)).run(exec);
-  // example-end expj-test-1
   exec.sync();
 
   EXPECT_TRUE(MatXUtils::MatXTypeCompare(


### PR DESCRIPTION
As an optimization, use sincos() to compute the real and imaginary components of expj() rather than separate sin() and cos(). Also update the expj example in the documentation and add new test cases.