### PR TITLE
Avoid deprecated `thrust` iterators

### DIFF
--- a/include/matx/transforms/cccl_iterators.h
+++ b/include/matx/transforms/cccl_iterators.h
@@ -1,0 +1,61 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+
+#pragma once
+
+//! @file CCCL is deprecating a lot of thrust iterators for the newer `cuda` iterators
+//! Work around the deprecation warning by conditionally replacing the definition of the iterators
+
+#include <cuda/std/version>
+#if CCCL_VERSION >= 3002000
+#include <cuda/iterator>
+#else // CCCL_VERSION < 3002000
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+#endif // CCCL_VERSION < 3002000
+
+namespace matx::detail {
+
+#if CCCL_VERSION >= 3002000
+using ::cuda::counting_iterator;
+using ::cuda::make_counting_iterator;
+using ::cuda::zip_iterator;
+using ::cuda::make_zip_iterator;
+#else // CCCL_VERSION < 3002000
+using thrust::counting_iterator;
+using thrust::make_counting_iterator;
+using thrust::zip_iterator;
+using thrust::make_zip_iterator;
+#endif // CCCL_VERSION < 3002000
+
+} // namespace matx::detail

--- a/include/matx/transforms/find_peaks.h
+++ b/include/matx/transforms/find_peaks.h
@@ -32,18 +32,17 @@
 
 #pragma once
 
-#include <thrust/copy.h>
-#include <thrust/execution_policy.h>
-#include <thrust/iterator/counting_iterator.h>
+#include <cuda/std/__algorithm/copy_if.h>
+
 #include "matx/core/type_utils.h"
 #include "matx/operators/base_operator.h"
 #include "matx/operators/permute.h"
 #include "matx/executors/cuda.h"
 #include "matx/executors/host.h"
+#include "matx/transforms/cccl_iterators.h"
 
 namespace matx {
 namespace detail {
-
 template <typename Op>
 struct PeakSearchCmpOp {
   using index_cmp_op = bool;
@@ -129,10 +128,9 @@ struct PeakSearchCmpOp {
     static_assert(MODE == ThreadsMode::SINGLE, "find_peaks() only supports a single threaded host executor");
 
     // Use thrust to find the number of peaks
-    const auto end_iter = thrust::copy_if(
-      thrust::host,
-      thrust::make_counting_iterator(static_cast<matx::index_t>(0)),
-      thrust::make_counting_iterator(TotalSize(in)),
+    const auto end_iter = cuda::std::copy_if(
+      detail::make_counting_iterator(static_cast<matx::index_t>(0)),
+      detail::make_counting_iterator(TotalSize(in)),
       out_idxs.Data(),
       PeakSearchCmpOp{in, height, threshold}
     );


### PR DESCRIPTION
I added a separate file, because we might deprecate other iterators too