### PR TITLE
fix flipud for 1D tensors

### DIFF
--- a/include/matx/operators/reverse.h
+++ b/include/matx/operators/reverse.h
@@ -196,12 +196,8 @@ namespace matx
   template <typename T1>
   auto __MATX_INLINE__ flipud(const T1 &t)
   {
-    if constexpr (T1::Rank() == 1)
-    {
-      return detail::ReverseOp<T1::Rank() - 1 , T1>(t);
-    }
-
-    return detail::ReverseOp<T1::Rank() - 2, T1>(t);
+    constexpr int dim = std::max(0, T1::Rank() - 2);
+    return detail::ReverseOp<dim, T1>(t);
   };
 
   /**

--- a/test/00_operators/reverse_test.cu
+++ b/test/00_operators/reverse_test.cu
@@ -16,16 +16,26 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Reverse)
 
   index_t count0 = 100;
   index_t count1 = 200;
+  tensor_t<TestType, 1> t1({count0});
+  tensor_t<TestType, 1> t1r({count0});
   tensor_t<TestType, 2> t2({count0, count1});
   tensor_t<TestType, 2> t2r({count0, count1});
 
   for (index_t i = 0; i < count0; i++) {
+    t1(i) = static_cast<detail::value_promote_t<TestType>>(i);
     for (index_t j = 0; j < count1; j++) {
       t2(i, j) = static_cast<detail::value_promote_t<TestType>>(i * count1 + j);
     }
   }
 
   {
+    (t1r = reverse<0>(t1)).run(exec);
+    exec.sync();
+
+    for (index_t i = 0; i < count0; i++) {
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1r(i), t1(count0 - i - 1)));
+    }
+
     // example-begin reverse-test-1
     // Reverse the values of t2 along dimension 0
     (t2r = reverse<0>(t2)).run(exec);
@@ -66,6 +76,12 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Reverse)
 
   // Flip versions
   {
+    (t1r = flipud(t1)).run(exec);
+    exec.sync();
+    for (index_t i = 0; i < count0; i++) {
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1r(i), t1(count0 - i - 1)));
+    }
+
     // example-begin flipud-test-1
     (t2r = flipud(t2)).run(exec);
     // example-end flipud-test-1
@@ -80,6 +96,12 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Reverse)
   }
 
   {
+    (t1r = fliplr(t1)).run(exec);
+    exec.sync();
+    for (index_t i = 0; i < count0; i++) {
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1r(i), t1(count0 - i - 1)));
+    }
+
     // example-begin fliplr-test-1
     (t2r = fliplr(t2)).run(exec);
     // example-end fliplr-test-1


### PR DESCRIPTION
The current `flipud` logic caused a compilation error when using it with 1D arrays. Changing the logic to seems to fix the issue. Added tests.