### PR TITLE
Remove runtime checks on memory spaces

### DIFF
--- a/include/matx/core/sparse_tensor.h
+++ b/include/matx/core/sparse_tensor.h
@@ -145,11 +145,6 @@ public:
     for (int l = 0; l < LVL; l++) {
       c[l] = coordinates_[l].data();
       p[l] = positions_[l].data();
-      // All non-null data resides in same space.
-      if (v) {
-        assert(!c[l] || GetPointerKind(c[l]) == GetPointerKind(v));
-        assert(!p[l] || GetPointerKind(p[l]) == GetPointerKind(v));
-      }
     }
     this->SetSparseData(v, c, p);
   }

--- a/include/matx/operators/solve.h
+++ b/include/matx/operators/solve.h
@@ -106,6 +106,7 @@ public:
   void Exec([[maybe_unused]] Out &&out, [[maybe_unused]] Executor &&ex) const {
     static_assert(!is_sparse_tensor_v<OpB>, "sparse rhs not implemented");
     if constexpr (is_sparse_tensor_v<OpA>) {
+      // Note that diagonal solve assumes TRI-diagonal storage currently.
       if constexpr (OpA::Format::isDIAI() || OpA::Format::isDIAJ()) {
         sparse_dia_solve_impl(cuda::std::get<0>(out), a_, b_, ex);
       } else if constexpr (OpA::Format::isBatchedDIAIUniform()) {

--- a/include/matx/transforms/solve/solve_cusparse.h
+++ b/include/matx/transforms/solve/solve_cusparse.h
@@ -210,9 +210,8 @@ void sparse_dia_solve_impl(TensorTypeC &C, const TensorTypeA &a,
   using CRD = typename atype::crd_type;
   CRD *diags = a.CRDData(0);
   const index_t numD = a.crdSize(0);
-  if (numD != 3 || diags[0] != -1 || diags[1] != 0 || diags[2] != 1) {
-    MATX_THROW(matxNotSupported, "Only tridiagonal solve supported");
-  }
+  // TODO: we should also check that offsets = {-1,0,1} (host and device)?
+  MATX_ASSERT(numD == 3, matxInvalidParameter);
   using T = std::conditional_t<
       std::is_same_v<TA, cuda::std::complex<double>>, cuDoubleComplex,
       std::conditional_t<std::is_same_v<TA, cuda::std::complex<float>>,
@@ -280,9 +279,8 @@ void sparse_batched_dia_solve_impl(TensorTypeC &C, const TensorTypeA &a,
   using CRD = typename atype::crd_type;
   CRD *diags = a.CRDData(0);
   const index_t numD = a.crdSize(0);
-  if (numD != 3 || diags[0] != -1 || diags[1] != 0 || diags[2] != 1) {
-    MATX_THROW(matxNotSupported, "Only tridiagonal solve supported");
-  }
+  // TODO: we should also check that offsets = {-1,0,1} (host and device)?
+  MATX_ASSERT(numD == 3, matxInvalidParameter);
   using T = std::conditional_t<
       std::is_same_v<TA, cuda::std::complex<double>>, cuDoubleComplex,
       std::conditional_t<std::is_same_v<TA, cuda::std::complex<float>>,


### PR DESCRIPTION
    (1) allow a mix of memory spaces inside the sparse tensor;
        ultimately, only the visibility matters, not the exact consistency

    (2) remove the runtime check on offset = {-1,0,+1} for now;
        I see no other solution than copying this to host or having
        some kernel check on device, which all seems too costly;
        given the very limited usage of UST, we just assume the solve
        is only called on tridiag with these offsets