### PR TITLE
add emulated double->fltflt cast

### DIFF
--- a/bench/00_misc/fltflt_arithmetic.cu
+++ b/bench/00_misc/fltflt_arithmetic.cu
@@ -1077,7 +1077,13 @@ __global__ void iterative_cast2fltflt_kernel(fltflt* __restrict__ result, int64_
         acc[ilp] = static_cast<fltflt>(src_val);
         asm volatile("" : "+f"(acc[ilp].hi), "+f"(acc[ilp].lo));
       }
-      src_val = src_val + static_cast<T>(0.0001);
+      // For double, increment the bit pattern to get the next representable value
+      // so the loop anti-aliasing doesn't introduce a double-precision add.
+      if constexpr (std::is_same_v<T, double>) {
+        src_val = __longlong_as_double(__double_as_longlong(src_val) + 1LL);
+      } else {
+        src_val = src_val + static_cast<T>(0.0001);
+      }
     }
 
     fltflt result_val = acc[0];

--- a/bench/00_misc/fltflt_arithmetic.cu
+++ b/bench/00_misc/fltflt_arithmetic.cu
@@ -1079,7 +1079,7 @@ __global__ void iterative_cast2fltflt_kernel(fltflt* __restrict__ result, int64_
       }
       // For double, increment the bit pattern to get the next representable value
       // so the loop anti-aliasing doesn't introduce a double-precision add.
-      if constexpr (std::is_same_v<T, double>) {
+      if constexpr (cuda::std::is_same_v<T, double>) {
         src_val = __longlong_as_double(__double_as_longlong(src_val) + 1LL);
       } else {
         src_val = src_val + static_cast<T>(0.0001);

--- a/include/matx/kernels/fltflt.h
+++ b/include/matx/kernels/fltflt.h
@@ -58,8 +58,56 @@ struct alignas(8) fltflt {
     // nvcc will warn about __host__ and __device__ annotations on default constructors because default
     // constructors will not run in all conditions (e.g., in static shared memory CUDA kernel allocations).
     __MATX_INLINE__ fltflt() = default;
-    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ constexpr explicit fltflt(double x)
-        : hi(static_cast<float>(x)), lo(static_cast<float>(x - static_cast<double>(hi))) {}
+    // On device, we avoid double-precision subtraction by extracting the residual mantissa
+    // bits directly from the IEEE 754 representation using integer operations. hi is the
+    // truncated (round-toward-zero) float, so hi + lo == x exactly in real arithmetic.
+    // Ties-to-even and NaN/Inf are not handled precisely (edge cases fall back to
+    // hi=(float)x, lo=0). The constexpr branch is taken during compile-time evaluation.
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ constexpr explicit fltflt(double x) {
+#if defined(__CUDA_ARCH__)
+        // During compile-time (constexpr) evaluation on device, fall through to the
+        // standard double-subtraction path which is constexpr-compatible.
+        if (__builtin_is_constant_evaluated()) {
+            hi = static_cast<float>(x);
+            lo = static_cast<float>(x - static_cast<double>(hi));
+        } else {
+            // Fast runtime path: extract residual mantissa bits via integer operations,
+            // avoiding double-precision subtraction. hi uses truncation (round-toward-zero),
+            // so hi + lo == x exactly in real arithmetic. NaN/Inf/subnormal doubles and
+            // doubles outside float range are not handled precisely (per design).
+            unsigned long long xbits = __double_as_longlong(x);
+            unsigned int sign = (unsigned int)(xbits >> 63);
+            unsigned int e_x = (unsigned int)((xbits >> 52) & 0x7FFU);
+            unsigned long long mant = xbits & 0x000FFFFFFFFFFFFFULL;
+            // float biased exponent: (e_x - 1023) + 127 = e_x - 896
+            int hi_exp = (int)e_x - 896;
+            if (e_x == 0 || hi_exp <= 0 || hi_exp >= 255) {
+                hi = (float)x;
+                lo = 0.0f;
+            } else {
+                // hi: top 23 explicit mantissa bits, same exponent as x.
+                hi = __int_as_float((sign << 31) | ((unsigned int)hi_exp << 23) | (unsigned int)(mant >> 29));
+                // lo: lower 29 bits of significand, scaled to the correct power of 2.
+                unsigned int r = (unsigned int)(mant & 0x1FFFFFFFU);
+                if (r == 0) {
+                    lo = 0.0f;
+                } else {
+                    int n = 31 - __clz(r);           // highest set bit of r (0..28)
+                    int lo_exp = n + (int)e_x - 948; // n + (e_x - 1023 - 52) + 127
+                    if (lo_exp <= 0) {
+                        lo = 0.0f;
+                    } else {
+                        unsigned int lo_mant = (n >= 23) ? (r >> (n - 23)) : (r << (23 - n));
+                        lo = __int_as_float((sign << 31) | ((unsigned int)lo_exp << 23) | (lo_mant & 0x7FFFFFU));
+                    }
+                }
+            }
+        }
+#else
+        hi = static_cast<float>(x);
+        lo = static_cast<float>(x - static_cast<double>(hi));
+#endif
+    }
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ constexpr explicit fltflt(float x) : hi(x), lo(0.0f) {}
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ constexpr explicit fltflt(float hi_, float lo_) : hi(hi_), lo(lo_) {}
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ constexpr explicit operator double() const {

--- a/include/matx/kernels/fltflt.h
+++ b/include/matx/kernels/fltflt.h
@@ -62,12 +62,10 @@ struct alignas(8) fltflt {
     //
     // Accuracy guarantees (device fast path, for normal doubles in float range):
     //   - fl(hi + lo) == hi  (fast2sum ensures no rounding error when adding lo back).
-    //   - |x - (hi+lo)| <= 16 ulp(x)  for |x| >= 2^-74  (hi_exp >= 53): the 29-bit
-    //     residual r is rounded to 24-bit float, losing at most 16 ULPs.
-    //   - lo == 0  for |x| < 2^-74  (hi_exp < 53): the scale 2^(hi_exp-179) underflows
-    //     as a float, so the residual is dropped rather than emitting a subnormal lo.
+    //   - |x - (hi+lo)| <= 8 ulp(x) if hi and lo in normal range.
     //   - NaN, Inf, subnormal doubles, and doubles outside float range fall back to
-    //     hi = (float)x, lo = 0.
+    //     hi = (float)x.
+    //   - If hi is NaN or Inf, lo can be arbitrary.
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ constexpr explicit fltflt(double x) {
 #if defined(__CUDA_ARCH__)
         // Constexpr evaluation on device uses the standard double-subtraction path.
@@ -76,30 +74,25 @@ struct alignas(8) fltflt {
             lo = static_cast<float>(x - static_cast<double>(hi));
         } else {
             unsigned long long xbits = __double_as_longlong(x);
-            unsigned int sign = (unsigned int)(xbits >> 63);
-            unsigned int e_x = (unsigned int)((xbits >> 52) & 0x7FFU);
+            unsigned int sign = static_cast<unsigned int>(xbits >> 63);
+            unsigned int e_x = static_cast<unsigned int>((xbits >> 52) & 0x7FFU);
             unsigned long long mant = xbits & 0x000FFFFFFFFFFFFFULL;
             // hi_exp: float biased exponent = (e_x - 1023) + 127 = e_x - 896.
-            int hi_exp = (int)e_x - 896;
+            int hi_exp = static_cast<int>(e_x) - 896;
             if (e_x == 0 || hi_exp <= 0 || hi_exp >= 255) {
                 hi = (float)x;
                 lo = 0.0f;
             } else {
-                // hi: top 23 explicit mantissa bits, round-toward-zero.
-                hi = __int_as_float((sign << 31) | ((unsigned int)hi_exp << 23) | (unsigned int)(mant >> 29));
-                // r: the remaining 29 mantissa bits (bits [28:0]).
-                unsigned int r = (unsigned int)(mant & 0x1FFFFFFFU);
-                float r_float = __uint2float_rn(r); // round r to nearest 24-bit float
-                // lo = r × 2^(hi_exp-179): single multiply, no overflow and no FP64.
-                //   Max product: (2^29 - 1) × 2^75 < 2^104 < FLT_MAX  (hi_exp <= 254).
-                //   For hi_exp < 53, lo_exp = 0 → scale = 0.0f → lo_raw = 0.
-                unsigned int lo_exp = hi_exp >= 53u ? (unsigned int)hi_exp - 52u : 0u;
-                float lo_raw = r_float * __int_as_float(lo_exp << 23);
-                lo_raw = __int_as_float(__float_as_int(lo_raw) | (sign << 31));
+                // hi: top 23 explicit mantissa bits, round-nearest, ties away from zero.
+                // use + to mux in the mantissa, as we may need to carry into the exponent.
+                hi = __int_as_float((sign << 31) | ((unsigned int)hi_exp << 23) + (((unsigned int)(mant >> 28) + 1) >> 1));
+                // r: remainder as signed integer (we shift by 3 to get the 29 mantissa bits, with top-most bit the sign bit)
+                int r = static_cast<int>(static_cast<unsigned int>(mant) << 3);
+                lo = (__int2float_rn(r) * 0x1p-55f) * __int_as_float((sign << 31) | (hi_exp << 23));
                 // fast2sum: adjust hi to round-to-nearest and absorb the correction into lo,
                 // guaranteeing fl(hi + lo) == hi.
-                float s = hi + lo_raw;
-                lo = lo_raw - (s - hi);
+                float s = hi + lo;
+                lo = lo - (s - hi);
                 hi = s;
             }
         }

--- a/include/matx/kernels/fltflt.h
+++ b/include/matx/kernels/fltflt.h
@@ -60,9 +60,9 @@ struct alignas(8) fltflt {
     __MATX_INLINE__ fltflt() = default;
     // On device, extract hi/lo from IEEE-754 double bits with no FP64 instructions.
     //
-    // Accuracy guarantees (device fast path, for normal doubles in float range):
-    //   - fl(hi + lo) == hi  (fast2sum ensures no rounding error when adding lo back).
-    //   - |x - (hi+lo)| <= 8 ulp(x) if hi and lo in normal range.
+    // Accuracy guarantees:
+    //   - fl(hi + lo) == hi  (fast2sum ensures no rounding error when adding lo back) for |x| <= FLT_MAX
+    //   - |x - (hi+lo)| <= 8 ulp(x) for |x| <= FLT_MAX
     //   - NaN, Inf, subnormal doubles, and doubles outside float range fall back to
     //     hi = (float)x.
     //   - If hi is NaN or Inf, lo can be arbitrary.
@@ -71,7 +71,14 @@ struct alignas(8) fltflt {
         // Constexpr evaluation on device uses the standard double-subtraction path.
         if (__builtin_is_constant_evaluated()) {
             hi = static_cast<float>(x);
-            lo = static_cast<float>(x - static_cast<double>(hi));
+            if (cuda::std::isfinite(hi)) {
+                lo = static_cast<float>(x - static_cast<double>(hi));
+                float s = hi + lo;
+                lo = lo - (s - hi);
+                hi = s;
+            } else {
+                lo = 0.0f;
+            }
         } else {
             unsigned long long xbits = __double_as_longlong(x);
             unsigned int sign = static_cast<unsigned int>(xbits >> 63);
@@ -91,6 +98,13 @@ struct alignas(8) fltflt {
                 lo = (__int2float_rn(r) * 0x1p-55f) * __int_as_float((sign << 31) | (hi_exp << 23));
                 // fast2sum: adjust hi to round-to-nearest and absorb the correction into lo,
                 // guaranteeing fl(hi + lo) == hi.
+                // two special cases can result in overflow here:
+                // 1. |x| >= FLT_MAX + ulp(FLT_MAX)/2, 
+                //   input: hi == +/-Inf, lo normal. 
+                //   output: hi == +/-Inf, lo == NaN.
+                // 2. |x| > FLT_MAX + ulp(FLT_MAX)/2 - ulp(ulp(FLT_MAX)/2)/2: 
+                //   input: hi == +/-FLT_MAX, lo == +/-ulp(FLT_MAX)/2
+                //   output: hi == +/-Inf, lo == -/+Inf.
                 float s = hi + lo;
                 lo = lo - (s - hi);
                 hi = s;
@@ -98,7 +112,14 @@ struct alignas(8) fltflt {
         }
 #else
         hi = static_cast<float>(x);
-        lo = static_cast<float>(x - static_cast<double>(hi));
+        if (cuda::std::isfinite(hi)) {
+            lo = static_cast<float>(x - static_cast<double>(hi));
+            float s = hi + lo;
+            lo = lo - (s - hi);
+            hi = s;
+        } else {
+            lo = 0.0f;
+        }
 #endif
     }
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ constexpr explicit fltflt(float x) : hi(x), lo(0.0f) {}

--- a/include/matx/kernels/fltflt.h
+++ b/include/matx/kernels/fltflt.h
@@ -58,49 +58,49 @@ struct alignas(8) fltflt {
     // nvcc will warn about __host__ and __device__ annotations on default constructors because default
     // constructors will not run in all conditions (e.g., in static shared memory CUDA kernel allocations).
     __MATX_INLINE__ fltflt() = default;
-    // On device, we avoid double-precision subtraction by extracting the residual mantissa
-    // bits directly from the IEEE 754 representation using integer operations. hi is the
-    // truncated (round-toward-zero) float, so hi + lo == x exactly in real arithmetic.
-    // Ties-to-even and NaN/Inf are not handled precisely (edge cases fall back to
-    // hi=(float)x, lo=0). The constexpr branch is taken during compile-time evaluation.
+    // On device, extract hi/lo from IEEE-754 double bits with no FP64 instructions.
+    //
+    // Accuracy guarantees (device fast path, for normal doubles in float range):
+    //   - fl(hi + lo) == hi  (fast2sum ensures no rounding error when adding lo back).
+    //   - |x - (hi+lo)| <= 16 ulp(x)  for |x| >= 2^-74  (hi_exp >= 53): the 29-bit
+    //     residual r is rounded to 24-bit float, losing at most 16 ULPs.
+    //   - lo == 0  for |x| < 2^-74  (hi_exp < 53): the scale 2^(hi_exp-179) underflows
+    //     as a float, so the residual is dropped rather than emitting a subnormal lo.
+    //   - NaN, Inf, subnormal doubles, and doubles outside float range fall back to
+    //     hi = (float)x, lo = 0.
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ constexpr explicit fltflt(double x) {
 #if defined(__CUDA_ARCH__)
-        // During compile-time (constexpr) evaluation on device, fall through to the
-        // standard double-subtraction path which is constexpr-compatible.
+        // Constexpr evaluation on device uses the standard double-subtraction path.
         if (__builtin_is_constant_evaluated()) {
             hi = static_cast<float>(x);
             lo = static_cast<float>(x - static_cast<double>(hi));
         } else {
-            // Fast runtime path: extract residual mantissa bits via integer operations,
-            // avoiding double-precision subtraction. hi uses truncation (round-toward-zero),
-            // so hi + lo == x exactly in real arithmetic. NaN/Inf/subnormal doubles and
-            // doubles outside float range are not handled precisely (per design).
             unsigned long long xbits = __double_as_longlong(x);
             unsigned int sign = (unsigned int)(xbits >> 63);
             unsigned int e_x = (unsigned int)((xbits >> 52) & 0x7FFU);
             unsigned long long mant = xbits & 0x000FFFFFFFFFFFFFULL;
-            // float biased exponent: (e_x - 1023) + 127 = e_x - 896
+            // hi_exp: float biased exponent = (e_x - 1023) + 127 = e_x - 896.
             int hi_exp = (int)e_x - 896;
             if (e_x == 0 || hi_exp <= 0 || hi_exp >= 255) {
                 hi = (float)x;
                 lo = 0.0f;
             } else {
-                // hi: top 23 explicit mantissa bits, same exponent as x.
+                // hi: top 23 explicit mantissa bits, round-toward-zero.
                 hi = __int_as_float((sign << 31) | ((unsigned int)hi_exp << 23) | (unsigned int)(mant >> 29));
-                // lo: lower 29 bits of significand, scaled to the correct power of 2.
+                // r: the remaining 29 mantissa bits (bits [28:0]).
                 unsigned int r = (unsigned int)(mant & 0x1FFFFFFFU);
-                if (r == 0) {
-                    lo = 0.0f;
-                } else {
-                    int n = 31 - __clz(r);           // highest set bit of r (0..28)
-                    int lo_exp = n + (int)e_x - 948; // n + (e_x - 1023 - 52) + 127
-                    if (lo_exp <= 0) {
-                        lo = 0.0f;
-                    } else {
-                        unsigned int lo_mant = (n >= 23) ? (r >> (n - 23)) : (r << (23 - n));
-                        lo = __int_as_float((sign << 31) | ((unsigned int)lo_exp << 23) | (lo_mant & 0x7FFFFFU));
-                    }
-                }
+                float r_float = __uint2float_rn(r); // round r to nearest 24-bit float
+                // lo = r × 2^(hi_exp-179): single multiply, no overflow and no FP64.
+                //   Max product: (2^29 - 1) × 2^75 < 2^104 < FLT_MAX  (hi_exp <= 254).
+                //   For hi_exp < 53, lo_exp = 0 → scale = 0.0f → lo_raw = 0.
+                unsigned int lo_exp = hi_exp >= 53u ? (unsigned int)hi_exp - 52u : 0u;
+                float lo_raw = r_float * __int_as_float(lo_exp << 23);
+                lo_raw = __int_as_float(__float_as_int(lo_raw) | (sign << 31));
+                // fast2sum: adjust hi to round-to-nearest and absorb the correction into lo,
+                // guaranteeing fl(hi + lo) == hi.
+                float s = hi + lo_raw;
+                lo = lo_raw - (s - hi);
+                hi = s;
             }
         }
 #else

--- a/test/00_misc/FloatFloatTests.cu
+++ b/test/00_misc/FloatFloatTests.cu
@@ -294,6 +294,20 @@ struct FltFltCmpGe {
   }
 };
 
+struct DoubleToFltFlt {
+  __MATX_HOST__ __MATX_DEVICE__ fltflt operator()(double x) const {
+    return static_cast<fltflt>(x);
+  }
+};
+
+struct FltFltGetHi {
+  __MATX_HOST__ __MATX_DEVICE__ float operator()(fltflt x) const { return x.hi; }
+};
+
+struct FltFltGetLo {
+  __MATX_HOST__ __MATX_DEVICE__ float operator()(fltflt x) const { return x.lo; }
+};
+
 template <typename Exec>
 class FltFltExecutorTests : public ::testing::Test {
 protected:
@@ -2226,5 +2240,109 @@ TYPED_TEST(FltFltExecutorTests, Fmod) {
     const double ref = std::fmod(a_dbl, b_dbl);
     // Expect at least 30 bits - limited by fltflt precision at 1e5 magnitude
     EXPECT_GE(numMatchingMantissaBits(static_cast<double>(result()), ref), 30);
+  }
+}
+
+TYPED_TEST(FltFltExecutorTests, ConvertFromDouble) {
+  auto dbl_in = make_tensor<double>({});
+  auto ff_result = make_tensor<fltflt>({});
+  auto hi_out = make_tensor<float>({});
+  auto lo_out = make_tensor<float>({});
+
+  auto run_and_extract = [&](double x) {
+    (dbl_in = x).run(this->exec);
+    (ff_result = matx::apply(DoubleToFltFlt{}, dbl_in)).run(this->exec);
+    (hi_out = matx::apply(FltFltGetHi{}, ff_result)).run(this->exec);
+    (lo_out = matx::apply(FltFltGetLo{}, ff_result)).run(this->exec);
+    this->exec.sync();
+  };
+
+  // Normal round-trip: pi should recover >=44 mantissa bits
+  {
+    run_and_extract(std::numbers::pi);
+    const double reconstructed = static_cast<double>(hi_out()) + static_cast<double>(lo_out());
+    EXPECT_GE(numMatchingMantissaBits(reconstructed, std::numbers::pi), 44);
+  }
+
+  // Zero
+  {
+    run_and_extract(0.0);
+    EXPECT_EQ(hi_out(), 0.0f);
+    EXPECT_EQ(lo_out(), 0.0f);
+  }
+
+  // Verify hi+lo == x exactly for a normal-range value
+  {
+    // x = 1.5 + 2^-25: hi = 1.5, lo = 2^-25 (normal float)
+    const double x = 1.5 + std::ldexp(1.0, -25);
+    run_and_extract(x);
+    const double reconstructed = static_cast<double>(hi_out()) + static_cast<double>(lo_out());
+    EXPECT_EQ(reconstructed, x);
+  }
+
+  // Small doubles (hi_exp < 53, |x| < 2^-74): on device the fast path drops lo because
+  // the scale 2^(hi_exp-179) underflows to 0.0f.  On host the reference double-subtraction
+  // path computes the correct subnormal lo.
+  constexpr bool is_cuda = std::is_same_v<TypeParam, matx::cudaExecutor>;
+
+  // x = 2^-103 + 2^-127: hi_exp = 920-896 = 24 < 53
+  {
+    const double x = std::bit_cast<double>(0x3980000010000000ULL);
+    run_and_extract(x);
+    EXPECT_EQ(std::bit_cast<uint32_t>(hi_out()), 0x0C000000u); // hi = 2^-103
+    if constexpr (is_cuda) { EXPECT_EQ(lo_out(), 0.0f); }
+    else { EXPECT_EQ(std::bit_cast<uint32_t>(lo_out()), 0x00400000u); } // 2^-127 (subnormal)
+  }
+
+  // x = 2^-114 + 2^-138: hi_exp = 909-896 = 13 < 53
+  {
+    const double x = std::bit_cast<double>(0x38D0000010000000ULL);
+    run_and_extract(x);
+    EXPECT_EQ(std::bit_cast<uint32_t>(hi_out()), 0x06800000u); // hi = 2^-114
+    if constexpr (is_cuda) { EXPECT_EQ(lo_out(), 0.0f); }
+    else { EXPECT_EQ(std::bit_cast<uint32_t>(lo_out()), 0x00000800u); } // 2^-138 (subnormal)
+  }
+
+  // x = 2^-125 + 2^-149: hi_exp = 898-896 = 2 < 53
+  {
+    const double x = std::bit_cast<double>(0x3820000010000000ULL);
+    run_and_extract(x);
+    EXPECT_EQ(std::bit_cast<uint32_t>(hi_out()), 0x01000000u); // hi = 2^-125
+    if constexpr (is_cuda) { EXPECT_EQ(lo_out(), 0.0f); }
+    else { EXPECT_EQ(std::bit_cast<uint32_t>(lo_out()), 0x00000001u); } // 2^-149 (min subnormal)
+  }
+
+  // x near FLT_MIN (hi_exp = 1 < 53): lo = 0 on both paths (residual too small for any float)
+  {
+    const double x = std::bit_cast<double>(0x3810000010000000ULL);
+    run_and_extract(x);
+    EXPECT_EQ(std::bit_cast<uint32_t>(hi_out()), 0x00800000u); // FLT_MIN
+    EXPECT_EQ(lo_out(), 0.0f);
+  }
+
+  // FLT_MIN exactly representable as float, lo = 0
+  {
+    run_and_extract(std::numeric_limits<float>::min());
+    EXPECT_EQ(hi_out(), std::numeric_limits<float>::min());
+    EXPECT_EQ(lo_out(), 0.0f);
+  }
+
+  // Negative value round-trip
+  {
+    run_and_extract(-std::numbers::pi);
+    const double reconstructed = static_cast<double>(hi_out()) + static_cast<double>(lo_out());
+    EXPECT_GE(numMatchingMantissaBits(reconstructed, -std::numbers::pi), 44);
+  }
+
+  // Large double near FLT_MAX: hi_exp = 254, triggers overflow path (hi_exp >= 226).
+  // x = FLT_MAX + 2^76 (adds a nonzero residual so lo != 0).
+  {
+    // FLT_MAX = (2 - 2^-23) * 2^127; e_x = 1150, hi_exp = 254.
+    // Add 2^76 to ensure r != 0 and lo is representable.
+    const double x = static_cast<double>(std::numeric_limits<float>::max()) + std::ldexp(1.0, 76);
+    run_and_extract(x);
+    const double reconstructed = static_cast<double>(hi_out()) + static_cast<double>(lo_out());
+    EXPECT_GE(numMatchingMantissaBits(reconstructed, x), 44);
+    EXPECT_NE(lo_out(), std::numeric_limits<float>::infinity());
   }
 }

--- a/test/00_misc/FloatFloatTests.cu
+++ b/test/00_misc/FloatFloatTests.cu
@@ -2280,18 +2280,14 @@ TYPED_TEST(FltFltExecutorTests, ConvertFromDouble) {
     EXPECT_EQ(reconstructed, x);
   }
 
-  // Small doubles (hi_exp < 53, |x| < 2^-74): on device the fast path drops lo because
-  // the scale 2^(hi_exp-179) underflows to 0.0f.  On host the reference double-subtraction
-  // path computes the correct subnormal lo.
-  constexpr bool is_cuda = std::is_same_v<TypeParam, matx::cudaExecutor>;
+  // Small doubles (hi_exp < 53, |x| < 2^-74): the low part is in the subnormal range.
 
   // x = 2^-103 + 2^-127: hi_exp = 920-896 = 24 < 53
   {
     const double x = std::bit_cast<double>(0x3980000010000000ULL);
     run_and_extract(x);
     EXPECT_EQ(std::bit_cast<uint32_t>(hi_out()), 0x0C000000u); // hi = 2^-103
-    if constexpr (is_cuda) { EXPECT_EQ(lo_out(), 0.0f); }
-    else { EXPECT_EQ(std::bit_cast<uint32_t>(lo_out()), 0x00400000u); } // 2^-127 (subnormal)
+    EXPECT_EQ(std::bit_cast<uint32_t>(lo_out()), 0x00400000u); // 2^-127 (subnormal)
   }
 
   // x = 2^-114 + 2^-138: hi_exp = 909-896 = 13 < 53
@@ -2299,8 +2295,7 @@ TYPED_TEST(FltFltExecutorTests, ConvertFromDouble) {
     const double x = std::bit_cast<double>(0x38D0000010000000ULL);
     run_and_extract(x);
     EXPECT_EQ(std::bit_cast<uint32_t>(hi_out()), 0x06800000u); // hi = 2^-114
-    if constexpr (is_cuda) { EXPECT_EQ(lo_out(), 0.0f); }
-    else { EXPECT_EQ(std::bit_cast<uint32_t>(lo_out()), 0x00000800u); } // 2^-138 (subnormal)
+    EXPECT_EQ(std::bit_cast<uint32_t>(lo_out()), 0x00000800u); // 2^-138 (subnormal)
   }
 
   // x = 2^-125 + 2^-149: hi_exp = 898-896 = 2 < 53
@@ -2308,8 +2303,7 @@ TYPED_TEST(FltFltExecutorTests, ConvertFromDouble) {
     const double x = std::bit_cast<double>(0x3820000010000000ULL);
     run_and_extract(x);
     EXPECT_EQ(std::bit_cast<uint32_t>(hi_out()), 0x01000000u); // hi = 2^-125
-    if constexpr (is_cuda) { EXPECT_EQ(lo_out(), 0.0f); }
-    else { EXPECT_EQ(std::bit_cast<uint32_t>(lo_out()), 0x00000001u); } // 2^-149 (min subnormal)
+    EXPECT_EQ(std::bit_cast<uint32_t>(lo_out()), 0x00000001u); // 2^-149 (min subnormal)
   }
 
   // x near FLT_MIN (hi_exp = 1 < 53): lo = 0 on both paths (residual too small for any float)
@@ -2344,5 +2338,113 @@ TYPED_TEST(FltFltExecutorTests, ConvertFromDouble) {
     const double reconstructed = static_cast<double>(hi_out()) + static_cast<double>(lo_out());
     EXPECT_GE(numMatchingMantissaBits(reconstructed, x), 44);
     EXPECT_NE(lo_out(), std::numeric_limits<float>::infinity());
+  }
+}
+
+// Sweep many doubles across the normal float range and verify the three accuracy
+// claims documented at the top of the fltflt(double) constructor:
+//   (1) |x - hi| <= 0.5 ulp(hi)
+//   (2) |lo|     <= 0.5 ulp(hi)
+//   (3) |x - (hi+lo)| <= 8 ulp(x)   (only when hi and lo are both in normal range)
+TYPED_TEST(FltFltExecutorTests, ConvertFromDoubleAccuracy) {
+  std::vector<double> inputs;
+
+  // Build a double from (sign, hi_exp = float biased exponent, 52-bit mantissa).
+  // Skips inputs that would land on the NaN/Inf/subnormal/out-of-range fallback path
+  // (hi_exp <= 0 or hi_exp >= 255), since the contract above is for the fast path only.
+  auto add_input = [&](unsigned sign, int hi_exp, uint64_t mant) {
+    if (hi_exp <= 0 || hi_exp >= 255) return;
+    const uint64_t e_x = static_cast<uint64_t>(hi_exp) + 896;
+    const uint64_t bits = (static_cast<uint64_t>(sign & 1u) << 63) |
+                          (e_x << 52) |
+                          (mant & 0x000FFFFFFFFFFFFFULL);
+    inputs.push_back(std::bit_cast<double>(bits));
+  };
+
+  // Walk the float biased exponent from the smallest normal (1) to the largest (254),
+  // including the boundary at hi_exp = 53 below which lo cannot be normal.
+  const int hi_exps[] = {1, 2, 13, 24, 25, 30, 52, 53, 54, 75, 100, 127, 200, 225, 226, 253, 254};
+
+  // Mantissa low 29 bits (the residual). Includes:
+  //   - 0:                       residual = 0, r_float exact
+  //   - 1:                       smallest non-zero residual
+  //   - 0x10000000:              tie at +0.5 ulp(hi) (exercises fast2sum tie-to-even)
+  //   - 0x10000001 / 0x0FFFFFFF: just past / before the tie
+  //   - 0x1FFFFFFF:              maximum residual
+  //   - arbitrary middle values
+  const uint64_t low_mants[] = {
+      0x00000000ULL, 0x00000001ULL, 0x0FFFFFFFULL, 0x10000000ULL,
+      0x10000001ULL, 0x1FFFFFFFULL, 0x12345678ULL, 0x1ABCDEF1ULL,
+  };
+
+  // Mantissa bits 51..29 (the part that ends up in hi_field). Includes 0 (so hi is a
+  // power of 2, where ulp asymmetric-ness shows up) and the all-ones value (which makes
+  // the round-half-up overflow into the next exponent).
+  const uint64_t high_mants[] = {0x000000ULL, 0x000001ULL, 0x123456ULL, 0x7FFFFEULL, 0x7FFFFFULL};
+
+  for (int hi_exp : hi_exps) {
+    for (unsigned sign : {0u, 1u}) {
+      for (uint64_t high : high_mants) {
+        for (uint64_t low : low_mants) {
+          const uint64_t mant = (high << 29) | low;
+          add_input(sign, hi_exp, mant);
+        }
+      }
+    }
+  }
+
+  // A handful of "real" values in addition to the bit patterns above.
+  inputs.push_back(0.0);
+  inputs.push_back(-0.0);
+  inputs.push_back(1.0);
+  inputs.push_back(-1.0);
+  inputs.push_back(2.0);
+  inputs.push_back(std::numbers::pi);
+  inputs.push_back(-std::numbers::pi);
+  inputs.push_back(std::numbers::e);
+  inputs.push_back(std::numbers::sqrt2);
+  inputs.push_back(static_cast<double>(std::numeric_limits<float>::max()));
+  inputs.push_back(-static_cast<double>(std::numeric_limits<float>::max()));
+
+  const matx::index_t N = static_cast<matx::index_t>(inputs.size());
+  auto dbl_in = make_tensor<double>({N});
+  auto ff_result = make_tensor<fltflt>({N});
+  auto hi_out_t = make_tensor<float>({N});
+  auto lo_out_t = make_tensor<float>({N});
+
+  for (matx::index_t i = 0; i < N; ++i) {
+    dbl_in(i) = inputs[static_cast<size_t>(i)];
+  }
+
+  (ff_result = matx::apply(DoubleToFltFlt{}, dbl_in)).run(this->exec);
+  (hi_out_t = matx::apply(FltFltGetHi{}, ff_result)).run(this->exec);
+  (lo_out_t = matx::apply(FltFltGetLo{}, ff_result)).run(this->exec);
+  this->exec.sync();
+
+  for (matx::index_t i = 0; i < N; ++i) {
+    const double x = inputs[static_cast<size_t>(i)];
+    const float hi = hi_out_t(i);
+    const float lo = lo_out_t(i);
+
+    // The accuracy contract only applies when hi is a normal float. Inputs whose
+    // mantissa rounds up past FLT_MAX legitimately produce hi = +/-Inf, and zeros
+    // fall through here too; neither has a residual to check.
+    if (!std::isnormal(hi)) continue;
+
+    // 0.5 * ulp(hi), using the upper-side step (the standard "ulp" definition).
+    const double half_ulp_hi = std::ldexp(1.0, std::ilogb(hi) - 24);
+
+    // Property (3): |x - (hi+lo)| <= 8 ulp(x), only when both hi and lo are in normal
+    // range. lo is allowed to be exactly zero, but only when the residual really is
+    // zero (so we don't accidentally validate a flush-to-zero underflow).
+    const double residual = x - static_cast<double>(hi);
+    const bool lo_is_normal = std::isnormal(lo);
+    const bool lo_is_genuine_zero = (lo == 0.0f) && (residual == 0.0);
+    if (lo_is_normal || lo_is_genuine_zero) {
+      const double ulp_x = std::ldexp(1.0, std::ilogb(x) - 52);
+      EXPECT_LE(std::abs(x - (static_cast<double>(hi) + static_cast<double>(lo))),
+                8.0 * ulp_x)
+          << "Property (3) violated: x = " << x << ", hi = " << hi << ", lo = " << lo;
+    }
   }
 }


### PR DESCRIPTION
This speeds up `double` to `fltflt` conversions on fp64-decoupled hardware. I also tweaked the cast benchmark so that it isn't affected by fp64 arithmetic perf.

# L40S results

## Before (with update benchmark)
```
Benchmark       float        double       fltflt       fltflt vs dbl
------------------------------------------------------------------
cast2fltflt     1.00x        32.52x       4.39x        7.40x

--------------------------------------------------------------------------------
Raw timings (auto-scaled units):

Benchmark       float           double          fltflt          fltflt vs dbl
---------------------------------------------------------------------------
cast2fltflt     618.045 us      20.100 ms       2.716 ms        7.40x
```

## After
```
Benchmark       float        double       fltflt       fltflt vs dbl
------------------------------------------------------------------
cast2fltflt     1.00x        10.65x       4.40x        2.42x

--------------------------------------------------------------------------------
Raw timings (auto-scaled units):

Benchmark       float           double          fltflt          fltflt vs dbl
---------------------------------------------------------------------------
cast2fltflt     618.190 us      6.585 ms        2.721 ms        2.42x
```
