### PR TITLE
Rename `version_config.h` -> `matx/version_config.h`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if (NOT CMAKE_CUDA_ARCHITECTURES)
 endif()
 message(STATUS "Using GPU architectures ${CMAKE_CUDA_ARCHITECTURES}")
 
-rapids_cmake_write_version_file(include/version_config.h)
+rapids_cmake_write_version_file(include/matx/version_config.h)
 
 # Command line options
 option(MATX_BUILD_EXAMPLES "Build examples" OFF)
@@ -362,7 +362,7 @@ if (NOT_SUBPROJECT)
 
     install(TARGETS matx EXPORT matx-exports)
     install(DIRECTORY include/ DESTINATION include)
-    install(FILES ${CMAKE_BINARY_DIR}/include/version_config.h DESTINATION include)
+    install(FILES ${CMAKE_BINARY_DIR}/include/matx/version_config.h DESTINATION include)
 
     set(doc_string
     [=[


### PR DESCRIPTION
Just a suggestion to be more in line with other NVIDIA/RAPIDS libraries: https://github.com/search?q=%22rapids_cmake_write_version_file%28include%2F%22+language%3ACMake&ref=opensearch&type=code

Having to do `#include <version_config.h>` to get the version defines for MatX is confusing and looks incorrect, especially considering that most of the actual headers live under `matx/...`.