### PR TITLE
Fixed-size reductions

### DIFF
--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -1,10 +1,10 @@
 {
   "packages": {
     "CCCL": {
-      "version": "3.2.0",
+      "version": "3.0.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "4071a73"
+      "git_tag": "e944297"
     },
     "nvbench" : {
       "version" : "0.0",

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -1,10 +1,10 @@
 {
   "packages": {
     "CCCL": {
-      "version": "3.0.0",
+      "version": "3.2.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "e944297"
+      "git_tag": "4071a73"
     },
     "nvbench" : {
       "version" : "0.0",


### PR DESCRIPTION
Add optimized fixed-size segmented reduce support for CUB 3.2+

Implement conditional support for CUB's new fixed-size segmented reduction API
when using CUB version 3.2 or higher. This optimization applies to both generic
reduce and sum operations when:
- Input is a tensor view
- Both input and output tensors are contiguous memory
- All segments have uniform size

The new implementation uses CUB's simplified API that takes a segment size
parameter instead of begin/end iterators, providing better performance for
uniform segment reductions.

Changes:
- Add version checks for CUB_MAJOR_VERSION >= 3 && CUB_MINOR_VERSION >= 2
- Implement fast path using fixed segment size for contiguous tensors
- Fall back to iterator-based API for non-contiguous or non-uniform cases
- Apply optimization to both DeviceSegmentedReduce::Reduce and ::Sum

This maintains backward compatibility while leveraging newer CUB features
when available.