### PR TITLE
Avoid warning about unused variables

### DIFF
--- a/docs_input/notebooks/gtc_lab/samples/kernel_fusion.cu
+++ b/docs_input/notebooks/gtc_lab/samples/kernel_fusion.cu
@@ -29,24 +29,16 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   for (int i = 0; i < 10; i++) {
 
     // first individual, independent kernels
-    MATX_NVTX_START_RANGE("Unfused Kernels");
+    [[maybe_unused]] int unfused_range = MATX_NVTX_START_RANGE("Unfused Kernels");
     (result = cos(C)).run(exec);
     (result = result / D).run(exec);
     (result = result * B).run(exec);
     MATX_NVTX_END_RANGE(unfused_range);
 
     // now, as a fused operation
-    MATX_NVTX_START_RANGE("Fused Operation");
+    [[maybe_unused]] int fused_range = MATX_NVTX_START_RANGE("Fused Operation");
     (A = B * cos(C)/D).run(exec);
     MATX_NVTX_END_RANGE(fused_range);
-
-#ifdef MATX_NVTX_FLAGS
-    ASSERT_NE(unfused_range, 0);
-    ASSERT_NE(fused_range, 0);
-#else
-    ASSERT_EQ(unfused_range, 0);
-    ASSERT_EQ(fused_range, 0);
-#endif
   }
 
   MATX_EXIT_HANDLER();

--- a/examples/kernel_fusion.cu
+++ b/examples/kernel_fusion.cu
@@ -29,16 +29,17 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   for (int i = 0; i < 10; i++) {
 
     // first individual, independent kernels
-    MATX_NVTX_START_RANGE("Unfused Kernels");
+    [[maybe_unused]] int unfused_range = MATX_NVTX_START_RANGE("Unfused Kernels");
     (result = cos(C)).run(exec);
     (result = result / D).run(exec);
     (result = result * B).run(exec);
     MATX_NVTX_END_RANGE(unfused_range);
 
     // now, as a fused operation
-    MATX_NVTX_START_RANGE("Fused Operation");
+    [[maybe_unused]] int fused_range = MATX_NVTX_START_RANGE("Fused Operation");
     (A = B * cos(C)/D).run(exec);
     MATX_NVTX_END_RANGE(fused_range);
+
   }
   MATX_EXIT_HANDLER();
 }


### PR DESCRIPTION
Commonly the NVTX annotations do not get a variable assigned

Picked up in CCCL CI