### PR TITLE
Added `find_peaks` operator

### DIFF
--- a/docs_input/api/searchsort/find_peaks.rst
+++ b/docs_input/api/searchsort/find_peaks.rst
@@ -1,0 +1,22 @@
+.. _find_peaks_func:
+
+find_peaks
+##########
+
+Finds the peaks in a 1D input operator. 
+
+Currently only the `height` and `threshold` parameters are supported.
+
+.. doxygenfunction:: find_peaks
+
+Examples
+~~~~~~~~
+
+.. literalinclude:: ../../../test/00_operators/find_peaks.cu
+   :language: cpp
+   :start-after: example-begin findpeaks-test-1
+   :end-before: example-end findpeaks-test-1
+   :dedent:
+
+
+

--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -677,6 +677,26 @@ inline constexpr bool has_shape_type_v = detail::has_shape_type<typename remove_
 
 
 
+// Detect presence of nested alias `index_cmp_op` and verify it equals bool
+namespace detail {
+template <typename T, typename = void>
+struct has_index_cmp_op : std::false_type {};
+
+template <typename T>
+struct has_index_cmp_op<T, std::void_t<typename T::index_cmp_op>>
+    : std::bool_constant<std::is_same_v<typename T::index_cmp_op, bool>> {};
+}
+
+/**
+ * @brief Determine if a type defines `using index_cmp_op = bool;`
+ * 
+ * @tparam T Type to test
+ */
+template <typename T>
+inline constexpr bool has_index_cmp_op_v = detail::has_index_cmp_op<typename remove_cvref<T>::type>::value;
+
+
+
 namespace detail {
 template <typename T>
 struct is_complex_half

--- a/include/matx/operators/find_peaks.h
+++ b/include/matx/operators/find_peaks.h
@@ -10,12 +10,12 @@
 // 1. Redistributions of source code must retain the above copyright notice, this
 //    list of conditions and the following disclaimer.
 //
-// 2. Redistributions in binary form must resumuce the above copyright notice,
+// 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
 //    and/or other materials provided with the distribution.
 //
 // 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote sumucts derived from
+//    contributors may be used to endorse or promote products derived from
 //    this software without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COpBRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -122,7 +122,9 @@ namespace detail {
 /**
  * Compute peak search of input
  *
- * Returns a tensor representing the peak search of all items in the reduction
+ * Returns a tensor representing the indices of peaks found in the input operator. The first output parameter holds the indices
+ * while the second holds the number of indices/peaks found. The output index tensor must be large enough to hold all of the peaks 
+ * found or the behavior is undefined.
  *
  * @tparam InType
  *   Input data type

--- a/include/matx/operators/find_peaks.h
+++ b/include/matx/operators/find_peaks.h
@@ -131,13 +131,13 @@ namespace detail {
  *
  * @param in
  *   Input data to reduce
+ * @param height
+ *   Height threshold for peak detection. Values below this threshold are not considered peaks.
+ * @param threshold
+ *   Threshold for peak detection. Neighboring values must be larger in vertical distance than this threshold
  * @returns Operator with reduced values of peak search computed
  */
-#ifdef DOXYGEN_ONLY
 template <typename InType>
-#else
-template <typename InType>
-#endif
 __MATX_INLINE__ auto find_peaks(const InType &in,
                                  typename InType::value_type height,
                                  typename InType::value_type threshold)

--- a/include/matx/operators/find_peaks.h
+++ b/include/matx/operators/find_peaks.h
@@ -1,0 +1,149 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// sum rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must resumuce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote sumucts derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COpBRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHsum THE COpBRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+
+#include "matx/core/type_utils.h"
+#include "matx/operators/base_operator.h"
+#include "matx/operators/permute.h"
+#include "matx/transforms/find_peaks.h"
+
+namespace matx {
+
+
+
+namespace detail {
+  template<typename OpA>
+  class FindPeaksOp : public BaseOp<FindPeaksOp<OpA>>
+  {
+    private:
+      typename detail::base_type_t<OpA> a_;
+      typename remove_cvref_t<OpA>::value_type height_;
+      typename remove_cvref_t<OpA>::value_type threshold_;
+
+    public:
+      using matxop = bool;
+      using value_type = typename remove_cvref_t<OpA>::value_type;
+      using matx_transform_op = bool;
+      using find_peaks_xform_op = bool;
+
+      __MATX_INLINE__ std::string str() const { return "find_peaks(" + get_type_str(a_) + ")"; }
+      __MATX_INLINE__ FindPeaksOp(const OpA &a, value_type height, 
+                                                value_type threshold) : 
+                                                a_(a), height_(height), threshold_(threshold) { 
+      }
+
+      template <typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
+
+      template <OperatorCapability Cap>
+      __MATX_INLINE__ __MATX_HOST__ auto get_capability() const {
+        auto self_has_cap = capability_attributes<Cap>::default_value;
+        return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(a_));
+      }
+
+      template <typename Out, typename Executor>
+      void Exec(Out &&out, Executor &&ex) const {
+        static_assert(cuda::std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 2 outputs on find_peaks(). ie: (mtie(O, num_found) = find_peaks(A, height, threshold))");     
+        static_assert(remove_cvref_t<decltype(cuda::std::get<1>(out))>::Rank() == 0 &&
+                      std::is_same_v<typename remove_cvref_t<decltype(cuda::std::get<1>(out))>::value_type, int>, 
+                      "Num elements output must be a scalar integer tensor");
+        static_assert(std::is_same_v<typename remove_cvref_t<decltype(cuda::std::get<0>(out))>::value_type, index_t>, 
+                      "Peak indices output must be a 1D matx::index_t tensor");
+        find_peaks_impl(cuda::std::get<0>(out), cuda::std::get<1>(out), a_, height_, threshold_, ex);
+      }
+
+      static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
+      {
+        return remove_cvref_t<OpA>::Rank();
+      }
+
+      template <typename ShapeType, typename Executor>
+      __MATX_INLINE__ void InnerPreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
+      {
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }          
+      }      
+
+      template <typename ShapeType, typename Executor>
+      __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
+      {
+        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));    
+      }
+
+      template <typename ShapeType, typename Executor>
+      __MATX_INLINE__ void PostRun(ShapeType &&shape, Executor &&ex) const noexcept
+      {
+        if constexpr (is_matx_op<OpA>()) {
+          a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+      }
+
+      constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
+      {
+        return a_.Size(dim);
+      }
+
+  };
+}
+
+
+/**
+ * Compute peak search of input
+ *
+ * Returns a tensor representing the peak search of all items in the reduction
+ *
+ * @tparam InType
+ *   Input data type
+ * @tparam D
+ *   Number of right-most dimensions to reduce over
+ *
+ * @param in
+ *   Input data to reduce
+ * @returns Operator with reduced values of peak search computed
+ */
+#ifdef DOXYGEN_ONLY
+template <typename InType>
+#else
+template <typename InType>
+#endif
+__MATX_INLINE__ auto find_peaks(const InType &in,
+                                 typename InType::value_type height,
+                                 typename InType::value_type threshold)
+{
+  static_assert(InType::Rank() == 1, "Input to find_peaks() must be rank 1");
+  return detail::FindPeaksOp<decltype(in)>(in, height, threshold);
+}
+
+}

--- a/include/matx/operators/operators.h
+++ b/include/matx/operators/operators.h
@@ -63,6 +63,7 @@
 #include "matx/operators/fft.h"
 #include "matx/operators/fftshift.h"
 #include "matx/operators/filter.h"
+#include "matx/operators/find_peaks.h"
 #include "matx/operators/flatten.h"
 #include "matx/operators/frexp.h"
 #include "matx/operators/hermitian.h"

--- a/include/matx/transforms/find_peaks.h
+++ b/include/matx/transforms/find_peaks.h
@@ -1,0 +1,143 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, NVIDIA Corporation
+// peak search rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must resumuce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote sumucts derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COpBRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHsum THE COpBRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <thrust/copy.h>
+#include <thrust/execution_policy.h>
+#include "matx/core/type_utils.h"
+#include "matx/operators/base_operator.h"
+#include "matx/operators/permute.h"
+#include "matx/executors/cuda.h"
+#include "matx/executors/host.h"
+
+namespace matx {
+namespace detail {
+
+template <typename Op>
+struct PeakSearchCmpOp {
+  using index_cmp_op = bool;
+  using value_type = typename Op::value_type;
+  Op op_;
+  value_type height_;
+  value_type threshold_;
+
+  PeakSearchCmpOp(Op op, value_type height,
+    value_type threshold) : op_(op), height_(height), threshold_(threshold) {}
+
+  __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ bool operator()(const index_t &idx) const {
+    if (idx == 0 || idx == op_.Size(0) - 1) {
+      return false;
+    }
+
+    const auto val = op_(idx);
+
+    if (val < height_) {
+      return false;
+    }    
+    
+    // Check two neighboring peaks
+    for (index_t i = -1; i <= 1; i++) {
+      if (i == 0) {
+        continue;
+      }
+
+      if (op_(idx + i) > val - threshold_) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+};
+
+/**
+ * Find the peaks in an operator
+ *
+ *
+ * @tparam OutIdxType
+ *   Output index type
+ * @tparam NumFoundType
+ *   Output number found type
+ * @tparam InType
+ *   Input data type
+ * @tparam RANK
+ *   Rank of output tensor
+ *
+ * @param out_idxs
+ *   Destination for peak indices
+ * @param num_found
+ *   Destination for number of peaks found
+ * @param in
+ *   Input data to find peaks in
+ * @param height
+ *   Height threshold. Each peak must be greater than this value.
+ * @param threshold
+ *   Threshold for peak detection. The neighboring values must be greater or equal to this distance from the peak (using immediate neighbors)
+ * @param exec
+ *   Executor
+ */
+ template <typename OutIdxType, typename NumFoundType, typename InType>
+ void __MATX_INLINE__ find_peaks_impl(OutIdxType &out_idxs, NumFoundType &num_found, const InType &in,
+                                       typename InType::value_type height,
+                                       typename InType::value_type threshold,
+                                       const cudaExecutor &exec)
+ {
+    MATX_NVTX_START("find_peaks_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
+
+    find_idx_impl(out_idxs, num_found, in, PeakSearchCmpOp{in, height, threshold}, exec);    
+ }
+
+ template <typename OutIdxType, typename NumFoundType, typename InType, ThreadsMode MODE>
+ void __MATX_INLINE__ find_peaks_impl(OutIdxType &out_idxs, NumFoundType &num_found, const InType &in,
+                                       typename InType::value_type height,
+                                       typename InType::value_type threshold,
+                                       [[maybe_unused]] const HostExecutor<MODE> &exec)
+ {
+    MATX_NVTX_START("find_peaks_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
+
+    static_assert(MODE == ThreadsMode::SINGLE, "find_peaks() only supports a single threaded host executor");
+
+    // Use thrust to find the number of peaks
+    const auto end_iter = thrust::copy_if(
+      thrust::host,
+      thrust::make_counting_iterator(static_cast<matx::index_t>(0)),
+      thrust::make_counting_iterator(TotalSize(in)),
+      out_idxs.Data(),
+      PeakSearchCmpOp{in, height, threshold}
+    );
+
+    num_found() = static_cast<int>(end_iter - out_idxs.Data());
+ }
+ 
+}
+}

--- a/test/00_operators/CMakeLists.txt
+++ b/test/00_operators/CMakeLists.txt
@@ -16,6 +16,7 @@ set(OPERATOR_TEST_FILES
   concat_test.cu
   cross_test.cu
   fftshift_test.cu
+  find_peaks.cu
   flatten_test.cu
   fmod_test.cu
   frexp_test.cu

--- a/test/00_operators/find_peaks.cu
+++ b/test/00_operators/find_peaks.cu
@@ -1,0 +1,37 @@
+#include "operator_test_types.hpp"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+
+using namespace matx;
+using namespace matx::test;
+
+TYPED_TEST(OperatorTestsFloatNonComplexSingleThreadedHostAllExecs, FindPeaks)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{}; 
+
+  // example-begin findpeaks-test-1
+  auto tiv = make_tensor<TestType>({32});
+  auto tidx = make_tensor<index_t>({32});
+  tiv.SetVals({ 3.9905e-01, 5.1668e-01, 2.4930e-02, 9.4008e-01, 9.4585e-01, 7.9673e-01, 4.1501e-01, 8.2026e-01, 2.2904e-01, 9.0959e-01, 1.0000e+01,
+    7.5222e-02, 4.0922e-01, 9.6007e-01, 2.0930e-01, 1.9395e-01, 8.9094e-01, 4.3867e-01, 3.5698e-01, 5.4537e-01, 8.2992e-01, 2.0994e-01, 7.6842e-01,
+    4.2899e-01, 2.1167e-01, 6.6055e-01, 1.6536e-01, 4.2499e-01, 9.9267e-01, 6.9642e-01, 2.4719e-01, 7.0281e-01});
+  auto num_found = make_tensor<int>({});
+
+  (mtie(tidx, num_found) = find_peaks(tiv, static_cast<TestType>(0.5), static_cast<TestType>(0.1))).run(exec);
+  // example-end findpeaks-test-1
+
+  exec.sync();
+  ASSERT_TRUE(num_found() == 9);
+
+  std::vector<int> expected_idxs = {1, 7, 10, 13, 16, 20, 22, 25, 28};
+  for (int i = 0; i < num_found(); i++) {
+    ASSERT_TRUE(tidx(i) == expected_idxs[i]);
+  }
+
+  MATX_EXIT_HANDLER();
+} 

--- a/test/00_operators/operator_test_types.hpp
+++ b/test/00_operators/operator_test_types.hpp
@@ -68,6 +68,9 @@ template <typename TensorType>
 class OperatorTestsFloatNonComplexAllExecs : public ::testing::Test {};
 
 template <typename TensorType>
+class OperatorTestsFloatNonComplexSingleThreadedHostAllExecs : public ::testing::Test {};
+
+template <typename TensorType>
 class OperatorTestsNumericAllExecs : public ::testing::Test {};
 
 template <typename TensorType>
@@ -87,6 +90,8 @@ TYPED_TEST_SUITE(OperatorTestsFloatNonComplexNonHalfAllExecs,
                  MatXFloatNonComplexNonHalfTypesAllExecs);  
 TYPED_TEST_SUITE(OperatorTestsFloatNonComplexAllExecs,
                  MatXTypesFloatNonComplexAllExecs);
+TYPED_TEST_SUITE(OperatorTestsFloatNonComplexSingleThreadedHostAllExecs,
+                 MatXTypesFloatNonComplexSingleThreadedHostAllExecs);
 TYPED_TEST_SUITE(OperatorTestsNumericAllExecs,
                  MatXTypesNumericAllExecs);                                
 TYPED_TEST_SUITE(OperatorTestsNumericNoHalfAllExecs, MatXNumericNoHalfTypesAllExecs);          

--- a/test/include/test_types.h
+++ b/test/include/test_types.h
@@ -74,6 +74,7 @@ template <> auto inline GenerateData<cuda::std::complex<double>>()
 
 using ExecutorTypesAll = cuda::std::tuple<matx::cudaExecutor, matx::SingleThreadedHostExecutor, matx::AllThreadsHostExecutor, matx::SelectThreadsHostExecutor>;
 using ExecutorTypesCUDAOnly = cuda::std::tuple<matx::cudaExecutor>;
+using ExecutorTypesAllSingleThreadedHost = cuda::std::tuple<matx::cudaExecutor, matx::SingleThreadedHostExecutor>;
 
 /* Taken from https://stackoverflow.com/questions/70404549/cartesian-product-of-stdtuple */
 template<typename T1, typename T2>
@@ -168,3 +169,5 @@ using MatXTypesNumericAllExecs                = TupleToTypes<TypedCartesianProdu
 using MatXTypesIntegralAllExecs               = TupleToTypes<TypedCartesianProduct<MatXIntegralTuple, ExecutorTypesAll>::type>::type;
 using MatXTypesBooleanAllExecs                = TupleToTypes<TypedCartesianProduct<MatXIntegralTuple, ExecutorTypesAll>::type>::type;
 using MatXTypesCastToFloatAllExecs            = TupleToTypes<TypedCartesianProduct<MatXCastToFloatTuple, ExecutorTypesAll>::type>::type;
+
+using MatXTypesFloatNonComplexSingleThreadedHostAllExecs = TupleToTypes<TypedCartesianProduct<MatXFloatNonComplexTuple, ExecutorTypesAllSingleThreadedHost>::type>::type;


### PR DESCRIPTION
Added a `find_peaks` operator similar to SciPy's. So far only threshold and height are implemented. Other parameters like `distance` require a second reduction and can be added if needed.

Closes #603 