### PR TITLE
Let X = solve(A, B) take X and B along rows

### DIFF
--- a/examples/sparse_tensor.cu
+++ b/examples/sparse_tensor.cu
@@ -152,9 +152,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
   colidx.SetVals({0, 1, 1, 2, 3});
   auto Acsr = experimental::make_tensor_csr(coeffs, rowptr, colidx, {4, 4});
   print(Acsr);
-  auto X = make_tensor<float>({4, 2});
-  auto Y = make_tensor<float>({4, 2});
-  Y.SetVals({{5, 17}, {6, 18}, {12, 28}, {20, 40}});
+  auto X = make_tensor<float>({2, 4}); // solution along rows
+  auto Y = make_tensor<float>({2, 4}); // RHS along rows
+  Y.SetVals({{5, 6, 12, 20}, {17, 18, 28, 40}});
   (X = solve(Acsr, Y)).run(exec);
   print(X);
 
@@ -197,7 +197,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
   auto doffsets = make_tensor<int>({3});
   dvals.SetVals({-1, -1, -1, -1, -1, 0, 4, 4, 4, 4, 4, 4, 0, 1, 1, 1, 1, 1});
   doffsets.SetVals({-1, 0, 1});
-  auto AdiaJ = experimental::make_tensor_dia<experimental::DIA_INDEX_J>(dvals, doffsets, {6, 6});
+  auto AdiaJ = experimental::make_tensor_dia<experimental::DIA_INDEX_J>(
+      dvals, doffsets, {6, 6});
   print(AdiaJ);
 
   //

--- a/test/00_sparse/Solve.cu
+++ b/test/00_sparse/Solve.cu
@@ -73,9 +73,9 @@ TYPED_TEST(SolveSparseTestsAll, SolveCSR) {
   // | 0 0 0 5 |   | 4 8 |   | 20 40 |
   //
   auto A = make_tensor<TestType>({4, 4});
-  auto X = make_tensor<TestType>({4, 2});
-  auto E = make_tensor<TestType>({4, 2});
-  auto Y = make_tensor<TestType>({4, 2});
+  auto X = make_tensor<TestType>({2, 4});
+  auto E = make_tensor<TestType>({2, 4});
+  auto Y = make_tensor<TestType>({2, 4});
   // Coeffs.
   A(0, 0) = static_cast<TestType>(1);
   A(0, 1) = static_cast<TestType>(2);
@@ -93,24 +93,24 @@ TYPED_TEST(SolveSparseTestsAll, SolveCSR) {
   A(3, 1) = static_cast<TestType>(0);
   A(3, 2) = static_cast<TestType>(0);
   A(3, 3) = static_cast<TestType>(5);
-  // Expected.
+  // Expected (along rows).
   E(0, 0) = static_cast<TestType>(1);
-  E(0, 1) = static_cast<TestType>(5);
-  E(1, 0) = static_cast<TestType>(2);
+  E(0, 1) = static_cast<TestType>(2);
+  E(0, 2) = static_cast<TestType>(3);
+  E(0, 3) = static_cast<TestType>(4);
+  E(1, 0) = static_cast<TestType>(5);
   E(1, 1) = static_cast<TestType>(6);
-  E(2, 0) = static_cast<TestType>(3);
-  E(2, 1) = static_cast<TestType>(7);
-  E(3, 0) = static_cast<TestType>(4);
-  E(3, 1) = static_cast<TestType>(8);
-  // RHS.
+  E(1, 2) = static_cast<TestType>(7);
+  E(1, 3) = static_cast<TestType>(8);
+  // RHS (along rows).
   Y(0, 0) = static_cast<TestType>(5);
-  Y(0, 1) = static_cast<TestType>(17);
-  Y(1, 0) = static_cast<TestType>(6);
+  Y(0, 1) = static_cast<TestType>(6);
+  Y(0, 2) = static_cast<TestType>(12);
+  Y(0, 3) = static_cast<TestType>(20);
+  Y(1, 0) = static_cast<TestType>(17);
   Y(1, 1) = static_cast<TestType>(18);
-  Y(2, 0) = static_cast<TestType>(12);
-  Y(2, 1) = static_cast<TestType>(28);
-  Y(3, 0) = static_cast<TestType>(20);
-  Y(3, 1) = static_cast<TestType>(40);
+  Y(1, 2) = static_cast<TestType>(28);
+  Y(1, 3) = static_cast<TestType>(40);
 
   // Convert dense A to sparse S in CSR format with int-32 indices.
   auto S =
@@ -123,8 +123,8 @@ TYPED_TEST(SolveSparseTestsAll, SolveCSR) {
 
   // Verify result.
   exec.sync();
-  for (index_t i = 0; i < 4; i++) {
-    for (index_t j = 0; j < 2; j++) {
+  for (index_t i = 0; i < 2; i++) {
+    for (index_t j = 0; j < 4; j++) {
       if constexpr (is_complex_v<TestType>) {
         ASSERT_NEAR(X(i, j).real(), E(i, j).real(), this->thresh);
         ASSERT_NEAR(X(i, j).imag(), E(i, j).imag(), this->thresh);
@@ -142,8 +142,8 @@ TYPED_TEST(SolveSparseTestsAll, SolveCSR) {
 
   // Verify result.
   exec.sync();
-  for (index_t i = 0; i < 4; i++) {
-    for (index_t j = 0; j < 2; j++) {
+  for (index_t i = 0; i < 2; i++) {
+    for (index_t j = 0; j < 4; j++) {
       if constexpr (is_complex_v<TestType>) {
         ASSERT_NEAR((X(i, j) - C5).real(), E(i, j).real(), this->thresh);
         ASSERT_NEAR((X(i, j) - C5).imag(), E(i, j).imag(), this->thresh);


### PR DESCRIPTION
Since all sparse direct solvers expect X and B in column-major format, it is better to adjust our definition for solve() than to insert artificial and costly data transpositions everywhere. Also, presenting the different rhs vectors and solutions along rows is more natural for a lot of direct solver problems.