### PR TITLE
Add unsafe aliased memory checking system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ option(MATX_EN_COMPLEX_OP_NAN_CHECKS "Enable full NaN/Inf handling for complex m
 option(MATX_EN_CUDA_LINEINFO "Enable line information for CUDA kernels via -lineinfo nvcc flag" OFF)
 option(MATX_EN_EXTENDED_LAMBDA "Enable extended lambda support for device/host lambdas" ON)
 option(MATX_EN_MATHDX "Enable MathDx support for kernel fusion" OFF)
+option(MATX_EN_UNSAFE_ALIAS_DETECTION "Enable aliased memory detection" OFF)
 
 set(MATX_EN_PYBIND11 OFF CACHE BOOL "Enable pybind11 support")
 
@@ -210,6 +211,10 @@ if (MATX_BUILD_32_BIT)
     target_compile_definitions(matx INTERFACE MATX_INDEX_32_BIT)
 else()
     set(MATX_NVPL_INT_TYPE "ilp64")
+endif()
+
+if (MATX_EN_UNSAFE_ALIAS_DETECTION)
+    target_compile_definitions(matx INTERFACE MATX_EN_UNSAFE_ALIAS_DETECTION)
 endif()
 
 # Host support

--- a/docs_input/basics/debug.rst
+++ b/docs_input/basics/debug.rst
@@ -1,0 +1,79 @@
+.. _debugging:
+
+Debugging
+#########
+
+MatX employs several tools for debugging and improving the correctness of the code. 
+
+Logging
+--------
+
+MatX provides a logging system that can be used to log messages to the console. This is useful for debugging your code and can be used to trace the execution of your code.
+
+See :ref:`logging_basics` for more information on the logging system.
+
+Compile Time
+------------
+
+At compile time MatX uses `static_assert` calls where possible to provide helpful error messages. Static assertions have a limitation that 
+they cannot display a formatted string, so the value of the invalid parameters are not displayed. Common compile time errors include:
+
+- Invalid rank
+- Invalid type
+- Invalid tensor shapes (for static tensor sizes)
+
+Runtime
+-------
+
+At runtime MatX uses C++ exceptions to throw errors. These errors are typically based on expected vs actual outcomes. Several macros are used 
+to raise these errors:
+
+- MATX_ASSERT (boolean assertion)
+- MATX_ASSERT_STR (boolean assertion with a formatted string)
+- MATX_ASSERT_STR_EXP (boolean assertion with a formatted string and an expected value)
+
+These macros are also listed in order of usefulness with the `MATX_ASSERT_STR_EXP` macro providing the most information to the user. Common 
+runtime errors include:
+
+- Invalid sizes
+- Invalid indexing
+- Errors returned from CUDA APIs 
+
+
+Null Pointer Checking
+---------------------
+
+Tensors in MatX may be left unitialized on declaration. This is common when a tensor is used as a class member and is not initialized in the constructor. For example: 
+
+.. code-block:: cpp
+
+    class MyClass {
+        public:
+            MyClass() {
+            }
+        private:
+            tensor_t<float> t; // Uninitialized
+    };
+
+Typically `make_tensor` is used at a later time to declare the shape allocate the memory backing the tensor. Detecting an unitialized tensor on the device 
+has a non-zero performance penalty and is disabled by default. To detect an unitialized tensor on the device, build your application in debug mode with the 
+`NDEBUG` flag undefined. When the `NDEBUG` flag is undefined, MatX will check for unitialized tensors on the device and assert if one is found.
+
+Unsafe Aliased Memory Checking
+------------------------------
+
+MatX provides an imperfect unsafe aliased memory checking system that can be used to detect when an input tensor may overlap with output tensor memory, 
+causing a data race. The word *unsafe* is used here because there are cases where aliasing is safe, such as a direct element-wise operation.
+To have a false positive rate of 0 we would need to check every possible input and output location to see if any of them overlap. 
+This would be impractical for most applications. Instead, we use several checks that can catch the most common cases of memory aliasing. Since aliasing can be 
+an expensive check and it's not perfect, alias checking must be explicitly enabled with the CMake option `MATX_EN_UNSAFE_ALIAS_DETECTION` or the compiler 
+define with the same name.
+
+The types of aliasing that can be detected are:
+
+- Safe element-wise aliasing: (a = a + a) // No aliasing since it's a direct element-wise operation
+- Safe element-wise aliasing: (slice(a, {0}, {5}) = slice(a, {0}, {5}) - slice(a, {0}, {5})) // No aliasing since it's a direct element-wise operation
+- Unsafe element-wise aliasing: (slice(a, {0}, {5}) = slice(a, {3}, {8}) - slice(a, {0}, {5})) // Unsafe since inputs and outputs overlap to different locations
+- Unsafe matrix multiplication: (c = matmul(c, d)) // Unsafe since matmul doesn't allow aliasing on input and output memory
+- Safe FFT: (c = fft(c)) // No aliasing since FFT allows aliasing
+- False positive: (slice(a, {0}, {6}, {2}) = slice(a, {0}, {6}, {2}) + slice(a, {0}, {6}, {2})) // Non-unity strides throw false positive currently

--- a/include/matx/core/capabilities.h
+++ b/include/matx/core/capabilities.h
@@ -68,6 +68,8 @@ namespace detail {
     SET_GROUPS_PER_BLOCK, // Set the number of groups per block for the operator.
     ASYNC_LOADS_REQUESTED, // Whether the operator requires asynchronous loads.
     MAX_EPT_VEC_LOAD, // The maximum EPT for a vector load.
+    ELEMENT_WISE, // Whether the operator is element-wise (safe with aliasing)
+    ALIASED_MEMORY, // Whether the operator's input and output pointers alias
     // Add more capabilities as needed
   };
 
@@ -134,6 +136,15 @@ namespace detail {
   struct capability_attributes<OperatorCapability::ASYNC_LOADS_REQUESTED> {
     using type = bool;
     using input_type = VoidCapabilityType;
+    static constexpr bool default_value = false;
+    static constexpr bool or_identity = false;
+    static constexpr bool and_identity = true;
+  };    
+
+  template <>
+  struct capability_attributes<OperatorCapability::ALIASED_MEMORY> {
+    using type = bool;
+    using input_type = AliasedMemoryQueryInput;
     static constexpr bool default_value = false;
     static constexpr bool or_identity = false;
     static constexpr bool and_identity = true;
@@ -266,6 +277,8 @@ namespace detail {
         return CapabilityQueryType::AND_QUERY; // The expression should use the range of groups per block of its children.
       case OperatorCapability::GROUPS_PER_BLOCK:
         return CapabilityQueryType::RANGE_QUERY; // The expression should use the range of groups per block of its children.
+      case OperatorCapability::ALIASED_MEMORY:
+        return CapabilityQueryType::OR_QUERY; // The expression should use the aliased memory of its children.
       case OperatorCapability::MAX_EPT_VEC_LOAD:
         return CapabilityQueryType::MIN_QUERY; // The expression should use the minimum EPT for a vector load of its children.
       case OperatorCapability::JIT_CLASS_QUERY:

--- a/include/matx/core/operator_options.h
+++ b/include/matx/core/operator_options.h
@@ -168,6 +168,7 @@ namespace detail {
 
   // Input structure for types that require it
 
+  // Capabilities structures
 
   struct EPTQueryInput {
     bool jit;
@@ -185,6 +186,13 @@ namespace detail {
 
   struct SetGroupsPerBlockQueryInput {
     int groups_per_block;
+  };
+
+  struct AliasedMemoryQueryInput {
+    bool permutes_input_output;
+    bool is_prerun;
+    void *start_ptr;
+    void *end_ptr;
   };
 
 }

--- a/include/matx/core/type_utils_both.h
+++ b/include/matx/core/type_utils_both.h
@@ -174,6 +174,28 @@ template <typename T> constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_trans
 
 namespace detail {
 template <typename T, typename = void>
+struct has_can_alias_impl : cuda::std::false_type {
+};
+
+template <typename T>
+struct has_can_alias_impl<T, cuda::std::void_t<typename remove_cvref_t<T>::can_alias>> : cuda::std::true_type {
+};
+}
+
+/**
+ * @brief Determine if operator can alias
+ * 
+ * Returns true if the type is a transform operator and has the can_alias trait set
+ * 
+ * @tparam T Type to test
+ */
+template <typename T> constexpr __MATX_HOST__ __MATX_DEVICE__ bool can_alias()
+{
+  return is_matx_transform_op<T>() && detail::has_can_alias_impl<typename remove_cvref<T>::type>::value;
+}
+
+namespace detail {
+template <typename T, typename = void>
 struct has_matx_op_type : cuda::std::false_type {
 };
 

--- a/include/matx/generators/alternate.h
+++ b/include/matx/generators/alternate.h
@@ -60,17 +60,6 @@ namespace matx
           }
         }       
 
-        template <OperatorCapability Cap>
-        __MATX_INLINE__ __MATX_HOST__ auto get_capability_proc() const {
-          if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-            const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
-            return my_cap;
-          } else {        
-            auto self_has_cap = detail::capability_attributes<Cap>::default_value;
-            return self_has_cap;
-          }
-        } 
-
         template <typename CapType>
         __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto operator()(index_t i) const
         {

--- a/include/matx/generators/diag.h
+++ b/include/matx/generators/diag.h
@@ -68,16 +68,6 @@ namespace matx
         }
       }
 
-      template <OperatorCapability Cap>
-      __MATX_INLINE__ __MATX_HOST__ auto get_capability_proc() const {
-        if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-          const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
-          return my_cap;
-        } else {        
-          return detail::capability_attributes<Cap>::default_value;
-        }
-      }
-
       // Does not support vectorization yet
       template <typename CapType, typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const {

--- a/include/matx/generators/linspace.h
+++ b/include/matx/generators/linspace.h
@@ -79,17 +79,6 @@ namespace matx
           }
         }
 
-        template <OperatorCapability Cap>
-        __MATX_INLINE__ __MATX_HOST__ auto get_capability_proc() const {
-          if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-            const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
-            return my_cap;
-          } else {          
-            auto self_has_cap = detail::capability_attributes<Cap>::default_value;
-            return self_has_cap;
-          }
-        }
-
         template <typename CapType, typename... Is>
         __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ auto operator()(Is... indices) const { 
           static_assert(sizeof...(indices) == NUM_RC, "Number of indices incorrect in linspace");

--- a/include/matx/generators/logspace.h
+++ b/include/matx/generators/logspace.h
@@ -98,16 +98,6 @@ namespace matx
           }
         }       
 
-        template <OperatorCapability Cap>
-        __MATX_INLINE__ __MATX_HOST__ auto get_capability_proc() const {
-          if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-            const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
-            return my_cap;
-          } else {          
-            auto self_has_cap = detail::capability_attributes<Cap>::default_value;
-            return self_has_cap;
-          }
-        }
 
         __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ auto operator()(index_t idx) const
         {

--- a/include/matx/operators/argmax.h
+++ b/include/matx/operators/argmax.h
@@ -63,6 +63,12 @@ namespace detail {
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
+      template <OperatorCapability Cap, typename InType>
+      __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
+        auto self_has_cap = capability_attributes<Cap>::default_value;
+        return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(a_, in));
+      }      
+
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
         static_assert(cuda::std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 2 outputs on argmax(). ie: (mtie(O, I) = argmax(A))");   

--- a/include/matx/operators/argminmax.h
+++ b/include/matx/operators/argminmax.h
@@ -63,6 +63,12 @@ namespace detail {
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
+      template <OperatorCapability Cap, typename InType>
+      __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
+        auto self_has_cap = capability_attributes<Cap>::default_value;
+        return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(a_, in));
+      }        
+
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
         static_assert(cuda::std::tuple_size_v<remove_cvref_t<Out>> == 5, "Must use mtie with 4 outputs on argminmax(). ie: (mtie(MinVal, MinIdx, MaxVal, MaxIdx) = argminmax(A))");   

--- a/include/matx/operators/base_operator.h
+++ b/include/matx/operators/base_operator.h
@@ -37,9 +37,106 @@
 #include "matx/core/nvtx.h"
 #include "matx/core/operator_utils.h"
 #include "matx/core/capabilities.h"
+#include "matx/core/error.h"
 
 namespace matx
 {
+  namespace detail {
+    /**
+     * @brief Helper to get memory range from a tensor/lvalue for aliasing check
+     * 
+     * @tparam T Type of the lvalue
+     * @param lval The lvalue to get memory range from
+     * @return AliasedMemoryQueryInput with start and end pointers
+     */
+    template <typename T>
+    __MATX_INLINE__ __MATX_HOST__ AliasedMemoryQueryInput get_memory_range(const T& lval, bool is_prerun) {
+      // Handle both direct tensor views and operators with lvalue capability (like reshape, slice, etc.)
+      if constexpr ((is_tensor_view_v<T> || is_matx_op_lvalue<T>()) && T::Rank() > 0) {
+        using value_type = typename T::value_type;
+        
+        // Get address of first element using operator()(0, 0, ...)
+        auto get_first = [&lval]<size_t... Is>(cuda::std::index_sequence<Is...>) {
+          return &(const_cast<T&>(lval)(static_cast<index_t>(Is*0)...));
+        };
+        auto* start = static_cast<void*>(const_cast<value_type*>(get_first(cuda::std::make_index_sequence<T::Rank()>{})));
+        
+        // Get address of last element using operator()(Size(0)-1, Size(1)-1, ...)
+        auto get_last = [&lval]<size_t... Is>(cuda::std::index_sequence<Is...>) {
+          return &(const_cast<T&>(lval)(static_cast<index_t>(lval.Size(Is)-1)...));
+        };
+        auto* end = static_cast<void*>(const_cast<value_type*>(get_last(cuda::std::make_index_sequence<T::Rank()>{})) + 1);
+        
+        return AliasedMemoryQueryInput{false, is_prerun, start, end};
+      }
+      else {
+        // For non-tensor types or rank 0, return null pointers (no aliasing checks needed)
+        return AliasedMemoryQueryInput{false, is_prerun, nullptr, nullptr};
+      }
+    }
+
+    /**
+     * @brief Check if RHS operator aliases with LHS memory range
+     * 
+     * @tparam RHS Type of the right-hand side operator
+     * @tparam LHS Type of the left-hand side operator
+     * @param rhs The right-hand side operator
+     * @param lhs The left-hand side operator
+     * @param is_prerun Whether we are in prerun mode
+     * @return true if memory is aliased, false otherwise
+     */
+    template <typename LHS, typename RHS>
+    __MATX_INLINE__ __MATX_HOST__ bool check_aliased_memory([[maybe_unused]] const LHS& lhs, [[maybe_unused]] const RHS& rhs, [[maybe_unused]] bool is_prerun) {
+#ifdef MATX_EN_UNSAFE_ALIAS_DETECTION      
+      auto mem_range = get_memory_range(lhs, is_prerun);
+      
+      // If we got null pointers, no aliasing is possible
+      if (mem_range.start_ptr == nullptr || mem_range.end_ptr == nullptr) {
+        return false;
+      }
+      
+      // Query the RHS operator to see if it uses aliased memory
+      return get_operator_capability<OperatorCapability::ALIASED_MEMORY>(rhs, mem_range);
+#else
+      return false;
+#endif
+    }
+
+    /**
+     * @brief Check if mtie operation has aliased memory between LHS elements and RHS
+     * 
+     * @tparam MtieType Type of the mtie object
+     * @param mtie_obj The mtie object to check
+     */
+    template <typename MtieType>
+    __MATX_INLINE__ __MATX_HOST__ void check_mtie_aliased_memory([[maybe_unused]] const MtieType& mtie_obj) {
+#ifdef MATX_EN_UNSAFE_ALIAS_DETECTION      
+      constexpr size_t tuple_size = cuda::std::tuple_size_v<decltype(mtie_obj.ts_)>;
+      
+      // Get the RHS (last element of the tuple)
+      auto& rhs = cuda::std::get<tuple_size - 1>(mtie_obj.ts_);
+      
+      // Check each LHS element (all elements except the last one)
+      bool has_alias = false;
+      
+      // Use C++20 template lambda with index_sequence
+      [&]<size_t... Is>(cuda::std::index_sequence<Is...>) {
+        ([&] {
+          if constexpr (Is < tuple_size - 1) {
+            auto& lhs_elem = cuda::std::get<Is>(mtie_obj.ts_);
+            if (check_aliased_memory(lhs_elem, rhs, false)) {
+              has_alias = true;
+            }
+          }
+        }(), ...);
+      }(cuda::std::make_index_sequence<tuple_size>{});
+      
+      if (has_alias) {
+        MATX_THROW(matxInvalidParameter, "Aliased memory detected: One or more LHS tensors overlap with RHS memory");
+      }
+#endif      
+    }
+  } // namespace detail
 
   /**
    * @brief Provides a base class with functions common to all operators
@@ -80,23 +177,30 @@ namespace matx
           static_assert(is_executor_t<Ex>(), "Ex must be a MatX executor type");
 
           auto tp = static_cast<T *>(this);
-          // If we're doing a simple set operation from a transform we take a shorcut to avoid the extra
-          // async allocation we'd normally have to do
 
-          // If we're doing a simple set operation from a transform we take a shorcut to avoid the extra
-          // async allocation we'd normally have to do. For JIT CUDA executors, we don't need to run PreRun/PostRun
-          // since there's no async allocation.
+          // For JIT CUDA executors, we don't need to run PreRun/PostRun since there's no async allocation.
           if constexpr (is_jit_cuda_executor_t<Ex>()) {
             ex.Exec(*tp);
           }
           else if constexpr (is_mtie<T>() ) {
+            detail::check_mtie_aliased_memory(*tp);
             tp->Exec(ex);
           }
           else if constexpr (is_matx_set_op<T>()) {
             if constexpr (is_matx_transform_op<typename T::op_type>() && is_tensor_view_v<typename T::tensor_type>) {
+              // If we're doing a simple set operation from a transform we take a shorcut to avoid the extra
+              // async allocation we'd normally have to do   
+              if (!can_alias<decltype(tp->get_rhs())>() && detail::check_aliased_memory(tp->get_lhs(), tp->get_rhs(), false)) {
+                MATX_THROW(matxInvalidParameter, "Possible aliased memory detected: LHS and RHS memory ranges overlap");
+              }
+
               tp->TransformExec(tp->Shape(), ex);
             }
             else {
+              if (detail::check_aliased_memory(tp->get_lhs(), tp->get_rhs(), true)) {
+                MATX_THROW(matxInvalidParameter, "Possible aliased memory detected: LHS and RHS memory ranges overlap");
+              }
+
               if constexpr (is_matx_op<T>()) {
                 tp->PreRun(tp->Shape(), ex);
               }
@@ -109,6 +213,9 @@ namespace matx
             }
           }
           else {
+            // These can be operators like custom operators that take an output as a parameter. In those cases we cannot 
+            // check for aliasing since we don't control the operator.
+
             if constexpr (is_matx_op<T>()) {
               tp->PreRun(tp->Shape(), ex);
             }

--- a/include/matx/operators/binary_operators.h
+++ b/include/matx/operators/binary_operators.h
@@ -240,7 +240,7 @@ namespace matx
           return 
             detail::get_operator_capability<Cap>(in1_, in) +
             detail::get_operator_capability<Cap>(in2_, in);
-        }     
+        }   
         else {
           auto self_has_cap = capability_attributes<Cap>::default_value;
           return combine_capabilities<Cap>(self_has_cap, 

--- a/include/matx/operators/chol.h
+++ b/include/matx/operators/chol.h
@@ -58,6 +58,7 @@ namespace detail {
       using value_type = typename OpA::value_type;
       using matx_transform_op = bool;
       using chol_xform_op = bool;
+      using can_alias = bool; // Chol is allowed to use the same input/output memory
 
       __MATX_INLINE__ std::string str() const { return "chol()"; }
       __MATX_INLINE__ CholOp(const OpA &a, SolverFillMode uplo) : a_(a), uplo_(uplo) { }

--- a/include/matx/operators/conv.h
+++ b/include/matx/operators/conv.h
@@ -164,17 +164,6 @@ namespace matx
           return combine_capabilities<Cap>(self_has_cap, a_cap, b_cap);
         }
 
-        template <OperatorCapability Cap>
-        __MATX_INLINE__ __MATX_HOST__ auto get_capability_proc() const {
-          if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-            const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
-            return my_cap;
-          } else {        
-            auto self_has_cap = detail::capability_attributes<Cap>::default_value;
-            return self_has_cap;
-          }
-        }
-
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {
           return max_rank;

--- a/include/matx/operators/fftshift.h
+++ b/include/matx/operators/fftshift.h
@@ -97,6 +97,11 @@ namespace matx
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
           }
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op_, in_copy));
+          }
           else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));
@@ -192,6 +197,11 @@ namespace matx
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
           }
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op_, in_copy));
+          }          
           else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));
@@ -284,6 +294,11 @@ namespace matx
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
           }
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op_, in_copy));
+          }          
           else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));
@@ -377,6 +392,11 @@ namespace matx
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
           }
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op_, in_copy));
+          }          
           else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));

--- a/include/matx/operators/find_peaks.h
+++ b/include/matx/operators/find_peaks.h
@@ -66,10 +66,10 @@ namespace detail {
       template <typename... Is>
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const = delete;
 
-      template <OperatorCapability Cap>
-      __MATX_INLINE__ __MATX_HOST__ auto get_capability() const {
+      template <OperatorCapability Cap, typename InType>
+      __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
         auto self_has_cap = capability_attributes<Cap>::default_value;
-        return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(a_));
+        return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(a_, in));
       }
 
       template <typename Out, typename Executor>

--- a/include/matx/operators/hermitian.h
+++ b/include/matx/operators/hermitian.h
@@ -109,7 +109,13 @@ namespace matx
           if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
-          } else {
+          } 
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op_, in_copy));
+          }
+          else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));
           }

--- a/include/matx/operators/index.h
+++ b/include/matx/operators/index.h
@@ -90,17 +90,6 @@ namespace matx
             return capability_attributes<Cap>::default_value;
           }
         }
-
-        template <OperatorCapability Cap>
-        __MATX_INLINE__ __MATX_HOST__ auto get_capability_proc() const {
-          if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-            const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
-            return my_cap;
-          } else {        
-            auto self_has_cap = detail::capability_attributes<Cap>::default_value;
-            return self_has_cap;
-          }
-        }
     };
   }   
 

--- a/include/matx/operators/interleaved.h
+++ b/include/matx/operators/interleaved.h
@@ -121,6 +121,11 @@ namespace matx
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
           }
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op_, in_copy));
+          }
           else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));

--- a/include/matx/operators/interp.h
+++ b/include/matx/operators/interp.h
@@ -176,17 +176,6 @@ namespace matx {
         }
       }
 
-      template <OperatorCapability Cap>
-      __MATX_INLINE__ __MATX_HOST__ auto get_capability_proc() const {
-        if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-          const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
-          return my_cap;
-        } else {        
-          auto self_has_cap = detail::capability_attributes<Cap>::default_value;
-          return self_has_cap;
-        }
-      }
-
       __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ index_t Size(uint32_t i) const  { return d_.Size(i); }
       static inline constexpr __host__ __device__ int32_t Rank() { return O::Rank(); }
     };

--- a/include/matx/operators/matmul.h
+++ b/include/matx/operators/matmul.h
@@ -110,10 +110,16 @@ namespace matx
 
         template <OperatorCapability Cap, typename InType>
         __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
-          auto self_has_cap = capability_attributes<Cap>::default_value;
-          return combine_capabilities<Cap>(self_has_cap, 
-                                           detail::get_operator_capability<Cap>(a_, in),
-                                           detail::get_operator_capability<Cap>(b_, in));
+          if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(a_, in_copy), detail::get_operator_capability<Cap>(b_, in_copy));
+          } else {
+            auto self_has_cap = capability_attributes<Cap>::default_value;
+            return combine_capabilities<Cap>(self_has_cap, 
+                                             detail::get_operator_capability<Cap>(a_, in),
+                                             detail::get_operator_capability<Cap>(b_, in));
+          }
         }
    
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()

--- a/include/matx/operators/planar.h
+++ b/include/matx/operators/planar.h
@@ -118,6 +118,11 @@ namespace matx
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
           }
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op_, in_copy));
+          }
           else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));

--- a/include/matx/operators/r2c.h
+++ b/include/matx/operators/r2c.h
@@ -100,7 +100,13 @@ namespace matx
           if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
-          } else {
+          } 
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op_, in_copy));
+          }
+          else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));
           }

--- a/include/matx/operators/reverse.h
+++ b/include/matx/operators/reverse.h
@@ -146,7 +146,13 @@ namespace matx
           if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
-          } else {
+          } 
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return detail::get_operator_capability<Cap>(op_, in_copy);
+          }
+          else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));
           }

--- a/include/matx/operators/shift.h
+++ b/include/matx/operators/shift.h
@@ -134,12 +134,14 @@ namespace matx
             detail::get_operator_capability<Cap>(op_, in),
               detail::get_operator_capability<Cap>(shift_, in)
             );
+          } else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op_, in_copy), detail::get_operator_capability<Cap>(shift_, in_copy));
           } else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(
-              self_has_cap,
-            detail::get_operator_capability<Cap>(op_, in),
-              detail::get_operator_capability<Cap>(shift_, in)
+              self_has_cap, detail::get_operator_capability<Cap>(op_, in), detail::get_operator_capability<Cap>(shift_, in)
             );
           }
         }

--- a/include/matx/operators/stack.h
+++ b/include/matx/operators/stack.h
@@ -198,7 +198,13 @@ namespace matx
         if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
           const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
           return combine_capabilities<Cap>(my_cap, get_combined_ops_capability<Cap>(in, ops_));
-        } else {
+        } 
+        else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+          auto in_copy = in;
+          in_copy.permutes_input_output = true;
+          return combine_capabilities<Cap>(detail::get_combined_ops_capability<Cap>(in_copy, ops_));
+        }
+        else {
           auto self_has_cap = capability_attributes<Cap>::default_value;
           return combine_capabilities<Cap>(self_has_cap, get_combined_ops_capability<Cap>(in, ops_));
         }

--- a/include/matx/operators/toeplitz.h
+++ b/include/matx/operators/toeplitz.h
@@ -130,7 +130,13 @@ namespace matx
             auto op1_cap = detail::get_operator_capability<Cap>(op1_, in);
             auto op2_cap = detail::get_operator_capability<Cap>(op2_, in);
             return combine_capabilities<Cap>(my_cap, op1_cap, op2_cap);
-          } else {
+          } 
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(op1_, in_copy), detail::get_operator_capability<Cap>(op2_, in_copy));
+          }
+          else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             auto op1_cap = detail::get_operator_capability<Cap>(op1_, in);
             auto op2_cap = detail::get_operator_capability<Cap>(op2_, in);

--- a/include/matx/operators/transpose.h
+++ b/include/matx/operators/transpose.h
@@ -93,8 +93,15 @@ namespace detail {
 
       template <OperatorCapability Cap, typename InType>
       __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType &in) const {
-        auto self_has_cap = capability_attributes<Cap>::default_value;
-        return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(a_, in));
+        if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+          auto in_copy = in;
+          in_copy.permutes_input_output = true;
+          return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(a_, in_copy));
+        }
+        else {
+          auto self_has_cap = capability_attributes<Cap>::default_value;
+          return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(a_, in));
+        }
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/transforms/svd/svd_cuda.h
+++ b/include/matx/transforms/svd/svd_cuda.h
@@ -677,7 +677,7 @@ public:
               MatXTypeToCudaType<T1>(), &this->dspace, &this->hspace);
     }
     else {
-      int i_dspace;
+      int i_dspace = 0;
 
       if constexpr (std::is_same_v<float, T1>) {
         ret = cusolverDnSgesvdjBatched_bufferSize(

--- a/test/00_operators/CMakeLists.txt
+++ b/test/00_operators/CMakeLists.txt
@@ -2,6 +2,7 @@ set(OPERATOR_TEST_FILES
   abs2_test.cu
   advanced_op_test.cu
   advanced_remap_test.cu
+  aliased_memory_test.cu
   angle_test.cu
   apply_test.cu
   apply_idx_test.cu

--- a/test/00_operators/aliased_memory_test.cu
+++ b/test/00_operators/aliased_memory_test.cu
@@ -1,0 +1,339 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "operator_test_types.hpp"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+
+using namespace matx;
+using namespace matx::test;
+
+#ifdef MATX_EN_UNSAFE_ALIAS_DETECTION
+
+// Test that simple element-wise aliasing (a = a + a) does NOT throw
+TYPED_TEST(OperatorTestsNumericAllExecs, SimpleAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({10, 20});
+
+  // This should NOT throw because it's a simple element-wise operation
+  EXPECT_NO_THROW({
+    (a = a + a).run(exec);
+    exec.sync();
+  });
+
+  MATX_EXIT_HANDLER();
+}
+
+// Test that non-aliasing (b = a + c) does NOT throw an error
+TYPED_TEST(OperatorTestsNumericAllExecs, NoAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({10, 20});
+  auto b = make_tensor<TestType>({10, 20});
+  auto c = make_tensor<TestType>({10, 20});
+
+  // This should NOT throw because a, b, and c are all different tensors
+  EXPECT_NO_THROW({
+    (b = a + c).run(exec);
+    exec.sync();
+  });
+
+  MATX_EXIT_HANDLER();
+}
+
+
+// Test that non-overlapping slices do NOT throw
+TYPED_TEST(OperatorTestsNumericAllExecs, NonOverlappingSlices)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({20, 20});
+
+  // Create non-overlapping slices
+  auto a_slice1 = slice(a, {0, 0}, {10, 10});
+  auto a_slice2 = slice(a, {10, 10}, {20, 20});
+  
+  // This should NOT throw because the slices don't overlap
+  EXPECT_NO_THROW({
+    (a_slice1 = a_slice2).run(exec);
+    exec.sync();
+  });
+
+  MATX_EXIT_HANDLER();
+}
+
+// Test overlapping slices with element-wise operations do NOT throw
+TYPED_TEST(OperatorTestsNumericAllExecs, OverlappingSlices)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({20, 20});
+
+  // Create overlapping slices
+  auto a_slice1 = slice(a, {0, 0}, {15, 15});
+  auto a_slice2 = slice(a, {5, 5}, {20, 20});
+  
+  // This should throw because it's an overlapping slice operation
+  EXPECT_THROW({
+    (a_slice1 = a_slice2).run(exec);
+    exec.sync();
+  }, matx::detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}
+
+
+// Test that cloned tensors do NOT alias
+TYPED_TEST(OperatorTestsNumericAllExecs, CloneNoAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({10});
+  auto b = make_tensor<TestType>({10, 20});
+  auto c = make_tensor<TestType>({10, 20});
+
+  // Clone creates a lazy operator, not actual memory, so no aliasing
+  auto a_cloned = clone<2>(a, {matxKeepDim, 20});
+  
+  // This should NOT throw because clone doesn't actually share memory
+  EXPECT_NO_THROW({
+    (b = a_cloned + c).run(exec);
+    exec.sync();
+  });
+
+  MATX_EXIT_HANDLER();
+}
+
+
+// Test that different tensors in expression do NOT alias
+TYPED_TEST(OperatorTestsNumericAllExecs, ComplexExpressionNoAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({10, 10});
+  auto b = make_tensor<TestType>({10, 10});
+  auto c = make_tensor<TestType>({10, 10});
+  auto d = make_tensor<TestType>({10, 10});
+
+  // This should NOT throw - all different tensors
+  EXPECT_NO_THROW({
+    (d = a + b + c).run(exec);
+    exec.sync();
+  });
+
+  MATX_EXIT_HANDLER();
+}
+
+
+// Test nested transform operations with aliasing (FFT example)
+TYPED_TEST(OperatorTestsComplexNonHalfTypesAllExecs, NestedTransformAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  if constexpr (!detail::CheckFFTSupport<ExecType, TestType>()) {
+    GTEST_SKIP();
+  }    
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({128});
+  auto b = make_tensor<TestType>({128});
+
+  // This should not throw because PreRun will allocate temporary memory for the FFTs
+  EXPECT_NO_THROW({
+    (a = ifft(fft(a) * fft(b))).run(exec);
+    exec.sync();
+  });
+
+  MATX_EXIT_HANDLER();
+}
+
+// Test nested transform operations WITHOUT aliasing
+TYPED_TEST(OperatorTestsComplexNonHalfTypesAllExecs, NestedTransformNoAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  if constexpr (!detail::CheckFFTSupport<ExecType, TestType>()) {
+    GTEST_SKIP();
+  }    
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({128});
+  auto b = make_tensor<TestType>({128});
+  auto c = make_tensor<TestType>({128});
+
+  // This should NOT throw because c, a, and b are all different
+  // c = ifft(fft(a) * fft(b))
+  EXPECT_NO_THROW({
+    (c = ifft(fft(a) * fft(b))).run(exec);
+    exec.sync();
+  });
+
+  MATX_EXIT_HANDLER();
+}
+
+// Test that shift() with aliasing DOES throw (permutation transform)
+TYPED_TEST(OperatorTestsNumericAllExecs, ShiftAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({100});
+
+  // This SHOULD throw because shift() is a permutation transform on RHS
+  EXPECT_THROW({
+    (a = shift<0>(a, 5)).run(exec);
+    exec.sync();
+  }, matx::detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}
+
+
+
+// Test that permute() with slice aliasing DOES throw
+TYPED_TEST(OperatorTestsNumericAllExecs, PermuteSliceAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({20, 20});
+  auto a_slice = slice(a, {0, 0}, {10, 10});
+
+  // This SHOULD throw - permute() transforms how a_slice is accessed
+  EXPECT_THROW({
+    (a_slice = permute(a_slice, {1, 0})).run(exec);
+    exec.sync();
+  }, matx::detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}
+
+// Test that reverse() with aliasing DOES throw (permutation transform)
+TYPED_TEST(OperatorTestsNumericAllExecs, ReverseAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({100});
+
+  // This SHOULD throw - reverse() is a permutation transform
+  EXPECT_THROW({
+    (a = reverse<0>(a)).run(exec);
+    exec.sync();
+  }, matx::detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}
+
+// Test that matmul() with aliasing DOES throw (transform operation)
+TYPED_TEST(OperatorTestsFloatAllExecs, MatmulAliasing)
+{
+  MATX_ENTER_HANDLER();
+  
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  if constexpr (!detail::CheckMatMulSupport<ExecType, TestType>()) {
+    GTEST_SKIP();
+  }
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({10, 10});
+  auto b = make_tensor<TestType>({10, 10});
+
+  // This SHOULD throw - a appears on LHS and in matmul on RHS
+  EXPECT_THROW({
+    (a = matmul(a, b)).run(exec);
+    exec.sync();
+  }, matx::detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}
+
+
+#endif


### PR DESCRIPTION
Closes #1025 

Implement detection for unsafe memory aliasing between input and output tensors in transform operations. Enabled via MATX_EN_UNSAFE_ALIAS_DETECTION flag. Includes can_alias() trait function and matmul aliasing unit test.