### PR TITLE
Fixed issue where op=transform was double-calling transform

### DIFF
--- a/include/matx/operators/base_operator.h
+++ b/include/matx/operators/base_operator.h
@@ -71,7 +71,7 @@ namespace matx
           // async allocation we'd normally have to do
           if constexpr (is_mtie<T>() ) {
             tp->Exec(ex);
-          }          
+          }
           else if constexpr (is_matx_set_op<T>()) {
             if constexpr (is_matx_transform_op<typename T::op_type>() && is_tensor_view_v<typename T::tensor_type>) {
               tp->TransformExec(tp->Shape(), ex);

--- a/include/matx/operators/collapse.h
+++ b/include/matx/operators/collapse.h
@@ -144,18 +144,10 @@ namespace matx
 
         ~LCollapseOp() = default;
         LCollapseOp(const LCollapseOp &rhs) = default;
-        __MATX_INLINE__ auto operator=(const self_type &rhs) {
-          return set(*this, rhs);
-        }
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
-          if constexpr (is_matx_transform_op<R>()) {
-            return mtie(*this, rhs);
-          }
-          else {
-            return set(*this, rhs);
-          }
+          return set(*this, rhs);
         }
 
         template <typename ShapeType, typename Executor>
@@ -319,18 +311,10 @@ MATX_LOOP_UNROLL
 
         ~RCollapseOp() = default;
         RCollapseOp(const RCollapseOp &rhs) = default;
-        __MATX_INLINE__ auto operator=(const self_type &rhs) {
-          return set(*this, rhs);
-        }
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
-          if constexpr (is_matx_transform_op<R>()) {
-            return mtie(*this, rhs);
-          }
-          else {
-            return set(*this, rhs);
-          }
+          return set(*this, rhs);
         }
 
         template <typename ShapeType, typename Executor>

--- a/include/matx/operators/collapse.h
+++ b/include/matx/operators/collapse.h
@@ -145,6 +145,10 @@ namespace matx
         ~LCollapseOp() = default;
         LCollapseOp(const LCollapseOp &rhs) = default;
 
+        __MATX_INLINE__ auto operator=(const self_type &rhs) {
+          return set(*this, rhs);
+        }
+
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
           return set(*this, rhs);
@@ -311,6 +315,10 @@ MATX_LOOP_UNROLL
 
         ~RCollapseOp() = default;
         RCollapseOp(const RCollapseOp &rhs) = default;
+
+        __MATX_INLINE__ auto operator=(const self_type &rhs) {
+          return set(*this, rhs);
+        }
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {

--- a/include/matx/operators/concat.h
+++ b/include/matx/operators/concat.h
@@ -200,18 +200,10 @@ namespace matx
 
       ~ConcatOp() = default;
       ConcatOp(const ConcatOp &rhs) = default;
-      __MATX_INLINE__ auto operator=(const self_type &rhs) {
-        return set(*this, rhs);
-      }
 
       template<typename R>
       __MATX_INLINE__ auto operator=(const R &rhs) {
-        if constexpr (is_matx_transform_op<R>()) {
-          return mtie(*this, rhs);
-        }
-        else {
-          return set(*this, rhs);
-        }
+        return set(*this, rhs);
       }
 
       template <int I, typename ShapeType, typename Executor>

--- a/include/matx/operators/concat.h
+++ b/include/matx/operators/concat.h
@@ -201,6 +201,10 @@ namespace matx
       ~ConcatOp() = default;
       ConcatOp(const ConcatOp &rhs) = default;
 
+      __MATX_INLINE__ auto operator=(const self_type &rhs) {
+        return set(*this, rhs);
+      }
+
       template<typename R>
       __MATX_INLINE__ auto operator=(const R &rhs) {
         return set(*this, rhs);

--- a/include/matx/operators/overlap.h
+++ b/include/matx/operators/overlap.h
@@ -145,18 +145,10 @@ namespace matx
 
         ~OverlapOp() = default;
         OverlapOp(const OverlapOp &rhs) = default;
-        __MATX_INLINE__ auto operator=(const self_type &rhs) { 
-          return set(*this, rhs); 
-        }                       
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
-          if constexpr (is_matx_transform_op<R>()) {
-            return mtie(*this, rhs);
-          }
-          else {
-            return set(*this, rhs);
-          }
+          return set(*this, rhs);
         }
 
         template <OperatorCapability Cap>

--- a/include/matx/operators/overlap.h
+++ b/include/matx/operators/overlap.h
@@ -146,6 +146,10 @@ namespace matx
         ~OverlapOp() = default;
         OverlapOp(const OverlapOp &rhs) = default;
 
+        __MATX_INLINE__ auto operator=(const self_type &rhs) {
+          return set(*this, rhs);
+        }
+
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
           return set(*this, rhs);

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -171,6 +171,10 @@ MATX_LOOP_UNROLL
         ~PermuteOp() = default;
         PermuteOp(const PermuteOp &rhs) = default;
 
+        __MATX_INLINE__ auto operator=(const self_type &rhs) {
+          return set(*this, rhs);
+        }
+
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
           return set(*this, rhs);

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -170,18 +170,10 @@ MATX_LOOP_UNROLL
 
         ~PermuteOp() = default;
         PermuteOp(const PermuteOp &rhs) = default;
-        __MATX_INLINE__ auto operator=(const self_type &rhs) {
-          return set(*this, rhs);
-        }
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
-          if constexpr (is_matx_transform_op<R>()) {
-            return mtie(*this, rhs);
-          }
-          else {
-            return set(*this, rhs);
-          }
+          return set(*this, rhs);
         }
     };
   }

--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -162,18 +162,10 @@ namespace matx
 
         ~RemapOp() = default;
         RemapOp(const RemapOp &rhs) = default;
-        __MATX_INLINE__ auto operator=(const self_type &rhs) {
-          return set(*this, rhs);
-        }
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
-          if constexpr (is_matx_transform_op<R>()) {
-            return mtie(*this, rhs);
-          }
-          else {
-            return set(*this, rhs);
-          }
+          return set(*this, rhs);
         }
     };
   }

--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -163,6 +163,10 @@ namespace matx
         ~RemapOp() = default;
         RemapOp(const RemapOp &rhs) = default;
 
+        __MATX_INLINE__ auto operator=(const self_type &rhs) {
+          return set(*this, rhs);
+        }        
+
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
           return set(*this, rhs);

--- a/include/matx/operators/reshape.h
+++ b/include/matx/operators/reshape.h
@@ -166,18 +166,14 @@ MATX_LOOP_UNROLL
 
         ~ReshapeOp() = default;
         ReshapeOp(const ReshapeOp &rhs) = default;
+
         __MATX_INLINE__ auto operator=(const self_type &rhs) {
           return set(*this, rhs);
         }
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
-          if constexpr (is_matx_transform_op<R>()) {
-            return mtie(*this, rhs);
-          }
-          else {
-            return set(*this, rhs);
-          }
+          return set(*this, rhs);
         }
     };
   }

--- a/include/matx/operators/reverse.h
+++ b/include/matx/operators/reverse.h
@@ -131,18 +131,10 @@ namespace matx
 
         ~ReverseOp() = default;
         ReverseOp(const ReverseOp &rhs) = default;
-        __MATX_INLINE__ auto operator=(const self_type &rhs) { 
-          return set(*this, rhs); 
-        }                       
 
         template<typename R> 
         __MATX_INLINE__ auto operator=(const R &rhs) { 
-          if constexpr (is_matx_transform_op<R>()) {
-            return mtie(*this, rhs);
-          }
-          else {          
-            return set(*this, rhs); 
-          }
+          return set(*this, rhs); 
         }
 
         template <OperatorCapability Cap>

--- a/include/matx/operators/reverse.h
+++ b/include/matx/operators/reverse.h
@@ -132,6 +132,10 @@ namespace matx
         ~ReverseOp() = default;
         ReverseOp(const ReverseOp &rhs) = default;
 
+        __MATX_INLINE__ auto operator=(const self_type &rhs) {
+          return set(*this, rhs);
+        }
+
         template<typename R> 
         __MATX_INLINE__ auto operator=(const R &rhs) { 
           return set(*this, rhs); 

--- a/include/matx/operators/shift.h
+++ b/include/matx/operators/shift.h
@@ -167,18 +167,10 @@ namespace matx
 
         ~ShiftOp() = default;
         ShiftOp(const ShiftOp &rhs) = default;
-        __MATX_INLINE__ auto operator=(const self_type &rhs) {
-          return set(*this, rhs);
-        }
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
-          if constexpr (is_matx_transform_op<R>()) {
-            return mtie(*this, rhs);
-          }
-          else {
-            return set(*this, rhs);
-          }
+          return set(*this, rhs);
         }
 
       private:

--- a/include/matx/operators/shift.h
+++ b/include/matx/operators/shift.h
@@ -168,6 +168,10 @@ namespace matx
         ~ShiftOp() = default;
         ShiftOp(const ShiftOp &rhs) = default;
 
+        __MATX_INLINE__ auto operator=(const self_type &rhs) {
+          return set(*this, rhs);
+        }
+
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
           return set(*this, rhs);

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -190,18 +190,10 @@ namespace matx
 
         ~SliceOp() = default;
         SliceOp(const SliceOp &rhs) = default;
-        __MATX_INLINE__ auto operator=(const self_type &rhs) {
-          return set(*this, rhs);
-        }
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
-          if constexpr (is_matx_transform_op<R>()) {
-            return mtie(*this, rhs);
-          }
-          else {
-            return set(*this, rhs);
-          }
+          return set(*this, rhs);
         }
 
         template <typename ShapeType, typename Executor>

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -191,6 +191,10 @@ namespace matx
         ~SliceOp() = default;
         SliceOp(const SliceOp &rhs) = default;
 
+        __MATX_INLINE__ auto operator=(const self_type &rhs) {
+          return set(*this, rhs);
+        }
+
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {
           return set(*this, rhs);

--- a/include/matx/operators/stack.h
+++ b/include/matx/operators/stack.h
@@ -184,6 +184,10 @@ namespace matx
       ~StackOp() = default;
       StackOp(const StackOp &rhs) = default;
 
+      __MATX_INLINE__ auto operator=(const self_type &rhs) {
+        return set(*this, rhs);
+      }
+
       template<typename R> 
       __MATX_INLINE__ auto operator=(const R &rhs) { 
         return set(*this, rhs); 

--- a/include/matx/operators/stack.h
+++ b/include/matx/operators/stack.h
@@ -183,18 +183,10 @@ namespace matx
 
       ~StackOp() = default;
       StackOp(const StackOp &rhs) = default;
-      __MATX_INLINE__ auto operator=(const self_type &rhs) { 
-        return set(*this, rhs); 
-      }       
 
       template<typename R> 
       __MATX_INLINE__ auto operator=(const R &rhs) { 
-        if constexpr (is_matx_transform_op<R>()) {
-          return mtie(*this, rhs);
-        }
-        else {          
-          return set(*this, rhs); 
-        }
+        return set(*this, rhs); 
       }
 
       template <OperatorCapability Cap>

--- a/include/matx/operators/transpose.h
+++ b/include/matx/operators/transpose.h
@@ -138,18 +138,10 @@ namespace detail {
       }
 
       TransposeMatrixOp(const TransposeMatrixOp &rhs) = default;
-      __MATX_INLINE__ auto operator=(const self_type &rhs) { 
-        return set(*this, rhs); 
-      }       
 
       template<typename R> 
       __MATX_INLINE__ auto operator=(const R &rhs) { 
-        if constexpr (is_matx_transform_op<R>()) {
-          return mtie(*this, rhs);
-        }
-        else {          
-          return set(*this, rhs); 
-        }
+        return set(*this, rhs); 
       }
 
   };

--- a/include/matx/operators/transpose.h
+++ b/include/matx/operators/transpose.h
@@ -139,6 +139,10 @@ namespace detail {
 
       TransposeMatrixOp(const TransposeMatrixOp &rhs) = default;
 
+      __MATX_INLINE__ auto operator=(const self_type &rhs) {
+        return set(*this, rhs);
+      }
+
       template<typename R> 
       __MATX_INLINE__ auto operator=(const R &rhs) { 
         return set(*this, rhs); 

--- a/include/matx/operators/updownsample.h
+++ b/include/matx/operators/updownsample.h
@@ -133,6 +133,10 @@ namespace matx
         ~UpsampleOp() = default;
         UpsampleOp(const UpsampleOp &rhs) = default;
         
+        __MATX_INLINE__ auto operator=(const self_type &rhs) {
+          return set(*this, rhs);
+        }
+
         template<typename R> __MATX_INLINE__ auto operator=(const R &rhs) { 
           return set(*this, rhs); 
         }

--- a/include/matx/operators/updownsample.h
+++ b/include/matx/operators/updownsample.h
@@ -132,11 +132,10 @@ namespace matx
 
         ~UpsampleOp() = default;
         UpsampleOp(const UpsampleOp &rhs) = default;
-        __MATX_INLINE__ auto operator=(const self_type &rhs) { 
-          return set(*this, rhs); 
-        } 
         
-        template<typename R> __MATX_INLINE__ auto operator=(const R &rhs) { return set(*this, rhs); }
+        template<typename R> __MATX_INLINE__ auto operator=(const R &rhs) { 
+          return set(*this, rhs); 
+        }
     };
   }
 


### PR DESCRIPTION
When a statement `op = transform` occurred where op was not a tensor, the transform was being called twice incorrectly leading to poor performance. This simplifies the code and calls it once.