### PR TITLE
Fixes for 32-bit builds. Tested w/ gcc 11.4 and CTK 12.9

### DIFF
--- a/examples/black_scholes.cu
+++ b/examples/black_scholes.cu
@@ -272,7 +272,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
     float v4 = output_tensor4(i);
     if (fabsf(v1 - v2) > tol || fabsf(v1 - v3) > tol || fabsf(v1 - v4) > tol || 
         fabsf(v2 - v3) > tol || fabsf(v2 - v4) > tol || fabsf(v3 - v4) > tol) {
-      printf("Mismatch at idx %lld: v1=%.8f v2=%.8f v3=%.8f v4=%.8f\n", i, v1, v2, v3, v4);
+      printf("Mismatch at idx %" MATX_INDEX_T_FMT ": v1=%.8f v2=%.8f v3=%.8f v4=%.8f\n", i, v1, v2, v3, v4);
       all_match = false;
       break;
     }

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -372,7 +372,9 @@ auto make_tensor( TensorType &tensor,
  * @returns New tensor
  **/
 template <typename T, typename ShapeType>
-  requires (!is_matx_descriptor<ShapeType> && !std::is_array_v<remove_cvref_t<ShapeType>>)
+  requires (!is_matx_descriptor<ShapeType> &&
+            !std::is_array_v<remove_cvref_t<ShapeType>> &&
+            is_tuple_c<remove_cvref_t<ShapeType>>)
 auto make_tensor( T *data,
                   ShapeType &&shape,
                   bool owning = false) {
@@ -464,7 +466,9 @@ auto make_tensor( TensorType &tensor,
  * @returns New tensor
  **/
 template <typename T, typename ShapeType>
-  requires (!is_matx_descriptor<ShapeType> && !std::is_array_v<remove_cvref_t<ShapeType>>)
+  requires (!is_matx_descriptor<ShapeType> &&
+            !std::is_array_v<remove_cvref_t<ShapeType>> &&
+            is_tuple_c<remove_cvref_t<ShapeType>>)
 auto make_tensor_p( T *const data,
                     ShapeType &&shape,
                     bool owning = false) {

--- a/include/matx/kernels/filter.cuh
+++ b/include/matx/kernels/filter.cuh
@@ -109,13 +109,13 @@ MATX_LOOP_UNROLL
   // blocks for the map step, store that value as well
   if (tid < len) {
 MATX_LOOP_UNROLL
-    for (uint32_t r = 0; r < RECURSIVE_VALS_PER_THREAD; r++) {
-      vals[r] = d_in(blockIdx.y, tid + BLOCK_SIZE_RECURSIVE * r);
+    for (index_t r = 0; r < RECURSIVE_VALS_PER_THREAD; r++) {
+      vals[r] = d_in(static_cast<index_t>(blockIdx.y), static_cast<index_t>(tid + BLOCK_SIZE_RECURSIVE * r));
     }
 
     if (lane > WARP_SIZE - num_non_recursive) {
 MATX_LOOP_UNROLL
-      for (uint32_t r = 0; r < RECURSIVE_VALS_PER_THREAD; r++) {
+      for (index_t r = 0; r < RECURSIVE_VALS_PER_THREAD; r++) {
         s_exch[((BLOCK_SIZE_RECURSIVE / WARP_SIZE) * r + (warp_id + 1)) *
                    (num_non_recursive - 1) +
                (WARP_SIZE - lane - 1)] =
@@ -134,7 +134,7 @@ MATX_LOOP_UNROLL
       }
       else {
         s_exch[threadIdx.x] =
-            d_in(blockIdx.y, chunk_id * blockDim.x - threadIdx.x - 1);
+            d_in(static_cast<index_t>(blockIdx.y), static_cast<index_t>(chunk_id * blockDim.x - threadIdx.x - 1));
       }
     }
   }
@@ -603,7 +603,7 @@ MATX_LOOP_UNROLL
 MATX_LOOP_UNROLL
   for (uint32_t r = 0; r < RECURSIVE_VALS_PER_THREAD; r++) {
     if ((tid + r * BLOCK_SIZE_RECURSIVE) < len) {
-      d_out(blockIdx.y, tid + r * BLOCK_SIZE_RECURSIVE) = vals[r];
+      d_out(static_cast<index_t>(blockIdx.y), static_cast<index_t>(tid + r * BLOCK_SIZE_RECURSIVE)) = vals[r];
     }
   }
 


### PR DESCRIPTION
Adjust the make_tensor constraints to not match allocators to a ShapeType. Use MATX_INDEX_T_FMT in place of lld and explicitly convert indices in filter.cuh to index_t.