### PR TITLE
Add prerun_done_ flag to prevent duplicate PreRun executions in transform operators

### DIFF
--- a/include/matx/operators/all.h
+++ b/include/matx/operators/all.h
@@ -50,7 +50,8 @@ namespace detail {
       typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;     
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;     
 
     public:
       using matxop = bool;
@@ -105,10 +106,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/ambgfun.h
+++ b/include/matx/operators/ambgfun.h
@@ -52,7 +52,8 @@ namespace matx
         float cut_val_;
         cuda::std::array<index_t, 2> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpX>::value_type, 2> tmp_out_;
-        mutable typename remove_cvref_t<OpX>::value_type *ptr = nullptr;         
+        mutable typename remove_cvref_t<OpX>::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false;         
 
       public:
         using matxop = bool;
@@ -142,10 +143,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));         
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/any.h
+++ b/include/matx/operators/any.h
@@ -50,7 +50,8 @@ namespace detail {
       OpA a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false; 
 
     public:
       using matxop = bool;
@@ -105,10 +106,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));   
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/argsort.h
+++ b/include/matx/operators/argsort.h
@@ -50,7 +50,8 @@ namespace detail {
       SortDirection_t dir_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<index_t, OpA::Rank()> tmp_out_;
-      mutable index_t *ptr = nullptr; 
+      mutable index_t *ptr = nullptr;
+      mutable bool prerun_done_ = false; 
 
     public:
       using matxop = bool;
@@ -105,10 +106,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));     
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/cgsolve.h
+++ b/include/matx/operators/cgsolve.h
@@ -50,7 +50,8 @@ namespace matx
         int max_iters_;
         cuda::std::array<index_t, 2> out_dims_;
         mutable detail::tensor_impl_t<typename OpA::value_type, 2> tmp_out_;
-        mutable typename OpA::value_type *ptr = nullptr;               
+        mutable typename OpA::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false;               
 
       public:
         using matxop = bool;
@@ -125,10 +126,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));         
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/channelize_poly.h
+++ b/include/matx/operators/channelize_poly.h
@@ -56,7 +56,8 @@ namespace detail {
       index_t decimation_factor_;
       cuda::std::array<index_t, OpA::Rank() + 1> out_dims_;
       mutable detail::tensor_impl_t<out_t, OpA::Rank() + 1> tmp_out_;
-      mutable out_t *ptr = nullptr;       
+      mutable out_t *ptr = nullptr;
+      mutable bool prerun_done_ = false;       
 
     public:
       using matxop = bool;
@@ -127,10 +128,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));           
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/chol.h
+++ b/include/matx/operators/chol.h
@@ -49,7 +49,8 @@ namespace detail {
       typename detail::base_type_t<OpA> a_;
       SolverFillMode uplo_;
       mutable detail::tensor_impl_t<typename OpA::value_type, OpA::Rank()> tmp_out_;
-      mutable typename OpA::value_type *ptr = nullptr;      
+      mutable typename OpA::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;      
 
     public:
       using matxop = bool;
@@ -93,10 +94,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), a_.Shape(), &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/corr.h
+++ b/include/matx/operators/corr.h
@@ -56,7 +56,8 @@ namespace matx
         PermDims perm_;
         cuda::std::array<index_t, max_rank> out_dims_;
         mutable detail::tensor_impl_t<out_t, max_rank> tmp_out_;
-        mutable out_t *ptr = nullptr; 
+        mutable out_t *ptr = nullptr;
+        mutable bool prerun_done_ = false; 
 
       public:
         using matxop = bool;
@@ -183,10 +184,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));        
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/cov.h
+++ b/include/matx/operators/cov.h
@@ -47,7 +47,8 @@ namespace matx
         typename detail::base_type_t<OpA> a_;
         cuda::std::array<index_t, OpA::Rank()> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false; 
 
       public:
         using matxop = bool;
@@ -113,10 +114,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));      
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/cumsum.h
+++ b/include/matx/operators/cumsum.h
@@ -49,7 +49,8 @@ namespace detail {
       typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;  
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;  
 
     public:
       using matxop = bool;
@@ -103,10 +104,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));      
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/det.h
+++ b/include/matx/operators/det.h
@@ -45,7 +45,8 @@ namespace detail {
     private:
       typename detail::base_type_t<OpA> a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false; 
 
     public:
       using matxop = bool;
@@ -89,10 +90,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), a_.Shape(), &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/fft.h
+++ b/include/matx/operators/fft.h
@@ -57,7 +57,8 @@ namespace matx
                                           typename scalar_to_complex<typename OpA::value_type>::ctype>;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in fft
         mutable detail::tensor_impl_t<ttype, OpA::Rank()> tmp_out_;
-        mutable ttype *ptr = nullptr;                                           
+        mutable ttype *ptr = nullptr;
+        mutable bool prerun_done_ = false;                                       
 
       public:
         using matxop = bool;
@@ -208,10 +209,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);         
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 
@@ -439,7 +445,8 @@ namespace matx
                                           typename scalar_to_complex<typename OpA::value_type>::ctype>;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in fft
         mutable detail::tensor_impl_t<ttype, OpA::Rank()> tmp_out_; 
-        mutable ttype *ptr = nullptr;                                                
+        mutable ttype *ptr = nullptr;
+        mutable bool prerun_done_ = false;                                                
 
       public:
         using matxop = bool;
@@ -548,10 +555,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);          
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/filter.h
+++ b/include/matx/operators/filter.h
@@ -51,7 +51,8 @@ namespace detail {
       cuda::std::array<FilterType, NNR> h_nonrec_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false; 
 
     public:
       using matxop = bool;
@@ -111,10 +112,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));     
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
     

--- a/include/matx/operators/hist.h
+++ b/include/matx/operators/hist.h
@@ -52,7 +52,8 @@ namespace detail {
       int num_levels_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<int, OpA::Rank()> tmp_out_;
-      mutable int *ptr = nullptr;  
+      mutable int *ptr = nullptr;
+      mutable bool prerun_done_ = false;  
 
     public:
       using matxop = bool;
@@ -111,10 +112,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));     
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/inverse.h
+++ b/include/matx/operators/inverse.h
@@ -47,7 +47,8 @@ namespace detail {
     private:
       typename detail::base_type_t<OpA> a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false; 
 
     public:
       using matxop = bool;
@@ -104,10 +105,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), a_.Shape(), &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }      
 

--- a/include/matx/operators/matmul.h
+++ b/include/matx/operators/matmul.h
@@ -58,7 +58,8 @@ namespace matx
         cuda::std::array<index_t, out_rank> out_dims_;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in matmul
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, out_rank> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false; 
 
       public:
         using matxop = bool;
@@ -161,10 +162,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/matvec.h
+++ b/include/matx/operators/matvec.h
@@ -52,7 +52,8 @@ namespace matx
         static constexpr int RANK = remove_cvref_t<OpB>::Rank();
         cuda::std::array<index_t, RANK> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, RANK> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false; 
 
       public:
         using matxop = bool;
@@ -129,10 +130,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));           
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/max.h
+++ b/include/matx/operators/max.h
@@ -50,7 +50,8 @@ namespace detail {
       typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;    
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;    
 
     public:
       using matxop = bool;
@@ -104,10 +105,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));    
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/mean.h
+++ b/include/matx/operators/mean.h
@@ -50,7 +50,8 @@ namespace detail {
       typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;     
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;     
 
     public:
       using matxop = bool;
@@ -104,10 +105,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));       
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/min.h
+++ b/include/matx/operators/min.h
@@ -50,7 +50,8 @@ namespace detail {
       typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;     
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;     
 
     public:
       using matxop = bool;
@@ -104,10 +105,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));    
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/norm.h
+++ b/include/matx/operators/norm.h
@@ -50,7 +50,8 @@ namespace matx
         static constexpr int ORank = std::is_same_v<NormType, detail::NormTypeVector> ? OpA::Rank() - 1 : OpA::Rank() - 2;
         cuda::std::array<index_t, ORank> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false; 
 
       public:
         using matxop = bool;
@@ -117,10 +118,15 @@ namespace matx
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/outer.h
+++ b/include/matx/operators/outer.h
@@ -52,7 +52,8 @@ namespace matx
         static constexpr int RANK = cuda::std::max(remove_cvref_t<OpA>::Rank(), remove_cvref_t<OpB>::Rank()) + 1;
         cuda::std::array<index_t, RANK> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, RANK> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false; 
 
       public:
         using matxop = bool;
@@ -133,10 +134,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));            
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/percentile.h
+++ b/include/matx/operators/percentile.h
@@ -50,7 +50,8 @@ namespace detail {
       PercentileMethod method_;
       cuda::std::array<index_t, ORank> out_dims_; 
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false; 
 
     public:
       using matxop = bool;
@@ -104,10 +105,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/pinv.h
+++ b/include/matx/operators/pinv.h
@@ -47,7 +47,8 @@ namespace detail {
       float rcond_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false; 
 
     public:
       using matxop = bool;
@@ -113,10 +114,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/prod.h
+++ b/include/matx/operators/prod.h
@@ -50,7 +50,8 @@ namespace detail {
       typename detail::base_type_t<OpA> a_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false; 
 
     public:
       using matxop = bool;
@@ -104,10 +105,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));       
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/pwelch.h
+++ b/include/matx/operators/pwelch.h
@@ -131,10 +131,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 
@@ -164,6 +169,7 @@ namespace matx
         cuda::std::array<index_t, 1> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpX>::value_type, 1> tmp_out_;
         mutable typename remove_cvref_t<OpX>::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false;
     };
   }
 

--- a/include/matx/operators/reduce.h
+++ b/include/matx/operators/reduce.h
@@ -51,7 +51,8 @@ namespace matx
         bool init_;
         cuda::std::array<index_t, ORank> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false; 
 
       public:
         using matxop = bool;
@@ -123,10 +124,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));           
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/resample_poly.h
+++ b/include/matx/operators/resample_poly.h
@@ -54,7 +54,8 @@ namespace detail {
       index_t down_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<out_t, OpA::Rank()> tmp_out_;
-      mutable out_t *ptr = nullptr;       
+      mutable out_t *ptr = nullptr;
+      mutable bool prerun_done_ = false;       
 
     public:
       using matxop = bool;
@@ -124,10 +125,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));         
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/softmax.h
+++ b/include/matx/operators/softmax.h
@@ -48,7 +48,8 @@ namespace matx
         PermDims perm_;
         cuda::std::array<index_t, OpA::Rank()> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+        mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+        mutable bool prerun_done_ = false; 
 
       public:
         using matxop = bool;
@@ -119,10 +120,15 @@ namespace matx
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
         {
+          if (prerun_done_) {
+            return;
+          }
+
           InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));          
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+          prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
 

--- a/include/matx/operators/solve.h
+++ b/include/matx/operators/solve.h
@@ -53,6 +53,7 @@ private:
   cuda::std::array<index_t, out_rank> out_dims_;
   mutable detail::tensor_impl_t<typename OpA::value_type, out_rank> tmp_out_;
   mutable typename OpA::value_type *ptr = nullptr;
+  mutable bool prerun_done_ = false;
 
 public:
   using matxop = bool;
@@ -138,9 +139,14 @@ public:
   template <typename ShapeType, typename Executor>
   __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape,
                               [[maybe_unused]] Executor &&ex) const noexcept {
+    if (prerun_done_) {
+      return;
+    }
+
     InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
     detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_,
                                &ptr);
+    prerun_done_ = true;
     Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
   }
 

--- a/include/matx/operators/sort.h
+++ b/include/matx/operators/sort.h
@@ -50,7 +50,8 @@ namespace detail {
       SortDirection_t dir_;
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr; 
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false; 
 
     public:
       using matxop = bool;
@@ -104,10 +105,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));     
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/sparse2dense.h
+++ b/include/matx/operators/sparse2dense.h
@@ -49,6 +49,7 @@ private:
   cuda::std::array<index_t, out_rank> out_dims_;
   mutable detail::tensor_impl_t<typename OpA::value_type, out_rank> tmp_out_;
   mutable typename OpA::value_type *ptr = nullptr;
+  mutable bool prerun_done_ = false;
 
 public:
   using matxop = bool;
@@ -123,9 +124,14 @@ public:
   template <typename ShapeType, typename Executor>
   __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape,
                               [[maybe_unused]] Executor &&ex) const noexcept {
+    if (prerun_done_) {
+      return;
+    }
+
     InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
     detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_,
                                &ptr);
+    prerun_done_ = true;
     Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
   }
 

--- a/include/matx/operators/stdd.h
+++ b/include/matx/operators/stdd.h
@@ -51,7 +51,8 @@ namespace detail {
       int ddof_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;   
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;   
 
     public:
       using matxop = bool;
@@ -105,10 +106,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/sum.h
+++ b/include/matx/operators/sum.h
@@ -51,6 +51,7 @@ namespace detail {
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;
 
     public:
       using matxop = bool;
@@ -104,10 +105,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));    
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/trace.h
+++ b/include/matx/operators/trace.h
@@ -49,6 +49,7 @@ namespace detail {
       typename detail::base_type_t<OpA> a_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, 0> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;
 
     public:
       using matxop = bool;
@@ -98,10 +99,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));      
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), {}, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 

--- a/include/matx/operators/var.h
+++ b/include/matx/operators/var.h
@@ -51,7 +51,8 @@ namespace detail {
       int ddof_;
       cuda::std::array<index_t, ORank> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
-      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;  
+      mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
+      mutable bool prerun_done_ = false;  
 
     public:
       using matxop = bool;
@@ -105,10 +106,15 @@ namespace detail {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
+        if (prerun_done_) {
+          return;
+        }
+
         InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));      
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
+        prerun_done_ = true;
         Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
       }
 


### PR DESCRIPTION
Introduced a mutable bool prerun_done_ flag to 40 transform operators that allocate temporary tensors in their PreRun() method. This prevents duplicate memory allocations and executions when PreRun() is called multiple times on the same operator instance.

In an fft convolution example it was inadvertently launching 2 more kernels than it needed to since the assignment inside fft_impl was causing a second PreRun to be called after the initial binary operator.

The flag is checked at the start of PreRun() and causes an early return if the method has already been executed. The flag is set to true after temporary tensor allocation but before calling Exec().

Modified operators:
- FFT operators: FFT2Op
- Reduction ops: SumOp, ProdOp, MeanOp, VarOp, StddOp, MinOp, MaxOp, NormOp, MedianOp, PercentileOp, AllOp, AnyOp, ReduceOp, TraceOp
- Linear algebra: MatMulOp, MatVecOp, OuterOp, TransposeMatrixOp, SolveOp, InvOp, DetOp, PinvOp, CholOp, CovOp, CGSolveOp
- Signal processing: PWelchOp, ResamplePolyOp, ChannelizePolyOp, SoftmaxOp, NormalizeOp
- Sparse ops: Sparse2DenseOp
- Sorting: SortOp, ArgsortOp
- Convolution/correlation: Conv1DOp, CorrOp, FilterOp
- Other: HistOp, CumSumOp, AmbgFunOp

Operators not modified (don't allocate temps in PreRun): lu, unique, svd, qr, sparse2sparse, argmax, argmin, argminmax, find, find_idx, find_peaks, einsum, eig, dense2sparse