### PR TITLE
Added enum documentation for all operators

### DIFF
--- a/docs_input/api/dft/fft/fft.rst
+++ b/docs_input/api/dft/fft/fft.rst
@@ -9,6 +9,15 @@ Perform a 1D FFT. Batching is supported for any tensor with a rank higher than 1
 .. doxygenfunction:: fft(const OpA &a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
 .. doxygenfunction:: fft(const OpA &a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
 
+FFT Normalization
+~~~~~~~~~~~~~~~~~
+
+The ``norm`` parameter specifies how the FFT and inverse FFT are scaled:
+
+- ``FFTNorm::BACKWARD``: FFT is unscaled, inverse FFT is scaled by 1/N (default)
+- ``FFTNorm::FORWARD``: FFT is scaled by 1/N, inverse FFT is unscaled
+- ``FFTNorm::ORTHO``: Both FFT and inverse FFT are scaled by 1/sqrt(N)
+
 Examples
 ~~~~~~~~
 .. literalinclude:: ../../../../test/00_transform/FFT.cu

--- a/docs_input/api/dft/fft/fft2d.rst
+++ b/docs_input/api/dft/fft/fft2d.rst
@@ -9,6 +9,15 @@ Perform a 2D FFT. Batching is supported for any tensor with a rank higher than 2
 .. doxygenfunction:: fft2(const OpA &a, FFTNorm norm = FFTNorm::BACKWARD)
 .. doxygenfunction:: fft2(const OpA &a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD)  
 
+FFT Normalization
+~~~~~~~~~~~~~~~~~
+
+The ``norm`` parameter specifies how the FFT and inverse FFT are scaled:
+
+- ``FFTNorm::BACKWARD``: FFT is unscaled, inverse FFT is scaled by 1/N (default)
+- ``FFTNorm::FORWARD``: FFT is scaled by 1/N, inverse FFT is unscaled
+- ``FFTNorm::ORTHO``: Both FFT and inverse FFT are scaled by 1/sqrt(N)
+
 Examples
 ~~~~~~~~
 .. literalinclude:: ../../../../test/00_transform/FFT.cu

--- a/docs_input/api/dft/fft/ifft.rst
+++ b/docs_input/api/dft/fft/ifft.rst
@@ -9,6 +9,15 @@ Perform a 1D inverse FFT. Batching is supported for any tensor with a rank highe
 .. doxygenfunction:: ifft(const OpA &a, uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
 .. doxygenfunction:: ifft(const OpA &a, const int32_t (&axis)[1], uint64_t fft_size = 0, FFTNorm norm = FFTNorm::BACKWARD)
 
+FFT Normalization
+~~~~~~~~~~~~~~~~~
+
+The ``norm`` parameter specifies how the FFT and inverse FFT are scaled:
+
+- ``FFTNorm::BACKWARD``: FFT is unscaled, inverse FFT is scaled by 1/N (default)
+- ``FFTNorm::FORWARD``: FFT is scaled by 1/N, inverse FFT is unscaled
+- ``FFTNorm::ORTHO``: Both FFT and inverse FFT are scaled by 1/sqrt(N)
+
 Examples
 ~~~~~~~~
 .. literalinclude:: ../../../../test/00_transform/FFT.cu

--- a/docs_input/api/dft/fft/ifft2.rst
+++ b/docs_input/api/dft/fft/ifft2.rst
@@ -8,6 +8,15 @@ Perform a 2D inverse FFT. Batching is supported for any tensor with a rank highe
 
 .. doxygenfunction:: ifft2(const OpA &a, FFTNorm norm = FFTNorm::BACKWARD)
 .. doxygenfunction:: ifft2(const OpA &a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD)
+
+FFT Normalization
+~~~~~~~~~~~~~~~~~
+
+The ``norm`` parameter specifies how the FFT and inverse FFT are scaled:
+
+- ``FFTNorm::BACKWARD``: FFT is unscaled, inverse FFT is scaled by 1/N (default)
+- ``FFTNorm::FORWARD``: FFT is scaled by 1/N, inverse FFT is unscaled
+- ``FFTNorm::ORTHO``: Both FFT and inverse FFT are scaled by 1/sqrt(N)
   
 Examples
 ~~~~~~~~

--- a/docs_input/api/searchsort/argsort.rst
+++ b/docs_input/api/searchsort/argsort.rst
@@ -7,6 +7,14 @@ Compute the indices that would sort the elements of a tensor in either ascending
 
 .. doxygenfunction:: argsort(const InputOperator &a, const SortDirection_t dir)
 
+Sort Direction
+~~~~~~~~~~~~~~
+
+The ``dir`` parameter specifies the sort direction:
+
+- ``SORT_DIR_ASC``: Sort in ascending order (smallest to largest)
+- ``SORT_DIR_DESC``: Sort in descending order (largest to smallest)
+
 Examples
 ~~~~~~~~
 

--- a/docs_input/api/searchsort/sort.rst
+++ b/docs_input/api/searchsort/sort.rst
@@ -7,6 +7,14 @@ Sort elements of a tensor in either ascending or descending order
 
 .. doxygenfunction:: sort(const InputOperator &a, const SortDirection_t dir)
 
+Sort Direction
+~~~~~~~~~~~~~~
+
+The ``dir`` parameter specifies the sort direction:
+
+- ``SORT_DIR_ASC``: Sort in ascending order (smallest to largest)
+- ``SORT_DIR_DESC``: Sort in descending order (largest to smallest)
+
 Examples
 ~~~~~~~~
 

--- a/docs_input/api/signalimage/convolution/conv1d.rst
+++ b/docs_input/api/signalimage/convolution/conv1d.rst
@@ -13,6 +13,23 @@ for the target input sizes.
 
 .. doxygenfunction:: conv1d(const In1Type &i1, const In2Type &i2, matxConvCorrMode_t mode, matxConvCorrMethod_t method)
 
+Convolution/Correlation Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``mode`` parameter specifies how the output size is determined:
+
+- ``MATX_C_MODE_FULL``: Keep all elements including ramp-up/down (output size = N + M - 1)
+- ``MATX_C_MODE_SAME``: Keep only elements where entire filter was present (output size = max(N, M))
+- ``MATX_C_MODE_VALID``: Keep only elements with full overlap (output size = max(N, M) - min(N, M) + 1)
+
+Convolution/Correlation Method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``method`` parameter specifies the algorithm to use:
+
+- ``MATX_C_METHOD_DIRECT``: Direct convolution using sliding window approach
+- ``MATX_C_METHOD_FFT``: FFT-based convolution using the convolution theorem (may be faster for large inputs)
+
 Examples
 ~~~~~~~~
 

--- a/docs_input/api/signalimage/convolution/conv2d.rst
+++ b/docs_input/api/signalimage/convolution/conv2d.rst
@@ -8,6 +8,15 @@ conv2d
 .. doxygenfunction:: conv2d(const In1Type &i1, const In2Type &i2, matxConvCorrMode_t mode)
 .. doxygenfunction:: conv2d(const In1Type &i1, const In2Type &i2, const int32_t (&axis)[2], matxConvCorrMode_t mode)   
 
+Convolution/Correlation Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``mode`` parameter specifies how the output size is determined:
+
+- ``MATX_C_MODE_FULL``: Keep all elements including ramp-up/down (output size = N + M - 1)
+- ``MATX_C_MODE_SAME``: Keep only elements where entire filter was present (output size = max(N, M))
+- ``MATX_C_MODE_VALID``: Keep only elements with full overlap (output size = max(N, M) - min(N, M) + 1)
+
 Examples
 ~~~~~~~~
 

--- a/docs_input/api/stats/corr/corr.rst
+++ b/docs_input/api/stats/corr/corr.rst
@@ -8,6 +8,23 @@ Cross-correlation of two inputs
 .. doxygenfunction:: corr(const In1Type &i1, const In2Type &i2, matxConvCorrMode_t mode, matxConvCorrMethod_t method)
 .. doxygenfunction:: corr(const In1Type &i1, const In2Type &i2, const int32_t (&axis)[1], matxConvCorrMode_t mode, matxConvCorrMethod_t method)
 
+Convolution/Correlation Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``mode`` parameter specifies how the output size is determined:
+
+- ``MATX_C_MODE_FULL``: Keep all elements including ramp-up/down (output size = N + M - 1)
+- ``MATX_C_MODE_SAME``: Keep only elements where entire filter was present (output size = max(N, M))
+- ``MATX_C_MODE_VALID``: Keep only elements with full overlap (output size = max(N, M) - min(N, M) + 1)
+
+Convolution/Correlation Method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``method`` parameter specifies the algorithm to use:
+
+- ``MATX_C_METHOD_DIRECT``: Direct convolution using sliding window approach
+- ``MATX_C_METHOD_FFT``: FFT-based convolution using the convolution theorem (may be faster for large inputs)
+
 Examples
 ~~~~~~~~
 

--- a/include/matx/kernels/conv.cuh
+++ b/include/matx/kernels/conv.cuh
@@ -21,15 +21,25 @@ namespace matx_conv1d_detail {
 };
 using namespace matx_conv1d_detail;
 
+/**
+ * @brief Convolution/Correlation mode
+ *
+ * Specifies how the output size is determined and which elements are kept.
+ */
 typedef enum {
-  MATX_C_MODE_FULL, // Default. Keep all elements of ramp up/down
-  MATX_C_MODE_SAME, // Only keep elements where entire filter was present
-  MATX_C_MODE_VALID
+  MATX_C_MODE_FULL,  ///< Keep all elements including ramp-up/down (output size = N + M - 1)
+  MATX_C_MODE_SAME,  ///< Keep only elements where entire filter was present (output size = max(N, M))
+  MATX_C_MODE_VALID  ///< Keep only elements with full overlap (output size = max(N, M) - min(N, M) + 1)
 } matxConvCorrMode_t;
 
+/**
+ * @brief Convolution/Correlation method
+ *
+ * Specifies the algorithm to use for computing convolution or correlation.
+ */
 typedef enum {
-  MATX_C_METHOD_DIRECT,
-  MATX_C_METHOD_FFT
+  MATX_C_METHOD_DIRECT, ///< Direct convolution using sliding window approach
+  MATX_C_METHOD_FFT     ///< FFT-based convolution using the convolution theorem
 } matxConvCorrMethod_t;
 
 #ifdef __CUDACC__

--- a/include/matx/operators/pad.h
+++ b/include/matx/operators/pad.h
@@ -43,11 +43,11 @@ namespace matx
   /**
    * @brief Padding mode
    *
-   * The padding mode to use for the pad operator. The default value is MATX_PAD_MODE_CONSTANT.
+   * Specifies the padding mode to use for the pad operator.
    */
   enum PadMode {
-    MATX_PAD_MODE_CONSTANT, ///<Constant padding mode. All padding elements will be set to the user-provided pad_value.
-    MATX_PAD_MODE_EDGE ///<Edge padding mode. All padding elements will be set to the edge values of the original operator.
+    MATX_PAD_MODE_CONSTANT, ///< Constant padding mode. All padding elements will be set to the user-provided pad_value.
+    MATX_PAD_MODE_EDGE ///< Edge padding mode. All padding elements will be set to the edge values of the original operator.
   };
 
   namespace detail {

--- a/include/matx/transforms/cub.h
+++ b/include/matx/transforms/cub.h
@@ -54,8 +54,12 @@ namespace matx {
 /**
  * @brief Direction for sorting
  *
+ * Specifies whether to sort in ascending or descending order.
  */
-typedef enum { SORT_DIR_ASC, SORT_DIR_DESC } SortDirection_t;
+typedef enum { 
+  SORT_DIR_ASC,  ///< Sort in ascending order (smallest to largest)
+  SORT_DIR_DESC  ///< Sort in descending order (largest to smallest)
+} SortDirection_t;
 
 // define of dimension size for when the cub segemented sort
 // is outperformed by the radixSort

--- a/include/matx/transforms/fft/fft_common.h
+++ b/include/matx/transforms/fft/fft_common.h
@@ -34,10 +34,15 @@
 
 namespace matx {
 
+/**
+ * @brief FFT normalization mode
+ *
+ * Specifies how the FFT and inverse FFT are scaled/normalized.
+ */
 enum class FFTNorm {
-  BACKWARD, /// fft is unscaled, ifft is 1/N
-  FORWARD, /// fft is scaled 1/N, ifft is not scaled
-  ORTHO /// fft is scaled 1/sqrt(N), ifft is scaled 1/sqrt(N)
+  BACKWARD, ///< FFT is unscaled, inverse FFT is scaled by 1/N
+  FORWARD, ///< FFT is scaled by 1/N, inverse FFT is unscaled
+  ORTHO ///< Both FFT and inverse FFT are scaled by 1/sqrt(N)
 };
 
 namespace detail {


### PR DESCRIPTION
Some of the operators were missing documentation on their enum parameters. This covers all missing parameters.

Closes #574 