### PR TITLE
Fix ARM relocation trucation build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,13 @@ else()
 endif()
 set(WARN_FLAGS ${WARN_FLAGS} $<$<COMPILE_LANGUAGE:CXX>:-Werror>)
 
+# ARM64-specific flags to handle relocation issues
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -fPIC")
+    message(STATUS "Added ARM64-specific flags for relocation handling")
+endif()
+
 # CUTLASS slows down compile times when used, so leave it as optional for now
 # if (MATX_EN_CUTLASS)
 #     include(cmake/GetCUTLASS.cmake)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,14 @@ target_include_directories(matx_test SYSTEM PRIVATE "${system_inc}")
 target_link_libraries(matx_test PRIVATE matx::matx) # Transitive properties
 target_link_libraries(matx_test PRIVATE ${NVSHMEM_LIBRARY} gtest)
 
+# Enable position independent code to fix relocation issues on ARM64
+set_property(TARGET matx_test PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+# For ARM64, prefer dynamic linking to avoid relocation issues
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(TARGET matx_test PROPERTY LINK_PREFERENCE_PUBLIC SHARED)
+endif()
+
 add_custom_target(test
     DEPENDS matx_test
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/matx_test)


### PR DESCRIPTION
When building unit tests on an AGX Orin Devkit, the following error was observed:
```
[100%] Linking CXX executable matx_test
CMakeFiles/matx_test.dir/main.cu.o: in function `main':
/home/deustice/MatX/test/main.cu:40:(.text+0xa4): relocation truncated to fit: R_AARCH64_CALL26 against symbol `testing::InitGoogleTest(int*, char**)' defined in .text section in ../lib/libgtest.a(gtest-all.cc.o)
CMakeFiles/matx_test.dir/main.cu.o: in function `__sti____cudaRegisterAll()':
/tmp/tmpxft_001053bc_00000000-6_main.cudafe1.stub.c:13:(.text+0x1b4): relocation truncated to fit: R_AARCH64_CALL26 against symbol `atexit' defined in .text section in /usr/lib/aarch64-linux-gnu/libc_nonshared.a(atexit.oS)
CMakeFiles/matx_test.dir/main.cu.o: in function `RUN_ALL_TESTS()':
/home/deustice/MatX/build/_deps/gtest-src/googletest/include/gtest/gtest.h:2334:(.text._Z13RUN_ALL_TESTSv[_Z13RUN_ALL_TESTSv]+0x8): relocation truncated to fit: R_AARCH64_CALL26 against symbol `testing::UnitTest::GetInstance()' defined in .text section in ../lib/libgtest.a(gtest-all.cc.o)
/home/deustice/MatX/build/_deps/gtest-src/googletest/include/gtest/gtest.h:2334:(.text._Z13RUN_ALL_TESTSv[_Z13RUN_ALL_TESTSv]+0xc): relocation truncated to fit: R_AARCH64_CALL26 against symbol `testing::UnitTest::Run()' defined in .text section in ../lib/libgtest.a(gtest-all.cc.o)
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/matx_test.dir/build.make:1726: test/matx_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:1119: test/CMakeFiles/matx_test.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

This fixes the relocation errors by enabling position independent code instead of the default 26-bit offsets. Since there is a small performance trade-off by doing this, we might want to think about a less heavy-handed fix. It's unknown if this is actually needed for all ARM architectures or just Jetsons.