### PR TITLE
Use the underlying memory pointer to determine where memory resides in ToDlPack

### DIFF
--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -1470,7 +1470,7 @@ MATX_LOOP_UNROLL
     t->device.device_id = 0;
 
     // Determine where this memory resides
-    void *data_ptr = this->GetStorage().data();
+    void *data_ptr = const_cast<tensor_t*>(this)->GetStorage().data();
     auto kind = GetPointerKind(data_ptr);
     [[maybe_unused]] auto mem_res = cuPointerGetAttributes(sizeof(attr)/sizeof(attr[0]), attr, data, reinterpret_cast<CUdeviceptr>(data_ptr));
     MATX_ASSERT_STR_EXP(mem_res, CUDA_SUCCESS, matxCudaError, "Error returned from cuPointerGetAttributes");


### PR DESCRIPTION
For tensor slices, ToDlPack was previously incorrectly assigning the device_type because Data() pointed to the offset. When using MATX_MANAGED_MEMORY, cuPointerGetAttributes cannot tell the difference between CPU and GPU memory.