### PR TITLE
Add FMA function for the fltflt data type

### DIFF
--- a/include/matx/kernels/sar_bp.cuh
+++ b/include/matx/kernels/sar_bp.cuh
@@ -72,7 +72,8 @@ __device__ inline fltflt ComputeRangeToPixelFloatFloat(fltflt apx, fltflt apy, f
     const fltflt dx = px - apx;
     const fltflt dy = py - apy;
     const fltflt dz = pz - apz;
-    return fltflt_sqrt(dx * dx + dy * dy + dz * dz);
+    const fltflt dx2dy2 = fltflt_fma(dx, dx, dy * dy);
+    return fltflt_sqrt(fltflt_fma(dz, dz, dx2dy2));
 }
 
 template <typename PlatPosType, SarBpComputeType ComputeType, typename strict_compute_t, typename loose_compute_t>


### PR DESCRIPTION
fltflt_fma() performs a * b + c for fltflt types more efficiently than a fltflt_mul() followed by a fltflt_add(). The fused function can perform one fewer normalization than the separate functions.

This PR also switches from function names like fltflt_add_float(fltflt, float) to overloads of fltflt_add(). The former were intended to be more easily usable in a C context, but the file now contains many other C++ features (ctors, conversion operators, comparison operators, etc.).w