### PR TITLE
Add pad operator for padding input operators along one dimension

### DIFF
--- a/docs_input/api/manipulation/joinrepeat/pad.rst
+++ b/docs_input/api/manipulation/joinrepeat/pad.rst
@@ -1,0 +1,33 @@
+.. _pad_func:
+
+pad
+===
+
+Pad operators along a dimension. The returned operator will have the same rank as the input operator.
+The sizes of the unpadded dimensions will be the same as the input operator and the padded dimension
+will increase by the sum of the pre- and post-padding sizes.
+
+The currently suported padding modes are MATX_PAD_MODE_CONSTANT and MATX_PAD_MODE_EDGE. The constant
+padding mode uses the specified pad value for all padded elements. The edge padding mode uses the edge
+values of the input operator for the padded elements (i.e., pre-padding will use the value of the first
+element and post-padding will use the value of the last element).
+
+.. doxygenenum:: matx::PadMode
+
+.. doxygenfunction:: pad(const T& op, int axis, const std::array<index_t, 2>& pad_sizes, const typename T::value_type& pad_value, PadMode mode = MATX_PAD_MODE_CONSTANT)
+.. doxygenfunction:: pad(const T& op, int axis, const index_t (&pad_sizes)[2], const typename T::value_type& pad_value, PadMode mode = MATX_PAD_MODE_CONSTANT)
+
+Examples
+~~~~~~~~
+
+.. literalinclude:: ../../../../test/00_operators/pad_test.cu
+   :language: cpp
+   :start-after: example-begin pad-test-1
+   :end-before: example-end pad-test-1
+   :dedent:
+
+.. literalinclude:: ../../../../test/00_operators/pad_test.cu
+   :language: cpp
+   :start-after: example-begin pad-test-2
+   :end-before: example-end pad-test-2
+   :dedent:

--- a/include/matx/operators/operators.h
+++ b/include/matx/operators/operators.h
@@ -84,6 +84,7 @@
 #include "matx/operators/normalize.h"
 #include "matx/operators/outer.h"
 #include "matx/operators/overlap.h"
+#include "matx/operators/pad.h"
 #include "matx/operators/percentile.h"
 #include "matx/operators/pinv.h"
 #include "matx/operators/permute.h"

--- a/include/matx/operators/pad.h
+++ b/include/matx/operators/pad.h
@@ -1,0 +1,242 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <array>
+
+#include "matx/core/type_utils.h"
+#include "matx/core/tensor_utils.h"
+#include "matx/operators/base_operator.h"
+
+namespace matx
+{
+  /**
+   * @brief Padding mode
+   *
+   * The padding mode to use for the pad operator. The default value is MATX_PAD_MODE_CONSTANT.
+   */
+  enum PadMode {
+    MATX_PAD_MODE_CONSTANT, ///<Constant padding mode. All padding elements will be set to the user-provided pad_value.
+    MATX_PAD_MODE_EDGE ///<Edge padding mode. All padding elements will be set to the edge values of the original operator.
+  };
+
+  namespace detail {
+    /**
+   * PadOp operator
+   *
+   * Class for padding operators along a single dimension. Sizes of the operator in the 
+   * dimensions not being padded will be the same as the original operator. The size of the
+   * operator in the dimension being padded will increase by the size of the padding.
+   *
+   */
+   template <typename T>
+      class PadOp : public BaseOp<PadOp<T>>
+    {
+      using self_type = PadOp<T>;
+
+      static constexpr int RANK = T::Rank();
+
+      public:
+      using matxop = bool;
+
+      // Scalar type of operation
+      using value_type = typename T::value_type;
+
+      __MATX_INLINE__ std::string str() const {
+        return "pad(" + op_.str() + ")";
+      }
+
+      // Constructor for tuple/array-based padding
+      template<typename PadSizeType>
+      __MATX_INLINE__ PadOp(const T& op, int axis, const PadSizeType& pad_sizes, const value_type& pad_value, PadMode mode = MATX_PAD_MODE_CONSTANT) 
+        : op_(op), axis_(axis), pad_value_(pad_value), mode_(mode)
+      {
+        static_assert(RANK > 0, "Cannot pad rank-0 tensors");
+        MATX_ASSERT_STR(axis >= 0 && axis < RANK, matxInvalidDim, "pad axis must be >= 0 and less than the rank of the operator");
+        MATX_ASSERT_STR(pad_sizes.size() == 2, matxInvalidParameter, "pad_sizes must contain exactly 2 elements [before, after]");
+        
+        before_ = pad_sizes[0];
+        after_ = pad_sizes[1];
+        
+        MATX_ASSERT_STR(before_ >= 0, matxInvalidParameter, "pad before size must be non-negative");
+        MATX_ASSERT_STR(after_ >= 0, matxInvalidParameter, "pad after size must be non-negative");
+      }
+
+      template <ElementsPerThread EPT, typename Op, typename... Is>
+      static __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) get_impl(
+          Op&& op, int axis, index_t before, const value_type& pad_value, PadMode mode, Is... indices) {
+        if constexpr (EPT == ElementsPerThread::ONE) {
+          cuda::std::array<index_t, sizeof...(Is)> ind_array = {{indices...}};
+          index_t idx = ind_array[axis];
+          index_t op_size = op.Size(axis);
+          
+          // Check if we're in the padding region
+          if (idx < before || idx >= before + op_size) {
+            if (mode == MATX_PAD_MODE_EDGE) {
+              // Edge padding - replicate edge values
+              ind_array[axis] = (idx < before) ? 0 : (op_size - 1);
+            } else {
+              // Default to constant padding
+              return value_type(pad_value);
+            }
+          } else {
+            // Original tensor region - adjust index to remove padding offset
+            ind_array[axis] = idx - before;
+          }
+          return value_type(get_value<EPT>(cuda::std::forward<Op>(op), ind_array));
+        } else {
+          return Vector<value_type, static_cast<index_t>(EPT)>{};
+        }
+      }
+
+      template <ElementsPerThread EPT, typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is) const
+      {
+        return get_impl<EPT>(cuda::std::as_const(op_), axis_, before_, pad_value_, mode_, is...);
+      }
+
+      template <typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is) const
+      {
+        return this->operator()<detail::ElementsPerThread::ONE>(is...);
+      }
+
+      template <ElementsPerThread EPT, typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is)
+      {
+        return get_impl<EPT>(cuda::std::forward<decltype(op_)>(op_), axis_, before_, pad_value_, mode_, is...);
+      }
+
+      template <typename... Is>
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... is)
+      {
+        return this->operator()<detail::ElementsPerThread::ONE>(is...);
+      }
+
+      template <OperatorCapability Cap>
+      __MATX_INLINE__ __MATX_HOST__ auto get_capability() const {
+        if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
+          // With padding, vectorized access would be problematic in cases where the padding is
+          // not a multiple of the vector size.
+          return ElementsPerThread::ONE;
+        } else {
+          auto self_has_cap = capability_attributes<Cap>::default_value;
+          return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_));
+        }
+      }
+
+      static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() noexcept
+      {
+        return RANK;
+      }
+
+      constexpr index_t __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ Size(int dim) const noexcept
+      {
+        if (dim == axis_) {
+          return before_ + op_.Size(dim) + after_;
+        } else {
+          return op_.Size(dim);
+        }
+      }
+
+      ~PadOp() = default;
+      PadOp(const PadOp &rhs) = default;
+
+      template <typename ShapeType, typename Executor>
+      __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+      {
+        if constexpr (is_matx_op<T>()) {
+          op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+      }
+
+      template <typename ShapeType, typename Executor>
+      __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const noexcept
+      {
+        if constexpr (is_matx_op<T>()) {
+          op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+      }
+
+      private:
+      typename detail::base_type_t<T> op_;
+      int axis_;
+      index_t before_;
+      index_t after_;
+      value_type pad_value_;
+      PadMode mode_;
+    }; // end class PadOp
+  } // end namespace detail
+
+  /**
+   * @brief Pad an operator along a single dimension
+   *
+   * Creates a new operator that pads the input operator along the specified dimension
+   * with a constant value or edge replication.
+   *
+   * @tparam T Input operator type
+   * @param op Input operator to pad
+   * @param axis Dimension along which to pad
+   * @param pad_sizes std::array containing {before, after} padding sizes. This operator will add before elements before
+   * the original operator and after elements after the original operator.
+   * @param pad_value Value to use for padding (constant padding mode only)
+   * @param mode Padding mode. Defaults to MATX_PAD_MODE_CONSTANT if not provided.
+   * @return Padded operator
+   */
+  template <typename T>
+  __MATX_INLINE__ __MATX_HOST__ auto pad(const T& op, int axis, const std::array<index_t, 2>& pad_sizes, const typename T::value_type& pad_value, PadMode mode = MATX_PAD_MODE_CONSTANT)
+  {
+    return detail::PadOp<T>{op, axis, pad_sizes, pad_value, mode};
+  }
+
+  /**
+   * @brief Pad an operator along a single dimension
+   *
+   * Creates a new operator that pads the input operator along the specified dimension
+   * with a constant value or edge replication.
+   *
+   * @tparam T Input operator type
+   * @param op Input operator to pad
+   * @param axis Dimension along which to pad
+   * @param pad_sizes C-style array containing {before, after} padding sizes. This operator will add before elements before
+   * the original operator and after elements after the original operator.
+   * @param pad_value Value to use for padding (constant padding mode only)
+   * @param mode Padding mode. Defaults to MATX_PAD_MODE_CONSTANT if not provided.
+   * @return Padded operator
+   */
+  template <typename T>
+  __MATX_INLINE__ __MATX_HOST__ auto pad(const T& op, int axis, const index_t (&pad_sizes)[2], const typename T::value_type& pad_value, PadMode mode = MATX_PAD_MODE_CONSTANT)
+  {
+    return detail::PadOp<T>{op, axis, std::array<index_t, 2>{pad_sizes[0], pad_sizes[1]}, pad_value, mode};
+  }
+} // end namespace matx

--- a/test/00_operators/CMakeLists.txt
+++ b/test/00_operators/CMakeLists.txt
@@ -29,6 +29,7 @@ set(OPERATOR_TEST_FILES
   legendre_test.cu
   operator_func_test.cu
   overlap_test.cu
+  pad_test.cu
   permute_test.cu
   planar_test.cu
   polyval_test.cu

--- a/test/00_operators/pad_test.cu
+++ b/test/00_operators/pad_test.cu
@@ -1,0 +1,237 @@
+#include "operator_test_types.hpp"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+
+using namespace matx;
+using namespace matx::test;
+
+TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Pad)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{}; 
+
+  {
+    // example-begin pad-test-1
+    const int N = 5;
+    const int before = 2;
+    const int after = 3;
+
+    auto t1 = make_tensor<TestType>({N});
+    auto t1_padded = make_tensor<TestType>({N+before+after});
+
+    for (int i = 0; i < N; i++) {
+      t1(i) = TestType(i+1);
+    }
+
+    // Pad tensor t1 along dimension 0 using value 42. This will included two padding
+    // elements before the original data and three padding elements after the original data.
+    (t1_padded = pad(t1, 0, {before, after}, TestType{42})).run(exec);
+
+    exec.sync();
+    // t1_padded is {42, 42, 1, 2, 3, 4, 5, 42, 42, 42}
+    // example-end pad-test-1
+
+    // Check padding values
+    for (int i = 0; i < before; i++) {
+      ASSERT_EQ(t1_padded(i), TestType{static_cast<TestType>(42)}); // before padding
+    }
+    for (int i = before; i < N+before; i++) {
+      ASSERT_EQ(t1_padded(i), TestType{static_cast<TestType>(i-before+1)}); // original data
+    }
+    for (int i = N+before; i < N+before+after; i++) {
+      ASSERT_EQ(t1_padded(i), TestType{static_cast<TestType>(42)}); // after padding
+    }
+  }
+
+  {
+    // example-begin pad-test-2
+    const int N = 5;
+    const int before = 2;
+    const int after = 3;
+
+    auto t1 = make_tensor<TestType>({N});
+    auto t1_padded = make_tensor<TestType>({N+before+after});
+
+    for (int i = 0; i < N; i++) {
+      t1(i) = TestType(i+1);
+    }
+
+    // Pad tensor t1 along dimension 0 using edge padding. This will included two padding
+    // elements before the original data and three padding elements after the original data.
+    (t1_padded = pad(t1, 0, {before, after}, TestType{42}, matx::MATX_PAD_MODE_EDGE)).run(exec);
+
+    exec.sync();
+    // t1_padded is {1, 1, 1, 2, 3, 4, 5, 5, 5, 5}
+    // example-end pad-test-2
+
+    // Check padding values
+    for (int i = 0; i < before; i++) {
+      ASSERT_EQ(t1_padded(i), TestType{static_cast<TestType>(1)}); // before padding
+    }
+    for (int i = before; i < N+before; i++) {
+      ASSERT_EQ(t1_padded(i), TestType{static_cast<TestType>(i-before+1)}); // original data
+    }
+    for (int i = N+before; i < N+before+after; i++) {
+      ASSERT_EQ(t1_padded(i), TestType{static_cast<TestType>(N)}); // after padding
+    }
+  }
+
+  {
+    // Test 2D constant padding along dimension 1
+    const int M = 3;
+    const int N = 4;
+    const int before = 1;
+    const int after = 2;
+    auto t2d = make_tensor<TestType>({M, N});
+    auto t2d_padded = make_tensor<TestType>({M, N+before+after});
+
+    // Fill with values [0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]
+    for (int i = 0; i <M; i++) {
+      for (int j = 0; j < N; j++) {
+        t2d(i, j) = TestType(i * N + j);
+      }
+    }
+
+    // Pad along dimension 1 with {before, after} padding (before, after), using value 42
+    (t2d_padded = pad(t2d, 1, {before, after}, TestType{42})).run(exec);
+    exec.sync();
+
+    for (int i = 0; i < M; i++) {
+      for (int j = 0; j < before; j++) {
+        ASSERT_EQ(t2d_padded(i, j), TestType{static_cast<TestType>(42)}); // before padding
+      }
+      for (int j = before; j < N+before; j++) {
+        ASSERT_EQ(t2d_padded(i, j), TestType{static_cast<TestType>(i*N+j-before)}); // original data
+      }
+      for (int j = N+before; j < N+before+after; j++) {
+        ASSERT_EQ(t2d_padded(i, j), TestType{static_cast<TestType>(42)}); // after padding
+      }
+    }
+  }
+
+  {
+    // Test 2D edge padding along dimension 1
+    const int M = 3;
+    const int N = 4;
+    const int before = 1;
+    const int after = 2;
+    auto t2d = make_tensor<TestType>({M, N});
+    auto t2d_padded = make_tensor<TestType>({M, N+before+after});
+
+    // Fill with values [0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]
+    for (int i = 0; i <M; i++) {
+      for (int j = 0; j < N; j++) {
+        t2d(i, j) = TestType(i * N + j);
+      }
+    }
+
+    // Pad along dimension 1 with {before, after} padding (before, after), using edge padding
+    (t2d_padded = pad(t2d, 1, {before, after}, TestType{0}, matx::MATX_PAD_MODE_EDGE)).run(exec);
+    exec.sync();
+
+    for (int i = 0; i < M; i++) {
+      for (int j = 0; j < before; j++) {
+        ASSERT_EQ(t2d_padded(i, j), TestType{static_cast<TestType>(i*N+0)}); // before padding
+      }
+      for (int j = before; j < N+before; j++) {
+        ASSERT_EQ(t2d_padded(i, j), TestType{static_cast<TestType>(i*N+j-before)}); // original data
+      }
+      for (int j = N+before; j < N+before+after; j++) {
+        ASSERT_EQ(t2d_padded(i, j), TestType{static_cast<TestType>(i*N+N-1)}); // after padding
+      }
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, PadAPIVariations)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{}; 
+
+  const int N = 3;
+  auto t1d = make_tensor<TestType>({N});
+  for (int i = 0; i < N; i++) {
+    t1d(i) = TestType(i+1);
+  }
+
+  // tuple API with {,} syntax
+  auto t1_tuple = make_tensor<TestType>({N+2+2}); 
+  (t1_tuple = pad(t1d, 0, {2, 2}, TestType{0})).run(exec);
+  exec.sync();
+
+  for (int i = 0; i < 2; i++) {
+    ASSERT_EQ(t1_tuple(i), TestType{static_cast<TestType>(0)}); // before padding
+  }
+  for (int i = 2; i < N+2; i++) {
+    ASSERT_EQ(t1_tuple(i), TestType{static_cast<TestType>(i-2+1)}); // original data
+  }
+  for (int i = N+2; i < N+2+2; i++) {
+    ASSERT_EQ(t1_tuple(i), TestType{static_cast<TestType>(0)}); // after padding
+  }
+
+  // tuple API with std::array
+  auto t1_array = make_tensor<TestType>({N+1+2}); 
+  std::array<index_t, 2> pad_sizes = {1, 2};
+  (t1_array = pad(t1d, 0, pad_sizes, TestType{0})).run(exec);
+  exec.sync();
+
+  for (int i = 0; i < 1; i++) {
+    ASSERT_EQ(t1_array(i), TestType{static_cast<TestType>(0)}); // before padding
+  }
+  for (int i = 1; i < N+1; i++) {
+    ASSERT_EQ(t1_array(i), TestType{static_cast<TestType>(i-1+1)}); // original data
+  }
+  for (int i = N+1; i < N+1+2; i++) {
+    ASSERT_EQ(t1_array(i), TestType{static_cast<TestType>(0)}); // after padding
+  }
+
+  // Asymmetric padding
+  auto t1_asym = make_tensor<TestType>({N+3+2}); 
+  (t1_asym = pad(t1d, 0, {3, 2}, TestType{0})).run(exec);
+  exec.sync();
+
+  for (int i = 0; i < 3; i++) {
+    ASSERT_EQ(t1_asym(i), TestType{static_cast<TestType>(0)}); // before padding
+  }
+  for (int i = 3; i < N+3; i++) {
+    ASSERT_EQ(t1_asym(i), TestType{static_cast<TestType>(i-3+1)}); // original data
+  }
+  for (int i = N+3; i < N+3+2; i++) {
+    ASSERT_EQ(t1_asym(i), TestType{static_cast<TestType>(0)}); // after padding
+  }
+
+  // Padding using C-style array
+  auto t1_c_array = make_tensor<TestType>({N+1+1});
+  const index_t c_pad_sizes[] = {1, 1};
+  (t1_c_array = pad(t1d, 0, c_pad_sizes, TestType{0})).run(exec);
+  exec.sync();
+
+  for (int i = 0; i < 1; i++) {
+    ASSERT_EQ(t1_c_array(i), TestType{static_cast<TestType>(0)}); // before padding
+  }
+  for (int i = 1; i < N+1; i++) {
+    ASSERT_EQ(t1_c_array(i), TestType{static_cast<TestType>(i-1+1)}); // original data
+  }
+  for (int i = N+1; i < N+1+1; i++) {
+    ASSERT_EQ(t1_c_array(i), TestType{static_cast<TestType>(0)}); // after padding
+  }
+
+  // Zero-length padding
+  auto t1_zero = make_tensor<TestType>({N});
+  (t1_zero = pad(t1d, 0, {0, 0}, TestType{0})).run(exec);
+  exec.sync();
+  for (int i = 0; i < N; i++) {
+    ASSERT_EQ(t1_zero(i), TestType{static_cast<TestType>(i+1)}); // original data
+  }
+
+  MATX_EXIT_HANDLER();
+}


### PR DESCRIPTION
The pad operator supports pre- and post-padding with constant pad values and edge padding.

Closes Issue #451 