### PR TITLE
Add zipvec operator

### DIFF
--- a/docs_input/api/manipulation/rearranging/zipvec.rst
+++ b/docs_input/api/manipulation/rearranging/zipvec.rst
@@ -1,0 +1,21 @@
+.. _zipvec_func:
+
+zipvec
+======
+
+Zips together multiple operators to yield a vectorized operator, like float2.
+zipvec can be used, for example, to create a 2D/3D set of coordinates stored as float2/float3
+using operators that represent the independent coordinate components.
+
+__MATX_INLINE__ __MATX_HOST__  auto zipvec(const Ts&... ts)
+.. doxygenfunction:: zipvec(const Ts&... ts)
+
+Examples
+~~~~~~~~
+
+.. literalinclude:: ../../../../test/00_operators/zipvec_test.cu
+   :language: cpp
+   :start-after: example-begin zipvec-test-1
+   :end-before: example-end zipvec-test-1
+   :dedent:
+

--- a/docs_input/api/manipulation/rearranging/zipvec.rst
+++ b/docs_input/api/manipulation/rearranging/zipvec.rst
@@ -7,7 +7,6 @@ Zips together multiple operators to yield a vectorized operator, like float2.
 zipvec can be used, for example, to create a 2D/3D set of coordinates stored as float2/float3
 using operators that represent the independent coordinate components.
 
-__MATX_INLINE__ __MATX_HOST__  auto zipvec(const Ts&... ts)
 .. doxygenfunction:: zipvec(const Ts&... ts)
 
 Examples

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -1045,14 +1045,6 @@ MATX_IGNORE_WARNING_POP_GCC
         constexpr int EPT_int = static_cast<int>(EPT);
         if constexpr (EPT == detail::ElementsPerThread::ONE) {
           return data_.ldata_[GetValC<EPT, 0, Is...>(cuda::std::make_tuple(indices...))];
-        } else if constexpr (sizeof(T) != detail::alignment_by_type<T>()) {
-          // If the alignment of the type does not match the types size, then we use the Vector load
-          // method. That method specializes this case to load the elements as scalars in a loop over
-          // all EPT elements. A common case where sizeof(T) != detail::alignment_by_type<T>() is for vector types,
-          // e.g. float3 has an alignment of 4B, but a size of 12B.
-          detail::Vector<T, EPT_int> vec;
-          vec.template load<EPT_int>(data_.ldata_ + GetValC<EPT, 0, Is...>(cuda::std::make_tuple(indices...)));
-          return vec;
         } else if constexpr (EPT_int * sizeof(T) <= MAX_VEC_WIDTH_BYTES ) {
           return *reinterpret_cast<detail::Vector<T, EPT_int>*>(data_.ldata_ + GetValC<EPT, 0, Is...>(cuda::std::make_tuple(indices...)));
         } else {

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -1045,7 +1045,15 @@ MATX_IGNORE_WARNING_POP_GCC
         constexpr int EPT_int = static_cast<int>(EPT);
         if constexpr (EPT == detail::ElementsPerThread::ONE) {
           return data_.ldata_[GetValC<EPT, 0, Is...>(cuda::std::make_tuple(indices...))];
-        } else if constexpr (EPT_int * detail::alignment_by_type<T>() <= MAX_VEC_WIDTH_BYTES ) {
+        } else if constexpr (sizeof(T) != detail::alignment_by_type<T>()) {
+          // If the alignment of the type does not match the types size, then we use the Vector load
+          // method. That method specializes this case to load the elements as scalars in a loop over
+          // all EPT elements. A common case where sizeof(T) != detail::alignment_by_type<T>() is for vector types,
+          // e.g. float3 has an alignment of 4B, but a size of 12B.
+          detail::Vector<T, EPT_int> vec;
+          vec.template load<EPT_int>(data_.ldata_ + GetValC<EPT, 0, Is...>(cuda::std::make_tuple(indices...)));
+          return vec;
+        } else if constexpr (EPT_int * sizeof(T) <= MAX_VEC_WIDTH_BYTES ) {
           return *reinterpret_cast<detail::Vector<T, EPT_int>*>(data_.ldata_ + GetValC<EPT, 0, Is...>(cuda::std::make_tuple(indices...)));
         } else {
           detail::Vector<T, EPT_int> vec;

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -1045,7 +1045,7 @@ MATX_IGNORE_WARNING_POP_GCC
         constexpr int EPT_int = static_cast<int>(EPT);
         if constexpr (EPT == detail::ElementsPerThread::ONE) {
           return data_.ldata_[GetValC<EPT, 0, Is...>(cuda::std::make_tuple(indices...))];
-        } else if constexpr (EPT_int * sizeof(T) <= MAX_VEC_WIDTH_BYTES ) {
+        } else if constexpr (EPT_int * detail::alignment_by_type<T>() <= MAX_VEC_WIDTH_BYTES ) {
           return *reinterpret_cast<detail::Vector<T, EPT_int>*>(data_.ldata_ + GetValC<EPT, 0, Is...>(cuda::std::make_tuple(indices...)));
         } else {
           detail::Vector<T, EPT_int> vec;
@@ -1085,7 +1085,7 @@ MATX_IGNORE_WARNING_POP_GCC
         constexpr int EPT_int = static_cast<int>(EPT);
         if constexpr (EPT == detail::ElementsPerThread::ONE) {
           return data_.ldata_[GetVal<EPT, 0, Is...>(cuda::std::make_tuple(indices...))];
-        } else if constexpr (EPT_int * sizeof(T) <= MAX_VEC_WIDTH_BYTES ) {
+        } else if constexpr (EPT_int * detail::alignment_by_type<T>() <= MAX_VEC_WIDTH_BYTES ) {
           return *reinterpret_cast<detail::Vector<T, EPT_int>*>(data_.ldata_ + GetVal<EPT, 0, Is...>(cuda::std::make_tuple(indices...)));
         } else {
           detail::Vector<T, EPT_int> vec;
@@ -1173,10 +1173,10 @@ MATX_IGNORE_WARNING_POP_GCC
           return detail::ElementsPerThread::ONE;
         }
 
-        int width = MAX_VEC_WIDTH_BYTES / sizeof(T);
+        int width = MAX_VEC_WIDTH_BYTES / alignment_by_type<T>();
         while (width > 1) {
           if (((Lsize() % width) == 0) &&                                       // Last dim is a multiple of vector load size
-            ((reinterpret_cast<uintptr_t>(data_.ldata_) % (sizeof(T) * width)) == 0)) {
+            ((reinterpret_cast<uintptr_t>(data_.ldata_) % (alignment_by_type<T>() * width)) == 0)) {
             break;
           }
 

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -1085,7 +1085,7 @@ MATX_IGNORE_WARNING_POP_GCC
         constexpr int EPT_int = static_cast<int>(EPT);
         if constexpr (EPT == detail::ElementsPerThread::ONE) {
           return data_.ldata_[GetVal<EPT, 0, Is...>(cuda::std::make_tuple(indices...))];
-        } else if constexpr (EPT_int * detail::alignment_by_type<T>() <= MAX_VEC_WIDTH_BYTES ) {
+        } else if constexpr (EPT_int * sizeof(T) <= MAX_VEC_WIDTH_BYTES ) {
           return *reinterpret_cast<detail::Vector<T, EPT_int>*>(data_.ldata_ + GetVal<EPT, 0, Is...>(cuda::std::make_tuple(indices...)));
         } else {
           detail::Vector<T, EPT_int> vec;

--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (c) 2025, NVIDIA Corporation
+// Copyright (c) 2021, NVIDIA Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/include/matx/operators/operators.h
+++ b/include/matx/operators/operators.h
@@ -117,6 +117,7 @@
 #include "matx/operators/unique.h"
 #include "matx/operators/updownsample.h"
 #include "matx/operators/var.h"
+#include "matx/operators/zipvec.h"
 
 #include "matx/operators/softmax.h"
 #include "matx/operators/sum.h"

--- a/include/matx/operators/zipvec.h
+++ b/include/matx/operators/zipvec.h
@@ -76,7 +76,7 @@ namespace matx
 
       __MATX_INLINE__ ZipVecOp(const Ts&... ts) : ops_(ts...)
       {
-        static_assert(sizeof...(Ts) > 0 && sizeof...(Ts) <= 4, "Must have between 1 and 4 tensors for zipvec");
+        static_assert(sizeof...(Ts) > 0 && sizeof...(Ts) <= 4, "Must have between 1 and 4 operators for zipvec");
         static_assert((... && (RANK == Ts::Rank())), "zipped ops must have the same rank");
         // All ops must have the same scalar value type; that is enforced by AggregateToVecType
 

--- a/include/matx/operators/zipvec.h
+++ b/include/matx/operators/zipvec.h
@@ -141,19 +141,10 @@ namespace matx
       }
 
       ~ZipVecOp() = default;
-      ZipVecOp(const ZipVecOp &rhs) = default;
-      __MATX_INLINE__ auto operator=(const self_type &rhs) {
-        return set(*this, rhs);
-      }
 
       template<typename R>
       __MATX_INLINE__ auto operator=(const R &rhs) {
-        if constexpr (is_matx_transform_op<R>()) {
-          return mtie(*this, rhs);
-        }
-        else {
-          return set(*this, rhs);
-        }
+        return set(*this, rhs);
       }
 
       template <int I, typename ShapeType, typename Executor>

--- a/include/matx/operators/zipvec.h
+++ b/include/matx/operators/zipvec.h
@@ -211,11 +211,16 @@ namespace matx
   } // end namespace detail
 
   /**
-   * @brief ZipVecOp zips multiple operators together into a vectorized operator. This allows combining multiple operators
+   * @brief zipvec zips multiple operators together into a vectorized operator. This allows combining multiple operators
    * that represent scalar types into an operator with vectorized types. For example, two operators of type float can
    * be combined into an operator of type float2.
    *
-   * The operators must have the same rank and size in all dimensions and the types must be compatible.
+   * The input operators must have the same rank and size in all dimensions and the types must be compatible. This
+   * is only supported for the types for which CUDA has corresponding vector types, including [u]char, [u]short,
+   * [u]int, [u]long, float, and double. For these sizes, the number of input operators and the corresponding zipped
+   * vector length can be 1-4. __half types are also supported, but only for a vector length of 2.
+   *
+   * The components from the input operators are accessed by the fields x, y, z, and w, respectively, in the zipped operator.
    *
    * @tparam Ts input operator types
    * @param ts input operators

--- a/include/matx/operators/zipvec.h
+++ b/include/matx/operators/zipvec.h
@@ -214,7 +214,7 @@ namespace matx
    * The input operators must have the same rank and size in all dimensions and the types must be compatible. This
    * is only supported for the types for which CUDA has corresponding vector types, including [u]char, [u]short,
    * [u]int, [u]long, float, and double. For these sizes, the number of input operators and the corresponding zipped
-   * vector length can be 1-4. __half types are also supported, but only for a vector length of 2.
+   * vector length can be 1-4.
    *
    * The components from the input operators are accessed by the fields x, y, z, and w, respectively, in the zipped operator.
    *

--- a/include/matx/operators/zipvec.h
+++ b/include/matx/operators/zipvec.h
@@ -1,0 +1,231 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+
+#include "matx/core/type_utils.h"
+#include "matx/operators/base_operator.h"
+
+namespace matx
+{
+  /**
+   * ZipVecOp operator
+   *
+   * Class for concatening operators along a single dimension. Sizes of the operators not
+   * being concatenated must be the same, and the new operator has dimensions equal to the original
+   * operator on non-index dimension, and the sum of sizes along the index dimension.
+   */
+  namespace detail {
+    template <typename... Ts>
+      class ZipVecOp : public BaseOp<ZipVecOp<Ts...>>
+    {
+      using first_type = cuda::std::tuple_element_t<0, cuda::std::tuple<Ts...>>;
+      using scalar_value_type = typename first_type::value_type;
+      using self_type = ZipVecOp<Ts...>;
+
+      static constexpr int RANK = first_type::Rank();
+
+      public:
+      using matxop = bool;
+      using matxoplvalue = bool;
+
+      // Scalar type of operation
+      using value_type = AggregateToVecType<typename Ts::value_type...>;
+
+      template <int I = -1>
+      __MATX_INLINE__ std::string get_str() const {
+        if constexpr (I==-1) return "zipvec(" + get_str<I+1>();
+        else if constexpr (I < sizeof...(Ts)-1) return cuda::std::get<I>(ops_).str() + "," + get_str<I+1>();
+        else if constexpr (I == sizeof...(Ts)-1) return cuda::std::get<I>(ops_).str() + ")";
+        else return "";
+      }
+
+      __MATX_INLINE__ std::string str() const {
+        return get_str<-1>();
+      }
+
+      __MATX_INLINE__ ZipVecOp(const Ts&... ts) : ops_(ts...)
+      {
+        static_assert(sizeof...(Ts) > 0 && sizeof...(Ts) <= 4, "Must have between 1 and 4 tensors for zipvec");
+        static_assert((... && (RANK == Ts::Rank())), "zipped ops must have the same rank");
+        // All ops must have the same scalar value type; that is enforced by AggregateToVecType
+
+        for (int32_t i = 0; i < RANK; i++) {
+            MATX_ASSERT_STR(((ts.Size(i) == pp_get<0>(ts).Size(i)) && ...), 
+                matxInvalidSize, "zipped operators must have the same size in all dimensions");
+        }
+      }
+
+      template <ElementsPerThread EPT, typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is) const
+      {
+        return cuda::std::apply([&](auto&&... ops) { 
+          using scalar_type = typename AggregateToVec<typename Ts::value_type...>::common_type;
+          return value_type{ static_cast<scalar_type>(ops(std::forward<Is>(is)...))... }; 
+        }, ops_);
+      }
+
+      template <typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is) const
+      {
+        return cuda::std::apply([&](auto&&... ops) { 
+          using scalar_type = typename AggregateToVec<typename Ts::value_type...>::common_type;
+          return value_type{ static_cast<scalar_type>(ops(std::forward<Is>(is)...))... }; 
+        }, ops_);
+      }
+
+      template <ElementsPerThread EPT, typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is)
+      {
+        return cuda::std::apply([&](auto&&... ops) { 
+          using scalar_type = typename AggregateToVec<typename Ts::value_type...>::common_type;
+          return value_type{ static_cast<scalar_type>(ops(std::forward<Is>(is)...))... }; 
+        }, ops_);
+      }
+
+      template <typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is)
+      {
+        return cuda::std::apply([&](auto&&... ops) { 
+          using scalar_type = typename AggregateToVec<typename Ts::value_type...>::common_type;
+          return value_type{ static_cast<scalar_type>(ops(std::forward<Is>(is)...))... }; 
+        }, ops_);
+      }
+
+      template <OperatorCapability Cap>
+      __MATX_INLINE__ __MATX_HOST__ auto get_capability() const {
+        if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
+          // For now, we do not support vectorization. We could support it, but it will require some
+          // rework of the assumptions used in the matx::Vector class.
+          return ElementsPerThread::ONE;
+        } else {
+          auto self_has_cap = capability_attributes<Cap>::default_value;
+          return self_has_cap;
+        }
+      }
+
+      static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() noexcept
+      {
+        return RANK;
+      }
+
+      constexpr index_t __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ Size(int dim) const noexcept
+      {
+        // All ops must have the same size in all dimensions
+        return cuda::std::get<0>(ops_).Size(dim);
+      }
+
+      ~ZipVecOp() = default;
+      ZipVecOp(const ZipVecOp &rhs) = default;
+      __MATX_INLINE__ auto operator=(const self_type &rhs) {
+        return set(*this, rhs);
+      }
+
+      template<typename R>
+      __MATX_INLINE__ auto operator=(const R &rhs) {
+        if constexpr (is_matx_transform_op<R>()) {
+          return mtie(*this, rhs);
+        }
+        else {
+          return set(*this, rhs);
+        }
+      }
+
+      template <int I, typename ShapeType, typename Executor>
+      __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+      {
+        if constexpr (I < sizeof...(Ts)-1) {
+          if constexpr (is_matx_op<cuda::std::tuple_element_t<I,cuda::std::tuple<Ts...>>>()) {
+            cuda::std::get<I>(ops_).PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+            PreRun<I+1, ShapeType, Executor>(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        } else if constexpr (I == sizeof...(Ts)-1) {
+          if constexpr (is_matx_op<cuda::std::tuple_element_t<I,cuda::std::tuple<Ts...>>>()) {
+            cuda::std::get<I>(ops_).PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+            // This was the last ops_ element, so stop recursion
+          }
+        }
+      }
+
+      template <typename ShapeType, typename Executor>
+      __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+      {
+        PreRun<0, ShapeType, Executor>(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+      }
+
+      template <int I, typename ShapeType, typename Executor>
+      __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+      {
+        if constexpr (I < sizeof...(Ts)-1) {
+          if constexpr (is_matx_op<cuda::std::tuple_element_t<I,cuda::std::tuple<Ts...>>>()) {
+            cuda::std::get<I>(ops_).PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+            PostRun<I+1, ShapeType, Executor>(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        } else if constexpr (I == sizeof...(Ts)-1) {
+          if constexpr (is_matx_op<cuda::std::tuple_element_t<I,cuda::std::tuple<Ts...>>>()) {
+            cuda::std::get<I>(ops_).PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+            // This was the last ops_ element, so stop recursion
+          }
+        }
+      }
+
+      template <typename ShapeType, typename Executor>
+      __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+      {
+        PostRun<0, ShapeType, Executor>(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+      }
+
+      private:
+      cuda::std::tuple<typename detail::base_type_t<Ts> ...> ops_;
+    }; // end class ZipVecOp
+  } // end namespace detail
+
+  /**
+   * @brief ZipVecOp zips multiple operators together into a vectorized operator. This allows combining multiple operators
+   * that represent scalar types into an operator with vectorized types. For example, two operators of type float can
+   * be combined into an operator of type float2.
+   *
+   * The operators must have the same rank and size in all dimensions and the types must be compatible.
+   *
+   * @tparam Ts input operator types
+   * @param ts input operators
+   * @return zipped operator
+   */
+  template <typename... Ts>
+  __MATX_INLINE__ __MATX_HOST__  auto zipvec(const Ts&... ts)
+  {
+    static_assert(sizeof...(Ts) > 0, "zipvec must take at least one operator");
+
+    return detail::ZipVecOp<Ts...>{ts...};
+  }
+} // end namespace matx

--- a/include/matx/operators/zipvec.h
+++ b/include/matx/operators/zipvec.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (c) 2021, NVIDIA Corporation
+// Copyright (c) 2025, NVIDIA Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,6 @@ namespace matx
       class ZipVecOp : public BaseOp<ZipVecOp<Ts...>>
     {
       using first_type = cuda::std::tuple_element_t<0, cuda::std::tuple<Ts...>>;
-      using scalar_value_type = typename first_type::value_type;
       using self_type = ZipVecOp<Ts...>;
 
       static constexpr int RANK = first_type::Rank();
@@ -212,9 +211,9 @@ namespace matx
    * be combined into an operator of type float2.
    *
    * The input operators must have the same rank and size in all dimensions and the types must be compatible. This
-   * is only supported for the types for which CUDA has corresponding vector types, including [u]char, [u]short,
-   * [u]int, [u]long, float, and double. For these sizes, the number of input operators and the corresponding zipped
-   * vector length can be 1-4.
+   * is only supported for the types for which CUDA has corresponding vector types, including char, short,
+   * int, long, float, and double. The integer types also support unsigned variants (uchar, ushort, etc.).
+   * For these sizes, the number of input operators and the corresponding zipped vector length can be 1-4.
    *
    * The components from the input operators are accessed by the fields x, y, z, and w, respectively, in the zipped operator.
    *

--- a/include/matx/operators/zipvec.h
+++ b/include/matx/operators/zipvec.h
@@ -41,9 +41,9 @@ namespace matx
   /**
    * ZipVecOp operator
    *
-   * Class for concatening operators along a single dimension. Sizes of the operators not
-   * being concatenated must be the same, and the new operator has dimensions equal to the original
-   * operator on non-index dimension, and the sum of sizes along the index dimension.
+   * Class for zipping operators into a vectorized output operator. The rank and
+   * dimensions of the input operators must all be the same and the output operator
+   * will have the same rank and dimensions.
    */
   namespace detail {
     template <typename... Ts>
@@ -58,7 +58,6 @@ namespace matx
       using matxop = bool;
       using matxoplvalue = bool;
 
-      // Scalar type of operation
       using value_type = AggregateToVecType<typename Ts::value_type...>;
 
       template <int I = -1>

--- a/include/matx/operators/zipvec.h
+++ b/include/matx/operators/zipvec.h
@@ -141,6 +141,11 @@ namespace matx
       }
 
       ~ZipVecOp() = default;
+      ZipVecOp(const ZipVecOp &rhs) = default;
+
+      __MATX_INLINE__ auto operator=(const self_type &rhs) {
+        return set(*this, rhs);
+      }
 
       template<typename R>
       __MATX_INLINE__ auto operator=(const R &rhs) {

--- a/test/00_operators/CMakeLists.txt
+++ b/test/00_operators/CMakeLists.txt
@@ -53,4 +53,5 @@ set(OPERATOR_TEST_FILES
   transpose_test.cu
   trig_funcs_test.cu
   updownsample_test.cu 
+  zipvec_test.cu
 )

--- a/test/00_operators/zipvec_test.cu
+++ b/test/00_operators/zipvec_test.cu
@@ -1,0 +1,156 @@
+#include "operator_test_types.hpp"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+
+using namespace matx;
+using namespace matx::test;
+
+TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, ZipVecOp)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  if constexpr (!std::is_same_v<TestType, __half>) // __half only supports size 2 (__half2)
+  { // Test 1D vector types
+    using vec1_type = typename matx::detail::VecTypeSelector<TestType, 1>::type;
+    auto t = make_tensor<vec1_type>({1});
+    (t = zipvec(static_cast<TestType>(2)*ones<TestType>({1}))).run(exec);
+    exec.sync();
+    ASSERT_EQ(t(0).x, static_cast<TestType>(2));
+  }
+
+  if constexpr (std::is_same_v<TestType, float>)
+  { // 2D example for documentation
+    // example-begin zipvec-test-1
+    auto v = linspace<float>(0.25f, 1.0f, 4);
+    auto duplicate_rows = clone<2>(v, {4, matxKeepDim});
+    auto duplicate_cols = clone<2>(v, {matxKeepDim, 4});
+    // Form a 2D grid of coordinates by replicating v along the rows and columns
+    // and zipping the two 2D tensors together into a 2D vector tensor. This creates
+    // coordinates in the form:
+    //   [ (0.25, 0.25) (0.5, 0.25) (0.75, 0.25) (1.0, 0.25) ]
+    //   [ (0.25, 0.5)  (0.5, 0.5)  (0.75, 0.5)  (1.0, 0.5)  ]
+    //   [ (0.25, 0.75) (0.5, 0.75) (0.75, 0.75) (1.0, 0.75) ]
+    //   [ (0.25, 1.0)  (0.5, 1.0)  (0.75, 1.0)  (1.0, 1.0)  ]
+    auto coords = make_tensor<float2>({4, 4});
+    (coords = zipvec(duplicate_rows, duplicate_cols)).run(exec);
+    exec.sync();
+
+    for (int r = 0; r < 4; r++) {
+      for (int c = 0; c < 4; c++) {
+        ASSERT_EQ(coords(r,c).x, static_cast<TestType>((c+1)*0.25f));
+        ASSERT_EQ(coords(r,c).y, static_cast<TestType>((r+1)*0.25f));
+      }
+    }
+    // example-end zipvec-test-1
+  }
+
+  { // Test 2D vector types
+    // Similar to the float2 example above, but we use integer values to make
+    // them representable for all numeric types.
+    using vec2_type = typename matx::detail::VecTypeSelector<TestType, 2>::type;
+    auto v = linspace<TestType>(1, 3, 3);
+    auto duplicate_rows = clone<2>(v, {3, matxKeepDim});
+    auto duplicate_cols = clone<2>(v, {matxKeepDim, 3});
+    auto coords = make_tensor<vec2_type>({3, 3});
+    (coords = zipvec(duplicate_rows, duplicate_cols)).run(exec);
+    exec.sync();
+
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 3; j++) {
+        ASSERT_EQ(coords(i,j).x, static_cast<TestType>(j+1));
+        ASSERT_EQ(coords(i,j).y, static_cast<TestType>(i+1));
+      }
+    }
+  }
+
+  if constexpr (!std::is_same_v<TestType, __half>) // __half only supports size 2 (__half2)
+  { // Test 3D vector types
+    using vec3_type = typename matx::detail::VecTypeSelector<TestType, 3>::type;
+    auto v = linspace<TestType>(1, 3, 3);
+    auto duplicate_rows = clone<2>(v, {3, matxKeepDim});
+    auto duplicate_cols = clone<2>(v, {matxKeepDim, 3});
+    auto coords = make_tensor<vec3_type>({3, 3});
+    (coords = zipvec(duplicate_rows, ones<TestType>({3, 3}), duplicate_cols)).run(exec);
+    exec.sync();
+
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 3; j++) {
+        ASSERT_EQ(coords(i,j).x, static_cast<TestType>(j+1));
+        ASSERT_EQ(coords(i,j).y, static_cast<TestType>(1));
+        ASSERT_EQ(coords(i,j).z, static_cast<TestType>(i+1));
+      }
+    }
+  }
+
+  if constexpr (!std::is_same_v<TestType, __half>) // __half only supports size 2 (__half2)
+  { // Test 4D vector types
+    using vec4_type = typename matx::detail::VecTypeSelector<TestType, 4>::type;
+    auto v = linspace<TestType>(1, 3, 3);
+    auto duplicate_rows = clone<2>(v, {3, matxKeepDim});
+    auto duplicate_cols = clone<2>(v, {matxKeepDim, 3});
+    auto coords = make_tensor<vec4_type>({3, 3});
+    auto twos = static_cast<TestType>(2)*ones<TestType>({3, 3});
+    (coords = zipvec(duplicate_rows, ones<TestType>({3, 3}), duplicate_cols, twos)).run(exec);
+    exec.sync();
+
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 3; j++) {
+        ASSERT_EQ(coords(i,j).x, static_cast<TestType>(j+1));
+        ASSERT_EQ(coords(i,j).y, static_cast<TestType>(1));
+        ASSERT_EQ(coords(i,j).z, static_cast<TestType>(i+1));
+        ASSERT_EQ(coords(i,j).w, static_cast<TestType>(2));
+      }
+    }
+  }
+
+  { // Test that non-narrowing conversions are supported
+    {
+      // short can be converted to float without narrowing
+      auto t = ones<float>({1});
+      auto t2 = ones<short>({1});
+      auto t3 = make_tensor<float2>({1});
+      (t3 = zipvec(t, t2)).run(exec);
+      exec.sync();
+      ASSERT_EQ(t3(0).x, static_cast<float>(1));
+      ASSERT_EQ(t3(0).y, static_cast<float>(1));  
+    }
+    {
+      // float can be converted to double without narrowing
+      auto t = ones<double>({1});
+      auto t2 = ones<float>({1});
+      auto t3 = make_tensor<double2>({1});
+      (t3 = zipvec(t, t2)).run(exec);
+      exec.sync();
+      ASSERT_EQ(t3(0).x, static_cast<double>(1));
+      ASSERT_EQ(t3(0).y, static_cast<double>(1));  
+    }
+    {
+      // __half can be converted to float without narrowing
+      auto t = ones<float>({1});
+      auto t2 = ones<__half>({1});
+      auto t3 = make_tensor<float2>({1});
+      (t3 = zipvec(t, as_type<float>(t2))).run(exec);
+      exec.sync();
+      ASSERT_EQ(t3(0).x, static_cast<float>(1));
+      ASSERT_EQ(t3(0).y, static_cast<float>(1));  
+    }
+    {
+      // int can be converted to double without narrowing
+      auto t = ones<double>({1});
+      auto t2 = ones<int>({1});
+      auto t3 = make_tensor<double2>({1});
+      (t3 = zipvec(t, t2)).run(exec);
+      exec.sync();
+      ASSERT_EQ(t3(0).x, static_cast<double>(1));
+      ASSERT_EQ(t3(0).y, static_cast<double>(1));  
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+} 

--- a/test/00_operators/zipvec_test.cu
+++ b/test/00_operators/zipvec_test.cu
@@ -15,7 +15,6 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, ZipVecOp)
 
   ExecType exec{};
 
-  if constexpr (!std::is_same_v<TestType, __half>) // __half only supports size 2 (__half2)
   { // Test 1D vector types
     using vec1_type = typename matx::detail::VecTypeSelector<TestType, 1>::type;
     auto t = make_tensor<vec1_type>({1});
@@ -69,7 +68,6 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, ZipVecOp)
     }
   }
 
-  if constexpr (!std::is_same_v<TestType, __half>) // __half only supports size 2 (__half2)
   { // Test 3D vector types
     using vec3_type = typename matx::detail::VecTypeSelector<TestType, 3>::type;
     auto v = linspace<TestType>(1, 3, 3);
@@ -88,7 +86,6 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, ZipVecOp)
     }
   }
 
-  if constexpr (!std::is_same_v<TestType, __half>) // __half only supports size 2 (__half2)
   { // Test 4D vector types
     using vec4_type = typename matx::detail::VecTypeSelector<TestType, 4>::type;
     auto v = linspace<TestType>(1, 3, 3);
@@ -131,16 +128,6 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, ZipVecOp)
       ASSERT_EQ(t3(0).y, static_cast<double>(1));  
     }
     {
-      // __half can be converted to float without narrowing
-      auto t = ones<float>({1});
-      auto t2 = ones<__half>({1});
-      auto t3 = make_tensor<float2>({1});
-      (t3 = zipvec(t, as_type<float>(t2))).run(exec);
-      exec.sync();
-      ASSERT_EQ(t3(0).x, static_cast<float>(1));
-      ASSERT_EQ(t3(0).y, static_cast<float>(1));  
-    }
-    {
       // int can be converted to double without narrowing
       auto t = ones<double>({1});
       auto t2 = ones<int>({1});
@@ -150,6 +137,9 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, ZipVecOp)
       ASSERT_EQ(t3(0).x, static_cast<double>(1));
       ASSERT_EQ(t3(0).y, static_cast<double>(1));  
     }
+    // Note that some narrowing conversions like int -> float are currently allowed.
+    // This is because std::common_type_t<int, float> is float, and the zipvec operator
+    // uses std::common_type for its value_type.
   }
 
   MATX_EXIT_HANDLER();


### PR DESCRIPTION
Add a new zipvec operator that zips multiple input operators into a vectorized operation (e.g., an operator with type float3 when zipping x, y, and z coordinates). 

The input operators must have the same rank and size in all dimensions and the types must be compatible where compatible means that we can convert each input to the derived output type without narrowing. For types char, short, int, long (and their unsigned variants) and float/double, the vector size can be 1-4 elements. For __half, only length-2 vectors are supported. The components from the input operators are accessed by the fields x, y, z, and w, respectively, in the zipped operator.