### PR TITLE
Add fast-path TensorAccessor & Optimize SarBp/ChannelizePoly

### DIFF
--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -1021,7 +1021,7 @@ MATX_LOOP_UNROLL
    * @returns Stride (in elements) in dimension
    *
    */
-  __MATX_INLINE__ __MATX_HOST__ typename Desc::stride_type Stride(uint32_t dim) const
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ typename Desc::stride_type Stride(uint32_t dim) const
   {
     static_assert(RANK >= 1, "Indexed strides are only available on tensors of rank 1 or higher.");
     return this->desc_.Stride(dim);

--- a/include/matx/kernels/channelize_poly.cuh
+++ b/include/matx/kernels/channelize_poly.cuh
@@ -436,8 +436,8 @@ __global__ void ChannelizePoly1D_SmemTiled(
             }
         } else {
             // The dispatch must not select FilterInSmem when K exceeds the
-            // rotations[] array size. Assert this invariant at runtime.
-            assert(K <= detail::cpoly::SmemTiledMaxRotations);
+            // rotations[] array size. We rely on the transform dispatch to
+            // ensure this invariant due to the cost of run-time kernel checks.
             int32_t rotations[detail::cpoly::SmemTiledMaxRotations];
             for (int32_t k = 0; k < K; k++) {
                 rotations[k] = static_cast<int32_t>((static_cast<int64_t>(k) * decimation_factor) % M);

--- a/include/matx/kernels/channelize_poly.cuh
+++ b/include/matx/kernels/channelize_poly.cuh
@@ -42,22 +42,27 @@
 #include "matx/core/utils.h"
 #include "matx/core/type_utils.h"
 #include "matx/core/tensor_utils.h"
+#include "matx/kernels/tensor_accessor.h"
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__algorithm/max.h>
 
 namespace matx {
 
-// detail constants that require both host and device visibility at compile time
+// detail constants that require both host and device visibility at compile
+// time. Scoped to matx::detail::cpoly so the transform's helpers can sit in
+// the same namespace without colliding with other transforms' internals.
 namespace detail {
+namespace cpoly {
     // Number of output elements generated per thread
-    constexpr index_t CHANNELIZE_POLY1D_ELEMS_PER_THREAD = 1;
+    constexpr index_t ElemsPerThread = 1;
 
     // Maximum number of filter rotations per channel for the SmemTiled kernel.
-    // This is used to determine if the filter can be stored in shared memory. The
-    // number of rotations can exceed this value, but the filter will be read from
-    // global memory rather than cached in shared memory.
-    constexpr int MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_ROTATIONS = 32;
-}
+    // This is used to determine if the filter can be stored in shared memory.
+    // The number of rotations can exceed this value, but the filter will be
+    // read from global memory rather than cached in shared memory.
+    constexpr int SmemTiledMaxRotations = 32;
+} // namespace cpoly
+} // namespace detail
 
 #ifdef __CUDACC__ 
 
@@ -108,13 +113,13 @@ __MATX_DEVICE__ __MATX_INLINE__ void channelize_cmac(
         a_im = h_im * i_re + a_im;
         accum = {a_re, a_im};
     } else if constexpr (is_complex_v<AccumT> && !is_complex_v<FilterValT> && is_complex_v<InputValT>) {
-        // Real filter × complex input
+        // Real filter * complex input
         auto a_re = accum.real(), a_im = accum.imag();
         a_re = hv * iv.real() + a_re;
         a_im = hv * iv.imag() + a_im;
         accum = {a_re, a_im};
     } else if constexpr (is_complex_v<AccumT> && is_complex_v<FilterValT> && !is_complex_v<InputValT>) {
-        // Complex filter × real input
+        // Complex filter * real input
         auto a_re = accum.real(), a_im = accum.imag();
         a_re = hv.real() * iv + a_re;
         a_im = hv.imag() * iv + a_im;
@@ -126,7 +131,7 @@ __MATX_DEVICE__ __MATX_INLINE__ void channelize_cmac(
 
 } // namespace detail
 
-template <int THREADS, bool MaximallyDecimated, typename OutType, typename InType, typename FilterType, typename AccumType>
+template <int THREADS, bool MaximallyDecimated, bool IsUnitStride, typename OutType, typename InType, typename FilterType, typename AccumType>
 __launch_bounds__(THREADS)
 __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter, index_t decimation_factor, uint32_t smem_filter_bytes)
 {
@@ -153,14 +158,30 @@ __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter
     const int channel = blockIdx.y;
     const int tid = threadIdx.x;
 
-    constexpr index_t ELEMS_PER_BLOCK = detail::CHANNELIZE_POLY1D_ELEMS_PER_THREAD * THREADS;
-    const index_t first_out_elem = elem_block * detail::CHANNELIZE_POLY1D_ELEMS_PER_THREAD * THREADS;
+    constexpr index_t ELEMS_PER_BLOCK = detail::cpoly::ElemsPerThread * THREADS;
+    const index_t first_out_elem = elem_block * detail::cpoly::ElemsPerThread * THREADS;
     const index_t last_out_elem = cuda::std::min(
         output_len_per_channel - 1, first_out_elem + ELEMS_PER_BLOCK - 1);
 
-    auto indims = BlockToIdx(input, blockIdx.z, 1);
-    auto outdims = BlockToIdx(output, blockIdx.z, 2);
-    outdims[ChannelRank] = channel;
+    // Wrap input/output/filter in TensorAccessor and bind the per-block batch
+    // coords once. After binding, per-access calls supply only the inner
+    // indices: (sample_idx) for input, (t, channel) for output. On the fast
+    // path this collapses to base_ptr[stride*inner + ...] arithmetic with no
+    // per-access stride reload; on the slow path it forwards to operator().
+    //
+    // Note on output layout: MatX arranges output as [batch..., elem, channel]
+    // where channel is the LAST dim (see the size asserts in
+    // channelize_poly_impl). We therefore bind only the batch dims (first
+    // OutRank-2) and pass both elem (t) and channel at access time.
+    detail::TensorAccessor<InType, IsUnitStride> input_acc(input);
+    detail::TensorAccessor<OutType, IsUnitStride> output_acc(output);
+    detail::TensorAccessor<FilterType, IsUnitStride> filter_acc(filter);
+
+    const auto in_batch_idx = BlockToIdx(input, blockIdx.z, 1);   // last slot unused
+    const auto out_batch_idx = BlockToIdx(output, blockIdx.z, 2); // last two slots unused
+
+    auto input_b  = detail::bind_first_n<InRank  - 1>(input_acc,  in_batch_idx);
+    auto output_b = detail::bind_first_n<OutRank - 2>(output_acc, out_batch_idx);
 
     if constexpr (MaximallyDecimated) {
         // Maximally decimated (D == M) path: filter phase is fixed per channel
@@ -177,12 +198,12 @@ __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter
         if (use_smem_filter) {
             for (index_t t = tid; t < filter_phase_len-1; t += THREADS) {
                 const index_t h_ind = channel + t * num_channels;
-                smem_filter[t] = filter.operator()(h_ind);
+                smem_filter[t] = filter_acc(h_ind);
             }
             if (tid == THREADS-1) {
                 const index_t h_ind = channel + (filter_phase_len-1) * num_channels;
                 smem_filter[filter_phase_len-1] = (h_ind < filter_full_len) ?
-                    filter.operator()(h_ind) : static_cast<filter_t>(0);
+                    filter_acc(h_ind) : static_cast<filter_t>(0);
             }
 
             __syncthreads();
@@ -191,29 +212,23 @@ __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter
         if (use_smem_filter) {
             for (index_t t = first_out_elem+tid; t <= last_out_elem; t += THREADS) {
                 accum_t accum {};
-                indims[InRank-1] = s + t * num_channels;
+                index_t sample_idx = s + t * num_channels;
                 index_t h_skip = 0;
-                if (indims[InRank-1] >= input_len) {
+                if (sample_idx >= input_len) {
                     h_skip = 1;
-                    indims[InRank-1] -= num_channels;
+                    sample_idx -= num_channels;
                 }
                 const filter_t *h = smem_filter + h_skip;
                 int niter = static_cast<int>(cuda::std::min(filter_phase_len - h_skip, t + 1 - h_skip));
-                input_t in_val;
                 for (int i = 0; i < niter; i++) {
-                    cuda::std::apply([&in_val, &input](auto &&...args) {
-                        in_val = input.operator()(args...);
-                    }, indims);
+                    const input_t in_val = input_b(sample_idx);
                     detail::channelize_cmac(accum,
                             detail::channelize_cast_filter<accum_t>(*h),
                             detail::channelize_cast_input<accum_t>(in_val));
-                    indims[InRank-1] -= num_channels;
+                    sample_idx -= num_channels;
                     h++;
                 }
-                outdims[OutElemRank] = t;
-                cuda::std::apply([accum, &output](auto &&...args) {
-                    output.operator()(args...) = static_cast<output_t>(accum);
-                }, outdims);
+                output_b(t, channel) = static_cast<output_t>(accum);
             }
         } else {
             index_t available_taps = filter_phase_len;
@@ -226,30 +241,24 @@ __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter
 
             for (index_t t = first_out_elem+tid; t <= last_out_elem; t += THREADS) {
                 accum_t accum {};
-                indims[InRank-1] = s + t * num_channels;
+                index_t sample_idx = s + t * num_channels;
                 index_t h_skip = 0;
-                if (indims[InRank-1] >= input_len) {
+                if (sample_idx >= input_len) {
                     h_skip = 1;
-                    indims[InRank-1] -= num_channels;
+                    sample_idx -= num_channels;
                 }
                 index_t h_ind = channel + h_skip * num_channels;
                 index_t niter = cuda::std::min(available_taps - h_skip, t + 1 - h_skip);
-                input_t in_val;
                 for (index_t i = 0; i < niter; i++) {
-                    cuda::std::apply([&in_val, &input](auto &&...args) {
-                        in_val = input.operator()(args...);
-                    }, indims);
-                    const filter_t h_val = filter.operator()(h_ind);
+                    const input_t in_val = input_b(sample_idx);
+                    const filter_t h_val = filter_acc(h_ind);
                     detail::channelize_cmac(accum,
                             detail::channelize_cast_filter<accum_t>(h_val),
                             detail::channelize_cast_input<accum_t>(in_val));
                     h_ind += num_channels;
-                    indims[InRank-1] -= num_channels;
+                    sample_idx -= num_channels;
                 }
-                outdims[OutElemRank] = t;
-                cuda::std::apply([accum, &output](auto &&...args) {
-                    output.operator()(args...) = static_cast<output_t>(accum);
-                }, outdims);
+                output_b(t, channel) = static_cast<output_t>(accum);
             }
         }
     } else {
@@ -265,15 +274,16 @@ __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter
             index_t niter = 0;
             const index_t phase = (channel + t * decimation_factor) % num_channels;
             index_t h_ind { phase };
+            index_t sample_idx = 0;
             accum_t accum {};
             if (last_arrived >= s) {
                 const index_t A = last_arrived - s;
-                indims[InRank-1] = last_arrived - (A % num_channels);
+                sample_idx = last_arrived - (A % num_channels);
                 const index_t causal_count = A / num_channels + 1;
                 index_t h_skip = 0;
-                if (indims[InRank-1] >= input_len) {
+                if (sample_idx >= input_len) {
                     h_skip = 1;
-                    indims[InRank-1] -= num_channels;
+                    sample_idx -= num_channels;
                 }
                 h_ind = phase + h_skip * num_channels;
                 index_t available_taps = filter_phase_len;
@@ -285,22 +295,16 @@ __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter
                 }
                 niter = cuda::std::min(available_taps - h_skip, causal_count - h_skip);
             }
-            input_t in_val;
             for (index_t i = 0; i < niter; i++) {
-                cuda::std::apply([&in_val, &input](auto &&...args) {
-                    in_val = input.operator()(args...);
-                }, indims);
-                const filter_t h_val = filter.operator()(h_ind);
+                const input_t in_val = input_b(sample_idx);
+                const filter_t h_val = filter_acc(h_ind);
                 detail::channelize_cmac(accum,
                         detail::channelize_cast_filter<accum_t>(h_val),
                         detail::channelize_cast_input<accum_t>(in_val));
                 h_ind += num_channels;
-                indims[InRank-1] -= num_channels;
+                sample_idx -= num_channels;
             }
-            outdims[OutElemRank] = t;
-            cuda::std::apply([accum, &output](auto &&...args) {
-                output.operator()(args...) = static_cast<output_t>(accum);
-            }, outdims);
+            output_b(t, channel) = static_cast<output_t>(accum);
         }
     }
 }
@@ -313,8 +317,8 @@ __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter
 // and oversampled (D < M) cases.
 //
 // Template parameters:
-//   FilterInSmem — when true, filter taps are cached in shared memory;
-//                  when false, filter taps are read from global/L2.
+//   FilterInSmem: when true, filter taps are cached in shared memory;
+//                 when false, filter taps are read from global/L2.
 //
 // Block: dim3(CTILE, NOUT)
 // Grid:  dim3(time_blocks, channel_tiles, batches)
@@ -329,8 +333,8 @@ __global__ void ChannelizePoly1D(OutType output, InType input, FilterType filter
 // Each column of smem_input is the circular buffer for one branch of the
 // commutator. Row r, column cx stores input[s(c) + r*M] where c = tile_base+cx
 // and s(c) = M-1-c.
-template <int CTILE, int NOUT, bool MaximallyDecimated, bool FilterInSmem,
-          typename IdxT,
+template <int CTILE, int NOUT, bool MaximallyDecimated, bool FilterInSmem, bool FilterFullLayout,
+          bool IsUnitStride, typename IdxT,
           typename OutType, typename InType, typename FilterType, typename AccumType>
 __launch_bounds__(CTILE * NOUT)
 __global__ void ChannelizePoly1D_SmemTiled(
@@ -378,7 +382,12 @@ __global__ void ChannelizePoly1D_SmemTiled(
     input_t  *smem_input = nullptr;
     if constexpr (FilterInSmem) {
         smem_filter_base = reinterpret_cast<filter_t *>(smem_raw);
-        const int32_t filter_elems = MaximallyDecimated ? (P * CTILE) : (CTILE * filter_stride);
+        // Filter smem slot count depends on chosen layout:
+        //   Full:    P * M unique taps
+        //   Rotated: per-channel redundant (CTILE * P for D==M, CTILE * K * P for D<M)
+        const int32_t filter_elems = FilterFullLayout
+            ? (P * M)
+            : (MaximallyDecimated ? (P * CTILE) : (CTILE * filter_stride));
         size_t input_byte_offset = sizeof(filter_t) * filter_elems;
         if (input_byte_offset % sizeof(input_t)) {
             input_byte_offset += sizeof(input_t) - input_byte_offset % sizeof(input_t);
@@ -388,23 +397,48 @@ __global__ void ChannelizePoly1D_SmemTiled(
         smem_input = reinterpret_cast<input_t *>(smem_raw);
     }
 
+    // TensorAccessors bind per-block batch coords once. After binding,
+    // input_b(sample_idx) reads one input sample for this batch, and
+    // output_b(t, ch) writes one output sample. Fast path folds the strides
+    // into pointer arithmetic; slow path forwards to operator().
+    detail::TensorAccessor<InType, IsUnitStride> input_acc(input);
+    detail::TensorAccessor<OutType, IsUnitStride> output_acc(output);
+    detail::TensorAccessor<FilterType, IsUnitStride> filter_acc(filter);
+
+    const auto in_batch_idx  = BlockToIdx(input,  blockIdx.z, 1);
+    const auto out_batch_idx = BlockToIdx(output, blockIdx.z, 2);
+    auto input_b  = detail::bind_first_n<InRank  - 1>(input_acc,  in_batch_idx);
+    auto output_b = detail::bind_first_n<OutRank - 2>(output_acc, out_batch_idx);
+
     if constexpr (FilterInSmem) {
         // Load filter into smem
-        if constexpr (MaximallyDecimated) {
+        if constexpr (FilterFullLayout) {
+            // Full layout: one copy of each unique tap, laid out as
+            //   smem_filter_base[p * M + phase] = filter[phase + p * M]
+            // No per-channel duplication, no per-K duplication. At access
+            // time the thread computes phase = (c + rotations[k]) % M and
+            // reads smem_filter_base[p * M + phase].
+            const int32_t total = P * M;
+            for (int32_t i = tid; i < total; i += nthreads) {
+                smem_filter_base[i] = (i < filter_full_len)
+                    ? filter_acc(static_cast<index_t>(i))
+                    : static_cast<filter_t>(0);
+            }
+        } else if constexpr (MaximallyDecimated) {
             for (int32_t i = tid; i < P * CTILE; i += nthreads) {
                 const int32_t p  = i / CTILE;
                 const int32_t local_channel = i % CTILE;
                 const int32_t global_channel = tile_base + local_channel;
                 const int32_t h_ind = global_channel + p * M;
                 smem_filter_base[i] = (global_channel < M && h_ind < filter_full_len)
-                    ? filter.operator()(static_cast<index_t>(h_ind))
+                    ? filter_acc(static_cast<index_t>(h_ind))
                     : static_cast<filter_t>(0);
             }
         } else {
             // The dispatch must not select FilterInSmem when K exceeds the
             // rotations[] array size. Assert this invariant at runtime.
-            assert(K <= detail::MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_ROTATIONS);
-            int32_t rotations[detail::MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_ROTATIONS];
+            assert(K <= detail::cpoly::SmemTiledMaxRotations);
+            int32_t rotations[detail::cpoly::SmemTiledMaxRotations];
             for (int32_t k = 0; k < K; k++) {
                 rotations[k] = static_cast<int32_t>((static_cast<int64_t>(k) * decimation_factor) % M);
             }
@@ -424,7 +458,7 @@ __global__ void ChannelizePoly1D_SmemTiled(
                     const int32_t phase = (global_channel + rotations[k]) % M;
                     const int32_t h_ind = phase + p * M;
                     smem_filter_base[i] = (h_ind < filter_full_len)
-                        ? filter.operator()(static_cast<index_t>(h_ind))
+                        ? filter_acc(static_cast<index_t>(h_ind))
                         : static_cast<filter_t>(0);
                 } else {
                     smem_filter_base[i] = static_cast<filter_t>(0);
@@ -446,10 +480,6 @@ __global__ void ChannelizePoly1D_SmemTiled(
         output_len_per_channel - 1,
         start_elem + elems_per_channel_per_cta - 1);
 
-    auto indims  = BlockToIdx(input,  blockIdx.z, 1);
-    auto outdims = BlockToIdx(output, blockIdx.z, 2);
-    outdims[ChannelRank] = c;
-
     // Helper: load one input sample into smem at (buf_row, col)
     auto load_smem_elem = [&](int32_t buf_row, int32_t col, IdxT global_row) {
         const int32_t gc = tile_base + col;
@@ -457,12 +487,7 @@ __global__ void ChannelizePoly1D_SmemTiled(
         const int32_t branch_s = (gc < M) ? (M - 1 - gc_remapped) : 0;
         const IdxT raw_idx = static_cast<IdxT>(branch_s) + global_row * M;
         if (gc < M && global_row >= 0 && raw_idx >= 0 && raw_idx < input_len) {
-            indims[InRank - 1] = raw_idx;
-            input_t val;
-            cuda::std::apply([&val, &input](auto &&...args) {
-                val = input.operator()(args...);
-            }, indims);
-            smem_input[buf_row * CTILE + col] = val;
+            smem_input[buf_row * CTILE + col] = input_b(raw_idx);
         } else {
             smem_input[buf_row * CTILE + col] = static_cast<input_t>(0);
         }
@@ -530,42 +555,56 @@ __global__ void ChannelizePoly1D_SmemTiled(
 
                 const int32_t prologue = cuda::std::min(my_buf_row + 1, niter);
                 const int32_t epilogue = niter - prologue;
-                int32_t h_ind = c + h_skip * M;
-                int32_t p = 0;
-                for (int32_t i = 0; i < prologue; i++, p++) {
+                // Single running counter instead of separate `p` and `h_ind`.
+                // Each layout's access pattern reduces to (init, stride):
+                //   Full:    smem[(p+h_skip)*M + c]           -> init h_skip*M+c, stride M
+                //   Rotated: smem[(p+h_skip)*CTILE + cx]      -> init h_skip*CTILE+cx, stride CTILE
+                //   Global:  filter[c + (p+h_skip)*M]         -> init c+h_skip*M, stride M
+                int32_t filter_idx;
+                if constexpr (FilterInSmem && !FilterFullLayout) {
+                    filter_idx = h_skip * CTILE + cx;
+                } else {
+                    filter_idx = c + h_skip * M;
+                }
+                for (int32_t i = 0; i < prologue; i++) {
                     filter_t hv;
                     if constexpr (FilterInSmem) {
-                        hv = smem_filter_base[(p + h_skip) * CTILE + cx];
+                        hv = smem_filter_base[filter_idx];
                     } else {
-                        hv = filter.operator()(static_cast<index_t>(h_ind));
+                        hv = filter_acc(static_cast<index_t>(filter_idx));
                     }
                     const input_t iv = smem_input[my_buf_row * CTILE + cx];
                     detail::channelize_cmac(accum,
                             detail::channelize_cast_filter<accum_t>(hv),
                             detail::channelize_cast_input<accum_t>(iv));
                     my_buf_row--;
-                    h_ind += M;
+                    if constexpr (FilterInSmem && !FilterFullLayout) {
+                        filter_idx += CTILE;
+                    } else {
+                        filter_idx += M;
+                    }
                 }
                 my_buf_row = height - 1;
-                for (int32_t i = 0; i < epilogue; i++, p++) {
+                for (int32_t i = 0; i < epilogue; i++) {
                     filter_t hv;
                     if constexpr (FilterInSmem) {
-                        hv = smem_filter_base[(p + h_skip) * CTILE + cx];
+                        hv = smem_filter_base[filter_idx];
                     } else {
-                        hv = filter.operator()(static_cast<index_t>(h_ind));
+                        hv = filter_acc(static_cast<index_t>(filter_idx));
                     }
                     const input_t iv = smem_input[my_buf_row * CTILE + cx];
                     detail::channelize_cmac(accum,
                             detail::channelize_cast_filter<accum_t>(hv),
                             detail::channelize_cast_input<accum_t>(iv));
                     my_buf_row--;
-                    h_ind += M;
+                    if constexpr (FilterInSmem && !FilterFullLayout) {
+                        filter_idx += CTILE;
+                    } else {
+                        filter_idx += M;
+                    }
                 }
 
-                outdims[OutElemRank] = t;
-                cuda::std::apply([accum, &output](auto &&...args) {
-                    output.operator()(args...) = static_cast<output_t>(accum);
-                }, outdims);
+                output_b(t, c) = static_cast<output_t>(accum);
             }
 
             if (next_start < last_start) {
@@ -632,43 +671,57 @@ __global__ void ChannelizePoly1D_SmemTiled(
 
                     const int32_t prologue = cuda::std::min(buf_row + 1, niter);
                     const int32_t epilogue = niter - prologue;
-                    int32_t h_ind = phase + h_skip * M;
-                    int32_t p = 0;
-                    for (int32_t i = 0; i < prologue; i++, p++) {
+                    // Single running counter instead of separate `p` and
+                    // `h_ind`. Per layout (init, stride):
+                    //   Full:    smem[(p+h_skip)*M + phase]         -> h_skip*M+phase, +M
+                    //   Rotated: smem[cx*K*P + k*P + (p+h_skip)]    -> cx*K*P+k*P+h_skip, +1
+                    //   Global:  filter[phase + (p+h_skip)*M]       -> phase+h_skip*M, +M
+                    int32_t filter_idx;
+                    if constexpr (FilterInSmem && !FilterFullLayout) {
+                        filter_idx = cx * filter_stride + k * P + h_skip;
+                    } else {
+                        filter_idx = phase + h_skip * M;
+                    }
+                    for (int32_t i = 0; i < prologue; i++) {
                         filter_t hv;
                         if constexpr (FilterInSmem) {
-                            hv = smem_filter_base[cx * filter_stride + k * P + (p + h_skip)];
+                            hv = smem_filter_base[filter_idx];
                         } else {
-                            hv = filter.operator()(static_cast<index_t>(h_ind));
+                            hv = filter_acc(static_cast<index_t>(filter_idx));
                         }
                         const input_t iv = smem_input[buf_row * CTILE + cx];
                         detail::channelize_cmac(accum,
                                 detail::channelize_cast_filter<accum_t>(hv),
                                 detail::channelize_cast_input<accum_t>(iv));
                         buf_row--;
-                        h_ind += M;
+                        if constexpr (FilterInSmem && !FilterFullLayout) {
+                            filter_idx += 1;
+                        } else {
+                            filter_idx += M;
+                        }
                     }
                     buf_row = height - 1;
-                    for (int32_t i = 0; i < epilogue; i++, p++) {
+                    for (int32_t i = 0; i < epilogue; i++) {
                         filter_t hv;
                         if constexpr (FilterInSmem) {
-                            hv = smem_filter_base[cx * filter_stride + k * P + (p + h_skip)];
+                            hv = smem_filter_base[filter_idx];
                         } else {
-                            hv = filter.operator()(static_cast<index_t>(h_ind));
+                            hv = filter_acc(static_cast<index_t>(filter_idx));
                         }
                         const input_t iv = smem_input[buf_row * CTILE + cx];
                         detail::channelize_cmac(accum,
                                 detail::channelize_cast_filter<accum_t>(hv),
                                 detail::channelize_cast_input<accum_t>(iv));
                         buf_row--;
-                        h_ind += M;
+                        if constexpr (FilterInSmem && !FilterFullLayout) {
+                            filter_idx += 1;
+                        } else {
+                            filter_idx += M;
+                        }
                     }
                 }
 
-                outdims[OutElemRank] = t;
-                cuda::std::apply([accum, &output](auto &&...args) {
-                    output.operator()(args...) = static_cast<output_t>(accum);
-                }, outdims);
+                output_b(t, c) = static_cast<output_t>(accum);
             }
 
             if (next_start < last_start) {
@@ -701,7 +754,7 @@ __global__ void ChannelizePoly1D_SmemTiled(
 
 // This kernel works in cases where the full filter (with potentially some zero padding) and
 // the inputs required to compute elems_per_channel_per_cta outputs all fit into shared memory.
-template <typename OutType, typename InType, typename FilterType, typename AccumType>
+template <bool IsUnitStride, typename OutType, typename InType, typename FilterType, typename AccumType>
 __global__ void ChannelizePoly1D_Smem(OutType output, InType input, FilterType filter, index_t elems_per_channel_per_cta)
 {
     using output_t = typename OutType::value_type;
@@ -743,8 +796,17 @@ __global__ void ChannelizePoly1D_Smem(OutType output, InType input, FilterType f
     const int32_t ty = static_cast<int32_t>(threadIdx.y);
     const int32_t by = static_cast<int32_t>(blockDim.y);
 
+    // TensorAccessors with per-block batch binding (see ChannelizePoly1D_SmemTiled).
+    detail::TensorAccessor<InType, IsUnitStride> input_acc(input);
+    detail::TensorAccessor<OutType, IsUnitStride> output_acc(output);
+    detail::TensorAccessor<FilterType, IsUnitStride> filter_acc(filter);
+    const auto in_batch_idx  = BlockToIdx(input,  blockIdx.z, 1);
+    const auto out_batch_idx = BlockToIdx(output, blockIdx.z, 2);
+    auto input_b  = detail::bind_first_n<InRank  - 1>(input_acc,  in_batch_idx);
+    auto output_b = detail::bind_first_n<OutRank - 2>(output_acc, out_batch_idx);
+
     for (int32_t t = tid; t < filter_full_len; t += nthreads) {
-        smem_h[t] = filter.operator()(t);
+        smem_h[t] = filter_acc(t);
     }
 
     for (int32_t t = filter_full_len+tid; t < filter_phase_len * num_channels; t += nthreads) {
@@ -758,19 +820,13 @@ __global__ void ChannelizePoly1D_Smem(OutType output, InType input, FilterType f
     const index_t start_elem = blockIdx.x * elems_per_channel_per_cta;
     const index_t last_elem_this_block = static_cast<index_t>(blockIdx.x) * elems_per_channel_per_cta + (elems_per_channel_per_cta - 1);
     const index_t last_elem = cuda::std::min(output_len_per_channel-1, last_elem_this_block);
-    auto indims = BlockToIdx(input, blockIdx.z, 1);
-    auto outdims = BlockToIdx(output, blockIdx.z, 2);
-    outdims[ChannelRank] = chan;
 
     for (int32_t t = ty; t < filter_phase_len-1; t += by) {
         const index_t out_sample_ind = start_elem - (filter_phase_len-1) + t;
         const int32_t smem_ind = t * num_channels + chan;
         const index_t input_ind = out_sample_ind * num_channels + chan;
         if (input_ind >= 0 && input_ind < input_len) {
-            indims[InRank-1] = input_ind;
-            cuda::std::apply([smem_input, smem_ind, &input](auto &&...args) {
-                smem_input[smem_ind] = input.operator()(args...);
-            }, indims);
+            smem_input[smem_ind] = input_b(input_ind);
         } else {
             smem_input[smem_ind] = static_cast<input_t>(0);
         }
@@ -789,12 +845,10 @@ __global__ void ChannelizePoly1D_Smem(OutType output, InType input, FilterType f
         const index_t next_last_elem = cuda::std::min(next_start_elem + static_cast<index_t>(by) - 1, last_elem);
         const int32_t out_samples_this_iter = static_cast<int32_t>(next_last_elem - next_start_elem + 1);
         if (ty < out_samples_this_iter) {
-            indims[InRank-1] = (next_start_elem + ty) * num_channels + chan;
+            const index_t input_ind = (next_start_elem + ty) * num_channels + chan;
             const int32_t smem_ind = cached_input_ind_tail * num_channels + chan;
-            if (indims[InRank-1] < input_len) {
-                cuda::std::apply([smem_input, smem_ind, &input](auto &&...args) {
-                    smem_input[smem_ind] = input.operator()(args...);
-                }, indims);
+            if (input_ind < input_len) {
+                smem_input[smem_ind] = input_b(input_ind);
             } else {
                 smem_input[smem_ind] = static_cast<input_t>(0);
             }
@@ -812,8 +866,8 @@ __global__ void ChannelizePoly1D_Smem(OutType output, InType input, FilterType f
 
         __syncthreads();
 
-        outdims[OutElemRank] = next_start_elem + ty;
-        if (outdims[OutElemRank] <= last_elem) {
+        const index_t out_elem_idx = next_start_elem + ty;
+        if (out_elem_idx <= last_elem) {
             const filter_t *h = h_start;
             accum_t accum { 0 };
             const int32_t first_end = cuda::std::min(cached_input_ind_tail + filter_phase_len - 1, smem_input_height - 1);
@@ -841,16 +895,14 @@ __global__ void ChannelizePoly1D_Smem(OutType output, InType input, FilterType f
                 h -= num_channels;
             }
 
-            cuda::std::apply([accum, &output](auto &&...args) {
-                output.operator()(args...) = static_cast<output_t>(accum);
-            }, outdims);
+            output_b(out_elem_idx, chan) = static_cast<output_t>(accum);
         }
 
         next_start_elem += out_samples_this_iter;
     }
 }
 
-template <int THREADS, int NUM_CHAN, typename OutType, typename InType, typename FilterType, typename AccumType>
+template <int THREADS, int NUM_CHAN, bool IsUnitStride, typename OutType, typename InType, typename FilterType, typename AccumType>
 __launch_bounds__(THREADS)
 __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterType filter)
 {
@@ -866,7 +918,6 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
 
     constexpr int InRank = InType::Rank();
     constexpr int OutRank = OutType::Rank();
-    constexpr int ChannelRank = OutRank-1;
     constexpr int OutElemRank = OutRank-2;
 
     const index_t input_len = input.Size(InRank-1);
@@ -877,11 +928,18 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
     const int elem_block = blockIdx.x;
     const int tid = threadIdx.x;
 
-    auto indims = BlockToIdx(input, blockIdx.z, 1);
-    auto outdims = BlockToIdx(output, blockIdx.z, 2);
+    // TensorAccessors + batch bind. Batch coords come from BlockToIdx; inner
+    // indices (sample for input, (t, chan) for output) are supplied per access.
+    detail::TensorAccessor<InType, IsUnitStride> input_acc(input);
+    detail::TensorAccessor<OutType, IsUnitStride> output_acc(output);
+    detail::TensorAccessor<FilterType, IsUnitStride> filter_acc(filter);
+    const auto in_batch_idx  = BlockToIdx(input,  blockIdx.z, 1);
+    const auto out_batch_idx = BlockToIdx(output, blockIdx.z, 2);
+    auto input_b  = detail::bind_first_n<InRank  - 1>(input_acc,  in_batch_idx);
+    auto output_b = detail::bind_first_n<OutRank - 2>(output_acc, out_batch_idx);
 
-    constexpr index_t ELEMS_PER_BLOCK = detail::CHANNELIZE_POLY1D_ELEMS_PER_THREAD * THREADS;
-    const index_t first_out_elem = elem_block * detail::CHANNELIZE_POLY1D_ELEMS_PER_THREAD * THREADS;
+    constexpr index_t ELEMS_PER_BLOCK = detail::cpoly::ElemsPerThread * THREADS;
+    const index_t first_out_elem = elem_block * detail::cpoly::ElemsPerThread * THREADS;
     const index_t last_out_elem = cuda::std::min(
         output_len_per_channel - 1, first_out_elem + ELEMS_PER_BLOCK - 1);
 
@@ -916,23 +974,21 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
             accum[i] = static_cast<filtering_accum_t>(0);
         }
         index_t first_ind = cuda::std::max(static_cast<index_t>(0), t - filter_phase_len + 1);
-        indims[InRank-1] = t * NUM_CHAN + NUM_CHAN - 1;
+        index_t sample_idx = t * NUM_CHAN + NUM_CHAN - 1;
         index_t j_start = t;
         index_t h_ind { 0 };
         index_t niter = j_start - first_ind + 1;
         // For the last signal element, we need bounds-checking because we may need to zero-pad the signal.
         if (niter > 0) {
             for (int chan = 0; chan < NUM_CHAN; chan++) {
-                const filter_t h_val = (h_ind < filter_full_len) ? filter.operator()(h_ind) : static_cast<filter_t>(0);
-                if (indims[InRank-1] < input_len) {
-                    cuda::std::apply([&accum, chan, h_val, &input](auto &&...args) {
-                        detail::channelize_cmac(accum[chan],
-                                detail::channelize_cast_filter<filtering_accum_t>(h_val),
-                                detail::channelize_cast_input<filtering_accum_t>(input.operator()(args...)));
-                    }, indims);
+                const filter_t h_val = (h_ind < filter_full_len) ? filter_acc(h_ind) : static_cast<filter_t>(0);
+                if (sample_idx < input_len) {
+                    detail::channelize_cmac(accum[chan],
+                            detail::channelize_cast_filter<filtering_accum_t>(h_val),
+                            detail::channelize_cast_input<filtering_accum_t>(input_b(sample_idx)));
                 }
                 h_ind++;
-                indims[InRank-1]--;
+                sample_idx--;
             }
         }
         niter--;
@@ -940,14 +996,12 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
         // The central elements require no bounds checking on the filter or signal.
         for (index_t i = 0; i < niter-1; i++) {
             for (int chan = 0; chan < NUM_CHAN; chan++) {
-                const filter_t h_val = filter.operator()(h_ind);
-                cuda::std::apply([&accum, chan, h_val, &input](auto &&...args) {                    
-                    detail::channelize_cmac(accum[chan],
-                            detail::channelize_cast_filter<filtering_accum_t>(h_val),
-                            detail::channelize_cast_input<filtering_accum_t>(input.operator()(args...)));
-                }, indims);
+                const filter_t h_val = filter_acc(h_ind);
+                detail::channelize_cmac(accum[chan],
+                        detail::channelize_cast_filter<filtering_accum_t>(h_val),
+                        detail::channelize_cast_input<filtering_accum_t>(input_b(sample_idx)));
                 h_ind++;
-                indims[InRank-1]--;
+                sample_idx--;
             }
         }
 
@@ -957,19 +1011,15 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
                 if (h_ind >= filter_full_len) {
                     break;
                 }
-                // const filter_t h_val = (h_ind < filter_full_len) ? filter.operator()(h_ind) : static_cast<filter_t>(0);
-                const filter_t h_val = filter.operator()(h_ind);
-                cuda::std::apply([&accum, chan, h_val, &input](auto &&...args) {                    
-                    detail::channelize_cmac(accum[chan],
-                            detail::channelize_cast_filter<filtering_accum_t>(h_val),
-                            detail::channelize_cast_input<filtering_accum_t>(input.operator()(args...)));
-                }, indims);
+                const filter_t h_val = filter_acc(h_ind);
+                detail::channelize_cmac(accum[chan],
+                        detail::channelize_cast_filter<filtering_accum_t>(h_val),
+                        detail::channelize_cast_input<filtering_accum_t>(input_b(sample_idx)));
                 h_ind++;
-                indims[InRank-1]--;
+                sample_idx--;
             }
         }
 
-        outdims[OutElemRank] = t;
 
         // For complex inputs, the DFT will not generally be conjugate symmetric, so compute all
         // terms. For real inputs, we only compute the unique (up to conjugate symmetry) components.
@@ -979,10 +1029,7 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
                 for (int j = 0; j < NUM_CHAN; j++) {
                     dft += accum[j] * smem_eij[chan][j];
                 }
-                outdims[ChannelRank] = chan;
-                cuda::std::apply([dft, &output](auto &&...args) {
-                    output.operator()(args...) = static_cast<output_t>(dft);
-                }, outdims);
+                output_b(t, static_cast<index_t>(chan)) = static_cast<output_t>(dft);
             }
         } else {
             constexpr int mid = NUM_CHAN/2 + 1;
@@ -993,10 +1040,7 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
                     for (int j = 0; j < NUM_CHAN; j++) {
                         dft += accum[j] * smem_eij[0][j];
                     }
-                    outdims[ChannelRank] = 0;
-                    cuda::std::apply([dft, &output](auto &&...args) {
-                        output.operator()(args...) = static_cast<output_t>(dft);
-                    }, outdims);
+                    output_b(t, static_cast<index_t>(0)) = static_cast<output_t>(dft);
                 }
                 // Channel mid-1, Nyquist. There is no conjugate symmetric component for this value.
                 {
@@ -1004,10 +1048,7 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
                     for (int j = 0; j < NUM_CHAN; j++) {
                         dft += accum[j] * smem_eij[mid-1][j];
                     }
-                    outdims[ChannelRank] = mid-1;
-                    cuda::std::apply([dft, &output](auto &&...args) {
-                        output.operator()(args...) = static_cast<output_t>(dft);
-                    }, outdims);
+                    output_b(t, static_cast<index_t>(mid-1)) = static_cast<output_t>(dft);
                 }
                 // Conjugate symmetric components
                 for (int chan = 1; chan < mid-1; chan++) {
@@ -1015,14 +1056,8 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
                     for (int j = 0; j < NUM_CHAN; j++) {
                         dft += accum[j] * smem_eij[chan][j];
                     }
-                    outdims[ChannelRank] = chan;
-                    cuda::std::apply([dft, &output](auto &&...args) {
-                        output.operator()(args...) = static_cast<output_t>(dft);
-                    }, outdims);
-                    outdims[ChannelRank] = NUM_CHAN - chan;
-                    cuda::std::apply([dft, &output](auto &&...args) {
-                        output.operator()(args...) = static_cast<output_t>(conj(dft));
-                    }, outdims);
+                    output_b(t, static_cast<index_t>(chan))             = static_cast<output_t>(dft);
+                    output_b(t, static_cast<index_t>(NUM_CHAN - chan))  = static_cast<output_t>(conj(dft));
                 }
             } else {
                 // Channel 0, DC. There is no conjugate symmetric component for this value.
@@ -1031,10 +1066,7 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
                     for (int j = 0; j < NUM_CHAN; j++) {
                         dft += accum[j] * smem_eij[0][j];
                     }
-                    outdims[ChannelRank] = 0;
-                    cuda::std::apply([dft, &output](auto &&...args) {
-                        output.operator()(args...) = static_cast<output_t>(dft);
-                    }, outdims);
+                    output_b(t, static_cast<index_t>(0)) = static_cast<output_t>(dft);
                 }
                 // Conjugate symmetric components
                 for (int chan = 1; chan < mid; chan++) {
@@ -1042,15 +1074,9 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
                     for (int j = 0; j < NUM_CHAN; j++) {
                         dft += accum[j] * smem_eij[chan][j];
                     }
-                    outdims[ChannelRank] = chan;
-                    cuda::std::apply([dft, &output](auto &&...args) {
-                        output.operator()(args...) = static_cast<output_t>(dft);
-                    }, outdims);
-                    outdims[ChannelRank] = NUM_CHAN - chan;
-                    cuda::std::apply([dft, &output](auto &&...args) {
-                        output.operator()(args...) = static_cast<output_t>(conj(dft));
-                    }, outdims);
-                }                
+                    output_b(t, static_cast<index_t>(chan))             = static_cast<output_t>(dft);
+                    output_b(t, static_cast<index_t>(NUM_CHAN - chan))  = static_cast<output_t>(conj(dft));
+                }
             }
         }
     }
@@ -1061,7 +1087,7 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
 // return a packed version of the output that includes only the unique elements
 // (up to conjugate symmetry). We unpack because for the channelizer we want all
 // channel outputs.
-template <typename DataType>
+template <bool IsUnitStride, typename DataType>
 __global__ void ChannelizePoly1DUnpackDFT(DataType inout)
 {
     constexpr int Rank = DataType::Rank();
@@ -1079,37 +1105,17 @@ __global__ void ChannelizePoly1DUnpackDFT(DataType inout)
         return;
     }
 
-    auto dims = BlockToIdx(inout, blockIdx.x, 2);
-    dims[ElemRank] = tid;
-    value_t val;
-    if (num_channels % 2 == 0) {
-        for (index_t i = 1; i < mid-1; i++) {
-            dims[ChannelRank] = i;
-            cuda::std::apply([&val, &inout](auto &&...args) {                    
-                val = inout.operator()(args...);
-            }, dims);
-            cuda::std::apply([&val, &inout](auto &&...args) {                    
-                inout.operator()(args...) = conj(val);
-            }, dims);
-            dims[ChannelRank] = num_channels - i;
-            cuda::std::apply([&val, &inout](auto &&...args) {                    
-                inout.operator()(args...) = val;
-            }, dims);            
-        }
-    } else {
-        for (index_t i = 1; i < mid; i++) {
-            dims[ChannelRank] = i;
-            cuda::std::apply([&val, &inout](auto &&...args) {                    
-                val = inout.operator()(args...);
-            }, dims);
-            cuda::std::apply([&val, &inout](auto &&...args) {                    
-                inout.operator()(args...) = conj(val);
-            }, dims);
-            dims[ChannelRank] = num_channels - i;
-            cuda::std::apply([&val, &inout](auto &&...args) {                    
-                inout.operator()(args...) = val;
-            }, dims);            
-        }
+    // Bind batch coords; remaining dims are (elem, channel). Access with
+    // inout_b(tid, chan).
+    detail::TensorAccessor<DataType, IsUnitStride> inout_acc(inout);
+    const auto batch_idx = BlockToIdx(inout, blockIdx.x, 2);
+    auto inout_b = detail::bind_first_n<Rank - 2>(inout_acc, batch_idx);
+
+    const index_t upper = (num_channels % 2 == 0) ? (mid - 1) : mid;
+    for (index_t i = 1; i < upper; i++) {
+        const value_t val = inout_b(static_cast<index_t>(tid), i);
+        inout_b(static_cast<index_t>(tid), i) = conj(val);
+        inout_b(static_cast<index_t>(tid), num_channels - i) = val;
     }
 }
 

--- a/include/matx/kernels/sar_bp.cuh
+++ b/include/matx/kernels/sar_bp.cuh
@@ -191,11 +191,14 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     static_assert(is_complex_v<typename InitialImageType::value_type>, "Initial image must be complex");
     static_assert(is_complex_v<typename RangeProfilesType::value_type>, "Range profiles must be complex");
 
-    static_assert(
-        (is_matx_op<RangeToMcpType>() && (RangeToMcpType::Rank() == 0 || RangeToMcpType::Rank() == 1) &&
-        (cuda::std::is_same_v<typename RangeToMcpType::value_type, float> || cuda::std::is_same_v<typename RangeToMcpType::value_type, double> || cuda::std::is_same_v<typename RangeToMcpType::value_type, fltflt>)) ||
-        (cuda::std::is_same_v<RangeToMcpType, float> || cuda::std::is_same_v<RangeToMcpType, double> || cuda::std::is_same_v<RangeToMcpType, fltflt>),
-        "RangeToMcpType must currently be a 0D tensor or scalar of type float, double, or fltflt");
+    static_assert(is_matx_op<RangeToMcpType>(),
+        "RangeToMcpType must be a MatX operator");
+    static_assert(RangeToMcpType::Rank() == 0 || RangeToMcpType::Rank() == 1,
+        "RangeToMcpType must be a rank-0 or rank-1 operator");
+    static_assert(cuda::std::is_same_v<typename RangeToMcpType::value_type, float> ||
+                  cuda::std::is_same_v<typename RangeToMcpType::value_type, double> ||
+                  cuda::std::is_same_v<typename RangeToMcpType::value_type, fltflt>,
+        "RangeToMcpType::value_type must be float, double, or fltflt");
 
     using initial_image_t = typename InitialImageType::value_type;
     using image_t = typename OutImageType::value_type;
@@ -266,26 +269,16 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     detail::TensorAccessor<RangeProfilesType, IsUnitStride> rp(range_profiles);
     detail::TensorAccessor<PlatPosType, IsUnitStride> pp(platform_positions);
 
-    // range_to_mcp can be a rank-0 or rank-1 matx op, or a plain scalar.
-    // The TensorAccessor's operator() overloads cover the matx-op cases;
-    // the scalar case is returned directly by the lambda.
-    [[maybe_unused]] const auto rtm_acc = [&]() {
-        if constexpr (is_matx_op<RangeToMcpType>()) {
-            return detail::TensorAccessor<RangeToMcpType, IsUnitStride>(range_to_mcp);
-        } else {
-            return int{0};  // placeholder; never dereferenced for scalars
-        }
-    }();
+    // range_to_mcp is required to be a rank-0 or rank-1 MatX operator; the
+    // TensorAccessor picks the fast pointer path on IsUnitStride for tensor
+    // views or forwards to operator() for computed ops (e.g. ConstVal).
+    const detail::TensorAccessor<RangeToMcpType, IsUnitStride> rtm_acc(range_to_mcp);
 
-    const auto r_to_mcp = [&range_to_mcp, rtm_acc](index_t p) -> auto {
-        if constexpr (is_matx_op<RangeToMcpType>()) {
-            if constexpr (RangeToMcpType::Rank() == 0) {
-                return rtm_acc();
-            } else {
-                return rtm_acc(p);
-            }
+    const auto r_to_mcp = [rtm_acc](index_t p) -> auto {
+        if constexpr (RangeToMcpType::Rank() == 0) {
+            return rtm_acc();
         } else {
-            return range_to_mcp;
+            return rtm_acc(p);
         }
     };
 

--- a/include/matx/kernels/sar_bp.cuh
+++ b/include/matx/kernels/sar_bp.cuh
@@ -44,6 +44,7 @@
 #include "matx/core/type_utils.h"
 #include "matx/core/tensor_utils.h"
 #include "matx/kernels/fltflt.h"
+#include "matx/kernels/tensor_accessor.h"
 
 #define PULSE_BLOCK_SIZE 512
 
@@ -80,24 +81,25 @@ __device__ inline fltflt ComputeRangeToPixelFloatFloat(fltflt apx, fltflt apy, f
     return fltflt_norm3d(dx, dy, dz);
 }
 
-template <typename PlatPosType, SarBpComputeType ComputeType, typename strict_compute_t, typename loose_compute_t>
-__device__ inline strict_compute_t ComputeRangeToPixel(const PlatPosType &ant_pos, const index_t pulse_idx, const loose_compute_t px, const loose_compute_t py, const loose_compute_t z0) {
-    using plat_pos_t = typename PlatPosType::value_type;
+template <typename PlatPosAccessor, SarBpComputeType ComputeType, typename strict_compute_t, typename loose_compute_t>
+__device__ inline strict_compute_t ComputeRangeToPixel(const PlatPosAccessor &ant_pos, const index_t pulse_idx, const loose_compute_t px, const loose_compute_t py, const loose_compute_t z0) {
+    using plat_pos_t = typename PlatPosAccessor::value_type;
+    constexpr int Rank = PlatPosAccessor::Rank;
 
     strict_compute_t dx, dy, dz;
-    static_assert((PlatPosType::Rank() == 1 && (std::is_same_v<plat_pos_t, double3> || std::is_same_v<plat_pos_t, double4> ||
-        std::is_same_v<plat_pos_t, float3> || std::is_same_v<plat_pos_t, float4>)) || PlatPosType::Rank() == 2,
+    static_assert((Rank == 1 && (cuda::std::is_same_v<plat_pos_t, double3> || cuda::std::is_same_v<plat_pos_t, double4> ||
+        cuda::std::is_same_v<plat_pos_t, float3> || cuda::std::is_same_v<plat_pos_t, float4>)) || Rank == 2,
         "ComputeRangeToPixel: plat_pos_t must be a 1D tensor of 3D or 4D vectorized type or a 2D tensor with size 3 (x,y,z) in the second dimension");
 
-    if constexpr (PlatPosType::Rank() == 1) {
-        const plat_pos_t ant_pos_p = ant_pos.operator()(pulse_idx);
+    if constexpr (Rank == 1) {
+        const plat_pos_t ant_pos_p = ant_pos(pulse_idx);
         dx = static_cast<strict_compute_t>(px) - static_cast<strict_compute_t>(ant_pos_p.x);
         dy = static_cast<strict_compute_t>(py) - static_cast<strict_compute_t>(ant_pos_p.y);
         dz = static_cast<strict_compute_t>(z0) - static_cast<strict_compute_t>(ant_pos_p.z);
     } else {
-        dx = static_cast<strict_compute_t>(px) - static_cast<strict_compute_t>(ant_pos.operator()(pulse_idx, 0));
-        dy = static_cast<strict_compute_t>(py) - static_cast<strict_compute_t>(ant_pos.operator()(pulse_idx, 1));
-        dz = static_cast<strict_compute_t>(z0) - static_cast<strict_compute_t>(ant_pos.operator()(pulse_idx, 2));
+        dx = static_cast<strict_compute_t>(px) - static_cast<strict_compute_t>(ant_pos(pulse_idx, 0));
+        dy = static_cast<strict_compute_t>(py) - static_cast<strict_compute_t>(ant_pos(pulse_idx, 1));
+        dz = static_cast<strict_compute_t>(z0) - static_cast<strict_compute_t>(ant_pos(pulse_idx, 2));
     }
 
     if constexpr (ComputeType == SarBpComputeType::Float) {
@@ -124,7 +126,7 @@ __global__ void SarBpFillPhaseLUT(cuda::std::complex<StorageType> *phase_lut, Co
     constexpr ComputeType four_pi_over_c = static_cast<ComputeType>(4.0 * M_PI / SPEED_OF_LIGHT);
     const ComputeType range_bin_start = static_cast<ComputeType>(tid - 0.5 * (num_range_bins-1)) * dr;
     const ComputeType phase = four_pi_over_c * ref_freq * range_bin_start;
-    if constexpr (std::is_same_v<ComputeType, float>) {
+    if constexpr (cuda::std::is_same_v<ComputeType, float>) {
         ComputeType sinx, cosx;
         ::sincosf(phase, &sinx, &cosx);
         phase_lut[tid] = cuda::std::complex<StorageType>(
@@ -147,15 +149,33 @@ using strict_or_ff_compute_param_t = typename std::conditional<ComputeType == Sa
 template <SarBpComputeType ComputeType>
 using loose_compute_param_t = typename std::conditional<ComputeType == SarBpComputeType::Double, double, float>::type;
 
-template <SarBpComputeType ComputeType>
+// Shared-memory layout is parameterized on whether the kernel runs the
+// cooperative preamble (see UseSharedPreamble in SarBp). The preamble loads
+// per-pulse antenna positions and pre-computes mcp_partial = bin_offset
+// - rtm*dr_inv once per pulse block, amortizing the global FP64 loads and
+// FP64->compute-type casts across all threads.
+template <SarBpComputeType ComputeType, bool PreambleEnabled>
 struct SarBpSharedMemory {};
 
-template <>
-struct SarBpSharedMemory<SarBpComputeType::FloatFloat> {
+template <bool PreambleEnabled>
+struct SarBpSharedMemory<SarBpComputeType::FloatFloat, PreambleEnabled> {
     fltflt ant_pos[PULSE_BLOCK_SIZE][4];
 };
 
-template <SarBpComputeType ComputeType, typename OutImageType, typename InitialImageType, typename RangeProfilesType, typename PlatPosType, typename VoxLocType, typename RangeToMcpType, bool PhaseLUT>
+template <>
+struct SarBpSharedMemory<SarBpComputeType::Float, true> {
+    // Slots: [0..2] = ant_pos.x/y/z as float, [3] = bin_offset - rtm*dr_inv
+    float ant_pos[PULSE_BLOCK_SIZE][4];
+};
+
+template <>
+struct SarBpSharedMemory<SarBpComputeType::Mixed, true> {
+    // Same layout as Float, but with double elements so strict_compute_t (double)
+    // arithmetic in the inner loop reads directly without up-casting.
+    double ant_pos[PULSE_BLOCK_SIZE][4];
+};
+
+template <SarBpComputeType ComputeType, typename OutImageType, typename InitialImageType, typename RangeProfilesType, typename PlatPosType, typename VoxLocType, typename RangeToMcpType, bool PhaseLUT, bool IsUnitStride>
 __launch_bounds__(16*16)
 __global__ void SarBp(OutImageType output, const InitialImageType initial_image, const __grid_constant__ RangeProfilesType range_profiles, const __grid_constant__ PlatPosType platform_positions, const __grid_constant__ VoxLocType voxel_locations, const __grid_constant__ RangeToMcpType range_to_mcp,
                       strict_or_ff_compute_param_t<ComputeType> dr_inv,
@@ -173,8 +193,8 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
 
     static_assert(
         (is_matx_op<RangeToMcpType>() && (RangeToMcpType::Rank() == 0 || RangeToMcpType::Rank() == 1) &&
-        (std::is_same_v<typename RangeToMcpType::value_type, float> || std::is_same_v<typename RangeToMcpType::value_type, double> || std::is_same_v<typename RangeToMcpType::value_type, fltflt>)) ||
-        (std::is_same_v<RangeToMcpType, float> || std::is_same_v<RangeToMcpType, double> || std::is_same_v<RangeToMcpType, fltflt>),
+        (cuda::std::is_same_v<typename RangeToMcpType::value_type, float> || cuda::std::is_same_v<typename RangeToMcpType::value_type, double> || cuda::std::is_same_v<typename RangeToMcpType::value_type, fltflt>)) ||
+        (cuda::std::is_same_v<RangeToMcpType, float> || cuda::std::is_same_v<RangeToMcpType, double> || cuda::std::is_same_v<RangeToMcpType, fltflt>),
         "RangeToMcpType must currently be a 0D tensor or scalar of type float, double, or fltflt");
 
     using initial_image_t = typename InitialImageType::value_type;
@@ -194,31 +214,75 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     const index_t ix = static_cast<index_t>(blockIdx.x * blockDim.x + threadIdx.x);
     const index_t iy = static_cast<index_t>(blockIdx.y * blockDim.y + threadIdx.y);
 
-    __shared__ SarBpSharedMemory<ComputeType> sh_mem;
+    // IsUnitStride=true implies the hot inputs must be tensor views (they
+    // use .Data()). The transform-level dispatch enforces this; the
+    // static_asserts below make the contract explicit so a misuse fails at
+    // compile time rather than via a missing-method error deep in the kernel.
+    if constexpr (IsUnitStride) {
+        static_assert(is_tensor_view_v<RangeProfilesType>,
+                      "SarBp IsUnitStride path requires range_profiles to be a tensor view");
+        static_assert(is_tensor_view_v<PlatPosType>,
+                      "SarBp IsUnitStride path requires platform_positions to be a tensor view");
+    }
+
+    // The cooperative shared-memory preamble is required for FloatFloat (its
+    // inner loop reads directly from shared memory) and enabled for Float and
+    // Mixed when PhaseLUT is on.  With PhaseLUT=false the inner loop still
+    // needs diffR = dist - rtm for sincos, which the preamble does not
+    // preserve, so fall back to direct global reads in that case.
+    constexpr bool UseSharedPreamble =
+        (ComputeType == SarBpComputeType::FloatFloat) ||
+        ((ComputeType == SarBpComputeType::Float ||
+          ComputeType == SarBpComputeType::Mixed) && PhaseLUT);
+
+    __shared__ SarBpSharedMemory<ComputeType, UseSharedPreamble> sh_mem;
 
     const bool is_valid = ix < image_width && iy < image_height;
-    if constexpr (ComputeType != SarBpComputeType::FloatFloat) {
-        // For the FloatFloat ComputeType, keep all threads active to participate in CTA-wide
-        // antenna position loads
+    if constexpr (!UseSharedPreamble) {
+        // When the preamble is enabled, keep all threads active so they can
+        // participate in the CTA-wide cooperative loads of antenna positions.
         if (! is_valid) return;
     }
 
     const index_t num_pulses = range_profiles.Size(0);
     const index_t num_range_bins = range_profiles.Size(1);
 
-    static_assert(std::is_same_v<voxel_loc_t, double3> || std::is_same_v<voxel_loc_t, double4> ||
-        std::is_same_v<voxel_loc_t, float3> || std::is_same_v<voxel_loc_t, float4>, "SarBp: VoxLocType must represent a 2D operator of type double3, double4, float3, or float4");
+    static_assert(cuda::std::is_same_v<voxel_loc_t, double3> || cuda::std::is_same_v<voxel_loc_t, double4> ||
+        cuda::std::is_same_v<voxel_loc_t, float3> || cuda::std::is_same_v<voxel_loc_t, float4>, "SarBp: VoxLocType must represent a 2D operator of type double3, double4, float3, or float4");
+    // voxel_locations is read once per thread (outside the pulse loop), so it
+    // is deliberately not covered by the IsUnitStride fast-path logic. The
+    // one-shot cost of its operator() is negligible and its layout is free to
+    // be anything the caller wants without blocking fast-path eligibility.
     const voxel_loc_t voxel_loc = is_valid ? voxel_locations(iy, ix) : voxel_loc_t{};
     const loose_compute_t py = voxel_loc.y;
     const loose_compute_t px = voxel_loc.x;
     const loose_compute_t pz = voxel_loc.z;
 
-    const auto r_to_mcp = [&range_to_mcp](index_t p) -> auto {
+    // TensorAccessor wraps each hot tensor and picks the fast pointer path
+    // when IsUnitStride && is_tensor_view_v<Op>, otherwise forwards to
+    // operator(). Binding the tensor's Data() and Stride(0) into the
+    // accessor's members forces the compiler to materialize the grid-constant
+    // LDCs once at kernel entry rather than reloading inside the pulse loop.
+    detail::TensorAccessor<RangeProfilesType, IsUnitStride> rp(range_profiles);
+    detail::TensorAccessor<PlatPosType, IsUnitStride> pp(platform_positions);
+
+    // range_to_mcp can be a rank-0 or rank-1 matx op, or a plain scalar.
+    // The TensorAccessor's operator() overloads cover the matx-op cases;
+    // the scalar case is returned directly by the lambda.
+    [[maybe_unused]] const auto rtm_acc = [&]() {
+        if constexpr (is_matx_op<RangeToMcpType>()) {
+            return detail::TensorAccessor<RangeToMcpType, IsUnitStride>(range_to_mcp);
+        } else {
+            return int{0};  // placeholder; never dereferenced for scalars
+        }
+    }();
+
+    const auto r_to_mcp = [&range_to_mcp, rtm_acc](index_t p) -> auto {
         if constexpr (is_matx_op<RangeToMcpType>()) {
             if constexpr (RangeToMcpType::Rank() == 0) {
-                return range_to_mcp();
+                return rtm_acc();
             } else {
-                return range_to_mcp(p);
+                return rtm_acc(p);
             }
         } else {
             return range_to_mcp;
@@ -238,7 +302,7 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
         } else {
             // With PhaseLUT == false, strict_or_ff_compute_t is either float or double, so we can use sincos[f] directly.
             strict_or_ff_compute_t sinx, cosx;
-            if constexpr (std::is_same_v<strict_compute_t, double>) {
+            if constexpr (cuda::std::is_same_v<strict_compute_t, double>) {
                 ::sincos(phase_correction_partial * diffR, &sinx, &cosx);
             } else {
                 ::sincosf(phase_correction_partial * diffR, &sinx, &cosx);
@@ -258,23 +322,42 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     for (int block = 0; block < num_pulse_blocks; ++block) {
         const int num_pulses_in_block = num_pulses - block * PULSE_BLOCK_SIZE < PULSE_BLOCK_SIZE ?
             num_pulses - block * PULSE_BLOCK_SIZE : PULSE_BLOCK_SIZE;
-        if constexpr (ComputeType == SarBpComputeType::FloatFloat) {
+        if constexpr (UseSharedPreamble) {
             __syncthreads();
             for (index_t ip = tid; ip < num_pulses_in_block; ip += blockDim.x * blockDim.y) {
                 const int p = block * PULSE_BLOCK_SIZE + ip;
-                if constexpr (PlatPosType::Rank() == 1) {
-                    const plat_pos_t ant_pos_p = platform_positions.operator()(p);
-                    sh_mem.ant_pos[ip][0] = static_cast<fltflt>(ant_pos_p.x);
-                    sh_mem.ant_pos[ip][1] = static_cast<fltflt>(ant_pos_p.y);
-                    sh_mem.ant_pos[ip][2] = static_cast<fltflt>(ant_pos_p.z);
+                // Accessor does the IsUnitStride / rank dispatch internally,
+                // so we just ask for (apx, apy, apz) uniformly.
+                auto load_xyz = [&]() {
+                    if constexpr (PlatPosType::Rank() == 1) {
+                        const plat_pos_t ap = pp(p);
+                        return cuda::std::make_tuple(ap.x, ap.y, ap.z);
+                    } else {
+                        return cuda::std::make_tuple(pp(p, 0), pp(p, 1), pp(p, 2));
+                    }
+                };
+                const auto xyz = load_xyz();
+
+                if constexpr (ComputeType == SarBpComputeType::FloatFloat) {
+                    sh_mem.ant_pos[ip][0] = static_cast<fltflt>(cuda::std::get<0>(xyz));
+                    sh_mem.ant_pos[ip][1] = static_cast<fltflt>(cuda::std::get<1>(xyz));
+                    sh_mem.ant_pos[ip][2] = static_cast<fltflt>(cuda::std::get<2>(xyz));
+                    const fltflt rtm = static_cast<fltflt>(r_to_mcp(p));
+                    const fltflt neg_rtm = fltflt{-rtm.hi, -rtm.lo};
+                    sh_mem.ant_pos[ip][3] = fltflt_fma(neg_rtm, dr_inv, bin_offset);
                 } else {
-                    sh_mem.ant_pos[ip][0] = static_cast<fltflt>(platform_positions.operator()(p, 0));
-                    sh_mem.ant_pos[ip][1] = static_cast<fltflt>(platform_positions.operator()(p, 1));
-                    sh_mem.ant_pos[ip][2] = static_cast<fltflt>(platform_positions.operator()(p, 2));
+                    // Float / Mixed: cast inputs to strict_compute_t (float / double)
+                    // once per pulse here, instead of once per pulse per pixel.
+                    sh_mem.ant_pos[ip][0] = static_cast<strict_compute_t>(cuda::std::get<0>(xyz));
+                    sh_mem.ant_pos[ip][1] = static_cast<strict_compute_t>(cuda::std::get<1>(xyz));
+                    sh_mem.ant_pos[ip][2] = static_cast<strict_compute_t>(cuda::std::get<2>(xyz));
+                    const strict_compute_t rtm = static_cast<strict_compute_t>(r_to_mcp(p));
+                    if constexpr (cuda::std::is_same_v<strict_compute_t, double>) {
+                        sh_mem.ant_pos[ip][3] = ::fma(-rtm, dr_inv, static_cast<double>(bin_offset));
+                    } else {
+                        sh_mem.ant_pos[ip][3] = ::fmaf(-rtm, dr_inv, bin_offset);
+                    }
                 }
-                const fltflt rtm = static_cast<fltflt>(r_to_mcp(p));
-                const fltflt neg_rtm = fltflt{-rtm.hi, -rtm.lo};
-                sh_mem.ant_pos[ip][3] = fltflt_fma(neg_rtm, dr_inv, bin_offset);
             }
             __syncthreads();
             if (! is_valid) {
@@ -303,12 +386,46 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
                 const float adjust = ::floorf(frac);  // -1, 0, or 1
                 bin_floor_int = static_cast<index_t>(floor_hi + adjust);
                 w = frac - adjust;
+            } else if constexpr (UseSharedPreamble) {
+                // Float / Mixed with shared-mem preamble: antenna position and
+                // mcp_partial have been pre-loaded / pre-computed in shared
+                // memory, so the inner loop is pure strict_compute_t arithmetic.
+                const strict_compute_t apx = sh_mem.ant_pos[ip][0];
+                const strict_compute_t apy = sh_mem.ant_pos[ip][1];
+                const strict_compute_t apz = sh_mem.ant_pos[ip][2];
+                const strict_compute_t mcp_partial = sh_mem.ant_pos[ip][3];
+                const strict_compute_t dx = static_cast<strict_compute_t>(px) - apx;
+                const strict_compute_t dy = static_cast<strict_compute_t>(py) - apy;
+                const strict_compute_t dz = static_cast<strict_compute_t>(pz) - apz;
+                strict_compute_t dist;
+                if constexpr (ComputeType == SarBpComputeType::Float) {
+                    dist = ::sqrtf(dx*dx + dy*dy + dz*dz);
+                } else {
+#if __CUDA_ARCH__ == 700 || __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 900 || __CUDA_ARCH__ == 1000
+                    dist = ::sqrt(dx*dx + dy*dy + dz*dz);
+#else
+                    dist = NewtonRaphsonSqrt(dx*dx + dy*dy + dz*dz);
+#endif
+                }
+                // bin = (dist - rtm)*dr_inv + bin_offset = dist*dr_inv + mcp_partial
+                const strict_compute_t bin = dist * dr_inv + mcp_partial;
+                strict_compute_t bin_floor;
+                if constexpr (cuda::std::is_same_v<strict_compute_t, double>) {
+                    bin_floor = ::floor(bin);
+                } else {
+                    bin_floor = ::floorf(bin);
+                }
+                w = static_cast<loose_compute_t>(bin - bin_floor);
+                bin_floor_int = static_cast<index_t>(bin_floor);
+                // diffR is unused when PhaseLUT=true (required for this branch);
+                // assign to avoid any maybe-uninitialized warning downstream.
+                diffR = dist;
             } else {
-                diffR = ComputeRangeToPixel<PlatPosType, ComputeType, strict_compute_t, loose_compute_t>(
-                    platform_positions, p, px, py, pz) - static_cast<strict_compute_t>(r_to_mcp(p));
+                diffR = ComputeRangeToPixel<decltype(pp), ComputeType, strict_compute_t, loose_compute_t>(
+                    pp, p, px, py, pz) - static_cast<strict_compute_t>(r_to_mcp(p));
                 const strict_compute_t bin = diffR * dr_inv + bin_offset;
                 strict_compute_t bin_floor;
-                if constexpr (std::is_same_v<strict_compute_t, double>) {
+                if constexpr (cuda::std::is_same_v<strict_compute_t, double>) {
                     bin_floor = ::floor(bin);
                 } else {
                     bin_floor = ::floorf(bin);
@@ -317,21 +434,15 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
                 bin_floor_int = static_cast<index_t>(bin_floor);
             }
             if (bin_floor_int >= 0 && bin_floor_int < static_cast<index_t>(num_range_bins-1)) {
-
-                range_profiles_t sample_lo, sample_hi;
-
-                cuda::std::apply([&sample_lo, &range_profiles](auto &&...args) {
-                    sample_lo = range_profiles.operator()(args...);
-                }, cuda::std::make_tuple(p, bin_floor_int));
-
-                cuda::std::apply([&sample_hi, &range_profiles](auto &&...args) {
-                    sample_hi = range_profiles.operator()(args...);
-                }, cuda::std::make_tuple(p, bin_floor_int + 1));
+                // rp accessor picks the fast pointer path on IsUnitStride or
+                // falls through to operator().
+                const range_profiles_t sample_lo = rp(p, bin_floor_int);
+                const range_profiles_t sample_hi = rp(p, bin_floor_int + 1);
 
                 const loose_complex_compute_t sample = [&sample_lo, &sample_hi, &w]() -> loose_complex_compute_t {
                     const loose_complex_compute_t loose_sample_lo = static_cast<loose_complex_compute_t>(sample_lo);
                     const loose_complex_compute_t loose_sample_hi = static_cast<loose_complex_compute_t>(sample_hi);
-                    if constexpr (std::is_same_v<loose_compute_t, float>) {
+                    if constexpr (cuda::std::is_same_v<loose_compute_t, float>) {
                         return loose_complex_compute_t{
                             __fmaf_rn(w, loose_sample_hi.real(), __fmaf_rn(-w, loose_sample_lo.real(), loose_sample_lo.real())),
                             __fmaf_rn(w, loose_sample_hi.imag(), __fmaf_rn(-w, loose_sample_lo.imag(), loose_sample_lo.imag()))
@@ -356,12 +467,17 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     } // pulse block
 
     if (is_valid) {
-        initial_image_t initial_image_voxel = initial_image.operator()(iy, ix);
+        // initial_image and output are each touched exactly once per thread,
+        // so they are intentionally not included in the IsUnitStride fast-path
+        // check in the transform layer. Direct operator() calls keep the
+        // transform's fast-path eligibility as permissive as possible:
+        // non-unit-stride or computed-op initial_image (e.g. ConstVal zeros)
+        // and non-unit-stride output layouts do not disqualify the fast path
+        // for the hot tensors (range_profiles, platform_positions, rtm).
+        const initial_image_t initial_image_voxel = initial_image.operator()(iy, ix);
         const image_t voxel_contribution {
             initial_image_voxel.real() + accum.real(), initial_image_voxel.imag() + accum.imag() };
-        cuda::std::apply([voxel_contribution, &output](auto &&...args) {
-            output.operator()(args...) = voxel_contribution;
-        }, cuda::std::make_tuple(iy, ix));
+        output.operator()(iy, ix) = voxel_contribution;
     }
 }
 

--- a/include/matx/kernels/tensor_accessor.h
+++ b/include/matx/kernels/tensor_accessor.h
@@ -1,0 +1,290 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cuda/std/cstddef>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "matx/core/defines.h"
+#include "matx/core/type_utils.h"
+
+namespace matx {
+namespace detail {
+
+// Lazily-evaluated "pointer type of Op::Data()" helper. Placing
+// decltype(op.Data()) inside a cuda::std::conditional_t would eagerly evaluate it
+// in both branches and fail to compile for operators without a Data() method
+// (e.g. ConstVal, CloneOp, ZipVecOp). Partial specialization defers the
+// decltype until is_tensor_view_v<Op> is known true.
+template <typename Op, bool HasData>
+struct data_ptr_of_op { using type = cuda::std::nullptr_t; };
+
+template <typename Op>
+struct data_ptr_of_op<Op, true> {
+    using type = decltype(cuda::std::declval<const Op&>().Data());
+};
+
+template <typename Op>
+using data_ptr_of_op_t = typename data_ptr_of_op<Op, is_tensor_view_v<Op>>::type;
+
+// Forward declaration — defined below.
+template <typename Op, bool IsUnitStride, int NumBound>
+struct BoundAccessor;
+
+// ----------------------------------------------------------------------------
+// TensorAccessor
+//
+// Wraps a MatX operator and picks, per instantiation, between a raw-pointer
+// fast path and the operator's operator() fallback based on
+// (IsUnitStride && is_tensor_view_v<Op>).
+//
+// Fast path: element access is base_ptr[i0*Stride(0) + ... + i_{N-1}], with
+// the last-dim stride folded to 1 (IsUnitStride guarantees that). Stores the
+// data pointer and Stride(0)..Stride(Rank-2) as members, so grid-constant
+// LDCs for those values are materialized once at construction instead of
+// being re-issued inside the hot loop.
+//
+// Slow path: forwards to op(indices...). Works for any MatX operator,
+// including computed ones without Data()/Stride() (ConstVal, CloneOp, ...).
+//
+// Rank 0 always takes the slow path — nothing to elide.
+//
+// bind(leading...) strips the leading K dimensions and returns a
+// BoundAccessor with (Rank - K) remaining dims. On the fast path it
+// precomputes a shifted base pointer so the bound dims cost nothing at
+// access time; on the slow path it captures the bound indices and forwards
+// them to op(leading..., is...).
+// ----------------------------------------------------------------------------
+template <typename Op, bool IsUnitStride, int RankParam = Op::Rank()>
+struct TensorAccessor {
+    static_assert(is_matx_op<Op>(), "TensorAccessor requires a MatX operator");
+    static constexpr bool FastPath = IsUnitStride && is_tensor_view_v<Op>;
+    static constexpr int Rank = RankParam;
+    using value_type = typename Op::value_type;
+
+    // Number of outer strides to cache. Rank 0 and 1 have none; store a
+    // size-1 buffer in those cases to avoid zero-length arrays.
+    static constexpr int NumOuter = (Rank >= 2) ? (Rank - 1) : 0;
+    static constexpr int NumOuterStored = (NumOuter > 0) ? NumOuter : 1;
+
+    const Op& op_;
+    data_ptr_of_op_t<Op> data_;
+    index_t outer_strides_[NumOuterStored];
+
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+    explicit TensorAccessor(const Op& op) : op_(op), data_(nullptr) {
+        if constexpr (FastPath) {
+            data_ = op.Data();
+            if constexpr (NumOuter > 0) {
+                MATX_LOOP_UNROLL
+                for (int d = 0; d < NumOuter; ++d) {
+                    outer_strides_[d] = op.Stride(d);
+                }
+            }
+        }
+    }
+
+    // Rank-0 access.
+    template <int R = Rank, cuda::std::enable_if_t<R == 0, int> = 0>
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+    decltype(auto) operator()() const { return op_(); }
+
+    // Rank >= 1 access; SFINAE enforces arity == Rank.
+    template <typename... Is,
+              cuda::std::enable_if_t<(Rank >= 1) && sizeof...(Is) == Rank, int> = 0>
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+    decltype(auto) operator()(Is... is) const {
+        if constexpr (FastPath) {
+            const index_t idx_arr[] = { static_cast<index_t>(is)... };
+            // Last-dim stride is 1 under IsUnitStride.
+            index_t offset = idx_arr[Rank - 1];
+            if constexpr (NumOuter > 0) {
+                MATX_LOOP_UNROLL
+                for (int d = 0; d < NumOuter; ++d) {
+                    offset += idx_arr[d] * outer_strides_[d];
+                }
+            }
+            return data_[offset];
+        } else {
+            return op_(is...);
+        }
+    }
+
+    // Bind the first sizeof...(Leading) dimensions. Returns a BoundAccessor
+    // with (Rank - sizeof...(Leading)) remaining dims.
+    template <typename... Leading,
+              cuda::std::enable_if_t<(sizeof...(Leading) > 0) &&
+                               (sizeof...(Leading) <= Rank), int> = 0>
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+    auto bind(Leading... leading) const {
+        return BoundAccessor<Op, IsUnitStride, sizeof...(Leading)>(
+            *this, static_cast<index_t>(leading)...);
+    }
+};
+
+// ----------------------------------------------------------------------------
+// BoundAccessor
+//
+// A TensorAccessor with the first NumBound leading dimensions fixed.
+// Accesses supply only the remaining indices.
+//
+// Fast path: base_ = op.Data() + Σ leading[d] * Stride(d) for d in [0, NumBound);
+// rem_outer_strides_ holds the still-needed Stride(NumBound .. Rank-2).
+// Per-access work is identical to TensorAccessor's fast path for the lower
+// rank — no per-access cost for the bound dims.
+//
+// Slow path: stores the bound indices and forwards them, together with the
+// per-access indices, to op(leading..., is...).
+// ----------------------------------------------------------------------------
+template <typename Op, bool IsUnitStride, int NumBound>
+struct BoundAccessor {
+    static_assert(NumBound > 0, "BoundAccessor requires at least one bound dim");
+    static_assert(is_matx_op<Op>(), "BoundAccessor requires a MatX operator");
+    static constexpr bool FastPath = IsUnitStride && is_tensor_view_v<Op>;
+    static constexpr int OriginalRank = Op::Rank();
+    static constexpr int Rank = OriginalRank - NumBound;
+    static_assert(Rank >= 0, "BoundAccessor: bound more dims than the op has");
+    using value_type = typename Op::value_type;
+
+    static constexpr int NumRemOuter = (Rank >= 2) ? (Rank - 1) : 0;
+    static constexpr int NumRemOuterStored = (NumRemOuter > 0) ? NumRemOuter : 1;
+
+    const Op& op_;
+    data_ptr_of_op_t<Op> base_;              // fast path: already advanced past bound coords
+    index_t rem_outer_strides_[NumRemOuterStored];
+    index_t bound_idxs_[NumBound];           // slow path: forward to op(bound..., is...)
+
+    // Construct from a parent TensorAccessor + leading index pack.
+    template <typename... Leading>
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+    BoundAccessor(const TensorAccessor<Op, IsUnitStride>& parent, Leading... leading)
+        : op_(parent.op_), base_(nullptr)
+    {
+        static_assert(sizeof...(Leading) == NumBound, "Mismatched bind arity");
+        const index_t leading_arr[] = { static_cast<index_t>(leading)... };
+
+        MATX_LOOP_UNROLL
+        for (int d = 0; d < NumBound; ++d) {
+            bound_idxs_[d] = leading_arr[d];
+        }
+
+        if constexpr (FastPath) {
+            base_ = parent.data_;
+            index_t off = 0;
+            MATX_LOOP_UNROLL
+            for (int d = 0; d < NumBound; ++d) {
+                // parent.outer_strides_ only covers dims 0..OriginalRank-2.
+                // The last dim's stride is implicitly 1 under IsUnitStride
+                // and is not stored, so bind of that dim must use 1 directly
+                // rather than read past the populated slots.
+                const index_t stride_d = (d < OriginalRank - 1)
+                    ? parent.outer_strides_[d]
+                    : static_cast<index_t>(1);
+                off += leading_arr[d] * stride_d;
+            }
+            base_ += off;
+            if constexpr (NumRemOuter > 0) {
+                MATX_LOOP_UNROLL
+                for (int d = 0; d < NumRemOuter; ++d) {
+                    rem_outer_strides_[d] = parent.outer_strides_[NumBound + d];
+                }
+            }
+        }
+    }
+
+    // Rank-0 remainder: nullary.
+    template <int R = Rank, cuda::std::enable_if_t<R == 0, int> = 0>
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+    decltype(auto) operator()() const {
+        if constexpr (FastPath) {
+            return base_[0];
+        } else {
+            return slow_forward(cuda::std::make_index_sequence<NumBound>{});
+        }
+    }
+
+    // Rank >= 1 remainder: variadic, arity == Rank.
+    template <typename... Is,
+              cuda::std::enable_if_t<(Rank >= 1) && sizeof...(Is) == Rank, int> = 0>
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+    decltype(auto) operator()(Is... is) const {
+        if constexpr (FastPath) {
+            const index_t idx_arr[] = { static_cast<index_t>(is)... };
+            index_t offset = idx_arr[Rank - 1];
+            if constexpr (NumRemOuter > 0) {
+                MATX_LOOP_UNROLL
+                for (int d = 0; d < NumRemOuter; ++d) {
+                    offset += idx_arr[d] * rem_outer_strides_[d];
+                }
+            }
+            return base_[offset];
+        } else {
+            return slow_forward(cuda::std::make_index_sequence<NumBound>{}, is...);
+        }
+    }
+
+private:
+    template <size_t... BoundIs, typename... NewIs>
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+    decltype(auto) slow_forward(cuda::std::index_sequence<BoundIs...>, NewIs... new_is) const {
+        return op_(bound_idxs_[BoundIs]..., new_is...);
+    }
+};
+
+// ----------------------------------------------------------------------------
+// bind_first_n<N>(acc, arr)
+//
+// Bind the first N entries of a cuda::std::array-like index container as
+// leading dims into acc. Returns a BoundAccessor when N > 0, or the accessor
+// unchanged when N == 0. Used by kernels that receive their batch coords
+// through BlockToIdx() and need to fold them into an accessor in one shot.
+// ----------------------------------------------------------------------------
+template <typename Acc, typename ArrT, size_t... Is>
+__MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+auto bind_first_n_impl(const Acc& acc, const ArrT& arr, cuda::std::index_sequence<Is...>) {
+    return acc.bind(arr[Is]...);
+}
+
+template <int N, typename Acc, typename ArrT>
+__MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
+auto bind_first_n(const Acc& acc, const ArrT& arr) {
+    if constexpr (N == 0) {
+        return acc;
+    } else {
+        return bind_first_n_impl(acc, arr, cuda::std::make_index_sequence<N>{});
+    }
+}
+
+}  // namespace detail
+}  // namespace matx

--- a/include/matx/transforms/channelize_poly.h
+++ b/include/matx/transforms/channelize_poly.h
@@ -47,70 +47,152 @@
 
 namespace matx {
 namespace detail {
+namespace cpoly {
 
-// Any channel count at or below MATX_CHANNELIZE_POLY1D_FUSED_CHAN_KERNEL_THRESHOLD will
+// Any channel count at or below FusedChanThreshold will
 // use the fused-channel kernel. If this is increased, then the switch statement
 // in the fused kernel wrapper below must be adjusted to include the additional
 // channel counts.
-constexpr index_t MATX_CHANNELIZE_POLY1D_FUSED_CHAN_KERNEL_THRESHOLD = 6;
+constexpr index_t FusedChanThreshold = 6;
 
 // Number of output samples per channel per iteration for the kernel that stores
 // the input data in shared memory. Ideally, this value would be determined dynamically
 // to balance occupancy and CTA size. For now, we choose a reasonable default.
-constexpr index_t MATX_CHANNELIZE_POLY1D_FULL_SMEM_KERNEL_NOUT_PER_ITER = 4;
+constexpr index_t FullSmemKernelNoutPerIter = 4;
 
 // Maximum dynamic shared memory (bytes) for caching filter taps in ChannelizePoly1D.
-constexpr size_t MATX_CHANNELIZE_POLY1D_MAX_FILTER_SMEM_BYTES = 6 * 1024;
+constexpr size_t GenericMaxFilterSmemBytes = 6 * 1024;
 
-// Constants for the SmemTiled kernel.
-constexpr int MATX_CHANNELIZE_POLY1D_SMEM_TILED_CTILE = 64;
-constexpr int MATX_CHANNELIZE_POLY1D_SMEM_TILED_NOUT  = 4;
-constexpr size_t MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_BYTES = 48 * 1024;
-// Maximum filter smem budget. When the filter exceeds this, it is read from
-// global/L2 instead, freeing smem for better occupancy.
-constexpr size_t MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_FILTER_BYTES = 2048;
+// Constants for the SmemTiled kernel. Two CTILE sizes are instantiated:
+//   CTILE=32 for num_channels <= 32: single channel tile, 100% thread
+//            utilization. Block size: 32 * NOUT = 128 threads.
+//   CTILE=64 for num_channels > 32: original shape. Block size: 64 * NOUT
+//            = 256 threads.
+// NOUT=4 across both variants; NOUT=8 for the CTILE=32 path was evaluated
+// and was ~5% slower (doubles block size without increasing elem_per_block,
+// so fewer blocks/SM and no occupancy win).
+constexpr int SmemTiledCtile = 64;
+constexpr int SmemTiledCtileSmall = 32;
+constexpr int SmemTiledNout  = 4;
+constexpr size_t SmemTiledMaxBytes = 48 * 1024;
+// Maximum filter smem budget. A filter is only considered for smem
+// residency if its footprint (in whichever layout we're considering, Full
+// or Rotated) fits under this cap. Raising this costs occupancy by
+// inflating per-block smem, so keep it small.
+constexpr size_t SmemTiledMaxFilterBytes = 4096;
 
-// Compute the shared memory footprint for the SmemTiled filter taps.
-// For D==M: one phase per tile channel → CTILE * P elements.
-// For D<M: K phases per tile channel → CTILE * K * P elements.
+// Filter-smem placement strategy chosen by the dispatcher and forwarded to
+// the kernel via template parameters.
+//   Full:    one copy of each tap at smem[p * M + phase]. Footprint M*P.
+//            No per-channel or per-rotation duplication; inner loop does a
+//            per-(c,k) phase compute.
+//   Rotated: [channel][k][p] redundant layout, footprint CTILE*K*P (or
+//            CTILE*P for D==M). Direct indexing, larger for oversampled
+//            configs with small num_channels, smaller for large num_channels.
+//   Global:  filter stays in GMEM, loaded through L1 in the inner loop.
+enum class SmemTiledFilterLayout { Full, Rotated, Global };
+
+// Pick the CTILE to use for this launch: 32 when num_channels fits in a
+// single 32-wide tile, 64 otherwise. Centralized so dispatch, sizing, and
+// launch agree.
+constexpr int SmemTiledCtileFor(index_t num_channels)
+{
+  return (num_channels <= SmemTiledCtileSmall)
+      ? SmemTiledCtileSmall
+      : SmemTiledCtile;
+}
+
+// Compute the shared memory footprint for the SmemTiled filter taps in the
+// Rotated layout (one [channel][k][p] block per CTILE, K phases duplicated
+// across channels, zero-padded when CTILE > M).
+// For D==M: one phase per tile channel -> CTILE * P elements.
+// For D<M: K phases per tile channel -> CTILE * K * P elements.
 // Returns a value exceeding the filter budget when K exceeds the rotation
 // limit, which causes FilterInSmem=false in the dispatch.
 template <typename FilterType>
-inline size_t matxChannelizePoly1DInternal_SmemTiledFilterSmemBytes(
-    index_t num_channels, index_t filter_len, index_t decimation_factor)
+inline size_t SmemTiledFilterBytesRotated(
+    index_t num_channels, index_t filter_len, index_t decimation_factor, int ctile)
 {
   using filter_t = typename FilterType::value_type;
-  constexpr int CTILE = MATX_CHANNELIZE_POLY1D_SMEM_TILED_CTILE;
   const index_t P = (filter_len + num_channels - 1) / num_channels;
   if (decimation_factor == num_channels) {
-    return static_cast<size_t>(CTILE) * P * sizeof(filter_t);
+    return static_cast<size_t>(ctile) * P * sizeof(filter_t);
   }
   const index_t gcd_val = std::gcd(num_channels, decimation_factor);
   const index_t K = num_channels / gcd_val;
-  if (K > detail::MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_ROTATIONS) {
-    return MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_FILTER_BYTES + 1; // exceeds budget, so FilterInSmem=false
+  if (K > SmemTiledMaxRotations) {
+    return SmemTiledMaxFilterBytes + 1; // exceeds budget, so FilterInSmem=false
   }
-  return static_cast<size_t>(CTILE) * K * P * sizeof(filter_t);
+  return static_cast<size_t>(ctile) * K * P * sizeof(filter_t);
+}
+
+// Shared memory footprint for the Full filter layout: M * P unique taps,
+// no per-channel or per-rotation duplication. Full's footprint scales with
+// num_channels while Rotated's scales with CTILE*K (D<M) or CTILE (D==M),
+// so which layout is smaller depends on the parameters: Full tends to be
+// smaller for small num_channels, Rotated for large num_channels.
+template <typename FilterType>
+inline size_t SmemTiledFilterBytesFull(
+    index_t num_channels, index_t filter_len)
+{
+  using filter_t = typename FilterType::value_type;
+  const index_t P = (filter_len + num_channels - 1) / num_channels;
+  return static_cast<size_t>(num_channels) * P * sizeof(filter_t);
+}
+
+// Pick a filter-smem layout for this dispatch. Of the candidates that fit
+// under the filter budget (Full, Rotated), choose the one with the smaller
+// footprint to maximize occupancy. Fall back to Global when neither fits.
+// The caller must separately verify that filter + input both fit under
+// MAX_BYTES.
+template <typename OutType, typename FilterType>
+inline SmemTiledFilterLayout SmemTiledChooseFilterLayout(
+    const OutType &o, const FilterType &filter, index_t decimation_factor, int ctile)
+{
+  const index_t num_channels = o.Size(OutType::Rank() - 1);
+  const index_t filter_len = filter.Size(FilterType::Rank() - 1);
+  const size_t full_bytes = SmemTiledFilterBytesFull<FilterType>(
+      num_channels, filter_len);
+  const size_t rotated_bytes = SmemTiledFilterBytesRotated<FilterType>(
+      num_channels, filter_len, decimation_factor, ctile);
+  const bool full_fits = full_bytes <= SmemTiledMaxFilterBytes;
+  const bool rotated_fits = rotated_bytes <= SmemTiledMaxFilterBytes;
+  if (full_fits && rotated_fits) {
+    return (full_bytes <= rotated_bytes)
+        ? SmemTiledFilterLayout::Full
+        : SmemTiledFilterLayout::Rotated;
+  }
+  if (full_fits) {
+    return SmemTiledFilterLayout::Full;
+  }
+  if (rotated_fits) {
+    return SmemTiledFilterLayout::Rotated;
+  }
+  return SmemTiledFilterLayout::Global;
 }
 
 template <typename OutType, typename InType, typename FilterType>
-inline size_t matxChannelizePoly1DInternal_SmemTiledSizeBytes(
-    const OutType &o, const InType &, const FilterType &filter, index_t decimation_factor)
+inline size_t SmemTiledSizeBytes(
+    const OutType &o, const InType &, const FilterType &filter, index_t decimation_factor, int ctile)
 {
   using input_t  = typename InType::value_type;
 
-  constexpr int CTILE = MATX_CHANNELIZE_POLY1D_SMEM_TILED_CTILE;
-  constexpr int NOUT  = MATX_CHANNELIZE_POLY1D_SMEM_TILED_NOUT;
+  constexpr int NOUT = SmemTiledNout;
 
   const index_t M = o.Size(OutType::Rank() - 1);
   const index_t filter_len = filter.Size(FilterType::Rank() - 1);
   const index_t P = (filter_len + M - 1) / M;
-  const size_t input_smem = static_cast<size_t>(P + NOUT - 1) * CTILE * sizeof(input_t);
+  const size_t input_smem = static_cast<size_t>(P + NOUT - 1) * ctile * sizeof(input_t);
 
-  const size_t filter_smem = matxChannelizePoly1DInternal_SmemTiledFilterSmemBytes<FilterType>(M, filter_len, decimation_factor);
-  if (filter_smem > MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_FILTER_BYTES) {
+  const auto layout = SmemTiledChooseFilterLayout(
+      o, filter, decimation_factor, ctile);
+  if (layout == SmemTiledFilterLayout::Global) {
     return input_smem;
   }
+
+  const size_t filter_smem = (layout == SmemTiledFilterLayout::Full)
+      ? SmemTiledFilterBytesFull<FilterType>(M, filter_len)
+      : SmemTiledFilterBytesRotated<FilterType>(M, filter_len, decimation_factor, ctile);
 
   const size_t filter_smem_aligned = filter_smem +
       ((filter_smem % sizeof(input_t)) ? (sizeof(input_t) - filter_smem % sizeof(input_t)) : 0);
@@ -118,32 +200,26 @@ inline size_t matxChannelizePoly1DInternal_SmemTiledSizeBytes(
 }
 
 template <typename OutType, typename InType, typename FilterType>
-inline bool matxChannelizePoly1DInternal_ShouldUseSmemTiledKernel(
+inline bool ShouldUseSmemTiled(
     const OutType &o, const InType &in, const FilterType &filter, index_t decimation_factor)
 {
   const index_t num_channels = o.Size(OutType::Rank() - 1);
-  // Skip SmemTiled for small channel counts where most of CTILE would be
-  // idle threads. The generic ChannelizePoly1D kernel is more efficient
-  // in this regime.
-  if (num_channels <= MATX_CHANNELIZE_POLY1D_SMEM_TILED_CTILE * 3 / 4) {
-    return false;
-  }
+  const int ctile = SmemTiledCtileFor(num_channels);
   // The input circular buffer must fit in smem. The filter may or may not
   // be included (FilterInSmem is decided separately).
-  return matxChannelizePoly1DInternal_SmemTiledSizeBytes(o, in, filter, decimation_factor)
-      <= MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_BYTES;
+  return SmemTiledSizeBytes(o, in, filter, decimation_factor, ctile)
+      <= SmemTiledMaxBytes;
 }
 
-template <typename OutType, typename InType, typename FilterType, typename AccumType>
-inline void matxChannelizePoly1DInternal_SmemTiled(
+template <int CTILE, typename OutType, typename InType, typename FilterType, typename AccumType>
+inline void SmemTiledImpl(
     OutType o, const InType &i, const FilterType &filter,
     index_t decimation_factor, cudaStream_t stream)
 {
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
-  constexpr int CTILE = MATX_CHANNELIZE_POLY1D_SMEM_TILED_CTILE;
-  constexpr int NOUT  = MATX_CHANNELIZE_POLY1D_SMEM_TILED_NOUT;
+  constexpr int NOUT = SmemTiledNout;
 
   const index_t num_channels = o.Size(OutType::Rank() - 1);
   const index_t nout_per_channel = o.Size(OutType::Rank() - 2);
@@ -153,7 +229,7 @@ inline void matxChannelizePoly1DInternal_SmemTiled(
   const int32_t K = static_cast<int32_t>(num_channels / gcd_val);
 
   const int channel_tiles = static_cast<int>((num_channels + CTILE - 1) / CTILE);
-  // Target ~1024 spatial blocks (time × channel tiles) to saturate the GPU.
+  // Target ~1024 spatial blocks (time * channel tiles) to saturate the GPU.
   // For large channel counts, fewer time blocks are needed.
   const int target_time_blocks = cuda::std::max(1, (1024 + channel_tiles - 1) / channel_tiles);
   const int elem_per_block = static_cast<int>(
@@ -164,10 +240,9 @@ inline void matxChannelizePoly1DInternal_SmemTiled(
   dim3 block(CTILE, NOUT);
   dim3 grid(time_blocks, channel_tiles, num_batches);
 
-  const index_t filter_len = filter.Size(FilterType::Rank() - 1);
-  const bool filter_in_smem = matxChannelizePoly1DInternal_SmemTiledFilterSmemBytes<FilterType>(
-      num_channels, filter_len, decimation_factor) <= MATX_CHANNELIZE_POLY1D_SMEM_TILED_MAX_FILTER_BYTES;
-  const size_t smem_size = matxChannelizePoly1DInternal_SmemTiledSizeBytes(o, i, filter, decimation_factor);
+  const auto filter_layout = SmemTiledChooseFilterLayout(
+      o, filter, decimation_factor, CTILE);
+  const size_t smem_size = SmemTiledSizeBytes(o, i, filter, decimation_factor, CTILE);
 
   // Use int32_t for intra-kernel index arithmetic when all tensor dimensions
   // fit, avoiding 64-bit IMAD.WIDE instructions in the inner loops.
@@ -177,49 +252,104 @@ inline void matxChannelizePoly1DInternal_SmemTiled(
        nout_per_channel <= std::numeric_limits<int32_t>::max() &&
        num_channels <= std::numeric_limits<int32_t>::max());
 
-  // Dispatch on MaximallyDecimated x FilterInSmem x IndexType
+  // Dispatch on MaximallyDecimated x (FilterInSmem, FilterFullLayout) x
+  // IndexType x IsUnitStride. Filter-smem layout selection: Full (smallest
+  // footprint, phase compute at access), Rotated (direct indexing, redundant
+  // storage), or Global (filter stays in GMEM).
   constexpr bool kMaxDec  = true;
   constexpr bool kOversampled = false;
-  constexpr bool kFiltSmem = true;
-  constexpr bool kFiltGlobal = false;
 
-  auto launch = [&](auto idx_tag) {
+  // Unit-stride fast path eligibility + runtime check: same pattern as
+  // sar_bp / ChannelizePoly1D. Computed ops without .Data() / .Stride() fall
+  // through to the slow-path (operator()) instantiation.
+  constexpr bool fast_path_eligible =
+      is_tensor_view_v<OutType> &&
+      is_tensor_view_v<InType> &&
+      is_tensor_view_v<FilterType>;
+
+  auto launch = [&](auto idx_tag, auto is_unit_c) {
     using IdxT = decltype(idx_tag);
+    constexpr bool IsUnitStride = decltype(is_unit_c)::value;
     const IdxT epb = static_cast<IdxT>(elem_per_block);
     const IdxT df  = static_cast<IdxT>(decimation_factor);
-    if (decimation_factor == num_channels) {
-      if (filter_in_smem) {
-        ChannelizePoly1D_SmemTiled<CTILE, NOUT, kMaxDec, kFiltSmem, IdxT, OutType, InType, FilterType, AccumType>
+
+    auto launch_with_layout = [&](auto in_smem_c, auto full_c) {
+      constexpr bool FIS = decltype(in_smem_c)::value;
+      constexpr bool FFL = decltype(full_c)::value;
+      if (decimation_factor == num_channels) {
+        ChannelizePoly1D_SmemTiled<CTILE, NOUT, kMaxDec, FIS, FFL, IsUnitStride, IdxT, OutType, InType, FilterType, AccumType>
             <<<grid, block, smem_size, stream>>>(o, i, filter, epb, df, K);
       } else {
-        ChannelizePoly1D_SmemTiled<CTILE, NOUT, kMaxDec, kFiltGlobal, IdxT, OutType, InType, FilterType, AccumType>
+        ChannelizePoly1D_SmemTiled<CTILE, NOUT, kOversampled, FIS, FFL, IsUnitStride, IdxT, OutType, InType, FilterType, AccumType>
             <<<grid, block, smem_size, stream>>>(o, i, filter, epb, df, K);
+      }
+    };
+
+    switch (filter_layout) {
+      case SmemTiledFilterLayout::Full:
+        launch_with_layout(cuda::std::bool_constant<true>{}, cuda::std::bool_constant<true>{});
+        break;
+      case SmemTiledFilterLayout::Rotated:
+        launch_with_layout(cuda::std::bool_constant<true>{}, cuda::std::bool_constant<false>{});
+        break;
+      case SmemTiledFilterLayout::Global:
+        launch_with_layout(cuda::std::bool_constant<false>{}, cuda::std::bool_constant<false>{});
+        break;
+    }
+  };
+
+  auto dispatch = [&](auto idx_tag) {
+    if constexpr (fast_path_eligible) {
+      const bool is_unit_stride =
+          o.Stride(OutType::Rank() - 1) == 1 &&
+          i.Stride(InType::Rank() - 1) == 1 &&
+          filter.Stride(FilterType::Rank() - 1) == 1;
+      if (is_unit_stride) {
+        launch(idx_tag, cuda::std::bool_constant<true>{});
+      } else {
+        launch(idx_tag, cuda::std::bool_constant<false>{});
       }
     } else {
-      if (filter_in_smem) {
-        ChannelizePoly1D_SmemTiled<CTILE, NOUT, kOversampled, kFiltSmem, IdxT, OutType, InType, FilterType, AccumType>
-            <<<grid, block, smem_size, stream>>>(o, i, filter, epb, df, K);
-      } else {
-        ChannelizePoly1D_SmemTiled<CTILE, NOUT, kOversampled, kFiltGlobal, IdxT, OutType, InType, FilterType, AccumType>
-            <<<grid, block, smem_size, stream>>>(o, i, filter, epb, df, K);
-      }
+      launch(idx_tag, cuda::std::bool_constant<false>{});
     }
   };
 
   if constexpr (sizeof(index_t) <= sizeof(int32_t)) {
-    launch(index_t{});
+    dispatch(index_t{});
   } else {
     if (use_32bit) {
-      launch(int32_t{});
+      dispatch(int32_t{});
     } else {
-      launch(index_t{});
+      dispatch(index_t{});
     }
   }
 #endif
 }
 
+// Wrapper that picks CTILE=32 (single-tile, full thread utilization) for
+// num_channels <= 32 and CTILE=64 otherwise. Previously this path was
+// rejected for num_channels <= 48 and fell through to the generic
+// ChannelizePoly1D kernel, which does uncoalesced strided global loads and
+// is ~3x slower.
 template <typename OutType, typename InType, typename FilterType, typename AccumType>
-inline void matxChannelizePoly1DInternal(OutType o, const InType &i,
+inline void SmemTiled(
+    OutType o, const InType &i, const FilterType &filter,
+    index_t decimation_factor, cudaStream_t stream)
+{
+  const index_t num_channels = o.Size(OutType::Rank() - 1);
+  if (num_channels <= SmemTiledCtileSmall) {
+    SmemTiledImpl<
+        SmemTiledCtileSmall,
+        OutType, InType, FilterType, AccumType>(o, i, filter, decimation_factor, stream);
+  } else {
+    SmemTiledImpl<
+        SmemTiledCtile,
+        OutType, InType, FilterType, AccumType>(o, i, filter, decimation_factor, stream);
+  }
+}
+
+template <typename OutType, typename InType, typename FilterType, typename AccumType>
+inline void Generic(OutType o, const InType &i,
                                      const FilterType &filter, index_t decimation_factor, cudaStream_t stream)
 {
 #ifdef __CUDACC__
@@ -233,27 +363,54 @@ inline void matxChannelizePoly1DInternal(OutType o, const InType &i,
   const index_t filter_len = filter.Size(FilterType::Rank()-1);
 
   const int THREADS = 256;
-  const index_t ELTS_PER_THREAD = detail::CHANNELIZE_POLY1D_ELEMS_PER_THREAD * THREADS;
+  const index_t ELTS_PER_THREAD = ElemsPerThread * THREADS;
   const int elem_blocks = static_cast<int>(
     (nout_per_channel + ELTS_PER_THREAD - 1) / ELTS_PER_THREAD);
   dim3 grid(elem_blocks, static_cast<int>(num_channels), num_batches);
-  if (decimation_factor == num_channels) {
-    // For M == D, cache one filter phase in dynamic shared memory if it fits.
-    const index_t filter_phase_len = (filter_len + num_channels - 1) / num_channels;
-    const size_t smem_needed = static_cast<size_t>(filter_phase_len) * sizeof(filter_t);
-    const uint32_t smem_bytes = (smem_needed <= MATX_CHANNELIZE_POLY1D_MAX_FILTER_SMEM_BYTES)
-        ? static_cast<uint32_t>(smem_needed) : 0;
-    ChannelizePoly1D<THREADS, true, OutType, InType, FilterType, AccumType><<<grid, THREADS, smem_bytes, stream>>>(
-        o, i, filter, decimation_factor, smem_bytes);
+
+  // Unit-stride fast path: only viable when every hot tensor is a
+  // storage-backed view (Data()/Stride() callable) AND each one's last-dim
+  // stride is 1. Runtime-check those strides and dispatch to the specialized
+  // kernel via a bool_constant lambda.
+  constexpr bool fast_path_eligible =
+      is_tensor_view_v<OutType> &&
+      is_tensor_view_v<InType> &&
+      is_tensor_view_v<FilterType>;
+
+  auto launch = [&](auto is_unit_c) {
+    constexpr bool IsUnitStride = decltype(is_unit_c)::value;
+    if (decimation_factor == num_channels) {
+      // For M == D, cache one filter phase in dynamic shared memory if it fits.
+      const index_t filter_phase_len = (filter_len + num_channels - 1) / num_channels;
+      const size_t smem_needed = static_cast<size_t>(filter_phase_len) * sizeof(filter_t);
+      const uint32_t smem_bytes = (smem_needed <= GenericMaxFilterSmemBytes)
+          ? static_cast<uint32_t>(smem_needed) : 0;
+      ChannelizePoly1D<THREADS, true, IsUnitStride, OutType, InType, FilterType, AccumType>
+          <<<grid, THREADS, smem_bytes, stream>>>(o, i, filter, decimation_factor, smem_bytes);
+    } else {
+      ChannelizePoly1D<THREADS, false, IsUnitStride, OutType, InType, FilterType, AccumType>
+          <<<grid, THREADS, 0, stream>>>(o, i, filter, decimation_factor, 0);
+    }
+  };
+
+  if constexpr (fast_path_eligible) {
+    const bool is_unit_stride =
+        o.Stride(OutType::Rank() - 1) == 1 &&
+        i.Stride(InType::Rank() - 1) == 1 &&
+        filter.Stride(FilterType::Rank() - 1) == 1;
+    if (is_unit_stride) {
+      launch(cuda::std::bool_constant<true>{});
+    } else {
+      launch(cuda::std::bool_constant<false>{});
+    }
   } else {
-    ChannelizePoly1D<THREADS, false, OutType, InType, FilterType, AccumType><<<grid, THREADS, 0, stream>>>(
-        o, i, filter, decimation_factor, 0);
+    launch(cuda::std::bool_constant<false>{});
   }
 #endif
 }
 
 template <typename OutType, typename InType, typename FilterType>
-inline size_t matxChannelizePoly1DInternal_SmemSizeBytes(const OutType &o, const InType &, const FilterType &filter)
+inline size_t SmemSizeBytes(const OutType &o, const InType &, const FilterType &filter)
 {
   using input_t = typename InType::value_type;
   using filter_t = typename FilterType::value_type;
@@ -264,7 +421,7 @@ inline size_t matxChannelizePoly1DInternal_SmemSizeBytes(const OutType &o, const
   const index_t filter_phase_len = (filter_len + num_channels - 1) / num_channels;
 
   size_t smem_size = sizeof(filter_t)*(num_channels)*(filter_phase_len) +
-    sizeof(input_t)*(num_channels)*(filter_phase_len + MATX_CHANNELIZE_POLY1D_FULL_SMEM_KERNEL_NOUT_PER_ITER - 1);
+    sizeof(input_t)*(num_channels)*(filter_phase_len + FullSmemKernelNoutPerIter - 1);
   const size_t max_sizeof = cuda::std::max(sizeof(filter_t), sizeof(input_t));
   if (smem_size % max_sizeof) {
     smem_size += max_sizeof - (smem_size % max_sizeof);
@@ -273,23 +430,23 @@ inline size_t matxChannelizePoly1DInternal_SmemSizeBytes(const OutType &o, const
 }
 
 template <typename OutType, typename InType, typename FilterType>
-inline size_t matxChannelizePoly1DInternal_ShouldUseSmemKernel(const OutType &out, const InType &in, const FilterType &filter)
+inline size_t ShouldUseSmem(const OutType &out, const InType &in, const FilterType &filter)
 {
   // 48 KB is the largest shared memory allocation that does not require
   // explicit opt-in via cudaFuncSetAttribute()
   const size_t MAX_SMEM_BYTES = 48 * 1024;
   // The full shared memory kernel uses blocks of size
-  // (num_channels, detail::MATX_CHANNELIZE_POLY1D_FULL_SMEM_KERNEL_NOUT_PER_ITER), so ensure
+  // (num_channels, FullSmemKernelNoutPerIter), so ensure
   // that the resulting thread per block count will not exceed MAX_NUM_THREADS_PER_BLOCK
   const int MAX_NUM_THREADS_PER_BLOCK = 1024;
   const index_t num_channels = out.Size(OutType::Rank()-1);
   return (
-      matxChannelizePoly1DInternal_SmemSizeBytes(out, in, filter) <= MAX_SMEM_BYTES &&
-      num_channels <= (MAX_NUM_THREADS_PER_BLOCK/detail::MATX_CHANNELIZE_POLY1D_FULL_SMEM_KERNEL_NOUT_PER_ITER));
+      SmemSizeBytes(out, in, filter) <= MAX_SMEM_BYTES &&
+      num_channels <= (MAX_NUM_THREADS_PER_BLOCK/FullSmemKernelNoutPerIter));
 }
 
 template <typename OutType, typename InType, typename FilterType, typename AccumType>
-inline void matxChannelizePoly1DInternal_Smem(OutType o, const InType &i, const FilterType &filter, cudaStream_t stream)
+inline void Smem(OutType o, const InType &i, const FilterType &filter, cudaStream_t stream)
 {
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
@@ -301,17 +458,38 @@ inline void matxChannelizePoly1DInternal_Smem(OutType o, const InType &i, const 
   const int target_num_blocks = 1024;
   const int elem_per_block = static_cast<int>(
     (nout_per_channel + target_num_blocks - 1) / target_num_blocks);
-  dim3 block(static_cast<int>(num_channels), MATX_CHANNELIZE_POLY1D_FULL_SMEM_KERNEL_NOUT_PER_ITER);
+  dim3 block(static_cast<int>(num_channels), FullSmemKernelNoutPerIter);
   const uint32_t num_blocks = static_cast<uint32_t>((nout_per_channel + elem_per_block - 1) / elem_per_block);
   dim3 grid(num_blocks, 1, num_batches);
-  const size_t smem_size = matxChannelizePoly1DInternal_SmemSizeBytes(o, i, filter);
-  ChannelizePoly1D_Smem<OutType, InType, FilterType, AccumType><<<grid, block, smem_size, stream>>>(
-      o, i, filter, elem_per_block);
+  const size_t smem_size = SmemSizeBytes(o, i, filter);
+
+  constexpr bool fast_path_eligible =
+      is_tensor_view_v<OutType> &&
+      is_tensor_view_v<InType> &&
+      is_tensor_view_v<FilterType>;
+  auto launch = [&](auto is_unit_c) {
+    constexpr bool IsUnitStride = decltype(is_unit_c)::value;
+    ChannelizePoly1D_Smem<IsUnitStride, OutType, InType, FilterType, AccumType>
+        <<<grid, block, smem_size, stream>>>(o, i, filter, elem_per_block);
+  };
+  if constexpr (fast_path_eligible) {
+    const bool is_unit_stride =
+        o.Stride(OutType::Rank() - 1) == 1 &&
+        i.Stride(InType::Rank() - 1) == 1 &&
+        filter.Stride(FilterType::Rank() - 1) == 1;
+    if (is_unit_stride) {
+      launch(cuda::std::bool_constant<true>{});
+    } else {
+      launch(cuda::std::bool_constant<false>{});
+    }
+  } else {
+    launch(cuda::std::bool_constant<false>{});
+  }
 #endif
 }
 
 template <typename OutType, typename InType, typename FilterType, typename AccumType>
-inline void matxChannelizePoly1DInternal_FusedChan(OutType o, const InType &i,
+inline void FusedChan(OutType o, const InType &i,
                                      const FilterType &filter, cudaStream_t stream)
 {
 #ifdef __CUDACC__
@@ -322,34 +500,54 @@ inline void matxChannelizePoly1DInternal_FusedChan(OutType o, const InType &i,
   const int num_batches = static_cast<int>(TotalSize(i)/i.Size(i.Rank() - 1));
 
   const int THREADS = 256;
-  const index_t ELTS_PER_THREAD = detail::CHANNELIZE_POLY1D_ELEMS_PER_THREAD * THREADS;
+  const index_t ELTS_PER_THREAD = ElemsPerThread * THREADS;
   const int elem_blocks = static_cast<int>(
     (nout_per_channel + ELTS_PER_THREAD - 1) / ELTS_PER_THREAD);
   dim3 grid(elem_blocks, 1, num_batches);
-  switch (num_channels) {
-    case 2:
-      ChannelizePoly1D_FusedChan<THREADS, 2, OutType, InType, FilterType, AccumType><<<grid,THREADS,0,stream>>>(o, i, filter);
-      break;
-    case 3:
-      ChannelizePoly1D_FusedChan<THREADS, 3, OutType, InType, FilterType, AccumType><<<grid,THREADS,0,stream>>>(o, i, filter);
-      break;
-    case 4:
-      ChannelizePoly1D_FusedChan<THREADS, 4, OutType, InType, FilterType, AccumType><<<grid,THREADS,0,stream>>>(o, i, filter);
-      break;
-    case 5:
-      ChannelizePoly1D_FusedChan<THREADS, 5, OutType, InType, FilterType, AccumType><<<grid,THREADS,0,stream>>>(o, i, filter);
-      break;
-    case 6:
-      ChannelizePoly1D_FusedChan<THREADS, 6, OutType, InType, FilterType, AccumType><<<grid,THREADS,0,stream>>>(o, i, filter);
-      break;
-    default:
-      MATX_THROW(matxInvalidDim, "channelize_poly: channel count not support with fused kernel");
+
+  constexpr bool fast_path_eligible =
+      is_tensor_view_v<OutType> &&
+      is_tensor_view_v<InType> &&
+      is_tensor_view_v<FilterType>;
+  auto launch = [&](auto is_unit_c) {
+    constexpr bool IsUnitStride = decltype(is_unit_c)::value;
+    // Dispatch on num_channels in [2, FusedChanThreshold]. Generated at
+    // compile time from the threshold so raising FusedChanThreshold
+    // automatically grows the dispatch table; no per-N switch case to
+    // update. A runtime value outside the range falls through to MATX_THROW.
+    constexpr int kMinChan = 2;
+    constexpr int kMaxChan = static_cast<int>(FusedChanThreshold);
+    const bool matched = [&]<int... Is>(cuda::std::integer_sequence<int, Is...>) {
+      return ((num_channels == kMinChan + Is
+                 ? (ChannelizePoly1D_FusedChan<THREADS, kMinChan + Is, IsUnitStride,
+                                               OutType, InType, FilterType, AccumType>
+                        <<<grid, THREADS, 0, stream>>>(o, i, filter),
+                    true)
+                 : false)
+               || ...);
+    }(cuda::std::make_integer_sequence<int, kMaxChan - kMinChan + 1>{});
+    if (!matched) {
+      MATX_THROW(matxInvalidDim, "channelize_poly: channel count not supported with fused kernel");
+    }
+  };
+  if constexpr (fast_path_eligible) {
+    const bool is_unit_stride =
+        o.Stride(OutType::Rank() - 1) == 1 &&
+        i.Stride(InType::Rank() - 1) == 1 &&
+        filter.Stride(FilterType::Rank() - 1) == 1;
+    if (is_unit_stride) {
+      launch(cuda::std::bool_constant<true>{});
+    } else {
+      launch(cuda::std::bool_constant<false>{});
+    }
+  } else {
+    launch(cuda::std::bool_constant<false>{});
   }
 #endif
 }
 
 template <typename DataType>
-inline void matxChannelizePoly1DUnpackInternal(DataType inout, cudaStream_t stream)
+inline void UnpackDFT(DataType inout, cudaStream_t stream)
 {
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
@@ -360,10 +558,26 @@ inline void matxChannelizePoly1DUnpackInternal(DataType inout, cudaStream_t stre
     (num_channels * num_elem_per_channel));
   const int gy = static_cast<int>((num_elem_per_channel + THREADS - 1) / THREADS);
   const dim3 grid(num_batches, gy);
-  ChannelizePoly1DUnpackDFT<<<grid, THREADS, 0, stream>>>(inout);
+
+  constexpr bool fast_path_eligible = is_tensor_view_v<DataType>;
+  auto launch = [&](auto is_unit_c) {
+    constexpr bool IsUnitStride = decltype(is_unit_c)::value;
+    ChannelizePoly1DUnpackDFT<IsUnitStride, DataType><<<grid, THREADS, 0, stream>>>(inout);
+  };
+  if constexpr (fast_path_eligible) {
+    const bool is_unit_stride = inout.Stride(DataType::Rank() - 1) == 1;
+    if (is_unit_stride) {
+      launch(cuda::std::bool_constant<true>{});
+    } else {
+      launch(cuda::std::bool_constant<false>{});
+    }
+  } else {
+    launch(cuda::std::bool_constant<false>{});
+  }
 #endif
 }
 
+} // end namespace cpoly
 } // end namespace detail
 
 /**
@@ -380,7 +594,9 @@ inline void matxChannelizePoly1DUnpackInternal(DataType inout, cudaStream_t stre
  * @param out Output tensor
  * @param in Input operator
  * @param f Filter operator
- * @param num_channels Number of channels in which to separate the signal. Must be greater than 1.
+ * @param num_channels Number of channels in which to separate the signal. Must be positive.
+ * num_channels == 1 is the degenerate (no-channelization) case and degrades to a plain FIR filter
+ * with decimation_factor == 1.
  * @param decimation_factor Factor by which to downsample the input signal into the channels. When
  * decimation_factor equals num_channels, this is the maximally decimated (critically sampled) case.
  * When decimation_factor is less than num_channels, this is the oversampled case with overlapping
@@ -412,8 +628,8 @@ inline void channelize_poly_impl(OutType out, const InType &in, const FilterType
   // Currently only support 1D filters.
   MATX_STATIC_ASSERT_STR(FilterType::Rank() == 1, matxInvalidDim, "channelize_poly: currently only support 1D filters");
 
-  MATX_ASSERT_STR(num_channels > 1, matxInvalidParameter,
-    "channelize_poly: num_channels must be greater than 1");
+  MATX_ASSERT_STR(num_channels > 0, matxInvalidParameter,
+    "channelize_poly: num_channels must be positive");
   MATX_ASSERT_STR(decimation_factor > 0, matxInvalidParameter,
     "channelize_poly: decimation_factor must be positive");
   MATX_ASSERT_STR(decimation_factor <= num_channels, matxInvalidParameter,
@@ -434,8 +650,13 @@ inline void channelize_poly_impl(OutType out, const InType &in, const FilterType
   // and we will use an R2C transform. Otherwise, we will use a C2C transform.
   if constexpr (! is_complex_v<input_t> && ! is_complex_half_v<input_t> && ! is_complex_v<filter_t> && ! is_complex_half_v<filter_t>) {
     // The fused-DFT kernel only supports the maximally decimated case (D == M).
-    if (decimation_factor == num_channels && num_channels <= detail::MATX_CHANNELIZE_POLY1D_FUSED_CHAN_KERNEL_THRESHOLD) {
-      matxChannelizePoly1DInternal_FusedChan<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, stream);
+    // num_channels == 1 is degenerate (no channelization, trivial DFT) and
+    // the fused kernel's switch starts at N=2. Let num_channels==1 fall
+    // through to Smem / SmemTiled / Generic, all of which handle it
+    // correctly as a plain FIR.
+    if (decimation_factor == num_channels && num_channels >= 2 &&
+        num_channels <= detail::cpoly::FusedChanThreshold) {
+      detail::cpoly::FusedChan<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, stream);
     } else {
       index_t start_dims[OUT_RANK], stop_dims[OUT_RANK];
       std::fill_n(start_dims, OUT_RANK, 0);
@@ -474,29 +695,34 @@ inline void channelize_poly_impl(OutType out, const InType &in, const FilterType
         }
       }();
 
-      if (decimation_factor == num_channels && matxChannelizePoly1DInternal_ShouldUseSmemKernel(out, in, f)) {
-        matxChannelizePoly1DInternal_Smem<decltype(fft_in_slice), InputOp, FilterOp, AccumType>(fft_in_slice, in, f, stream);
-      } else if (matxChannelizePoly1DInternal_ShouldUseSmemTiledKernel(out, in, f, decimation_factor)) {
-        matxChannelizePoly1DInternal_SmemTiled<decltype(fft_in_slice), InputOp, FilterOp, AccumType>(fft_in_slice, in, f, decimation_factor, stream);
+      if (decimation_factor == num_channels && detail::cpoly::ShouldUseSmem(out, in, f)) {
+        detail::cpoly::Smem<decltype(fft_in_slice), InputOp, FilterOp, AccumType>(fft_in_slice, in, f, stream);
+      } else if (detail::cpoly::ShouldUseSmemTiled(out, in, f, decimation_factor)) {
+        detail::cpoly::SmemTiled<decltype(fft_in_slice), InputOp, FilterOp, AccumType>(fft_in_slice, in, f, decimation_factor, stream);
       } else {
-        matxChannelizePoly1DInternal<decltype(fft_in_slice), InputOp, FilterOp, AccumType>(fft_in_slice, in, f, decimation_factor, stream);
+        detail::cpoly::Generic<decltype(fft_in_slice), InputOp, FilterOp, AccumType>(fft_in_slice, in, f, decimation_factor, stream);
       }
       stop_dims[OUT_RANK-1] = (num_channels/2) + 1;
       auto out_packed = slice<OUT_RANK>(out, start_dims, stop_dims);
       (out_packed = fft(fft_in_slice, num_channels)).run(stream);
-      matxChannelizePoly1DUnpackInternal(out, stream);
+      detail::cpoly::UnpackDFT(out, stream);
     }
   } else {
     // The fused-DFT kernel only supports the maximally decimated case (D == M).
-    if (decimation_factor == num_channels && num_channels <= detail::MATX_CHANNELIZE_POLY1D_FUSED_CHAN_KERNEL_THRESHOLD) {
-      matxChannelizePoly1DInternal_FusedChan<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, stream);
+    // num_channels == 1 is degenerate (no channelization, trivial DFT) and
+    // the fused kernel's switch starts at N=2. Let num_channels==1 fall
+    // through to Smem / SmemTiled / Generic, all of which handle it
+    // correctly as a plain FIR.
+    if (decimation_factor == num_channels && num_channels >= 2 &&
+        num_channels <= detail::cpoly::FusedChanThreshold) {
+      detail::cpoly::FusedChan<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, stream);
     } else {
-      if (decimation_factor == num_channels && matxChannelizePoly1DInternal_ShouldUseSmemKernel(out, in, f)) {
-        matxChannelizePoly1DInternal_Smem<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, stream);
-      } else if (matxChannelizePoly1DInternal_ShouldUseSmemTiledKernel(out, in, f, decimation_factor)) {
-        matxChannelizePoly1DInternal_SmemTiled<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, decimation_factor, stream);
+      if (decimation_factor == num_channels && detail::cpoly::ShouldUseSmem(out, in, f)) {
+        detail::cpoly::Smem<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, stream);
+      } else if (detail::cpoly::ShouldUseSmemTiled(out, in, f, decimation_factor)) {
+        detail::cpoly::SmemTiled<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, decimation_factor, stream);
       } else {
-        matxChannelizePoly1DInternal<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, decimation_factor, stream);
+        detail::cpoly::Generic<OutputOp, InputOp, FilterOp, AccumType>(out, in, f, decimation_factor, stream);
       }
       // Specify FORWARD here to prevent any normalization after the ifft. We do not
       // want any extra scaling on the output values.

--- a/include/matx/transforms/sar_bp.h
+++ b/include/matx/transforms/sar_bp.h
@@ -99,8 +99,10 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
   // kernel reads/writes them via direct operator() calls regardless of
   // IsUnitStride. This maximizes the set of input types that benefit from
   // the fast path.
+  // range_to_mcp is always a MatX operator (scalar wrapping is the caller's
+  // responsibility). Rank-0 ops have no stride; rank-1 ops need a tensor-view
+  // with unit stride for the fast path.
   constexpr bool rtm_fast_path_ok =
-      !is_matx_op<RangeToMcpType>() ||
       RangeToMcpType::Rank() == 0 ||
       is_tensor_view_v<RangeToMcpType>;
   constexpr bool fast_path_eligible =
@@ -113,10 +115,8 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
     is_unit_stride =
         range_profiles.Stride(RangeProfilesType::Rank() - 1) == 1 &&
         platform_positions.Stride(PlatPosType::Rank() - 1) == 1;
-    if constexpr (is_matx_op<RangeToMcpType>()) {
-      if constexpr (RangeToMcpType::Rank() == 1) {
-        is_unit_stride = is_unit_stride && range_to_mcp.Stride(0) == 1;
-      }
+    if constexpr (RangeToMcpType::Rank() == 1) {
+      is_unit_stride = is_unit_stride && range_to_mcp.Stride(0) == 1;
     }
   }
 

--- a/include/matx/transforms/sar_bp.h
+++ b/include/matx/transforms/sar_bp.h
@@ -82,56 +82,110 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
     static_cast<uint32_t>((out.Size(1) + block.x - 1) / block.x),
     static_cast<uint32_t>((out.Size(0) + block.y - 1) / block.y));
 
-  if(phase_lut_optimization) {
-    const bool PhaseLUT = true;
-    const double phase_correction_partial = 4.0 * M_PI * params.del_r * (params.center_frequency / SPEED_OF_LIGHT);
+  // Unit-stride fast path: when every tensor-backed input accessed in the
+  // inner loop has stride 1 in its last dimension, the kernel can skip the
+  // IMAD-by-1 and the LDC-stride reload the compiler would otherwise emit.
+  //
+  // The fast path uses .Data(), which only exists on tensor views (types
+  // that declare the `tensor_view` marker: tensor_t, tensor_impl_t, and
+  // their slices).  Computed operators (broadcasts, clones, zip ops) don't
+  // have Data(), so we compile-time gate the IsUnitStride=true kernel
+  // instantiation behind a full is_tensor_view_v check.
+  //
+  // Only tensors accessed inside the hot pulse loop participate in this
+  // check: range_profiles, platform_positions, and range_to_mcp. The output
+  // image, initial_image, and voxel_locations are each touched once per
+  // thread, so their layouts do not block fast-path eligibility and the
+  // kernel reads/writes them via direct operator() calls regardless of
+  // IsUnitStride. This maximizes the set of input types that benefit from
+  // the fast path.
+  constexpr bool rtm_fast_path_ok =
+      !is_matx_op<RangeToMcpType>() ||
+      RangeToMcpType::Rank() == 0 ||
+      is_tensor_view_v<RangeToMcpType>;
+  constexpr bool fast_path_eligible =
+      is_tensor_view_v<RangeProfilesType> &&
+      is_tensor_view_v<PlatPosType> &&
+      rtm_fast_path_ok;
 
-    const size_t workspace_elem_size = (params.compute_type == SarBpComputeType::Double) ?
-      sizeof(cuda::std::complex<double>) : sizeof(cuda::std::complex<float>);
-    void *workspace = detail::GetCache().GetStreamAlloc(stream, workspace_elem_size * range_profiles.Size(1));
-    const dim3 lut_block(128);
-    const dim3 lut_grid(static_cast<uint32_t>((range_profiles.Size(1) + lut_block.x - 1) / lut_block.x));
+  bool is_unit_stride = false;
+  if constexpr (fast_path_eligible) {
+    is_unit_stride =
+        range_profiles.Stride(RangeProfilesType::Rank() - 1) == 1 &&
+        platform_positions.Stride(PlatPosType::Rank() - 1) == 1;
+    if constexpr (is_matx_op<RangeToMcpType>()) {
+      if constexpr (RangeToMcpType::Rank() == 1) {
+        is_unit_stride = is_unit_stride && range_to_mcp.Stride(0) == 1;
+      }
+    }
+  }
 
-    if (params.compute_type == SarBpComputeType::Double) {
-      cuda::std::complex<double> *phase_lut = static_cast<cuda::std::complex<double> *>(workspace);
-      SarBpFillPhaseLUT<double, double><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-      SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT><<<grid, block, 0, stream>>>(
-        out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
-    } else if (params.compute_type == SarBpComputeType::Mixed) {
-      cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
-      SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-      SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT><<<grid, block, 0, stream>>>(
-        out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
-    } else if (params.compute_type == SarBpComputeType::FloatFloat) {
-      cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
-      SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-      SarBp<SarBpComputeType::FloatFloat, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT><<<grid, block, 0, stream>>>(
-        out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, static_cast<fltflt>(dr_inv), phase_correction_partial, phase_lut);
+  auto dispatch = [&](auto is_unit_c) {
+    constexpr bool IsUnitStride = decltype(is_unit_c)::value;
+    if (phase_lut_optimization) {
+      constexpr bool PhaseLUT = true;
+      const double phase_correction_partial = 4.0 * M_PI * params.del_r * (params.center_frequency / SPEED_OF_LIGHT);
+
+      const size_t workspace_elem_size = (params.compute_type == SarBpComputeType::Double) ?
+        sizeof(cuda::std::complex<double>) : sizeof(cuda::std::complex<float>);
+      void *workspace = detail::GetCache().GetStreamAlloc(stream, workspace_elem_size * range_profiles.Size(1));
+      const dim3 lut_block(128);
+      const dim3 lut_grid(static_cast<uint32_t>((range_profiles.Size(1) + lut_block.x - 1) / lut_block.x));
+
+      if (params.compute_type == SarBpComputeType::Double) {
+        cuda::std::complex<double> *phase_lut = static_cast<cuda::std::complex<double> *>(workspace);
+        SarBpFillPhaseLUT<double, double><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
+        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+          out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
+      } else if (params.compute_type == SarBpComputeType::Mixed) {
+        cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
+        SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
+        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+          out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
+      } else if (params.compute_type == SarBpComputeType::FloatFloat) {
+        cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
+        SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
+        SarBp<SarBpComputeType::FloatFloat, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+          out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, static_cast<fltflt>(dr_inv), phase_correction_partial, phase_lut);
+      } else {
+        cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
+        SarBpFillPhaseLUT<float, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, static_cast<float>(params.center_frequency), static_cast<float>(params.del_r), range_profiles.Size(1));
+        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+          out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp,
+          static_cast<float>(dr_inv), static_cast<float>(phase_correction_partial), phase_lut);
+      }
     } else {
-      cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
-      SarBpFillPhaseLUT<float, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, static_cast<float>(params.center_frequency), static_cast<float>(params.del_r), range_profiles.Size(1));
-      SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT><<<grid, block, 0, stream>>>(
-        out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp,
-        static_cast<float>(dr_inv), static_cast<float>(phase_correction_partial), phase_lut);
+      constexpr bool PhaseLUT = false;
+      const double phase_correction_partial = 4.0 * M_PI * (params.center_frequency / SPEED_OF_LIGHT);
+      if (params.compute_type == SarBpComputeType::Double) {
+        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+          out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, nullptr);
+      } else if (params.compute_type == SarBpComputeType::Mixed) {
+        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+          out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, nullptr);
+      } else if (params.compute_type == SarBpComputeType::FloatFloat) {
+        // We currently require that phase LUT optimization be enabled for the FloatFloat compute type. See comment
+        // in run-time check higher in this function.
+        MATX_THROW(matxInvalidParameter, "sar_bp: FloatFloat compute type requires phase LUT optimization");
+      } else {
+        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+          out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp,
+          static_cast<float>(dr_inv), static_cast<float>(phase_correction_partial), nullptr);
+      }
+    }
+  };
+
+  // Only instantiate the IsUnitStride=true kernel when the types support it;
+  // otherwise forcing that template instantiation would reach .Data() on a
+  // non-tensor-view and fail at compile time.
+  if constexpr (fast_path_eligible) {
+    if (is_unit_stride) {
+      dispatch(cuda::std::bool_constant<true>{});
+    } else {
+      dispatch(cuda::std::bool_constant<false>{});
     }
   } else {
-    const bool PhaseLUT = false;
-    const double phase_correction_partial = 4.0 * M_PI * (params.center_frequency / SPEED_OF_LIGHT);
-    if (params.compute_type == SarBpComputeType::Double) {
-      SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT><<<grid, block, 0, stream>>>(
-        out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, nullptr);
-    } else if (params.compute_type == SarBpComputeType::Mixed) {
-      SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT><<<grid, block, 0, stream>>>(
-        out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, nullptr);
-    } else if (params.compute_type == SarBpComputeType::FloatFloat) {
-      // We currently require that phase LUT optimization be enabled for the FloatFloat compute type. See comment
-      // in run-time check higher in this function.
-      MATX_THROW(matxInvalidParameter, "sar_bp: FloatFloat compute type requires phase LUT optimization");
-    } else {
-      SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT><<<grid, block, 0, stream>>>(
-        out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp,
-        static_cast<float>(dr_inv), static_cast<float>(phase_correction_partial), nullptr);
-    }
+    dispatch(cuda::std::bool_constant<false>{});
   }
 #endif // __CUDACC__
 }

--- a/test/00_misc/TensorAccessorTests.cu
+++ b/test/00_misc/TensorAccessorTests.cu
@@ -1,0 +1,287 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "matx.h"
+#include "matx/kernels/tensor_accessor.h"
+#include "gtest/gtest.h"
+
+using namespace matx;
+
+// ---- Fast path ----------------------------------------------------------
+
+TEST(TensorAccessor, FastPathRank1)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({16});
+    (t = range<0>({16}, 0, 1)).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), /*IsUnitStride=*/true> acc(t);
+    for (index_t i = 0; i < 16; ++i) {
+        ASSERT_EQ(acc(i), static_cast<int>(i));
+    }
+}
+
+TEST(TensorAccessor, FastPathRank2)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({4, 8});
+    // t(r, c) = 8*r + c (row-major flat index).
+    (t = 8 * range<0>({4, 8}, 0, 1) + range<1>({4, 8}, 0, 1)).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), true> acc(t);
+    for (index_t r = 0; r < 4; ++r) {
+        for (index_t c = 0; c < 8; ++c) {
+            ASSERT_EQ(acc(r, c), t(r, c));
+        }
+    }
+}
+
+TEST(TensorAccessor, FastPathRank3)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({3, 4, 5});
+    (t = 20 * range<0>({3, 4, 5}, 0, 1)
+           + 5 * range<1>({3, 4, 5}, 0, 1)
+           +     range<2>({3, 4, 5}, 0, 1)).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), true> acc(t);
+    for (index_t i = 0; i < 3; ++i) {
+        for (index_t j = 0; j < 4; ++j) {
+            for (index_t k = 0; k < 5; ++k) {
+                ASSERT_EQ(acc(i, j, k), t(i, j, k));
+            }
+        }
+    }
+}
+
+// Write-through: assigning via fast-path operator() modifies the underlying tensor.
+TEST(TensorAccessor, FastPathWriteThrough)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({4, 4});
+    (t = 0).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), true> acc(t);
+    for (index_t r = 0; r < 4; ++r) {
+        for (index_t c = 0; c < 4; ++c) {
+            acc(r, c) = static_cast<int>(100 + r * 10 + c);
+        }
+    }
+    cudaDeviceSynchronize();
+    for (index_t r = 0; r < 4; ++r) {
+        for (index_t c = 0; c < 4; ++c) {
+            ASSERT_EQ(t(r, c), static_cast<int>(100 + r * 10 + c));
+        }
+    }
+}
+
+// ---- Slow path ----------------------------------------------------------
+
+// IsUnitStride=false falls through to op_(indices...) regardless of the
+// underlying tensor's stride. Verifies read correctness on a plain view.
+TEST(TensorAccessor, SlowPathOnTensorView)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({4, 8});
+    (t = 8 * range<0>({4, 8}, 0, 1) + range<1>({4, 8}, 0, 1)).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), /*IsUnitStride=*/false> acc(t);
+    for (index_t r = 0; r < 4; ++r) {
+        for (index_t c = 0; c < 8; ++c) {
+            ASSERT_EQ(acc(r, c), t(r, c));
+        }
+    }
+}
+
+// Non-unit-stride slice: last-dim stride = 2. Fast path would give wrong
+// offsets, so these must be accessed through the slow path.
+TEST(TensorAccessor, SlowPathNonUnitStride)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({4, 16});
+    (t = 16 * range<0>({4, 16}, 0, 1) + range<1>({4, 16}, 0, 1)).run(exec);
+    exec.sync();
+    auto strided = slice(t, {0, 0}, {matxEnd, matxEnd}, {1, 2});
+    EXPECT_EQ(strided.Stride(1), 2);  // sanity: actually non-unit
+    detail::TensorAccessor<decltype(strided), false> acc(strided);
+    for (index_t r = 0; r < strided.Size(0); ++r) {
+        for (index_t c = 0; c < strided.Size(1); ++c) {
+            ASSERT_EQ(acc(r, c), strided(r, c));
+        }
+    }
+}
+
+// ConstVal is a computed op with no Data() / Stride(), so only the slow path
+// can work on it. IsUnitStride=false instantiates the slow path.
+TEST(TensorAccessor, SlowPathOnConstVal)
+{
+    auto z = zeros<int>({4, 8});
+    detail::TensorAccessor<decltype(z), false> acc(z);
+    for (index_t r = 0; r < 4; ++r) {
+        for (index_t c = 0; c < 8; ++c) {
+            ASSERT_EQ(acc(r, c), 0);
+        }
+    }
+}
+
+// ---- bind_first_n -------------------------------------------------------
+
+TEST(TensorAccessor, BindFirstN_Zero)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({4, 8});
+    (t = 8 * range<0>({4, 8}, 0, 1) + range<1>({4, 8}, 0, 1)).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), true> acc(t);
+    cuda::std::array<index_t, 0> idx{};
+    auto bound = detail::bind_first_n<0>(acc, idx);
+    // N=0 returns the accessor unchanged.
+    for (index_t r = 0; r < 4; ++r) {
+        for (index_t c = 0; c < 8; ++c) {
+            ASSERT_EQ(bound(r, c), t(r, c));
+        }
+    }
+}
+
+TEST(TensorAccessor, BindFirstN_BatchDim)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({3, 5, 7});
+    (t = 35 * range<0>({3, 5, 7}, 0, 1)
+           + 7 * range<1>({3, 5, 7}, 0, 1)
+           +     range<2>({3, 5, 7}, 0, 1)).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), true> acc(t);
+    for (index_t b = 0; b < 3; ++b) {
+        cuda::std::array<index_t, 3> idx{b, 0, 0}; // bind_first_n uses arr[0..N-1]
+        auto bound = detail::bind_first_n<1>(acc, idx);
+        for (index_t j = 0; j < 5; ++j) {
+            for (index_t k = 0; k < 7; ++k) {
+                ASSERT_EQ(bound(j, k), t(b, j, k));
+            }
+        }
+    }
+}
+
+// Bind-all-dims-of-rank-1 is the case that previously read an uninitialized
+// outer_strides_[0] in BoundAccessor's fast-path constructor. With the fix,
+// the last-dim stride is taken as 1 rather than from the unpopulated slot.
+TEST(TensorAccessor, BindAllDims_Rank1_FastPath)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({16});
+    (t = range<0>({16}, 0, 1)).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), true> acc(t);
+    for (index_t i = 0; i < 16; ++i) {
+        cuda::std::array<index_t, 1> idx{i};
+        auto bound = detail::bind_first_n<1>(acc, idx);
+        // After binding the single dim, the remaining rank is 0; call nullary operator().
+        ASSERT_EQ(bound(), static_cast<int>(i)) << "at i=" << i;
+    }
+}
+
+TEST(TensorAccessor, BindAllDims_Rank2_FastPath)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({3, 5});
+    (t = 5 * range<0>({3, 5}, 0, 1) + range<1>({3, 5}, 0, 1)).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), true> acc(t);
+    for (index_t r = 0; r < 3; ++r) {
+        for (index_t c = 0; c < 5; ++c) {
+            cuda::std::array<index_t, 2> idx{r, c};
+            auto bound = detail::bind_first_n<2>(acc, idx);
+            ASSERT_EQ(bound(), t(r, c));
+        }
+    }
+}
+
+// Same as BindFirstN_BatchDim but with IsUnitStride=false, forcing slow path.
+// Exercises BoundAccessor's slow_forward path.
+TEST(TensorAccessor, BindFirstN_SlowPath)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({3, 5, 7});
+    (t = 35 * range<0>({3, 5, 7}, 0, 1)
+           + 7 * range<1>({3, 5, 7}, 0, 1)
+           +     range<2>({3, 5, 7}, 0, 1)).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), false> acc(t);
+    for (index_t b = 0; b < 3; ++b) {
+        cuda::std::array<index_t, 3> idx{b, 0, 0};
+        auto bound = detail::bind_first_n<1>(acc, idx);
+        for (index_t j = 0; j < 5; ++j) {
+            for (index_t k = 0; k < 7; ++k) {
+                ASSERT_EQ(bound(j, k), t(b, j, k));
+            }
+        }
+    }
+}
+
+// Write-through via a bound accessor.
+TEST(TensorAccessor, BoundAccessor_WriteThrough)
+{
+    auto exec = cudaExecutor{};
+    auto t = make_tensor<int>({3, 5});
+    (t = 0).run(exec);
+    exec.sync();
+    detail::TensorAccessor<decltype(t), true> acc(t);
+    for (index_t b = 0; b < 3; ++b) {
+        cuda::std::array<index_t, 2> idx{b, 0};
+        auto bound = detail::bind_first_n<1>(acc, idx);
+        for (index_t j = 0; j < 5; ++j) {
+            bound(j) = static_cast<int>(1000 + b * 10 + j);
+        }
+    }
+    cudaDeviceSynchronize();
+    for (index_t b = 0; b < 3; ++b) {
+        for (index_t j = 0; j < 5; ++j) {
+            ASSERT_EQ(t(b, j), static_cast<int>(1000 + b * 10 + j));
+        }
+    }
+}
+
+// Slow-path bind on a ConstVal: remaining dim access returns the ConstVal's value
+// regardless of bound leading index.
+TEST(TensorAccessor, BindFirstN_ConstVal)
+{
+    auto z = zeros<int>({4, 8});
+    detail::TensorAccessor<decltype(z), false> acc(z);
+    for (index_t b = 0; b < 4; ++b) {
+        cuda::std::array<index_t, 2> idx{b, 0};
+        auto bound = detail::bind_first_n<1>(acc, idx);
+        for (index_t j = 0; j < 8; ++j) {
+            ASSERT_EQ(bound(j), 0);
+        }
+    }
+}

--- a/test/00_transform/ChannelizePoly.cu
+++ b/test/00_transform/ChannelizePoly.cu
@@ -184,6 +184,82 @@ TYPED_TEST(ChannelizePolyTestNonHalfFloatTypes, Simple)
   MATX_EXIT_HANDLER();
 }
 
+// num_channels == 1 is a degenerate case: no channelization and (with D==M==1)
+// no decimation, so channelize_poly collapses to a plain FIR. The dispatcher
+// used to throw here because the FusedChan switch started at N=2; now it
+// falls through to Smem / SmemTiled / Generic. Verify numeric correctness
+// against a hand-rolled FIR reference.
+TYPED_TEST(ChannelizePolyTestNonHalfFloatTypes, NumChannelsOne)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ComplexType = typename test_types::complex_type<TestType>::type;
+
+  const index_t a_len = 128;
+  const index_t f_len = 9;
+  const index_t num_channels = 1;
+  const index_t decimation_factor = 1;
+  const index_t b_len_per_channel = (a_len + num_channels - 1) / num_channels;
+
+  auto a = make_tensor<TestType>({a_len});
+  auto f = make_tensor<TestType>({f_len});
+  auto b = make_tensor<ComplexType>({b_len_per_channel, num_channels});
+
+  // Initialize input and filter with simple deterministic values via direct
+  // host operator() writes. Handles both real and complex TestType uniformly.
+  for (index_t i = 0; i < a_len; i++) {
+    if constexpr (is_complex_v<TestType>) {
+      using scalar_t = typename test_types::inner_type<TestType>::type;
+      a(i) = TestType{static_cast<scalar_t>(i + 1), static_cast<scalar_t>(-(i % 7))};
+    } else {
+      a(i) = static_cast<TestType>(i + 1);
+    }
+  }
+  for (index_t k = 0; k < f_len; k++) {
+    if constexpr (is_complex_v<TestType>) {
+      using scalar_t = typename test_types::inner_type<TestType>::type;
+      f(k) = TestType{static_cast<scalar_t>(k + 1), static_cast<scalar_t>(0)};
+    } else {
+      f(k) = static_cast<TestType>(k + 1);
+    }
+  }
+
+  (b = channelize_poly(a, f, num_channels, decimation_factor)).run(this->exec);
+  this->exec.sync();
+
+  // Reference FIR in double precision: b_ref[t] = sum_{k=0..F-1} f[k] * a[t-k]
+  // with zero padding for t-k < 0.
+  for (index_t t = 0; t < a_len; t++) {
+    cuda::std::complex<double> expect{0.0, 0.0};
+    for (index_t k = 0; k < f_len; k++) {
+      if (t - k >= 0) {
+        if constexpr (is_complex_v<TestType>) {
+          const auto ak = a(t - k);
+          const auto fk = f(k);
+          expect += cuda::std::complex<double>{
+              static_cast<double>(fk.real()) * static_cast<double>(ak.real())
+                - static_cast<double>(fk.imag()) * static_cast<double>(ak.imag()),
+              static_cast<double>(fk.real()) * static_cast<double>(ak.imag())
+                + static_cast<double>(fk.imag()) * static_cast<double>(ak.real())};
+        } else {
+          const double fk = static_cast<double>(f(k));
+          const double ak = static_cast<double>(a(t - k));
+          expect += cuda::std::complex<double>{fk * ak, 0.0};
+        }
+      }
+    }
+    const auto got = b(t, 0);
+    const double mag = std::abs(expect.real()) + std::abs(expect.imag());
+    ASSERT_NEAR(static_cast<double>(got.real()), expect.real(), this->thresh * (1.0 + mag))
+        << "real-part mismatch at t=" << t;
+    ASSERT_NEAR(static_cast<double>(got.imag()), expect.imag(), this->thresh * (1.0 + mag))
+        << "imag-part mismatch at t=" << t;
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
 // Mixed type tests verify that mixing float and double for the input and filter behaves
 // as expected (e.g., that the output is the complex version of the higher precision).
 TYPED_TEST(ChannelizePolyTestDoubleType, MixedPrecision)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set (test_sources
     00_misc/FloatFloatTests.cu
     00_misc/ProfilingTests.cu
     00_misc/PropertyTests.cu
+    00_misc/TensorAccessorTests.cu
     00_tensor/BasicTensorTests.cu
     00_tensor/CUBTests.cu
     00_tensor/Storage.cu


### PR DESCRIPTION
Adds detail::TensorAccessor (a per-kernel wrapper with an IsUnitStride fast path) and plumbs it through the SAR BP and channelize_poly transforms. Extends the SAR BP shared-mem preamble to float and mixed precisions. Adds a CTILE=32 variant of ChannelizePoly1D_SmemTiled for num_channels <= 32, which replaces the generic ChannelizePoly1D kernel for most small-channel oversampled configs (M=32/D=16, M=40/D=20 etc.) at roughly 3x the throughput. Adds a Full filter smem layout (single copy at smem[p*M + phase]) alongside the existing Rotated layout; dispatcher picks the smaller footprint. Refactors the SmemTiled FIR loops to use a single running filter_idx counter, saving 3 registers/thread. Scopes all channelize_poly internals under matx::detail::cpoly, dropping redundant MATX_CHANNELIZE_POLY1D_ and matxChannelizePoly1DInternal_ prefixes. Adds support for num_channels = 1 to channelize_poly() for completeness, although such cases should use conv1d() for better performance.

The TensorAccessor class improves performance for tensors with unit stride by eliding the load and multiply of the last-dimension stride. Speedups range from 3-12%, depending on the GPU and precision. The float path for the sarbp example improved by > 3x on GPUs with reduced double-precision throughput, but that is due to amortizing the cost of double-to-float conversions.

General polyphase channelizer improvements from the TensorAccessor class range from 0-10%. Oversampled cases with <= 48 channels improved by > 2x due to the addition of a tiled shared memory implementation with a smaller tiling factor.