### PR TITLE
Add helper functions to clear MatX caches and allocations

### DIFF
--- a/examples/channelize_poly_bench.cu
+++ b/examples/channelize_poly_bench.cu
@@ -139,7 +139,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   // printf("Benchmarking complex<double> -> complex<double>\n");
   // ChannelizePolyBench<cuda::std::complex<double>,cuda::std::complex<double>>(channel_start, channel_stop);
 
-  matx::ClearMatXCachesAndAllocations();
+  matx::ClearCachesAndAllocations();
 
   MATX_EXIT_HANDLER();
 }

--- a/include/matx/core/allocator.h
+++ b/include/matx/core/allocator.h
@@ -289,9 +289,12 @@ __MATX_INLINE__ MemTracker &GetAllocMap() {
 // made with matxAlloc. These allocations may have been made directly by the user or they
 // may have been made by MatX internally for workspaces. This function does not free the
 // caches (i.e., allocations made for FFT plans, cuBLAS handles, and other state required
-// for MatX transforms). To free those caches, use matx::FreeMatXCaches().
+// for MatX transforms). To free those caches, use matx::ClearCaches(). It is not safe to
+// call matxFree() on user-managed pointers after calling this function. This function should
+// be called after the user application has called matxFree() on any pointers for which it
+// will call matxFree().
 __attribute__ ((visibility ("default")))
-__MATX_INLINE__ void FreeMatXAllocations() {
+__MATX_INLINE__ void FreeAllocations() {
   GetAllocMap().free_all();
 }
 

--- a/test/00_misc/ClearCacheTests.cu
+++ b/test/00_misc/ClearCacheTests.cu
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2021, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "assert.h"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+#include "gtest/gtest.h"
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+
+using namespace matx;
+
+TEST(ClearCacheTests, TestCase) {
+    MATX_ENTER_HANDLER();
+
+    size_t initial_free_mem = 0;
+    size_t total_mem = 0;
+    cudaError_t err = cudaMemGetInfo(&initial_free_mem, &total_mem);
+    ASSERT_EQ(err, cudaSuccess);
+
+    // The cuBLAS handle will allocate an associated workspace of 4 MiB on pre-Hopper and
+    // 32 MiB on Hopper+.
+    {
+        auto c = matx::make_tensor<float, 2>({1024, 1024});
+        auto a = matx::make_tensor<float, 2>({1024, 1024});
+        auto b = matx::make_tensor<float, 2>({1024, 1024});
+        (c = matx::matmul(a, b)).run();
+        cudaDeviceSynchronize();    
+    }
+
+    // Manually allocate 4 MiB
+    const size_t four_MiB = 4 * 1024 * 1024;
+    void *ptr;
+    matxAlloc(&ptr, four_MiB, MATX_DEVICE_MEMORY);
+
+    size_t post_alloc_free_mem = 0;
+    err = cudaMemGetInfo(&post_alloc_free_mem, &total_mem);
+    ASSERT_EQ(err, cudaSuccess);
+
+    matx::ClearCachesAndAllocations();
+
+    size_t post_clear_free_mem = 0;
+    err = cudaMemGetInfo(&post_clear_free_mem, &total_mem);
+    ASSERT_EQ(err, cudaSuccess);
+
+    const ssize_t allocated = static_cast<ssize_t>(initial_free_mem) - static_cast<ssize_t>(post_alloc_free_mem);
+    const ssize_t freed = static_cast<ssize_t>(post_clear_free_mem) - static_cast<ssize_t>(post_alloc_free_mem);
+
+    // The cuBLAS cache and allocator data structure should have allocated at least 8 MiB
+    // in total and thus at least 8 MiB should be freed when clearing the caches/allocations.
+    ASSERT_GE(allocated, 2 * four_MiB);
+    ASSERT_GE(freed, 2 * four_MiB);
+
+    MATX_EXIT_HANDLER();
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ list(TRANSFORM OPERATOR_TEST_FILES PREPEND "00_operators/")
 
 set (test_sources
     00_misc/AllocatorTests.cu
+    00_misc/ClearCacheTests.cu
     00_misc/ProfilingTests.cu
     00_tensor/BasicTensorTests.cu
     00_tensor/CUBTests.cu
@@ -140,6 +141,8 @@ endforeach()
 
 # Number of test jobs to run in parallel
 set(CTEST_PARALLEL_JOBS 4)
+
+set_tests_properties(test_00_misc_ClearCacheTests PROPERTIES RUN_SERIAL TRUE)
 
 # Create a legacy matx_test script for CI compatibility
 configure_file(

--- a/test/main.cu
+++ b/test/main.cu
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
   ::testing::InitGoogleTest(&argc, argv);
   const int result = RUN_ALL_TESTS();
 
-  matx::ClearMatXCachesAndAllocations();
+  matx::ClearCachesAndAllocations();
 
   return result;
 }


### PR DESCRIPTION
MatX caches (e.g., cuFFT plans or cuBLAS handles) and allocations (user or internal allocations via matxAlloc) are stored in static data structures. These data structures are destroyed during program exit using the corresponding destructors. However, due to ordering of static destructors and atexit handlers, it is possible for resources to be freed after the CUDA context or some other dependent resource has been destroyed. This can result in a segmentation fault during program exit.

The helper function ClearCachesAndAllocations() can be called prior to program exit to free resources allocated by MatX. This will prevent conflicts with other static destructors and atexit handlers and thus allow clean shutdown. The function may also be useful at other times that the user wishes to free resources allocated via MatX.

There are two other helpers, ClearCaches() and FreeAllocations(), to dellocate data associated with the caches (plans, handles, workspaces, etc.) and allocations made via matxAlloc(), respectively.