### PR TITLE
Introduce DIA and SkewDIA format

### DIFF
--- a/examples/sparse_tensor.cu
+++ b/examples/sparse_tensor.cu
@@ -55,6 +55,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   experimental::CSR::print();
   experimental::CSC::print();
   experimental::DCSR::print();
+  experimental::DIA::print();
+  experimental::SkewDIA::print();
   experimental::BSR<2,2>::print(); // 2x2 blocks
   experimental::COO4::print();     // 4-dim tensor in COO
   experimental::CSF5::print();     // 5-dim tensor in CSF

--- a/include/matx/core/print.h
+++ b/include/matx/core/print.h
@@ -160,7 +160,7 @@ namespace matx {
         // A sparse tensor has no strides, so show the level sizes instead.
         // These are obtained by translating dims to levels using the format.
         cuda::std::array<index_t, Op::Format::LVL> lvlsz;
-        Op::Format::dim2lvl(op.Shape().data(), lvlsz.data(), /*asSize=*/true);
+        Op::Format::template dim2lvl<true>(op.Shape().data(), lvlsz.data());
         fprintf(fp, "], Levels:[");
         for (int lvlIdx = 0; lvlIdx < Op::Format::LVL; lvlIdx++) {
           fprintf(fp, "%" MATX_INDEX_T_FMT, lvlsz[lvlIdx]);


### PR DESCRIPTION
Adds Add/Sub operator and Range format. This change also makes the "asSize" of dim2lvl a template parameter for more optimized code and adds static_assert to avoid having unimplemented cases.