### PR TITLE
Use index_t with get_grid_dims to support 32-bit builds

### DIFF
--- a/examples/channelize_poly_bench.cu
+++ b/examples/channelize_poly_bench.cu
@@ -105,7 +105,8 @@ void ChannelizePolyBench(matx::index_t channel_start, matx::index_t channel_stop
       cudaEventElapsedTime(&elapsed_ms, start, stop);
 
       const double avg_elapsed_us = (static_cast<double>(elapsed_ms)/NUM_ITERATIONS)*1.0e3;
-      printf("Batches: %5lld Channels: %5lld FilterLen: %5lld InputLen: %7lld Elapsed Usecs: %12.1f MPts/sec: %12.3f\n",
+      printf("Batches: %5" MATX_INDEX_T_FMT " Channels: %5" MATX_INDEX_T_FMT " FilterLen: %5" MATX_INDEX_T_FMT
+        " InputLen: %7" MATX_INDEX_T_FMT " Elapsed Usecs: %12.1f MPts/sec: %12.3f\n",
         num_batches, num_channels, filter_len, input_len, avg_elapsed_us,
         static_cast<double>(num_batches*num_channels*output_len_per_channel)/1.0e6/(avg_elapsed_us/1.0e6));
     }

--- a/include/matx/core/get_grid_dims.h
+++ b/include/matx/core/get_grid_dims.h
@@ -38,7 +38,7 @@ namespace matx {
 namespace detail {
 
 template <int RANK>
-inline bool get_grid_dims(dim3 &blocks, dim3 &threads, const cuda::std::array<index_t, RANK> &sizes, uint32_t ept,
+inline bool get_grid_dims(dim3 &blocks, dim3 &threads, const cuda::std::array<index_t, RANK> &sizes, index_t ept,
                           int max_cta_size = 1024)
 {
   bool stride = false;
@@ -56,7 +56,7 @@ inline bool get_grid_dims(dim3 &blocks, dim3 &threads, const cuda::std::array<in
       nt *= 2;
     }
     // launch as many blocks as necessary
-    int rnd_threads = ept * threads.x;
+    index_t rnd_threads = ept * threads.x;
     blocks.x = static_cast<int>((sizes[0] + rnd_threads - 1) / rnd_threads);  
     blocks.y = 1;
     blocks.z = 1;  
@@ -72,7 +72,7 @@ inline bool get_grid_dims(dim3 &blocks, dim3 &threads, const cuda::std::array<in
       nt *= 2;
     }
     // launch as many blocks as necessary
-    int rnd_threads_x = ept * threads.x;
+    index_t rnd_threads_x = ept * threads.x;
     blocks.x = static_cast<int>((sizes[1] + rnd_threads_x - 1) / rnd_threads_x);
     blocks.y = static_cast<int>((sizes[0] + threads.y - 1) / threads.y);
     blocks.z = 1; 


### PR DESCRIPTION
A uint32_t elements-per-thread (ept) parameter is compatible with 64-bit index_t values, but will generate narrowing conversions when index_t is int32_t. Change that parameter to index_t to support builds with a 32-bit index_t. Also fix a few other conversion or format issues related to 32-bit builds.