### PR TITLE
Add conditional CUDA 13+ support for select vector types

### DIFF
--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -1202,7 +1202,11 @@ template <> struct VecTypeSelector<float, 4> { using type = float4; };
 template <> struct VecTypeSelector<double, 1> { using type = double1; };
 template <> struct VecTypeSelector<double, 2> { using type = double2; };
 template <> struct VecTypeSelector<double, 3> { using type = double3; };
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 13
+template <> struct VecTypeSelector<double, 4> { using type = double4_32a; };
+#else
 template <> struct VecTypeSelector<double, 4> { using type = double4; };
+#endif
 
 template <> struct VecTypeSelector<char, 1> { using type = char1; };
 template <> struct VecTypeSelector<char, 2> { using type = char2; };
@@ -1237,22 +1241,38 @@ template <> struct VecTypeSelector<unsigned int, 4> { using type = uint4; };
 template <> struct VecTypeSelector<long, 1> { using type = long1; };
 template <> struct VecTypeSelector<long, 2> { using type = long2; };
 template <> struct VecTypeSelector<long, 3> { using type = long3; };
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 13
+template <> struct VecTypeSelector<long, 4> { using type = long4_32a; };
+#else
 template <> struct VecTypeSelector<long, 4> { using type = long4; };
+#endif
 
 template <> struct VecTypeSelector<unsigned long, 1> { using type = ulong1; };
 template <> struct VecTypeSelector<unsigned long, 2> { using type = ulong2; };
 template <> struct VecTypeSelector<unsigned long, 3> { using type = ulong3; };
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 13
+template <> struct VecTypeSelector<unsigned long, 4> { using type = ulong4_32a; };
+#else
 template <> struct VecTypeSelector<unsigned long, 4> { using type = ulong4; };
+#endif
 
 template <> struct VecTypeSelector<long long, 1> { using type = longlong1; };
 template <> struct VecTypeSelector<long long, 2> { using type = longlong2; };
 template <> struct VecTypeSelector<long long, 3> { using type = longlong3; };
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 13
+template <> struct VecTypeSelector<long long, 4> { using type = longlong4_32a; };
+#else
 template <> struct VecTypeSelector<long long, 4> { using type = longlong4; };
+#endif
 
 template <> struct VecTypeSelector<unsigned long long, 1> { using type = ulonglong1; };
 template <> struct VecTypeSelector<unsigned long long, 2> { using type = ulonglong2; };
 template <> struct VecTypeSelector<unsigned long long, 3> { using type = ulonglong3; };
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 13
+template <> struct VecTypeSelector<unsigned long long, 4> { using type = ulonglong4_32a; };
+#else
 template <> struct VecTypeSelector<unsigned long long, 4> { using type = ulonglong4; };
+#endif
 
 template <typename... Ts>
 struct AggregateToVec {

--- a/include/matx/core/vector.h
+++ b/include/matx/core/vector.h
@@ -53,17 +53,29 @@ constexpr size_t __MATX_HOST__ __MATX_DEVICE__ alignment_by_type() {
     return 4;
   } else if constexpr (std::is_same_v<T, long3> || std::is_same_v<T, ulong3>) {
     return sizeof(long) == sizeof(int) ? 4 : 8;
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 13
+  } else if constexpr (std::is_same_v<T, long4_32a> || std::is_same_v<T, ulong4_32a>) {
+#else
   } else if constexpr (std::is_same_v<T, long4> || std::is_same_v<T, ulong4>) {
+#endif
     return 16;
   } else if constexpr (std::is_same_v<T, longlong3> || std::is_same_v<T, ulonglong3>) {
     return 8;
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 13
+  } else if constexpr (std::is_same_v<T, longlong4_32a> || std::is_same_v<T, ulonglong4_32a>) {
+#else
   } else if constexpr (std::is_same_v<T, longlong4> || std::is_same_v<T, ulonglong4>) {
+#endif
     return 16;
   } else if constexpr (std::is_same_v<T, float3>) {
     return 4;
   } else if constexpr (std::is_same_v<T, double3>) {
     return 8;
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 13
+  } else if constexpr (std::is_same_v<T, double4_32a>) {
+#else
   } else if constexpr (std::is_same_v<T, double4>) {
+#endif
     return 16;
   } else {
     return sizeof(T);


### PR DESCRIPTION
- Add CUDA version detection for double4, long4, ulong4, longlong4, ulonglong4
- Use _32a suffix variants for CUDA 13+ compatibility
- Maintain backward compatibility with legacy vector type names for older CUDA versions
- Conditional compilation based on __CUDACC_VER_MAJOR__ >= 13

Affected files:
- include/matx/core/vector.h: Updated alignment checks and type comparisons
- include/matx/core/type_utils.h: Added conditional VecTypeSelector specializations