### PR TITLE
add python deps to devcontainer

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -5,9 +5,16 @@ ARG REMOTE_USER
 ARG REMOTE_UID
 ARG REMOTE_GID
 
-RUN apt-get update && apt-get install -y locales && \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    locales \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    python3-numpy && \
     sed -i 's/^# *en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    locale-gen
+    locale-gen && \
+    rm -rf /var/lib/apt/lists/*
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Python is required for building the tests, so makes sense to install them in the devcontainer dockerfile.