### PR TITLE
Use new python dlpack interface, fixing warnings

### DIFF
--- a/examples/python_integration_sample/example_matxutil.py
+++ b/examples/python_integration_sample/example_matxutil.py
@@ -12,7 +12,7 @@ import matxutil
 # Demonstrate dlpack consumption invalidates it for future use
 def dlp_usage_error():
   a = cp.empty((3,3), dtype=cp.float32)
-  dlp = a.toDlpack()
+  dlp = a.__dlpack__()
   assert(matxutil.check_dlpack_status(dlp) == 0)
   a2 = cp.from_dlpack(dlp) # causes dlp to become unused
   assert(matxutil.check_dlpack_status(dlp) != 0)
@@ -22,7 +22,7 @@ def dlp_usage_error():
 def scope_okay():
   a = cp.empty((3,3), dtype=cp.float32)
   a[1,1] = 2
-  dlp = a.toDlpack()
+  dlp = a.__dlpack__()
   assert(matxutil.check_dlpack_status(dlp) == 0)
   return dlp
 
@@ -67,9 +67,9 @@ with stream:
    b = cp.array([[1,2,3],[4,5,6],[7,8,9]], dtype=cp.float32)
    c = cp.empty(b.shape, dtype=b.dtype)
 
-   c_dlp = c.toDlpack()
-   a_dlp = a.toDlpack()
-   b_dlp = b.toDlpack()
+   c_dlp = c.__dlpack__(stream=stream.ptr)
+   a_dlp = a.__dlpack__(stream=stream.ptr)
+   b_dlp = b.__dlpack__(stream=stream.ptr)
    matxutil.add_float_2D(c_dlp, a_dlp, b_dlp, stream.ptr)
    stream.synchronize()
    print(f"Tensor a {a}")


### PR DESCRIPTION
dlpack changed their Python interface to make the stream synchronization semantics clearer (see https://github.com/dmlc/dlpack/issues/57). The interface now involves the consumer calling the `__dlpack__()` method on the producer array, with an optional stream argument (see https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html).

Although I think this usage is correct, I'm not sure it is quite intended, as it doesn't formally "consume" the array (instead, it maintains a reference to the "unconsumed" object while operating on it, then lets it go out of scope, allowing it to be cleaned up). Part of the issue is that the Python dlpack interface is intended for python package interop, not Python <-> C++ interop.

This fixes some warnings when running the examples, e.g.
```
/workspaces/MatX/build/../examples/python_integration_sample/example_matxutil.py:70: VisibleDeprecationWarning: This function is deprecated and will be removed in a future release. Use the cupy.from_dlpack() array constructor instead.
  c_dlp = c.toDlpack()
/workspaces/MatX/build/../examples/python_integration_sample/example_matxutil.py:71: VisibleDeprecationWarning: This function is deprecated and will be removed in a future release. Use the cupy.from_dlpack() array constructor instead.
  a_dlp = a.toDlpack()
/workspaces/MatX/build/../examples/python_integration_sample/example_matxutil.py:72: VisibleDeprecationWarning: This function is deprecated and will be removed in a future release. Use the cupy.from_dlpack() array constructor instead.
  b_dlp = b.toDlpack()
```