### PR TITLE
Fix missing include of `<cuda/std/utility>`

### DIFF
--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -38,6 +38,7 @@
 #include <cublas_v2.h>
 #include <cuda/std/complex>
 #include <cuda/std/tuple>
+#include <cuda/std/utility>
 #include <cusparse.h>
 #include <type_traits>
 
@@ -53,7 +54,7 @@
 
 
 namespace matx {
-  
+
 
 namespace detail {
   template <int N, typename Executor, typename TupleType, typename... Ops>
@@ -91,7 +92,7 @@ struct is_noshape : std::integral_constant<bool, std::is_same_v<NoShape, T>> {};
 
 /**
  * @brief Determine if a type is a MatX half precision wrapper (either matxFp16 or matxBf16)
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -101,13 +102,13 @@ inline constexpr bool is_noshape_v = detail::is_noshape<T>::value;
 
 /**
  * @brief Removes cv and reference qualifiers on a type
- * 
+ *
  * @tparam T Type to remove qualifiers
  */
 template< class T >
 struct remove_cvref {
     using type = std::remove_cv_t<std::remove_reference_t<T>>; ///< Type after removal
-};  
+};
 
 template <typename T>
 using remove_cvref_t = typename remove_cvref<T>::type;
@@ -143,7 +144,7 @@ struct is_matx_op_impl<T, std::void_t<typename T::matxop>> : std::true_type {
 
 /**
  * @brief Determine if a type is a MatX operator
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T> constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_op()
@@ -183,7 +184,7 @@ struct is_matx_transform_op_impl<T, std::void_t<typename remove_cvref_t<T>::matx
 
 /**
  * @brief Determine if a type is a MatX transform operator
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T> constexpr bool is_matx_transform_op()
@@ -215,7 +216,7 @@ struct is_matx_set_op_impl<T, std::void_t<typename T::matx_setop>> : std::true_t
 
 /**
  * @brief Determine if a type is a MatX set operator
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T> constexpr bool is_matx_set_op()
@@ -239,7 +240,7 @@ struct is_matx_op_lvalue_impl<T, std::void_t<typename T::matxoplvalue>> : std::t
 
 /**
  * @brief Determine if a type is a left hand side operator
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T> constexpr bool is_matx_op_lvalue()
@@ -255,7 +256,7 @@ struct is_tensor_t<T, std::void_t<typename T::tensor_t_type>> : std::true_type {
 
 /**
  * @brief Determine if a type is a MatX tensor_t
- * 
+ *
  * @tparam T Type to test
  */
 template< class T >
@@ -269,7 +270,7 @@ struct is_tensor_impl<T, std::void_t<typename T::tensor_impl>> : std::true_type 
 
 /**
  * @brief Determine if a type is a MatX tensor_impl_t
- * 
+ *
  * @tparam T Type to test
  */
 template< class T >
@@ -287,7 +288,7 @@ struct is_tensor_view<T, std::void_t<typename T::tensor_view>>
 
 /**
  * @brief Determine if a type is a MatX tensor view type
- * 
+ *
  * @tparam T Type to test
  */
 template< class T >
@@ -297,7 +298,7 @@ template <typename> struct is_tuple: std::false_type {};
 template <typename ...T> struct is_tuple<cuda::std::tuple<T...>>: std::true_type {};
 
 template <typename T>
-inline constexpr bool is_settable_xform_v = std::conjunction_v<detail::is_matx_set_op_impl<T>, 
+inline constexpr bool is_settable_xform_v = std::conjunction_v<detail::is_matx_set_op_impl<T>,
                                                detail::is_matx_transform_set_op_impl<T>>;
                                                //detail::is_matx_tensor_set_op_impl<T>>; // Can be tuple also
 
@@ -310,10 +311,10 @@ struct is_executor<T, std::void_t<typename T::matx_executor>> : std::true_type {
 
 /**
  * @brief Determine if a type is a MatX executor
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 constexpr bool is_executor_t()
 {
   return detail::is_executor<typename remove_cvref<T>::type>::value;
@@ -329,10 +330,10 @@ struct is_cuda_executor<T, std::void_t<typename T::cuda_executor>> : std::true_t
 
 /**
  * @brief Determine if a type is a device executor
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 inline constexpr bool is_cuda_executor_v = detail::is_cuda_executor<typename remove_cvref<T>::type>::value;
 
 namespace detail {
@@ -346,18 +347,18 @@ template<> struct is_select_threads_host_executor<matx::SelectThreadsHostExecuto
 
 /**
  * @brief Determine if a type is a host executor
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 inline constexpr bool is_host_executor_v = detail::is_host_executor<typename remove_cvref<T>::type>::value;
 
 /**
  * @brief Determine if a type is a select threads host executor
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 inline constexpr bool is_select_threads_host_executor_v = detail::is_select_threads_host_executor<remove_cvref_t<T>>::value;
 
 namespace detail {
@@ -372,7 +373,7 @@ struct is_matx_reduction_impl<T, std::void_t<typename T::matx_reduce>>
 
 /**
  * @brief Determine if a type is a MatX reduction
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -390,7 +391,7 @@ struct is_matx_idx_reduction_impl<T, std::void_t<typename T::matx_reduce_index>>
 
 /**
  * @brief Determine if a type is a MatX index reduction type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -405,7 +406,7 @@ template<typename T> struct is_smart_ptr<std::unique_ptr<T>> : std::true_type {}
 
 /**
  * @brief Determine if a type is a smart pointer (unique or shared)
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T> inline constexpr bool is_smart_ptr_v = detail::is_smart_ptr<T>::value;
@@ -420,7 +421,7 @@ struct is_cuda_complex<cuda::std::complex<T>> : std::true_type {
 
 /**
  * @brief Determine if a type is a cuda::std::complex variant
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -448,7 +449,7 @@ template <> struct is_complex<matxBf16Complex> : std::true_type {
 
 /**
  * @brief Determine if a type is a complex type (any type supported)
- * 
+ *
  * @tparam T Type to test
  */
 template <class T> inline constexpr bool is_complex_v = detail::is_complex<remove_cvref_t<T>>::value;
@@ -482,7 +483,7 @@ struct inner_op_type_t {
 };
 
 template <typename T>
-struct inner_op_type_t<T, typename std::enable_if_t<is_complex_v<T>>> { 
+struct inner_op_type_t<T, typename std::enable_if_t<is_complex_v<T>>> {
   using type = typename T::value_type;
 };
 
@@ -495,7 +496,7 @@ template <> struct is_bf16_type<matxBf16> : std::true_type {};
 
 /**
  * @brief Determine if a type is a BF16 type
- * 
+ *
  * @tparam T Type to test
  */
 template <class T> inline constexpr bool is_bf16_type_v = detail::is_bf16_type<T>::value;
@@ -509,14 +510,14 @@ template <> struct is_fp16_type<matxFp16> : std::true_type {};
 
 /**
  * @brief Determine if a type is an FP16 type
- * 
+ *
  * @tparam T Type to test
  */
 template <class T> inline constexpr bool is_fp16_type_v = detail::is_fp16_type<T>::value;
 
 /**
  * @brief Determine if the inner type is an FP32 type
- * 
+ *
  * @tparam T Type to test
  */
 template<typename T>
@@ -524,7 +525,7 @@ inline constexpr bool is_fp32_inner_type_v = std::is_same_v<typename inner_op_ty
 
 /**
  * @brief Determine if the inner type is an FP64 type
- * 
+ *
  * @tparam T Type to test
  */
 template<typename T>
@@ -542,7 +543,7 @@ struct is_matx_shape<T, std::void_t<typename T::matx_shape>>
 
 /**
  * @brief Determine if a type is a MatX shape type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -561,7 +562,7 @@ struct is_matx_storage<T, std::void_t<typename T::matx_storage>>
 
 /**
  * @brief Determine if a type is a MatX storage type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -579,7 +580,7 @@ struct is_matx_storage_container<T, std::void_t<typename T::matx_storage_contain
 
 /**
  * @brief Determine if a type is a MatX storage container
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -596,7 +597,7 @@ struct is_sparse_data<T, std::void_t<typename T::sparse_data>>
 }
 /**
  * @brief Determine if a type is a MatX sparse data type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -612,7 +613,7 @@ struct is_sparse_tensor<T, std::void_t<typename T::sparse_tensor>>
 }
 /**
  * @brief Determine if a type is a MatX sparse tensor type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -631,7 +632,7 @@ struct is_matx_descriptor<T, std::void_t<typename T::matx_descriptor>>
 
 /**
  * @brief Determine if a type is a MatX descriptor
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -649,7 +650,7 @@ struct is_matx_static_descriptor<T, std::void_t<typename T::matx_static_descript
 
 /**
  * @brief Determine if a type is a MatX static descriptor
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -668,7 +669,7 @@ struct has_shape_type<T, std::void_t<typename T::shape_type>>
 
 /**
  * @brief Determine if a type has a shape_type attribute
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -689,7 +690,7 @@ struct has_index_cmp_op<T, std::void_t<typename T::index_cmp_op>>
 
 /**
  * @brief Determine if a type defines `using index_cmp_op = bool;`
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -708,7 +709,7 @@ struct is_complex_half
 
 /**
  * @brief Determine if a type is a MatX half precision wrapper (either matxFp16 or matxBf16)
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -716,7 +717,7 @@ inline constexpr bool is_complex_half_v = detail::is_complex_half<T>::value;
 
 /**
  * @brief Tests if a type is a half precision floating point
- * 
+ *
  * @tparam T Type to test
  * @return True if half precision floating point
  */
@@ -735,7 +736,7 @@ struct is_matx_half
 }
 /**
  * @brief Determine if a type is a MatX half precision wrapper (either matxFp16 or matxBf16)
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -751,7 +752,7 @@ struct is_half
 }
 /**
  * @brief Determine if a type is half precision (either __half or __nv_bfloat16)
- * 
+ *
  * @tparam T Type to test
  */
 template <class T> inline constexpr bool is_half_v = detail::is_half<T>::value;
@@ -769,7 +770,7 @@ struct is_matx_type
 
 /**
  * @brief Determine if a type is a MatX custom type (half precision wrappers)
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -788,7 +789,7 @@ struct extract_value_type_impl<T, typename std::enable_if_t<is_matx_op<T>()>> {
 
 /**
  * @brief Extract the value_type type
- * 
+ *
  * @tparam T Type to extract from
  */
 template <typename T>
@@ -796,7 +797,7 @@ using extract_value_type_t = typename detail::extract_value_type_impl<std::remov
 
 /**
  * @brief Promote half precision floating point value to fp32, or leave untouched if not half
- * 
+ *
  * @tparam T Type to convert
  */
 template <typename T>
@@ -805,41 +806,41 @@ using promote_half_t = typename std::conditional_t<is_half_v<T> || is_matx_half_
 
 
 namespace detail {
-  
-template <typename T> 
+
+template <typename T>
 struct convert_matx_type {
   using type = T;
 };
 
-template <> 
+template <>
 struct convert_matx_type<matxFp16> {
   using type = __half;
 };
 
-template <> 
+template <>
 struct convert_matx_type<matxBf16> {
   using type = __nv_bfloat16;
 };
 
-template <typename T> 
+template <typename T>
 using convert_matx_type_t = typename convert_matx_type<T>::type;
 
-template <typename T> 
+template <typename T>
 struct convert_half_to_matx_half {
   using type = T;
 };
 
-template <> 
+template <>
 struct convert_half_to_matx_half<__half> {
   using type = matxFp16;
 };
 
-template <> 
+template <>
 struct convert_half_to_matx_half<__nv_bfloat16> {
   using type = matxBf16;
 };
 
-template <typename T> 
+template <typename T>
 using convert_half_to_matx_half_t = typename convert_half_to_matx_half<T>::type;
 
 
@@ -860,29 +861,29 @@ constexpr cuda::std::array<std::remove_cv_t<T>, N> to_array(T (&a)[N])
 template <typename T, int RANK, typename Desc> class tensor_t;
 template <typename T, int RANK, typename Desc, typename Data> class tensor_impl_t;
 // Traits for casting down to impl tensor conditionally
-template <typename T, typename = void> 
+template <typename T, typename = void>
 struct base_type {
   using type = T;
 };
 
-template <typename T> 
+template <typename T>
 struct base_type<T, typename std::enable_if_t<is_tensor_t_v<T>>> {
   using type = tensor_impl_t<typename T::value_type, T::Rank(), typename T::desc_type, typename T::data_type>;
 };
 
 template <typename T> using base_type_t = typename base_type<typename remove_cvref<T>::type>::type;
 
-template <typename T, typename = void> 
+template <typename T, typename = void>
 struct complex_from_scalar {
   using type = T;
 };
 
-template <typename T> 
+template <typename T>
 struct complex_from_scalar<T, typename std::enable_if_t<std::is_same_v<float, T> || std::is_same_v<double, T>>> {
   using type = cuda::std::complex<T>;
 };
 
-template <typename T> 
+template <typename T>
 struct complex_from_scalar<T, typename std::enable_if_t<is_matx_half_v<T> || is_half_v<T> > > {
   using type = matxHalfComplex<typename convert_half_to_matx_half<T>::type>;
 };
@@ -916,7 +917,7 @@ using matx_convert_complex_type =
 template <class C>
 using matx_convert_cuda_complex_type =
     typename std::conditional_t<!is_complex_v<C>, identity<C>,
-                                cuda_complex_type_of<C>>::type;                                
+                                cuda_complex_type_of<C>>::type;
 
 
 template <class T, class = void> struct value_type {
@@ -998,7 +999,7 @@ struct permute_rank {
 template <typename T1>
 struct permute_rank<T1, no_permute_t> {
   static const int rank = 0;
-};  
+};
 
 // Supported MatX data types. This enum helps translate types into integers for
 // hashing purposes


### PR DESCRIPTION
We are using `cuda::std::as_const`. However, we relied on a transitive include from `<cuda/std/tuple>` that will be remove in a future release