### PR TITLE
Refactor Storage system to use duck-typed allocators

### DIFF
--- a/docs_input/api/creation/tensors/make.rst
+++ b/docs_input/api/creation/tensors/make.rst
@@ -22,14 +22,19 @@ Return by Value
 .. doxygenfunction:: make_tensor( T *data, ShapeType &&shape, bool owning = false)
 .. doxygenfunction:: make_tensor( TensorType &tensor, typename TensorType::value_type *data, typename TensorType::shape_container &&shape)
 .. doxygenfunction:: make_tensor( TensorType &tensor, typename TensorType::value_type *ptr)
-.. doxygenfunction:: make_tensor( Storage &&s, ShapeType &&shape)
-.. doxygenfunction:: make_tensor( TensorType &tensor, typename TensorType::storage_type &&s, typename TensorType::shape_container &&shape)
 .. doxygenfunction:: make_tensor( T* const data, D &&desc, bool owning = false)
 .. doxygenfunction:: make_tensor( TensorType &tensor, typename TensorType::value_type* const data, typename TensorType::desc_type &&desc)
 .. doxygenfunction:: make_tensor( D &&desc, matxMemorySpace_t space = MATX_MANAGED_MEMORY, cudaStream_t stream = 0)
 .. doxygenfunction:: make_tensor( TensorType &&tensor, typename TensorType::desc_type &&desc, matxMemorySpace_t space = MATX_MANAGED_MEMORY, cudaStream_t stream = 0)
 .. doxygenfunction:: make_tensor( T *const data, const index_t (&shape)[RANK], const index_t (&strides)[RANK], bool owning = false)
 .. doxygenfunction:: make_tensor( TensorType &tensor, typename TensorType::value_type *const data, const index_t (&shape)[TensorType::Rank()], const index_t (&strides)[TensorType::Rank()])
+
+Custom Allocator Support
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. doxygenfunction:: make_tensor( const index_t (&shape)[RANK], Allocator&& alloc)
+.. doxygenfunction:: make_tensor( ShapeType &&shape, Allocator&& alloc)
+.. doxygenfunction:: make_tensor( TensorType &tensor, const index_t (&shape)[TensorType::Rank()], Allocator&& alloc)
+.. doxygenfunction:: make_tensor( TensorType &tensor, ShapeType &&shape, Allocator&& alloc)
 
 Return by Pointer
 ~~~~~~~~~~~~~~~~~

--- a/include/matx/core/make_sparse_tensor.h
+++ b/include/matx/core/make_sparse_tensor.h
@@ -38,35 +38,6 @@
 namespace matx {
 namespace experimental {
 
-// Helper to convert Storage<T> to DefaultStorage<T> for sparse tensor compatibility
-template <typename T>
-__MATX_INLINE__ auto convertToDefaultStorage(const Storage<T>& storage) {
-  // Create an owning copy of the data to ensure it persists
-  // This is necessary because the original tensor may go out of scope
-  
-  // Determine the memory space and allocate in the same space
-  auto space = GetPointerKind(const_cast<void*>(static_cast<const void*>(storage.data())));
-  
-  // Allocate in the appropriate memory space
-  T* new_data = nullptr;
-  if (space == MATX_DEVICE_MEMORY || space == MATX_ASYNC_DEVICE_MEMORY) {
-    cudaMalloc(&new_data, storage.size() * sizeof(T));
-    cudaMemcpy(new_data, storage.data(), storage.size() * sizeof(T), cudaMemcpyDeviceToDevice);
-  } else if (space == MATX_HOST_MEMORY) {
-    new_data = static_cast<T*>(malloc(storage.size() * sizeof(T)));
-    memcpy(new_data, storage.data(), storage.size() * sizeof(T));
-  } else {
-    // Managed memory
-    cudaMallocManaged(&new_data, storage.size() * sizeof(T));
-    cudaMemcpy(new_data, storage.data(), storage.size() * sizeof(T), cudaMemcpyDefault);
-  }
-  
-  raw_pointer_buffer<T, matx_allocator<T>> buf{
-    new_data, storage.size(), /*owning=*/true
-  };
-  return basic_storage<decltype(buf)>{std::move(buf)};
-}
-
 // Helper method to zero memory.
 template <typename T>
 __MATX_INLINE__ static void setZero(T *ptr, index_t sz,
@@ -78,6 +49,25 @@ __MATX_INLINE__ static void setZero(T *ptr, index_t sz,
   }
 }
 
+// Helper to create a Storage<T> with zeros
+template <typename T>
+__MATX_INLINE__ Storage<T> makeZeroStorage(index_t sz, matxMemorySpace_t space) {
+  assert(sz > 0);
+  Storage<T> storage(sz, space);
+  if (storage.data() != nullptr) {
+    setZero(storage.data(), sz, space);
+  }
+  return storage;
+}
+
+// Helper to create an empty Storage<T>
+template <typename T>
+__MATX_INLINE__ Storage<T> makeEmptyStorage() {
+  return Storage<T>();
+}
+
+
+
 // Helper method to fill memory.
 template <typename T>
 __MATX_INLINE__ static void setVal(T *ptr, T val, matxMemorySpace_t space) {
@@ -88,25 +78,6 @@ __MATX_INLINE__ static void setVal(T *ptr, T val, matxMemorySpace_t space) {
   }
 }
 
-// Helper method to create zero storage.
-template <typename T>
-__MATX_INLINE__ static auto
-makeDefaultNonOwningZeroStorage(index_t sz, matxMemorySpace_t space) {
-  T *ptr = nullptr;
-  assert(sz > 0);
-  matxAlloc((void **)&ptr, sz * sizeof(T), space, /*stream=*/0);
-  setZero(ptr, sz, space);
-  raw_pointer_buffer<T, matx_allocator<T>> buf{ptr, static_cast<size_t>(sz),
-                                               /*owning=*/false};
-  return basic_storage<decltype(buf)>{std::move(buf)};
-}
-
-// Helper method to create empty storage.
-template <typename T>
-__MATX_INLINE__ static auto makeDefaultNonOwningEmptyStorage() {
-  raw_pointer_buffer<T, matx_allocator<T>> buf{nullptr, 0, /*owning=*/false};
-  return basic_storage<decltype(buf)>{std::move(buf)};
-}
 
 //
 // MatX implements a universal sparse tensor type that uses a tensor format
@@ -141,12 +112,12 @@ auto make_tensor_coo(ValTensor &val, CrdTensor &row, CrdTensor &col,
   // compression should set up pos[0] = {0, nse}. This is done
   // here, using the same memory space as the other data.
   matxMemorySpace_t space = GetPointerKind(val.GetStorage().data());
-  auto tp = makeDefaultNonOwningZeroStorage<POS>(2, space);
+  Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(val.Size(0)), space);
   // Construct COO.
   return sparse_tensor_t<VAL, CRD, POS, COO>(
-      shape, convertToDefaultStorage(val.GetStorage()), {convertToDefaultStorage(row.GetStorage()), convertToDefaultStorage(col.GetStorage())},
-      {tp, makeDefaultNonOwningEmptyStorage<POS>()});
+      shape, val.GetStorage(), {row.GetStorage(), col.GetStorage()},
+      {std::move(tp), makeEmptyStorage<POS>()});
 }
 
 // Constructs a zero sparse matrix in COO format (viz. nse=0).
@@ -154,11 +125,11 @@ template <typename VAL, typename CRD, typename POS = index_t>
 auto make_zero_tensor_coo(const index_t (&shape)[2],
                           matxMemorySpace_t space = MATX_MANAGED_MEMORY) {
   return sparse_tensor_t<VAL, CRD, POS, COO>(
-      shape, makeDefaultNonOwningEmptyStorage<VAL>(),
-      {makeDefaultNonOwningEmptyStorage<CRD>(),
-       makeDefaultNonOwningEmptyStorage<CRD>()},
-      {makeDefaultNonOwningZeroStorage<POS>(2, space),
-       makeDefaultNonOwningEmptyStorage<POS>()});
+      shape, makeEmptyStorage<VAL>(),
+      {makeEmptyStorage<CRD>(),
+       makeEmptyStorage<CRD>()},
+      {makeZeroStorage<POS>(2, space),
+       makeEmptyStorage<POS>()});
 }
 
 // Constructs a sparse matrix in CSR format directly from the values, the
@@ -181,9 +152,9 @@ auto make_tensor_csr(ValTensor &val, PosTensor &rowp, CrdTensor &col,
                   "data arrays should have consistent length (nse)");
   // Construct CSR.
   return sparse_tensor_t<VAL, CRD, POS, CSR>(
-      shape, convertToDefaultStorage(val.GetStorage()),
-      {makeDefaultNonOwningEmptyStorage<CRD>(), convertToDefaultStorage(col.GetStorage())},
-      {makeDefaultNonOwningEmptyStorage<POS>(), convertToDefaultStorage(rowp.GetStorage())});
+      shape, val.GetStorage(),
+      {makeEmptyStorage<CRD>(), col.GetStorage()},
+      {makeEmptyStorage<POS>(), rowp.GetStorage()});
 }
 
 // Constructs a zero sparse matrix in CSR format (viz. nse=0).
@@ -191,11 +162,11 @@ template <typename VAL, typename CRD, typename POS>
 auto make_zero_tensor_csr(const index_t (&shape)[2],
                           matxMemorySpace_t space = MATX_MANAGED_MEMORY) {
   return sparse_tensor_t<VAL, CRD, POS, CSR>(
-      shape, makeDefaultNonOwningEmptyStorage<VAL>(),
-      {makeDefaultNonOwningEmptyStorage<CRD>(),
-       makeDefaultNonOwningEmptyStorage<CRD>()},
-      {makeDefaultNonOwningEmptyStorage<POS>(),
-       makeDefaultNonOwningZeroStorage<POS>(shape[0] + 1, space)});
+      shape, makeEmptyStorage<VAL>(),
+      {makeEmptyStorage<CRD>(),
+       makeEmptyStorage<CRD>()},
+      {makeEmptyStorage<POS>(),
+       makeZeroStorage<POS>(shape[0] + 1, space)});
 }
 
 // Constructs a sparse matrix in CSC format directly from the values, the
@@ -218,9 +189,9 @@ auto make_tensor_csc(ValTensor &val, PosTensor &colp, CrdTensor &row,
                   "data arrays should have consistent length (nse)");
   // Construct CSC.
   return sparse_tensor_t<VAL, CRD, POS, CSC>(
-      shape, convertToDefaultStorage(val.GetStorage()),
-      {makeDefaultNonOwningEmptyStorage<CRD>(), convertToDefaultStorage(row.GetStorage())},
-      {makeDefaultNonOwningEmptyStorage<POS>(), convertToDefaultStorage(colp.GetStorage())});
+      shape, val.GetStorage(),
+      {makeEmptyStorage<CRD>(), row.GetStorage()},
+      {makeEmptyStorage<POS>(), colp.GetStorage()});
 }
 
 // Constructs a zero sparse matrix in CSC format (viz. nse=0).
@@ -228,11 +199,11 @@ template <typename VAL, typename CRD, typename POS>
 auto make_zero_tensor_csc(const index_t (&shape)[2],
                           matxMemorySpace_t space = MATX_MANAGED_MEMORY) {
   return sparse_tensor_t<VAL, CRD, POS, CSC>(
-      shape, makeDefaultNonOwningEmptyStorage<VAL>(),
-      {makeDefaultNonOwningEmptyStorage<CRD>(),
-       makeDefaultNonOwningEmptyStorage<CRD>()},
-      {makeDefaultNonOwningEmptyStorage<POS>(),
-       makeDefaultNonOwningZeroStorage<POS>(shape[1] + 1, space)});
+      shape, makeEmptyStorage<VAL>(),
+      {makeEmptyStorage<CRD>(),
+       makeEmptyStorage<CRD>()},
+      {makeEmptyStorage<POS>(),
+       makeZeroStorage<POS>(shape[1] + 1, space)});
 }
 
 // Constructs a sparse matrix in DIA format directly from the values and the
@@ -264,14 +235,14 @@ auto make_tensor_dia(ValTensor &val, CrdTensor &off,
   // compression should set up pos[0] = {0, #diags}. This is done
   // here, using the same memory space as the other data.
   matxMemorySpace_t space = GetPointerKind(val.GetStorage().data());
-  auto tp = makeDefaultNonOwningZeroStorage<POS>(2, space);
+  Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(off.Size(0)), space);
   // Construct DIA-I/J.
   using DIA = std::conditional_t<std::is_same_v<IDX, DIA_INDEX_I>, DIAI, DIAJ>;
   return sparse_tensor_t<VAL, CRD, POS, DIA>(
-      shape, convertToDefaultStorage(val.GetStorage()),
-      {convertToDefaultStorage(off.GetStorage()), makeDefaultNonOwningEmptyStorage<CRD>()},
-      {tp, makeDefaultNonOwningEmptyStorage<POS>()});
+      shape, val.GetStorage(),
+      {off.GetStorage(), makeEmptyStorage<CRD>()},
+      {std::move(tp), makeEmptyStorage<POS>()});
 }
 
 // Constructs a sparse tensor in uniform batched DIA format directly from
@@ -304,15 +275,15 @@ auto make_tensor_uniform_batched_dia(ValTensor &val, CrdTensor &off,
   // compression should set up pos[0] = {0, #diags}. This is done
   // here, using the same memory space as the other data.
   matxMemorySpace_t space = GetPointerKind(val.GetStorage().data());
-  auto tp = makeDefaultNonOwningZeroStorage<POS>(2, space);
+  Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(off.Size(0)), space);
   // Construct Batched DIA-I/J.
   using DIA = std::conditional_t<std::is_same_v<IDX, DIA_INDEX_I>,
                                  BatchedDIAIUniform, BatchedDIAJUniform>;
   return sparse_tensor_t<VAL, CRD, POS, DIA>(
-      shape, convertToDefaultStorage(val.GetStorage()),
-      {convertToDefaultStorage(off.GetStorage()), makeDefaultNonOwningEmptyStorage<CRD>()},
-      {tp, makeDefaultNonOwningEmptyStorage<POS>()});
+      shape, val.GetStorage(),
+      {off.GetStorage(), makeEmptyStorage<CRD>()},
+      {std::move(tp), makeEmptyStorage<POS>()});
 }
 
 // Convenience constructor for uniform batched tri-diagonal storage.
@@ -336,21 +307,21 @@ auto make_tensor_uniform_batched_tri_dia(ValTensor &val,
   }
   // Construct the off = { -1, 0, +1 } in values memory space.
   matxMemorySpace_t space = GetPointerKind(val.GetStorage().data());
-  auto off = makeDefaultNonOwningZeroStorage<CRD>(3, space);
+  Storage<CRD> off = makeZeroStorage<CRD>(3, space);
   setVal(off.data() + 0, static_cast<CRD>(-1), space);
   setVal(off.data() + 2, static_cast<CRD>(+1), space);
   // Note that the DIA API typically does not involve positions.
   // However, under the formal DSL specifications, the top level
   // compression should set up pos[0] = {0, #diags}. This is done
   // here, using the same memory space as the other data.
-  auto tp = makeDefaultNonOwningZeroStorage<POS>(2, space);
+  Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(3), space);
   // Construct Batched DIA-I/J.
   using DIA = std::conditional_t<std::is_same_v<IDX, DIA_INDEX_I>,
                                  BatchedDIAIUniform, BatchedDIAJUniform>;
   return sparse_tensor_t<VAL, CRD, POS, DIA>(
-      shape, convertToDefaultStorage(val.GetStorage()), {off, makeDefaultNonOwningEmptyStorage<CRD>()},
-      {tp, makeDefaultNonOwningEmptyStorage<POS>()});
+      shape, val.GetStorage(), {std::move(off), makeEmptyStorage<CRD>()},
+      {std::move(tp), makeEmptyStorage<POS>()});
 }
 
 } // namespace experimental

--- a/include/matx/core/make_sparse_tensor.h
+++ b/include/matx/core/make_sparse_tensor.h
@@ -76,7 +76,7 @@ makeDefaultNonOwningZeroStorage(index_t sz, matxMemorySpace_t space) {
   assert(sz > 0);
   matxAlloc((void **)&ptr, sz * sizeof(T), space, /*stream=*/0);
   setZero(ptr, sz, space);
-  raw_pointer_buffer<T, matx_allocator<T>> buf{ptr, sz * sizeof(T),
+  raw_pointer_buffer<T, matx_allocator<T>> buf{ptr, static_cast<size_t>(sz),
                                                /*owning=*/false};
   return basic_storage<decltype(buf)>{std::move(buf)};
 }

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -59,6 +59,23 @@ auto make_tensor( const index_t (&shape)[RANK],
 }
 
 /**
+ * Create a tensor from existing storage and a shape specification
+ *
+ * @param storage Storage object containing the data
+ * @param shape Shape specification for the tensor
+ * @returns New tensor
+ **/
+template <typename T, typename ShapeType,
+  std::enable_if_t<!is_matx_descriptor_v<ShapeType> && !std::is_array_v<typename remove_cvref<ShapeType>::type>, bool> = true>
+auto make_tensor(Storage<T> storage, ShapeType &&shape) {
+  MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+
+  constexpr int RANK = static_cast<int>(cuda::std::tuple_size<typename remove_cvref<ShapeType>::type>::value);
+  DefaultDescriptor<RANK> desc{std::forward<ShapeType>(shape)};
+  return tensor_t<T, RANK, decltype(desc)>{std::move(storage), std::move(desc)};
+}
+
+/**
  * Create a tensor with a C array for the shape using implicitly-allocated memory
  *
  * @param tensor Tensor object to store newly-created tensor into

--- a/include/matx/core/sparse_tensor.h
+++ b/include/matx/core/sparse_tensor.h
@@ -75,9 +75,9 @@ namespace experimental {
 //   TF  : tensor format
 //
 template <typename VAL, typename CRD, typename POS, typename TF,
-          typename StorageV = DefaultStorage<VAL>,
-          typename StorageC = DefaultStorage<CRD>,
-          typename StorageP = DefaultStorage<POS>,
+          typename StorageV = Storage<VAL>,
+          typename StorageC = Storage<CRD>,
+          typename StorageP = Storage<POS>,
           typename DimDesc = DefaultDescriptor<TF::DIM>>
 class sparse_tensor_t
     : public detail::tensor_impl_t<

--- a/include/matx/core/sparse_tensor.h
+++ b/include/matx/core/sparse_tensor.h
@@ -158,13 +158,13 @@ public:
 
   // Size getters.
   index_t Nse() const {
-    return static_cast<index_t>(values_.size() / sizeof(VAL));
+    return static_cast<index_t>(values_.size());
   }
   index_t crdSize(int l) const {
-    return static_cast<index_t>(coordinates_[l].size() / sizeof(CRD));
+    return static_cast<index_t>(coordinates_[l].size());
   }
   index_t posSize(int l) const {
-    return static_cast<index_t>(positions_[l].size() / sizeof(POS));
+    return static_cast<index_t>(positions_[l].size());
   }
 
 private:

--- a/include/matx/core/storage.h
+++ b/include/matx/core/storage.h
@@ -48,6 +48,7 @@ namespace matx
   template<typename T, typename = void>
   struct has_allocator_interface : std::false_type {};
 
+  /// @cond DOXYGEN_SHOULD_SKIP_THIS
   // For allocator objects
   template<typename T>
   struct has_allocator_interface<T, 
@@ -57,7 +58,9 @@ namespace matx
       void()
     )
   > : std::true_type {};
+  /// @endcond
 
+  /// @cond DOXYGEN_SHOULD_SKIP_THIS
   // For allocator pointers
   template<typename T>
   struct has_allocator_interface<T*, 
@@ -67,6 +70,7 @@ namespace matx
       void()
     )
   > : std::true_type {};
+  /// @endcond
 
   /**
    * @brief Unified storage class for both owning and non-owning pointers

--- a/include/matx/core/storage.h
+++ b/include/matx/core/storage.h
@@ -85,6 +85,9 @@ namespace matx
     using iterator = T*;
     using const_iterator = const T*;
 
+    // Default constructor - creates empty storage
+    Storage() : size_(0), data_(nullptr) {}
+
     // Non-owning constructor - wraps existing pointer
     Storage(T* ptr, size_t size) 
       : size_(size), data_(ptr, [](T*){}) {}

--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -808,7 +808,9 @@ MATX_LOOP_UNROLL
 
     // Copy descriptor and call ctor with shape
     Desc new_desc{this->desc_.Shape(), std::move(strides)};
-    return tensor_t<Type, RANK, Desc>{storage_, std::move(new_desc), data};
+    // Create non-owning storage with the correct type for the real view
+    auto real_storage = make_non_owning_storage<Type>(data, storage_.size() * 2);
+    return tensor_t<Type, RANK, Desc>{real_storage, std::move(new_desc), data};
   }
 
   /**
@@ -851,7 +853,9 @@ MATX_LOOP_UNROLL
     }
 
     Desc new_desc{this->desc_.Shape(), std::move(strides)};
-    return tensor_t<Type, RANK, Desc>{storage_, std::move(new_desc), data};
+    // Create non-owning storage with the correct type for the imaginary view  
+    auto imag_storage = make_non_owning_storage<Type>(data, storage_.size() * 2);
+    return tensor_t<Type, RANK, Desc>{imag_storage, std::move(new_desc), data};
   }
 
   /**

--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -51,7 +51,7 @@
 
 // forward declare
 namespace matx {
-template <typename T, int RANK, typename Storage, typename Desc> class tensor_t;
+template <typename T, int RANK, typename Desc> class tensor_t;
 } // namespace matx
 
 /* Special values used to indicate properties of tensors */
@@ -72,7 +72,6 @@ namespace matx {
  */
 template <typename T,
           int RANK,
-          typename Storage = DefaultStorage<T>,
           typename Desc = DefaultDescriptor<RANK>>
 class tensor_t : public detail::tensor_impl_t<T,RANK,Desc> {
 public:
@@ -84,13 +83,12 @@ public:
   using matxoplvalue = bool; ///< Indicate this is a MatX operator that can be on the lhs of an equation
   using tensor_view = bool; ///< Indicate this is a MatX tensor view
   using tensor_t_type = bool; ///< This is a tensor_t (not a tensor_impl_t)
-  using storage_type = Storage; ///< Storage type trait
   using shape_type = typename Desc::shape_type;
   using stride_type = typename Desc::stride_type;
   using shape_container = typename Desc::shape_container;
   using stride_container = typename Desc::stride_container;
   using desc_type = Desc; ///< Descriptor type trait
-  using self_type = tensor_t<T, RANK, Storage, Desc>;
+  using self_type = tensor_t<T, RANK, Desc>;
 
   /**
    * @brief Construct a new 0-D tensor t object
@@ -175,11 +173,11 @@ public:
    * @param s Shape object
    * @param desc Descriptor object
    */
-  template <typename S2 = Storage, typename D2 = Desc,
-            std::enable_if_t<is_matx_storage_v<typename remove_cvref<S2>::type> && is_matx_descriptor_v<typename remove_cvref<D2>::type>, bool> = true>
-  tensor_t(S2 &&s, D2 &&desc) :
+  template <typename D2 = Desc,
+            std::enable_if_t<is_matx_descriptor_v<typename remove_cvref<D2>::type>, bool> = true>
+  tensor_t(Storage<T> s, D2 &&desc) :
     detail::tensor_impl_t<T, RANK, Desc>{std::forward<D2>(desc)},
-    storage_{std::forward<S2>(s)}
+    storage_{std::move(s)}
   {
     this->SetLocalData(storage_.data());
   }
@@ -192,7 +190,7 @@ public:
    * @param ldata
    */
   template <typename D2 = Desc>
-  tensor_t(Storage s, D2 &&desc, T* ldata) :
+  tensor_t(Storage<T> s, D2 &&desc, T* ldata) :
     detail::tensor_impl_t<T, RANK, D2>{std::forward<D2>(desc)},
     storage_{std::move(s)}
   {
@@ -210,7 +208,7 @@ public:
     typename std::enable_if_t<is_matx_descriptor_v<D2>>>
   __MATX_INLINE__ tensor_t(D2 &&desc) :
     detail::tensor_impl_t<T, RANK, D2>{std::forward<D2>(desc)},
-    storage_{typename Storage::container{this->desc_.TotalSize()*sizeof(T)}}
+    storage_{make_owning_storage<T>(this->desc_.TotalSize())}
   {
     this->SetLocalData(storage_.data());
   }
@@ -225,7 +223,7 @@ public:
     // The ctor argument is unused, but matches {} for rank-0 tensors. We do
     // not use [[maybe_unused]] due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429 in gcc < 9.3
     detail::tensor_impl_t<T, RANK, Desc>(cuda::std::array<index_t, 0>{}),
-    storage_{typename Storage::container{sizeof(T)}}
+    storage_{make_owning_storage<T>(1)}
   {
     this->SetLocalData(storage_.data());
   }
@@ -239,7 +237,7 @@ public:
    */
   __MATX_INLINE__ tensor_t(const typename Desc::shape_type (&shape)[RANK]) :
     detail::tensor_impl_t<T, RANK, Desc>(shape),
-    storage_{typename Storage::container{this->desc_.TotalSize()*sizeof(T)}}
+    storage_{make_owning_storage<T>(this->desc_.TotalSize())}
   {
     this->SetLocalData(storage_.data());
   }
@@ -643,7 +641,7 @@ public:
     [[maybe_unused]] stride_type prod = std::accumulate(std::begin(shape), std::end(shape), static_cast<stride_type>(1), std::multiplies<stride_type>());
     // Ensure new shape's total size is not larger than the original
     MATX_ASSERT_STR(
-        sizeof(M) * prod <= storage_.Bytes(), matxInvalidSize,
+        sizeof(M) * prod <= storage_.bytes(), matxInvalidSize,
         "Total size of new tensor must not be larger than the original");
 
     // This could be loosened up to make sure only the fastest changing dims
@@ -653,7 +651,8 @@ public:
 
     // Copy descriptor and call ctor with shape
     Desc new_desc{std::forward<Shape>(shape)};
-    return tensor_t<M, R, Storage, Desc>{storage_, std::move(new_desc), this->Data()};
+    // Multiple views can share the same storage
+    return tensor_t<M, R, Desc>{storage_, std::move(new_desc), this->Data()};
   }
 
   /**
@@ -703,7 +702,7 @@ public:
 
     [[maybe_unused]] stride_type prod = std::accumulate(std::begin(shape), std::end(shape), static_cast<stride_type>(1), std::multiplies<stride_type>());
     MATX_ASSERT_STR(
-        sizeof(T) * prod <= storage_.Bytes(), matxInvalidSize,
+        sizeof(T) * prod <= storage_.bytes(), matxInvalidSize,
         "Total size of new tensor must not be larger than the original");
 
     // This could be loosened up to make sure only the fastest changing dims
@@ -712,7 +711,7 @@ public:
        "To get a reshaped view the tensor must be compact");
 
     DefaultDescriptor<tshape.size()> desc{std::move(tshape)};
-    return tensor_t<T, NRANK, Storage, decltype(desc)>{storage_, std::move(desc), this->Data()};
+    return tensor_t<T, NRANK, decltype(desc)>{storage_, std::move(desc), this->Data()};
   }
 
   /**
@@ -809,7 +808,7 @@ MATX_LOOP_UNROLL
 
     // Copy descriptor and call ctor with shape
     Desc new_desc{this->desc_.Shape(), std::move(strides)};
-    return tensor_t<Type, RANK, Storage, Desc>{storage_, std::move(new_desc), data};
+    return tensor_t<Type, RANK, Desc>{storage_, std::move(new_desc), data};
   }
 
   /**
@@ -852,7 +851,7 @@ MATX_LOOP_UNROLL
     }
 
     Desc new_desc{this->desc_.Shape(), std::move(strides)};
-    return tensor_t<Type, RANK, Storage, Desc>{storage_, std::move(new_desc), data};
+    return tensor_t<Type, RANK, Desc>{storage_, std::move(new_desc), data};
   }
 
   /**
@@ -875,7 +874,7 @@ MATX_LOOP_UNROLL
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
     auto new_desc = this->PermuteImpl(dims);
-    return tensor_t<T, RANK, Storage, Desc>{storage_, std::move(new_desc), this->Data()};
+    return tensor_t<T, RANK, Desc>{storage_, std::move(new_desc), this->Data()};
   }
 
 
@@ -940,7 +939,8 @@ MATX_LOOP_UNROLL
   Reset(T *const data, ShapeType &&shape) noexcept
   {
     this->desc_.InitFromShape(std::forward<ShapeType>(shape));
-    storage_.SetData(data);
+    // For non-owning storage, we need to recreate the storage object
+    storage_ = make_non_owning_storage<T>(data, this->desc_.TotalSize());
     this->SetData(data);
   }
 
@@ -960,7 +960,8 @@ MATX_LOOP_UNROLL
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
-    storage_.SetData(data);
+    // For non-owning storage, we need to recreate the storage object
+    storage_ = make_non_owning_storage<T>(data, this->desc_.TotalSize());
     this->SetData(data);
   }
 
@@ -980,7 +981,8 @@ MATX_LOOP_UNROLL
   __MATX_HOST__ __MATX_INLINE__ void
   Reset(T *const data, T *const ldata) noexcept
   {
-    storage_.SetData(data);
+    // For non-owning storage, we need to recreate the storage object
+    storage_ = make_non_owning_storage<T>(data, this->desc_.TotalSize());
     this->SetData(ldata);
   }
 
@@ -1043,7 +1045,7 @@ MATX_LOOP_UNROLL
   OverlapView(const cuda::std::array<typename Desc::shape_type, N> &windows,
               const cuda::std::array<typename Desc::stride_type, N> &strides) const {
     auto new_desc = this->template OverlapViewImpl<N>(windows, strides);
-    return tensor_t<T, RANK + 1, Storage, decltype(new_desc)>{storage_, std::move(new_desc), this->Data()};
+    return tensor_t<T, RANK + 1, decltype(new_desc)>{storage_, std::move(new_desc), this->Data()};
   }
 
   /**
@@ -1077,7 +1079,7 @@ MATX_LOOP_UNROLL
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
     auto new_desc = this->template CloneImpl<N>(clones);
-    return tensor_t<T, N, Storage, decltype(new_desc)>{storage_, std::move(new_desc), this->Data()};
+    return tensor_t<T, N, decltype(new_desc)>{storage_, std::move(new_desc), this->Data()};
   }
 
   template <int N>
@@ -1375,7 +1377,7 @@ MATX_LOOP_UNROLL
                             [[maybe_unused]] StrideType strides) const
   {
     auto [new_desc, data] = this->template SliceImpl<N, StrideType>(firsts, ends, strides);
-    return tensor_t<T, N, Storage, decltype(new_desc)>{storage_, std::move(new_desc), data};
+    return tensor_t<T, N, decltype(new_desc)>{storage_, std::move(new_desc), data};
   }
 
   template <typename StrideType, int N = RANK>
@@ -1523,7 +1525,7 @@ MATX_LOOP_UNROLL
   }
 
 private:
-  Storage storage_;
+  Storage<T> storage_;
   std::string name_ = std::string("tensor_") + std::to_string(RANK) + "_" + detail::to_short_str<T>();
 };
 

--- a/include/matx/core/tensor_desc.h
+++ b/include/matx/core/tensor_desc.h
@@ -79,9 +79,9 @@ public:
    */
   __MATX_INLINE__  tensor_desc_t& operator=(tensor_desc_t&&) = default;
 
-  /** Swaps two raw_pointer_buffers
+  /** Swaps two tensor descriptors
    *
-   * Swaps members of two raw_pointer_buffers
+   * Swaps members of two tensor descriptors
    *
    * @param lhs
    *   Left argument

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -116,9 +116,9 @@ class tensor_impl_t {
       return std::string("tensor_impl_") + std::to_string(RANK) + "_" + to_short_str<T>();
     }
 
-    /** Swaps two raw_pointer_buffers
+    /** Swaps two tensor implementations
      *
-     * Swaps members of two raw_pointer_buffers
+     * Swaps members of two tensor implementations
      *
      * @param lhs
      *   Left argument

--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -113,7 +113,7 @@ template <typename T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 
 template <typename T, int RANK, typename Desc, typename Data> class tensor_impl_t;
-template <typename T, int RANK, typename Storage, typename Desc> class tensor_t;
+template <typename T, int RANK, typename Desc> class tensor_t;
 
 namespace detail {
 template <typename T, typename = void>
@@ -857,7 +857,7 @@ constexpr cuda::std::array<std::remove_cv_t<T>, N> to_array(T (&a)[N])
     return to_array_impl(a, std::make_index_sequence<N>{});
 }
 
-template <typename T, int RANK, typename Storage, typename Desc> class tensor_t;
+template <typename T, int RANK, typename Desc> class tensor_t;
 template <typename T, int RANK, typename Desc, typename Data> class tensor_impl_t;
 // Traits for casting down to impl tensor conditionally
 template <typename T, typename = void> 

--- a/include/matx/kernels/matvec.cuh
+++ b/include/matx/kernels/matvec.cuh
@@ -45,7 +45,7 @@ __global__ void diai_spmv_kernel(VAL *A, CRD *diags, uint64_t numDiags, VAL *B,
                                  VAL *C, uint64_t m, uint64_t n) {
   uint64_t i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < m) {
-    VAL acc = static_cast<VAL>(0);
+    VAL acc = 0.0;
     for (uint64_t d = 0; d < numDiags; d++) {
       int64_t j = i + diags[d]; // signed
       if (0 <= j && j < static_cast<int64_t>(n)) {
@@ -62,7 +62,7 @@ __global__ void diaj_spmv_kernel(VAL *A, CRD *diags, uint64_t numDiags, VAL *B,
                                  VAL *C, uint64_t m, uint64_t n) {
   uint64_t i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < m) {
-    VAL acc = static_cast<VAL>(0);
+    VAL acc = 0.0;
     for (uint64_t d = 0; d < numDiags; d++) {
       int64_t j = i + diags[d]; // signed
       if (0 <= j && j < static_cast<int64_t>(n)) {

--- a/include/matx/kernels/matvec.cuh
+++ b/include/matx/kernels/matvec.cuh
@@ -45,7 +45,7 @@ __global__ void diai_spmv_kernel(VAL *A, CRD *diags, uint64_t numDiags, VAL *B,
                                  VAL *C, uint64_t m, uint64_t n) {
   uint64_t i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < m) {
-    VAL acc = 0.0;
+    VAL acc = static_cast<VAL>(0);
     for (uint64_t d = 0; d < numDiags; d++) {
       int64_t j = i + diags[d]; // signed
       if (0 <= j && j < static_cast<int64_t>(n)) {
@@ -62,7 +62,7 @@ __global__ void diaj_spmv_kernel(VAL *A, CRD *diags, uint64_t numDiags, VAL *B,
                                  VAL *C, uint64_t m, uint64_t n) {
   uint64_t i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < m) {
-    VAL acc = 0.0;
+    VAL acc = static_cast<VAL>(0);
     for (uint64_t d = 0; d < numDiags; d++) {
       int64_t j = i + diags[d]; // signed
       if (0 <= j && j < static_cast<int64_t>(n)) {

--- a/include/matx/operators/set.h
+++ b/include/matx/operators/set.h
@@ -39,7 +39,7 @@
 #include "matx/core/tensor_utils.h"
 
 namespace matx {
-template <typename T, int RANK, typename Storage, typename Desc> class tensor_t; ///< Tensor detail type
+template <typename T, int RANK, typename Desc> class tensor_t; ///< Tensor detail type
 template <typename T> class BaseOp; ///< Base operator type
 
 namespace detail {

--- a/include/matx/transforms/convert/dense2sparse_cusparse.h
+++ b/include/matx/transforms/convert/dense2sparse_cusparse.h
@@ -71,8 +71,8 @@ __MATX_INLINE__ static auto makeDefaultNonOwningStorage(size_t sz,
   if (sz != 0) {
     matxAlloc(reinterpret_cast<void **>(&ptr), sz * sizeof(T), space, stream);
   }
-  raw_pointer_buffer<T, matx_allocator<T>> buf{ptr, sz * sizeof(T),
-                                               /*owning=*/false};
+  // FIX: raw_pointer_buffer constructor expects ELEMENT count, not byte count
+  raw_pointer_buffer<T, matx_allocator<T>> buf{ptr, sz, /*owning=*/false};
   return basic_storage<decltype(buf)>{std::move(buf)};
 }
 
@@ -101,6 +101,8 @@ public:
     static_assert(is_tensor_view_v<TensorTypeA>);
     cudaDataType dta = MatXTypeToCudaType<TA>();
     const cusparseOrder_t order = CUSPARSE_ORDER_ROW;
+
+    
     ret = cusparseCreateDnMat(&matA_, params_.m, params_.n, /*ld=*/params_.n,
                               params_.ptrA, dta, order);
     MATX_ASSERT(ret == CUSPARSE_STATUS_SUCCESS, matxCudaError);
@@ -111,13 +113,21 @@ public:
     cusparseIndexType_t ct = MatXTypeToCuSparseIndexType<CRD>();
     cusparseIndexBase_t zb = CUSPARSE_INDEX_BASE_ZERO;
     cudaDataType dto = MatXTypeToCudaType<TO>();
+    fprintf(stderr, "[FORMAT DEBUG] TensorFormat detected\n");
+    fflush(stderr);
     if constexpr (TensorTypeO::Format::isCOO()) {
+      fprintf(stderr, "[FORMAT DEBUG] Using COO format\n");
+      fflush(stderr);
       ret = cusparseCreateCoo(&matO_, params_.m, params_.n, 0, nullptr, nullptr,
                               nullptr, ct, zb, dto);
     } else if constexpr (TensorTypeO::Format::isCSR()) {
+      fprintf(stderr, "[FORMAT DEBUG] Using CSR format\n");
+      fflush(stderr);
       ret = cusparseCreateCsr(&matO_, params_.m, params_.n, 0, params_.ptrO2,
                               nullptr, nullptr, pt, ct, zb, dto);
     } else if constexpr (TensorTypeO::Format::isCSC()) {
+      fprintf(stderr, "[FORMAT DEBUG] Using CSC format\n");
+      fflush(stderr);
       ret = cusparseCreateCsc(&matO_, params_.m, params_.n, 0, params_.ptrO2,
                               nullptr, nullptr, pt, ct, zb, dto);
     } else {
@@ -143,6 +153,14 @@ public:
     [[maybe_unused]] int64_t num_rows_tmp, num_cols_tmp, nnz;
     ret = cusparseSpMatGetSize(matO_, &num_rows_tmp, &num_cols_tmp, &nnz);
     MATX_ASSERT(ret == CUSPARSE_STATUS_SUCCESS, matxCudaError);
+    
+    if constexpr (TensorTypeO::Format::isCSC()) {
+      fprintf(stderr, "[CSC DEBUG] cuSPARSE analysis result: nnz=%ld\n", (long)nnz);
+      fflush(stderr);
+    }
+    
+    
+
 
     // Pre-allocate sparse tensor output.
     if constexpr (TensorTypeO::Format::isCOO()) {
@@ -169,10 +187,14 @@ public:
       ret = cusparseCsrSetPointers(matO_, o.POSData(1), o.CRDData(1), o.Data());
     } else if constexpr (TensorTypeO::Format::isCSC()) {
       matxMemorySpace_t space = GetPointerKind(params_.ptrO2);
+      fprintf(stderr, "[CSC DEBUG] Setting up CSC storage: nnz=%ld, space=%d\n", (long)nnz, (int)space);
+      fflush(stderr);
       o.SetVal(makeDefaultNonOwningStorage<VAL>(nnz, space, stream));
       o.SetCrd(1, makeDefaultNonOwningStorage<CRD>(nnz, space, stream));
       o.SetSparseDataImpl();
       ret = cusparseCscSetPointers(matO_, o.POSData(1), o.CRDData(1), o.Data());
+      fprintf(stderr, "[CSC DEBUG] After CSC setup, tensor Nse=%ld\n", (long)o.Nse());
+      fflush(stderr);
     }
     MATX_ASSERT(ret == CUSPARSE_STATUS_SUCCESS, matxCudaError);
   }

--- a/include/matx/transforms/convert/sparse2sparse_cusparse.h
+++ b/include/matx/transforms/convert/sparse2sparse_cusparse.h
@@ -36,6 +36,7 @@
 #include <cusparse.h>
 
 #include <numeric>
+#include <typeinfo>
 
 #include "matx/core/cache.h"
 #include "matx/core/sparse_tensor.h"
@@ -63,14 +64,14 @@ struct Sparse2SparseParams_t {
   void *ptrA1;
   void *ptrA2;
   void *ptrA3;
+  size_t format_hash_in;   // Hash of the input sparse tensor format type
+  size_t format_hash_out;  // Hash of the output sparse tensor format type
 };
 
 // Helper method to wrap pointer/size in new storage.
 template <typename T>
-__MATX_INLINE__ static auto wrapDefaultNonOwningStorage(T *ptr, size_t sz) {
-  // FIX: raw_pointer_buffer constructor expects ELEMENT count, not byte count
-  raw_pointer_buffer<T, matx_allocator<T>> buf{ptr, sz, /*owning=*/false};
-  return basic_storage<decltype(buf)>{std::move(buf)};
+__MATX_INLINE__ static Storage<T> wrapDefaultNonOwningStorage(T *ptr, size_t sz) {
+  return Storage<T>(ptr, sz);
 }
 
 template <typename TensorTypeO, typename TensorTypeA>
@@ -134,6 +135,9 @@ public:
     params.ptrA1 = a.POSData(0);
     params.ptrA2 = a.CRDData(0);
     params.ptrA3 = a.CRDData(1);
+    // Add format type hashes to distinguish between different sparse formats
+    params.format_hash_in = typeid(typename TensorTypeA::Format).hash_code();
+    params.format_hash_out = typeid(typename TensorTypeO::Format).hash_code();
     return params;
   }
 
@@ -165,7 +169,9 @@ struct Sparse2SparseParamsKeyHash {
   std::size_t operator()(const Sparse2SparseParams_t &k) const noexcept {
     return std::hash<uint64_t>()(reinterpret_cast<uint64_t>(k.ptrO1)) +
            std::hash<uint64_t>()(reinterpret_cast<uint64_t>(k.ptrA0)) +
-           std::hash<uint64_t>()(reinterpret_cast<uint64_t>(k.stream));
+           std::hash<uint64_t>()(reinterpret_cast<uint64_t>(k.stream)) +
+           std::hash<size_t>()(k.format_hash_in) +
+           std::hash<size_t>()(k.format_hash_out);
   }
 };
 
@@ -180,7 +186,8 @@ struct Sparse2SparseParamsKeyEq {
     return l.dtype == t.dtype && l.ptype == t.ptype && l.ctype == t.ctype &&
            l.stream == t.stream && l.nse == t.nse && l.m == t.m && l.n == t.n &&
            l.ptrO1 == t.ptrO1 && l.ptrA0 == t.ptrA0 && l.ptrA1 == t.ptrA1 &&
-           l.ptrA2 == t.ptrA2 && l.ptrA3 == t.ptrA3;
+           l.ptrA2 == t.ptrA2 && l.ptrA3 == t.ptrA3 && 
+           l.format_hash_in == t.format_hash_in && l.format_hash_out == t.format_hash_out;
   }
 };
 

--- a/include/matx/transforms/convert/sparse2sparse_cusparse.h
+++ b/include/matx/transforms/convert/sparse2sparse_cusparse.h
@@ -68,8 +68,8 @@ struct Sparse2SparseParams_t {
 // Helper method to wrap pointer/size in new storage.
 template <typename T>
 __MATX_INLINE__ static auto wrapDefaultNonOwningStorage(T *ptr, size_t sz) {
-  raw_pointer_buffer<T, matx_allocator<T>> buf{ptr, sz * sizeof(T),
-                                               /*owning=*/false};
+  // FIX: raw_pointer_buffer constructor expects ELEMENT count, not byte count
+  raw_pointer_buffer<T, matx_allocator<T>> buf{ptr, sz, /*owning=*/false};
   return basic_storage<decltype(buf)>{std::move(buf)};
 }
 

--- a/test/00_misc/AllocatorTests.cu
+++ b/test/00_misc/AllocatorTests.cu
@@ -1,0 +1,356 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "assert.h"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+#include "gtest/gtest.h"
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+
+using namespace matx;
+
+// Example 1: Simple custom allocator - NO INHERITANCE REQUIRED!
+class TrackedAllocator {
+private:
+    static inline std::unordered_map<void*, size_t> allocations_;
+    static inline size_t total_allocated_ = 0;
+    
+public:
+    // Duck-typed interface - just implement these methods!
+    void* allocate(size_t bytes) {
+        void* ptr = std::malloc(bytes);
+        allocations_[ptr] = bytes;
+        total_allocated_ += bytes;
+        std::cout << "TrackedAllocator::allocate(" << bytes << ") -> " << ptr << std::endl;
+        return ptr;
+    }
+    
+    void deallocate(void* ptr, size_t bytes) {
+        auto it = allocations_.find(ptr);
+        if (it != allocations_.end()) {
+            total_allocated_ -= it->second;
+            allocations_.erase(it);
+        }
+        std::cout << "TrackedAllocator::deallocate(" << ptr << ", " << bytes << ")" << std::endl;
+        std::free(ptr);
+    }
+    
+    // Utility methods for testing
+    static size_t getTotalAllocated() { return total_allocated_; }
+    static size_t getActiveAllocations() { return allocations_.size(); }
+    static void reset() { 
+        allocations_.clear(); 
+        total_allocated_ = 0; 
+    }
+};
+
+// Example 2: Pool allocator - also NO INHERITANCE!
+class PoolAllocator {
+private:
+    std::vector<char> pool_;
+    size_t offset_ = 0;
+    
+public:
+    PoolAllocator(size_t pool_size) : pool_(pool_size) {
+        std::cout << "PoolAllocator created with " << pool_size << " bytes" << std::endl;
+    }
+    
+    // Duck-typed interface
+    void* allocate(size_t bytes) {
+        if (offset_ + bytes > pool_.size()) {
+            throw std::bad_alloc();
+        }
+        void* ptr = pool_.data() + offset_;
+        offset_ += bytes;
+        std::cout << "PoolAllocator::allocate(" << bytes << ") -> " << ptr 
+                  << " (offset now " << offset_ << ")" << std::endl;
+        return ptr;
+    }
+    
+    void deallocate(void* ptr, size_t bytes) {
+        // Simple pool - just log the deallocation
+        std::cout << "PoolAllocator::deallocate(" << ptr << ", " << bytes << ")" << std::endl;
+    }
+    
+    size_t getBytesUsed() const { return offset_; }
+};
+
+// Example 3: Debug allocator with alignment
+struct AlignedDebugAllocator {
+    size_t alignment_;
+    
+    AlignedDebugAllocator(size_t alignment = 64) : alignment_(alignment) {}
+    
+    // Duck-typed interface
+    void* allocate(size_t bytes) {
+        size_t aligned_bytes = (bytes + alignment_ - 1) & ~(alignment_ - 1);
+        void* ptr = std::aligned_alloc(alignment_, aligned_bytes);
+        std::cout << "AlignedDebugAllocator::allocate(" << bytes 
+                  << ") aligned to " << aligned_bytes << " -> " << ptr << std::endl;
+        return ptr;
+    }
+    
+    void deallocate(void* ptr, size_t bytes) {
+        std::cout << "AlignedDebugAllocator::deallocate(" << ptr << ", " << bytes << ")" << std::endl;
+        std::free(ptr);
+    }
+};
+
+class DuckTypingAllocatorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        TrackedAllocator::reset();
+    }
+    
+    void TearDown() override {
+        TrackedAllocator::reset();
+    }
+};
+
+TEST_F(DuckTypingAllocatorTest, TrackedAllocatorObject) {
+    MATX_ENTER_HANDLER();
+    std::cout << "\n=== Testing TrackedAllocator with Storage (object) ===" << std::endl;
+    
+    TrackedAllocator alloc;
+    
+    {
+        // Use allocator object directly - no inheritance required!
+        Storage<float> storage(1000, alloc);
+        
+        EXPECT_NE(storage.data(), nullptr);
+        EXPECT_EQ(storage.size(), 1000);
+        EXPECT_GT(TrackedAllocator::getTotalAllocated(), 0);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+        
+        // Test the storage actually works
+        storage.data()[0] = 42.0f;
+        storage.data()[999] = 99.0f;
+        EXPECT_EQ(storage.data()[0], 42.0f);
+        EXPECT_EQ(storage.data()[999], 99.0f);
+    }
+    
+    // After destruction, memory should be freed
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0);
+    
+    MATX_EXIT_HANDLER();
+}
+
+TEST_F(DuckTypingAllocatorTest, TrackedAllocatorPointer) {
+    MATX_ENTER_HANDLER();
+    std::cout << "\n=== Testing TrackedAllocator with Storage (pointer) ===" << std::endl;
+    
+    TrackedAllocator alloc;
+    
+    {
+        // Use allocator pointer - also works!
+        Storage<double> storage(500, &alloc);
+        
+        EXPECT_NE(storage.data(), nullptr);
+        EXPECT_EQ(storage.size(), 500);
+        EXPECT_GT(TrackedAllocator::getTotalAllocated(), 0);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+    }
+    
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0);
+    
+    MATX_EXIT_HANDLER();
+}
+
+TEST_F(DuckTypingAllocatorTest, FactoryFunction) {
+    MATX_ENTER_HANDLER();
+    std::cout << "\n=== Testing TrackedAllocator with make_owning_storage ===" << std::endl;
+    
+    TrackedAllocator alloc;
+    
+    {
+        // Use with factory function
+        auto storage = make_owning_storage<int>(2000, alloc);
+        
+        EXPECT_NE(storage.data(), nullptr);
+        EXPECT_EQ(storage.size(), 2000);
+        EXPECT_GT(TrackedAllocator::getTotalAllocated(), 0);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+    }
+    
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0);
+    
+    MATX_EXIT_HANDLER();
+}
+
+TEST_F(DuckTypingAllocatorTest, PoolAllocator) {
+    MATX_ENTER_HANDLER();
+    std::cout << "\n=== Testing PoolAllocator ===" << std::endl;
+    
+    PoolAllocator pool(10000);  // 10KB pool
+    
+    {
+        Storage<float> storage1(100, pool);  // 400 bytes
+        Storage<int> storage2(200, pool);    // 800 bytes
+        
+        EXPECT_NE(storage1.data(), nullptr);
+        EXPECT_NE(storage2.data(), nullptr);
+        EXPECT_EQ(storage1.size(), 100);
+        EXPECT_EQ(storage2.size(), 200);
+        
+        // Pool should have allocated bytes
+        EXPECT_GT(pool.getBytesUsed(), 0);
+        
+        // Test the storages work
+        storage1.data()[0] = 3.14f;
+        storage2.data()[0] = 42;
+        EXPECT_EQ(storage1.data()[0], 3.14f);
+        EXPECT_EQ(storage2.data()[0], 42);
+    }
+    
+    std::cout << "Pool used " << pool.getBytesUsed() << " bytes total" << std::endl;
+    
+    MATX_EXIT_HANDLER();
+}
+
+TEST_F(DuckTypingAllocatorTest, AlignedAllocator) {
+    MATX_ENTER_HANDLER();
+    std::cout << "\n=== Testing AlignedDebugAllocator ===" << std::endl;
+    
+    AlignedDebugAllocator aligned_alloc(128);  // 128-byte alignment
+    
+    {
+        Storage<double> storage(64, aligned_alloc);
+        
+        EXPECT_NE(storage.data(), nullptr);
+        EXPECT_EQ(storage.size(), 64);
+        
+        // Check alignment
+        uintptr_t addr = reinterpret_cast<uintptr_t>(storage.data());
+        EXPECT_EQ(addr % 128, 0);  // Should be 128-byte aligned
+        
+        std::cout << "Storage pointer: " << storage.data() 
+                  << " (aligned to 128 bytes)" << std::endl;
+    }
+    
+    MATX_EXIT_HANDLER();
+}
+
+TEST_F(DuckTypingAllocatorTest, SharedOwnership) {
+    MATX_ENTER_HANDLER();
+    std::cout << "\n=== Testing Shared Ownership ===" << std::endl;
+    
+    TrackedAllocator alloc;
+    
+    {
+        Storage<int> storage1(100, alloc);
+        EXPECT_EQ(storage1.use_count(), 1);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+        
+        {
+            Storage<int> storage2 = storage1;  // Copy constructor
+            EXPECT_EQ(storage1.use_count(), 2);
+            EXPECT_EQ(storage2.use_count(), 2);
+            EXPECT_EQ(storage1.data(), storage2.data());  // Same data
+            EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);  // Still one allocation
+        }
+        
+        // After storage2 is destroyed, storage1 should still work
+        EXPECT_EQ(storage1.use_count(), 1);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+        storage1.data()[0] = 42;
+        EXPECT_EQ(storage1.data()[0], 42);
+    }
+    
+    // Now memory should be freed
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0);
+    
+    MATX_EXIT_HANDLER();
+}
+
+TEST_F(DuckTypingAllocatorTest, CompareWithDefault) {
+    MATX_ENTER_HANDLER();
+    std::cout << "\n=== Comparing Custom vs Default Allocator ===" << std::endl;
+    
+    TrackedAllocator custom_alloc;
+    
+    {
+        Storage<float> default_storage(1000);           // Default allocator
+        Storage<float> custom_storage(1000, custom_alloc);  // Custom allocator
+        
+        EXPECT_NE(default_storage.data(), nullptr);
+        EXPECT_NE(custom_storage.data(), nullptr);
+        EXPECT_EQ(default_storage.size(), 1000);
+        EXPECT_EQ(custom_storage.size(), 1000);
+        
+        // Only custom allocator should be tracked
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+        
+        // Both should work the same way
+        default_storage.data()[0] = 1.0f;
+        custom_storage.data()[0] = 2.0f;
+        EXPECT_EQ(default_storage.data()[0], 1.0f);
+        EXPECT_EQ(custom_storage.data()[0], 2.0f);
+    }
+    
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0);
+    
+    MATX_EXIT_HANDLER();
+}
+
+// Demonstrate that it works with tensor_t too!
+TEST_F(DuckTypingAllocatorTest, WithTensorAPI) {
+    MATX_ENTER_HANDLER();
+    std::cout << "\n=== Testing with Tensor API ===" << std::endl;
+    
+    TrackedAllocator alloc;
+    
+    {
+        // Create storage with custom allocator
+        auto storage = make_owning_storage<float>(1000, alloc);
+        
+        // Use with tensor_t (this shows the full integration)
+        DefaultDescriptor<1> desc({1000});
+        tensor_t<float, 1> tensor(std::move(storage), std::move(desc));
+        
+        EXPECT_NE(tensor.Data(), nullptr);
+        EXPECT_EQ(tensor.Size(0), 1000);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+        
+        // Test tensor operations
+        tensor(0) = 3.14f;
+        tensor(999) = 2.71f;
+        EXPECT_EQ(tensor(0), 3.14f);
+        EXPECT_EQ(tensor(999), 2.71f);
+    }
+    
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0);
+    
+    MATX_EXIT_HANDLER();
+}

--- a/test/00_tensor/Storage.cu
+++ b/test/00_tensor/Storage.cu
@@ -1,0 +1,507 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "assert.h"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+#include "gtest/gtest.h"
+#include <memory>
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+
+using namespace matx;
+
+// Test Custom Allocators - NO INHERITANCE REQUIRED!
+
+/**
+ * @brief TrackedAllocator - tracks allocation/deallocation calls
+ */
+class TrackedAllocator {
+private:
+    static std::atomic<size_t> allocations_;
+    static std::atomic<size_t> total_bytes_;
+    std::string name_;
+    
+public:
+    TrackedAllocator(const std::string& name = "TrackedAlloc") : name_(name) {}
+    
+    // Duck-typed interface - just implement these methods!
+    void* allocate(size_t bytes) {
+        void* ptr = std::malloc(bytes);
+        allocations_++;
+        total_bytes_ += bytes;
+        return ptr;
+    }
+    
+    void deallocate(void* ptr, size_t bytes) {
+        allocations_--;
+        total_bytes_ -= bytes;
+        std::free(ptr);
+    }
+    
+    static size_t getActiveAllocations() { return allocations_.load(); }
+    static size_t getTotalBytes() { return total_bytes_.load(); }
+    static void reset() { 
+        allocations_ = 0; 
+        total_bytes_ = 0;
+    }
+};
+
+std::atomic<size_t> TrackedAllocator::allocations_{0};
+std::atomic<size_t> TrackedAllocator::total_bytes_{0};
+
+/**
+ * @brief PoolAllocator - allocates from a fixed-size memory pool
+ */
+class PoolAllocator {
+private:
+    std::shared_ptr<char[]> pool_;
+    size_t pool_size_;
+    std::shared_ptr<size_t> offset_;  // Shared to support copying
+    
+public:
+    PoolAllocator(size_t size) 
+      : pool_(new char[size], std::default_delete<char[]>{}), 
+        pool_size_(size),
+        offset_(std::make_shared<size_t>(0)) {}
+    
+    // Duck-typed interface
+    void* allocate(size_t bytes) {
+        if (*offset_ + bytes > pool_size_) {
+            throw std::bad_alloc();
+        }
+        void* ptr = pool_.get() + *offset_;
+        *offset_ += bytes;
+        return ptr;
+    }
+    
+    void deallocate(void* ptr, size_t bytes) {
+        // Pool allocator doesn't deallocate individual allocations
+        (void)ptr;    // Unused
+        (void)bytes;  // Unused
+    }
+    
+    size_t getUsedBytes() const { return *offset_; }
+    size_t getRemainingBytes() const { return pool_size_ - *offset_; }
+    void reset() { *offset_ = 0; }
+};
+
+/**
+ * @brief AlignedAllocator - allocates memory with custom alignment
+ */
+class AlignedAllocator {
+private:
+    size_t alignment_;
+    
+public:
+    AlignedAllocator(size_t alignment = 64) : alignment_(alignment) {}
+    
+    // Duck-typed interface
+    void* allocate(size_t bytes) {
+        size_t aligned_bytes = (bytes + alignment_ - 1) & ~(alignment_ - 1);
+        void* ptr = std::aligned_alloc(alignment_, aligned_bytes);
+        if (!ptr) throw std::bad_alloc();
+        return ptr;
+    }
+    
+    void deallocate(void* ptr, size_t bytes) {
+        (void)bytes;  // Unused - size not needed for std::free
+        std::free(ptr);
+    }
+    
+    size_t getAlignment() const { return alignment_; }
+};
+
+/**
+ * @brief DebugAllocator - fills memory with patterns and checks for overwrites
+ */
+class DebugAllocator {
+private:
+    static constexpr uint8_t ALLOC_PATTERN = 0xAA;
+    static constexpr uint8_t FREE_PATTERN = 0xDD;
+    
+public:
+    void* allocate(size_t bytes) {
+        void* ptr = std::malloc(bytes);
+        if (ptr) {
+            std::memset(ptr, ALLOC_PATTERN, bytes);
+        }
+        return ptr;
+    }
+    
+    void deallocate(void* ptr, size_t bytes) {
+        if (ptr) {
+            std::memset(ptr, FREE_PATTERN, bytes);
+        }
+        std::free(ptr);
+    }
+};
+
+// Test fixture for Storage tests
+class StorageTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        TrackedAllocator::reset();
+    }
+    
+    void TearDown() override {
+        // Verify all allocations are freed
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0) 
+            << "Memory leak detected: " << TrackedAllocator::getActiveAllocations() 
+            << " allocations still active";
+    }
+};
+
+// Test basic storage creation with default allocator
+TEST_F(StorageTest, DefaultAllocator) {
+    Storage<float> storage(1000);
+    EXPECT_EQ(storage.size(), 1000);
+    EXPECT_NE(storage.data(), nullptr);
+    
+    // Write and read data
+    storage.data()[0] = 3.14f;
+    storage.data()[999] = 2.718f;
+    EXPECT_FLOAT_EQ(storage.data()[0], 3.14f);
+    EXPECT_FLOAT_EQ(storage.data()[999], 2.718f);
+}
+
+// Test non-owning storage
+TEST_F(StorageTest, NonOwningStorage) {
+    float data[100];
+    Storage<float> storage(data, 100);
+    
+    EXPECT_EQ(storage.size(), 100);
+    EXPECT_EQ(storage.data(), data);
+    
+    // Verify we can read/write
+    storage.data()[0] = 1.0f;
+    EXPECT_FLOAT_EQ(data[0], 1.0f);
+}
+
+// Test TrackedAllocator with object
+TEST_F(StorageTest, TrackedAllocatorObject) {
+    TrackedAllocator alloc("TestAlloc");
+    
+    {
+        Storage<float> storage(1000, alloc);
+        EXPECT_EQ(storage.size(), 1000);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+        EXPECT_EQ(TrackedAllocator::getTotalBytes(), 1000 * sizeof(float));
+        
+        // Use the storage
+        storage.data()[0] = 42.0f;
+        EXPECT_FLOAT_EQ(storage.data()[0], 42.0f);
+    }
+    
+    // Verify cleanup
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0);
+}
+
+// Test TrackedAllocator with pointer
+TEST_F(StorageTest, TrackedAllocatorPointer) {
+    TrackedAllocator alloc("TestAlloc");
+    
+    {
+        Storage<double> storage(500, &alloc);
+        EXPECT_EQ(storage.size(), 500);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+        EXPECT_EQ(TrackedAllocator::getTotalBytes(), 500 * sizeof(double));
+    }
+    
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0);
+}
+
+// Test PoolAllocator
+TEST_F(StorageTest, PoolAllocator) {
+    const size_t pool_size = 10000;
+    PoolAllocator pool(pool_size);
+    
+    Storage<int> storage1(100, pool);
+    Storage<float> storage2(200, pool);
+    
+    EXPECT_EQ(storage1.size(), 100);
+    EXPECT_EQ(storage2.size(), 200);
+    
+    // Verify pool usage
+    size_t expected_usage = 100 * sizeof(int) + 200 * sizeof(float);
+    EXPECT_EQ(pool.getUsedBytes(), expected_usage);
+    EXPECT_EQ(pool.getRemainingBytes(), pool_size - expected_usage);
+    
+    // Write data to both storages
+    storage1.data()[0] = 42;
+    storage2.data()[0] = 3.14f;
+    EXPECT_EQ(storage1.data()[0], 42);
+    EXPECT_FLOAT_EQ(storage2.data()[0], 3.14f);
+}
+
+// Test PoolAllocator exhaustion
+TEST_F(StorageTest, PoolAllocatorExhaustion) {
+    const size_t pool_size = 1000;
+    PoolAllocator pool(pool_size);
+    
+    // This should succeed
+    Storage<char> storage1(500, pool);
+    
+    // This should also succeed
+    Storage<char> storage2(400, pool);
+    
+    // This should fail (not enough space)
+    EXPECT_THROW({
+        Storage<char> storage3(200, pool);
+    }, std::bad_alloc);
+}
+
+// Test AlignedAllocator
+TEST_F(StorageTest, AlignedAllocator) {
+    const size_t alignment = 128;
+    AlignedAllocator aligned(alignment);
+    
+    Storage<double> storage(64, aligned);
+    
+    // Verify alignment
+    uintptr_t addr = reinterpret_cast<uintptr_t>(storage.data());
+    EXPECT_EQ(addr % alignment, 0) << "Memory not properly aligned";
+    
+    // Verify we can use the storage
+    storage.data()[0] = 1.23;
+    EXPECT_DOUBLE_EQ(storage.data()[0], 1.23);
+}
+
+// Test DebugAllocator
+TEST_F(StorageTest, DebugAllocator) {
+    DebugAllocator debug;
+    
+    {
+        Storage<uint8_t> storage(100, debug);
+        
+        // Verify memory is filled with allocation pattern
+        bool all_match = true;
+        for (size_t i = 0; i < 100; ++i) {
+            if (storage.data()[i] != 0xAA) {
+                all_match = false;
+                break;
+            }
+        }
+        EXPECT_TRUE(all_match) << "Debug allocator didn't fill memory with expected pattern";
+        
+        // Modify some data
+        storage.data()[0] = 0xFF;
+        storage.data()[99] = 0xEE;
+    }
+    // Storage destroyed, memory should be freed
+}
+
+// Test make_owning_storage factory function
+TEST_F(StorageTest, FactoryFunction) {
+    TrackedAllocator alloc;
+    
+    {
+        auto storage = make_owning_storage<float>(777, alloc);
+        EXPECT_EQ(storage.size(), 777);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+        
+        // Use the storage
+        storage.data()[0] = 3.14f;
+        EXPECT_FLOAT_EQ(storage.data()[0], 3.14f);
+    }
+    
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 0);
+}
+
+// Test shared ownership
+TEST_F(StorageTest, SharedOwnership) {
+    TrackedAllocator alloc;
+    
+    Storage<int> original(100, alloc);
+    EXPECT_EQ(original.use_count(), 1);
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+    
+    // Write some data
+    original.data()[0] = 42;
+    original.data()[99] = 999;
+    
+    {
+        Storage<int> copy = original;
+        EXPECT_EQ(original.use_count(), 2);
+        EXPECT_EQ(copy.use_count(), 2);
+        EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1); // Still just one allocation
+        
+        // Verify they share the same data
+        EXPECT_EQ(original.data(), copy.data());
+        EXPECT_EQ(copy.data()[0], 42);
+        EXPECT_EQ(copy.data()[99], 999);
+        
+        // Modify through copy
+        copy.data()[50] = 500;
+    }
+    
+    // Copy destroyed, original should still be valid
+    EXPECT_EQ(original.use_count(), 1);
+    EXPECT_EQ(original.data()[50], 500); // Change made through copy is visible
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+}
+
+// Test copy semantics (Storage uses shared_ptr, so it's copy-based sharing)
+TEST_F(StorageTest, CopySemantics) {
+    TrackedAllocator alloc;
+    
+    Storage<float> original(200, alloc);
+    original.data()[0] = 1.23f;
+    
+    float* original_ptr = original.data();
+    
+    // Copy construction (Storage doesn't have explicit move semantics)
+    Storage<float> copied(original);
+    EXPECT_EQ(copied.data(), original_ptr);
+    EXPECT_EQ(copied.size(), 200);
+    EXPECT_FLOAT_EQ(copied.data()[0], 1.23f);
+    
+    // Both should share the same data
+    EXPECT_EQ(original.data(), copied.data());
+    EXPECT_EQ(original.use_count(), 2);
+    EXPECT_EQ(copied.use_count(), 2);
+    
+    // Copy assignment
+    Storage<float> assigned;
+    assigned = copied;
+    EXPECT_EQ(assigned.data(), original_ptr);
+    EXPECT_EQ(assigned.size(), 200);
+    EXPECT_EQ(original.use_count(), 3);
+    
+    // Cleanup check - still only one allocation
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+}
+
+// Test multiple allocators simultaneously
+TEST_F(StorageTest, MultipleAllocators) {
+    TrackedAllocator tracked1("Alloc1");
+    TrackedAllocator tracked2("Alloc2");
+    AlignedAllocator aligned(256);
+    DebugAllocator debug;
+    
+    Storage<float> s1(100, tracked1);
+    Storage<double> s2(200, tracked2);
+    Storage<int> s3(50, aligned);
+    Storage<char> s4(1000, debug);
+    
+    // Verify all storages are valid
+    EXPECT_EQ(s1.size(), 100);
+    EXPECT_EQ(s2.size(), 200);
+    EXPECT_EQ(s3.size(), 50);
+    EXPECT_EQ(s4.size(), 1000);
+    
+    // Verify tracked allocator is tracking correctly
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 2);
+    
+    // Verify alignment
+    uintptr_t addr = reinterpret_cast<uintptr_t>(s3.data());
+    EXPECT_EQ(addr % 256, 0);
+}
+
+// Test with tensor integration (if tensor_t is available)
+TEST_F(StorageTest, TensorIntegration) {
+    TrackedAllocator alloc;
+    
+    // Create storage with custom allocator
+    auto storage = make_owning_storage<float>(1000, alloc);
+    
+    // Create tensor from storage
+    DefaultDescriptor<1> desc({1000});
+    tensor_t<float, 1> tensor(std::move(storage), std::move(desc));
+    
+    EXPECT_EQ(tensor.Size(0), 1000);
+    EXPECT_EQ(TrackedAllocator::getActiveAllocations(), 1);
+    
+    // Use the tensor
+    tensor(0) = 3.14f;
+    tensor(999) = 2.718f;
+    EXPECT_FLOAT_EQ(tensor(0), 3.14f);
+    EXPECT_FLOAT_EQ(tensor(999), 2.718f);
+}
+
+// Test iterator interface
+TEST_F(StorageTest, IteratorInterface) {
+    Storage<int> storage(10);
+    
+    // Fill with values
+    int value = 0;
+    for (auto& elem : storage) {
+        elem = value++;
+    }
+    
+    // Verify with const iterator
+    const Storage<int>& const_storage = storage;
+    value = 0;
+    for (const auto& elem : const_storage) {
+        EXPECT_EQ(elem, value++);
+    }
+    
+    // Test iterator arithmetic
+    EXPECT_EQ(storage.end() - storage.begin(), 10);
+    EXPECT_EQ(*(storage.begin() + 5), 5);
+}
+
+// Test empty storage
+TEST_F(StorageTest, EmptyStorage) {
+    Storage<float> empty;
+    
+    EXPECT_EQ(empty.size(), 0);
+    EXPECT_EQ(empty.data(), nullptr);
+    EXPECT_EQ(empty.begin(), empty.end());
+    EXPECT_EQ(empty.use_count(), 0);
+    
+    // Copy of empty storage
+    Storage<float> copy = empty;
+    EXPECT_EQ(copy.size(), 0);
+    EXPECT_EQ(copy.data(), nullptr);
+}
+
+// Test type traits for allocator detection
+TEST_F(StorageTest, AllocatorTypeTraits) {
+    // These should have allocator interface
+    EXPECT_TRUE(has_allocator_interface<TrackedAllocator>::value);
+    EXPECT_TRUE(has_allocator_interface<PoolAllocator>::value);
+    EXPECT_TRUE(has_allocator_interface<AlignedAllocator>::value);
+    EXPECT_TRUE(has_allocator_interface<DebugAllocator>::value);
+    
+    // Pointer versions should also work
+    EXPECT_TRUE(has_allocator_interface<TrackedAllocator*>::value);
+    EXPECT_TRUE(has_allocator_interface<PoolAllocator*>::value);
+    
+    // These should not have allocator interface
+    struct NotAnAllocator {};
+    EXPECT_FALSE(has_allocator_interface<NotAnAllocator>::value);
+    EXPECT_FALSE(has_allocator_interface<int>::value);
+    EXPECT_FALSE(has_allocator_interface<float*>::value);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ include(00_operators/CMakeLists.txt)
 list(TRANSFORM OPERATOR_TEST_FILES PREPEND "00_operators/")
 
 set (test_sources
+    00_misc/AllocatorTests.cu
     00_tensor/BasicTensorTests.cu
     00_tensor/CUBTests.cu
     00_tensor/ViewTests.cu

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set (test_sources
     00_misc/AllocatorTests.cu
     00_tensor/BasicTensorTests.cu
     00_tensor/CUBTests.cu
+    00_tensor/Storage.cu
     00_tensor/ViewTests.cu
     00_tensor/VizTests.cu
     00_tensor/TensorCreationTests.cu


### PR DESCRIPTION
- Replace template-based Storage with unified Storage<T> class
- Remove inheritance requirement from pmr_allocator_interface
- Implement pure duck typing - users just need allocate()/deallocate() methods
- Add SFINAE detection for both allocator objects and pointers
- Support owning/non-owning constructors with optional custom allocators
- Eliminate dynamic allocation overhead for common allocator cases
- Maintain backward compatibility with legacy sparse tensor types
- Add comprehensive unit tests for duck-typed allocator system
- Organize tests in new test/00_misc/ directory following MatX conventions

This provides maximum flexibility while removing inheritance requirements and virtual function overhead. Users can now implement any allocator without inheriting from base classes - if it has allocate() and deallocate() methods, it works automatically via SFINAE detection.

Closes #1043 #48 