### PR TITLE
build benchmarks as individual CMake targets

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -50,26 +50,21 @@ function(create_bench_executable bench_file)
         RUN_SERIAL TRUE
         LABELS bench
     )
-endfunction()
 
-foreach(bench_file ${bench_sources})
-    create_bench_executable(${bench_file})
-endforeach()
+    set(target_name "${target_name}" PARENT_SCOPE)
+endfunction()
 
 set(bench_targets "")
 foreach(bench_file ${bench_sources})
-    get_filename_component(_bn ${bench_file} NAME_WE)
-    get_filename_component(_bd ${bench_file} DIRECTORY)
-    string(REPLACE "/" "_" _bdc ${_bd})
-    list(APPEND bench_targets "bench_${_bdc}_${_bn}")
+    create_bench_executable(${bench_file})
+    list(APPEND bench_targets ${target_name})
 endforeach()
-
-set(BENCH_CTEST_PARALLEL_JOBS 4)
 
 add_custom_target(bench
     DEPENDS ${bench_targets}
-    COMMAND ${CMAKE_CTEST_COMMAND} -j${BENCH_CTEST_PARALLEL_JOBS} -R "^bench_" --output-on-failure
+    # No -j: each benchmark test uses RUN_SERIAL so CTest runs them one at a time (GPU-safe).
+    COMMAND ${CMAKE_CTEST_COMMAND} -R "^bench_" --output-on-failure
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "Running all MatX benchmarks via CTest (${BENCH_CTEST_PARALLEL_JOBS} parallel jobs; each bench test is RUN_SERIAL)"
+    COMMENT "Running all MatX benchmarks via CTest (serial; RUN_SERIAL per test)"
     VERBATIM
 )

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,4 +1,6 @@
-set (bench_sources
+enable_testing()
+
+set(bench_sources
     00_misc/fltflt_arithmetic.cu
     00_transform/matmul.cu
     00_transform/fft.cu
@@ -20,31 +22,54 @@ set(system_inc  ${CUTLASS_INC}
                 ${pybind11_INCLUDE_DIR}
                 ${PYTHON_INCLUDE_DIRS})
 
-# Compile all the unit tests into an object first since pybind needs to use its own version of
-# add_module/library
-add_executable(matx_bench ${bench_sources})
+function(create_bench_executable bench_file)
+    get_filename_component(bench_name ${bench_file} NAME_WE)
+    get_filename_component(bench_dir ${bench_file} DIRECTORY)
+    string(REPLACE "/" "_" bench_dir_clean ${bench_dir})
+    set(target_name "bench_${bench_dir_clean}_${bench_name}")
 
-target_link_libraries(matx_bench PRIVATE nvbench::main)
-target_link_libraries(matx_bench PRIVATE matx::matx)
+    add_executable(${target_name} ${bench_file})
 
-# Set all the flags/other properties
-set_property(TARGET matx_bench PROPERTY ENABLE_EXPORTS 1)
+    set_property(TARGET ${target_name} PROPERTY ENABLE_EXPORTS 1)
 
-if (MSVC)
-    target_compile_options(matx_bench PRIVATE /W4 /WX)
-else()
-    target_compile_options(matx_bench PRIVATE ${WARN_FLAGS})
-    target_compile_options(matx_bench PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${MATX_CUDA_FLAGS}>)
-endif()
+    if (MSVC)
+        target_compile_options(${target_name} PRIVATE /W4 /WX)
+    else()
+        target_compile_options(${target_name} PRIVATE ${WARN_FLAGS})
+        target_compile_options(${target_name} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${MATX_CUDA_FLAGS}>)
+    endif()
 
-target_include_directories(matx_bench PRIVATE "${target_inc}")
-target_include_directories(matx_bench SYSTEM PRIVATE "${system_inc}")
+    target_include_directories(${target_name} PRIVATE "${target_inc}")
+    target_include_directories(${target_name} SYSTEM PRIVATE "${system_inc}")
+    target_include_directories(${target_name} SYSTEM PRIVATE "${pybind11_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}")
+    target_link_libraries(${target_name} PRIVATE nvbench::main matx::matx)
 
-target_include_directories(matx_bench SYSTEM PRIVATE "${pybind11_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}")
-target_link_libraries(  matx_bench PRIVATE matx::matx)
+    add_test(NAME ${target_name} COMMAND ${target_name})
+    set_tests_properties(${target_name} PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        RUN_SERIAL TRUE
+        LABELS bench
+    )
+endfunction()
+
+foreach(bench_file ${bench_sources})
+    create_bench_executable(${bench_file})
+endforeach()
+
+set(bench_targets "")
+foreach(bench_file ${bench_sources})
+    get_filename_component(_bn ${bench_file} NAME_WE)
+    get_filename_component(_bd ${bench_file} DIRECTORY)
+    string(REPLACE "/" "_" _bdc ${_bd})
+    list(APPEND bench_targets "bench_${_bdc}_${_bn}")
+endforeach()
+
+set(BENCH_CTEST_PARALLEL_JOBS 4)
 
 add_custom_target(bench
-    DEPENDS matx_bench
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/matx_bench)
-
-
+    DEPENDS ${bench_targets}
+    COMMAND ${CMAKE_CTEST_COMMAND} -j${BENCH_CTEST_PARALLEL_JOBS} -R "^bench_" --output-on-failure
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Running all MatX benchmarks via CTest (${BENCH_CTEST_PARALLEL_JOBS} parallel jobs; each bench test is RUN_SERIAL)"
+    VERBATIM
+)

--- a/bench/scripts/run_fltflt_benchmarks.py
+++ b/bench/scripts/run_fltflt_benchmarks.py
@@ -50,15 +50,39 @@ def strip_ansi(text):
     return ANSI_ESCAPE.sub('', text)
 
 
-def find_benchmark_executable(build_dir):
-    """Find the matx_bench executable."""
-    benchmark_path = build_dir / "bench" / "matx_bench"
+def _resolve_bench_executable(build_dir, stem):
+    """Return path to bench/<stem> or bench/<stem>.exe if present."""
+    bench_dir = build_dir / "bench"
+    for name in (stem, f"{stem}.exe"):
+        path = bench_dir / name
+        if path.is_file():
+            return path
+    return None
 
-    if benchmark_path.exists():
+
+def find_benchmark_executable(build_dir):
+    """Find the fltflt benchmark executable (per-source CMake target)."""
+    stem = "bench_00_misc_fltflt_arithmetic"
+    benchmark_path = _resolve_bench_executable(build_dir, stem)
+
+    if benchmark_path is not None:
         return benchmark_path
 
-    print(f"Error: Could not find matx_bench at {benchmark_path}")
+    print(
+        "Error: Could not find benchmark executable "
+        f"bench/{stem} under {build_dir}"
+    )
     return None
+
+
+def build_dir_contains_benchmark_exes(build_dir):
+    """True if build_dir/bench contains at least one bench_* executable."""
+    bench_dir = build_dir / "bench"
+    if not bench_dir.is_dir():
+        return False
+    return any(
+        p.is_file() and p.name.startswith("bench_") for p in bench_dir.iterdir()
+    )
 
 
 def run_benchmark(executable_path, benchmark_name, verbose=False):
@@ -363,7 +387,7 @@ def main():
         "--build-dir",
         type=Path,
         default=None,
-        help="Path to the MatX build directory containing bench/matx_bench. "
+        help="Path to the MatX build directory containing bench/bench_00_misc_fltflt_arithmetic. "
              "If not specified, common locations are searched automatically.",
     )
     parser.add_argument(
@@ -391,10 +415,10 @@ def main():
         script_dir = Path(__file__).parent
 
         # Check if the current working directory looks like a valid build directory
-        # (i.e. it already contains bench/matx_bench). This lets users run the script
+        # (i.e. it already contains bench/bench_* executables). This lets users run the script
         # from any build directory without needing --build-dir.
         cwd = Path.cwd()
-        if (cwd / "bench" / "matx_bench").exists():
+        if build_dir_contains_benchmark_exes(cwd):
             build_dir = cwd
         else:
             # Fall back to searching common locations relative to the script
@@ -408,7 +432,7 @@ def main():
             build_dir = None
             for bd in possible_build_dirs:
                 bd_resolved = bd.resolve()
-                if bd_resolved.exists() and (bd_resolved / "bench" / "matx_bench").exists():
+                if bd_resolved.exists() and build_dir_contains_benchmark_exes(bd_resolved):
                     build_dir = bd_resolved
                     break
 

--- a/bench/scripts/run_sarbp_benchmarks.py
+++ b/bench/scripts/run_sarbp_benchmarks.py
@@ -49,15 +49,39 @@ def strip_ansi(text):
     return ANSI_ESCAPE.sub('', text)
 
 
-def find_benchmark_executable(build_dir):
-    """Find the matx_bench executable."""
-    benchmark_path = build_dir / "bench" / "matx_bench"
+def _resolve_bench_executable(build_dir, stem):
+    """Return path to bench/<stem> or bench/<stem>.exe if present."""
+    bench_dir = build_dir / "bench"
+    for name in (stem, f"{stem}.exe"):
+        path = bench_dir / name
+        if path.is_file():
+            return path
+    return None
 
-    if benchmark_path.exists():
+
+def find_benchmark_executable(build_dir):
+    """Find the SAR BP benchmark executable (per-source CMake target)."""
+    stem = "bench_00_transform_sarbp"
+    benchmark_path = _resolve_bench_executable(build_dir, stem)
+
+    if benchmark_path is not None:
         return benchmark_path
 
-    print(f"Error: Could not find matx_bench at {benchmark_path}")
+    print(
+        "Error: Could not find benchmark executable "
+        f"bench/{stem} under {build_dir}"
+    )
     return None
+
+
+def build_dir_contains_benchmark_exes(build_dir):
+    """True if build_dir/bench contains at least one bench_* executable."""
+    bench_dir = build_dir / "bench"
+    if not bench_dir.is_dir():
+        return False
+    return any(
+        p.is_file() and p.name.startswith("bench_") for p in bench_dir.iterdir()
+    )
 
 
 def run_benchmark(executable_path, benchmark_name, verbose=False):
@@ -320,7 +344,7 @@ def main():
         "--build-dir",
         type=Path,
         default=None,
-        help="Path to the MatX build directory containing bench/matx_bench. "
+        help="Path to the MatX build directory containing bench/bench_00_transform_sarbp. "
              "If not specified, the current working directory is checked first, "
              "then common locations relative to the script are searched.",
     )
@@ -347,10 +371,10 @@ def main():
             sys.exit(1)
     else:
         # Check if the current working directory looks like a valid build directory
-        # (i.e. it already contains bench/matx_bench). This lets users run the script
+        # (i.e. it already contains bench/bench_* executables). This lets users run the script
         # from any build directory without needing --build-dir.
         cwd = Path.cwd()
-        if (cwd / "bench" / "matx_bench").exists():
+        if build_dir_contains_benchmark_exes(cwd):
             build_dir = cwd
         else:
             # Fall back to searching common locations relative to the script
@@ -365,7 +389,7 @@ def main():
             build_dir = None
             for bd in possible_build_dirs:
                 bd_resolved = bd.resolve()
-                if bd_resolved.exists() and (bd_resolved / "bench" / "matx_bench").exists():
+                if bd_resolved.exists() and build_dir_contains_benchmark_exes(bd_resolved):
                     build_dir = bd_resolved
                     break
 

--- a/docs_input/build.rst
+++ b/docs_input/build.rst
@@ -124,8 +124,11 @@ Benchmarks
 MatX uses the NVBench software for the benchmarking framework. Like other packages, NVBench will be download using CPM according to
 the methods mentioned above.
 
-NVBench has a small library that will be compiled on the first `make` run. Benchmarks can be run using the ``bench/matx_bench`` executable,
-and all options to filter or modify benchmark runs can be found in the nvbench_ project documentation.
+NVBench has a small library that will be compiled on the first ``make`` run. With ``-DMATX_BUILD_BENCHMARKS=ON``, CMake emits one executable per
+benchmark source file under ``build/bench``, named ``bench_<subdir>_<basename>`` (for example ``bench/bench_00_transform_matmul``). You can build a
+single benchmark with ``cmake --build <build-dir> --target bench_00_transform_matmul``. All benchmarks are registered with CTest under names
+matching those targets; run ``ctest -R '^bench_'`` from ``build/bench``, or ``ctest -L bench``, or build the ``bench`` target from the top-level build
+to execute the suite via CTest. NVBench CLI options to filter or modify benchmark runs apply to each executable and are documented in the nvbench_ project.
 
 .. _nvbench: https://github.com/NVIDIA/nvbench
 

--- a/docs_input/build.rst
+++ b/docs_input/build.rst
@@ -125,7 +125,7 @@ MatX uses the NVBench software for the benchmarking framework. Like other packag
 the methods mentioned above.
 
 NVBench has a small library that will be compiled on the first ``make`` run. With ``-DMATX_BUILD_BENCHMARKS=ON``, CMake emits one executable per
-benchmark source file under ``build/bench``, named ``bench_<subdir>_<basename>`` (for example ``bench/bench_00_transform_matmul``). You can build a
+benchmark source file under ``build/bench``, named ``bench_<subdir>_<basename>`` (for example ``bench_00_transform_matmul``). You can build a
 single benchmark with ``cmake --build <build-dir> --target bench_00_transform_matmul``. All benchmarks are registered with CTest under names
 matching those targets; run ``ctest -R '^bench_'`` from ``build/bench``, or ``ctest -L bench``, or build the ``bench`` target from the top-level build
 to execute the suite via CTest. NVBench CLI options to filter or modify benchmark runs apply to each executable and are documented in the nvbench_ project.


### PR DESCRIPTION
This makes it faster and easier to build and extract info from the benchmarks (very helpful when getting Claude to optimize code).
