### PR TITLE
Add fill() generator that yields a user-provided value at all indices

### DIFF
--- a/docs_input/api/creation/operators/fill.rst
+++ b/docs_input/api/creation/operators/fill.rst
@@ -1,0 +1,49 @@
+.. _fill_func:
+
+fill
+====
+
+Generate an operator whose elements are all the same caller-supplied value.
+
+``fill()`` has a shape-taking form (rank inferred from the shape) and a
+shapeless form. The shapeless form is preferred in contexts where the shape
+can be deduced by the surrounding expression, e.g. as a broadcastable scalar
+inside an operator expression. ``fill<T>({}, value)`` produces a rank-0
+operator whose single element is ``value``.
+
+Unlike :ref:`ones <ones_func>` and :ref:`zeros <zeros_func>`, ``fill`` has no
+default for ``T``: the value type is either deduced from ``value`` or
+specified explicitly so that an int literal does not silently collapse a
+floating-point fill to an integer operator.
+
+
+.. doxygenfunction:: matx::fill(ShapeType &&s, T value)
+.. doxygenfunction:: matx::fill(const index_t (&s)[RANK], T value)
+.. doxygenfunction:: matx::fill(T value)
+
+Examples
+~~~~~~~~
+
+Shape-taking form, fills a 1D tensor:
+
+.. literalinclude:: ../../../../test/00_operators/GeneratorTests.cu
+   :language: cpp
+   :start-after: example-begin fill-gen-test-1
+   :end-before: example-end fill-gen-test-1
+   :dedent:
+
+Shapeless form, broadcast as a scalar inside an operator expression:
+
+.. literalinclude:: ../../../../test/00_operators/GeneratorTests.cu
+   :language: cpp
+   :start-after: example-begin fill-gen-test-2
+   :end-before: example-end fill-gen-test-2
+   :dedent:
+
+Rank-0 fill via the ``{}`` shape:
+
+.. literalinclude:: ../../../../test/00_operators/GeneratorTests.cu
+   :language: cpp
+   :start-after: example-begin fill-gen-test-3
+   :end-before: example-end fill-gen-test-3
+   :dedent:

--- a/docs_input/api/creation/operators/fill.rst
+++ b/docs_input/api/creation/operators/fill.rst
@@ -19,6 +19,7 @@ floating-point fill to an integer operator.
 
 .. doxygenfunction:: matx::fill(ShapeType &&s, T value)
 .. doxygenfunction:: matx::fill(const index_t (&s)[RANK], T value)
+.. doxygenfunction:: matx::fill(const std::initializer_list<detail::no_size_t> s, T value)
 .. doxygenfunction:: matx::fill(T value)
 
 Examples

--- a/docs_input/api/creation/operators/fill.rst
+++ b/docs_input/api/creation/operators/fill.rst
@@ -33,7 +33,10 @@ Shape-taking form, fills a 1D tensor:
    :end-before: example-end fill-gen-test-1
    :dedent:
 
-Shapeless form, broadcast as a scalar inside an operator expression:
+``fill()`` used in a slot that requires a MatX operator. ``zipvec`` is
+templated on operator types, so a bare scalar in the third slot fails to
+compile; ``fill<float>(5.0f)`` is the zero-storage adapter that satisfies
+the slot:
 
 .. literalinclude:: ../../../../test/00_operators/GeneratorTests.cu
    :language: cpp
@@ -41,7 +44,8 @@ Shapeless form, broadcast as a scalar inside an operator expression:
    :end-before: example-end fill-gen-test-2
    :dedent:
 
-Rank-0 fill via the ``{}`` shape:
+Rank-0 fill via the ``{}`` shape, for APIs that specifically expect a 0D
+operator:
 
 .. literalinclude:: ../../../../test/00_operators/GeneratorTests.cu
    :language: cpp

--- a/include/matx/generators/fill.h
+++ b/include/matx/generators/fill.h
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx/operators/constval.h"
+
+namespace matx
+{
+  /**
+   * Return value for all elements
+   *
+   * Creates an operator that returns the same value at every index. It can be
+   * used in place of memset to fill all elements with a chosen value, or as
+   * a zero-storage stand-in for a scalar in operator expressions and kernel
+   * arguments that expect a MatX op.
+   *
+   * @tparam T
+   *   Data type. Has no default; it is either deduced from `value` or
+   *   specified explicitly. Omitting a default forces deduction so that
+   *   `fill(shape, 3.14f)` produces a float-valued operator rather than
+   *   collapsing the value to an unrelated default type.
+   *
+   * @param s
+   *   Shape of tensor
+   * @param value
+   *   Value to fill
+   */
+  template <typename T, typename ShapeType>
+    requires (!cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
+  inline auto fill(ShapeType &&s, T value)
+  {
+    return detail::ConstVal<T, ShapeType>(std::forward<ShapeType>(s), value);
+  }
+
+  /**
+   * Return value for all elements
+   *
+   * Array-shape overload. See the ShapeType-taking overload for details.
+   *
+   * @tparam T
+   *   Data type
+   *
+   * @param s
+   *   Shape of tensor
+   * @param value
+   *   Value to fill
+   */
+  template <typename T, int RANK>
+  inline auto fill(const index_t (&s)[RANK], T value)
+  {
+    return fill<T>(detail::to_array(s), value);
+  }
+
+  /**
+   * Return value for all elements
+   *
+   * Rank-0 overload. `fill<T>({}, value)` produces a rank-0 ConstVal whose
+   * single element is `value`. Mirrors the empty-brace `make_tensor<T>({})`
+   * pattern.
+   *
+   * @tparam T
+   *   Data type
+   *
+   * @param value
+   *   Value to fill
+   */
+  template <typename T>
+  inline auto fill([[maybe_unused]] const std::initializer_list<detail::no_size_t> s, T value)
+  {
+    using shape_t = cuda::std::array<index_t, 0>;
+    return fill<T, shape_t>(shape_t{}, value);
+  }
+
+  /**
+   * Return value for all elements
+   *
+   * Shapeless form. The resulting operator has Rank() == matxNoRank and can
+   * be used in contexts where the shape can be deduced (e.g. broadcast in an
+   * operator expression).
+   *
+   * @tparam T
+   *   Data type
+   *
+   * @param value
+   *   Value to fill
+   */
+  template <typename T>
+  inline auto fill(T value)
+  {
+    return fill<T, detail::NoShape>(detail::NoShape{}, value);
+  }
+
+} // end namespace matx

--- a/include/matx/generators/fill.h
+++ b/include/matx/generators/fill.h
@@ -91,6 +91,9 @@ namespace matx
    * @tparam T
    *   Data type
    *
+   * @param s
+   *   Empty initializer list `{}`; unused, present to enable braced-init
+   *   overload resolution for the rank-0 case.
    * @param value
    *   Value to fill
    */

--- a/include/matx/generators/generators.h
+++ b/include/matx/generators/generators.h
@@ -37,6 +37,7 @@
 #include "matx/generators/blackman.h"
 #include "matx/generators/chirp.h"
 #include "matx/generators/diag.h"
+#include "matx/generators/fill.h"
 #include "matx/generators/flattop.h"
 #include "matx/generators/hamming.h"
 #include "matx/generators/hanning.h"

--- a/test/00_operators/GeneratorTests.cu
+++ b/test/00_operators/GeneratorTests.cu
@@ -418,6 +418,10 @@ TYPED_TEST(BasicGeneratorTestsAll, Fill)
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
   ExecType exec{};
   // example-begin fill-gen-test-1
+  // Note: for trivial "set every element to value", a bare scalar works too:
+  //   (t1 = value).run(exec);
+  // fill() is shown here for the shape-taking API surface; its real value is
+  // in slots that require an actual MatX operator (see fill-gen-test-2).
   const index_t count = 100;
   auto t1 = make_tensor<TestType>({count});
 
@@ -447,12 +451,10 @@ TYPED_TEST(BasicGeneratorTestsAll, FillNoShape)
   auto src = make_tensor<TestType>({count});
   (src = zeros<TestType>({count})).run(exec);
 
-  // example-begin fill-gen-test-2
   const TestType value = static_cast<TestType>(11);
   // Shapeless fill() broadcasts as a scalar across `src`. The result's
   // shape comes from `src`, so fill needs no shape of its own.
   (t1 = src + fill<TestType>(value)).run(exec);
-  // example-end fill-gen-test-2
   exec.sync();
 
   for (index_t i = 0; i < count; i++) {
@@ -490,8 +492,10 @@ TYPED_TEST(BasicGeneratorTestsAll, FillRank0EmptyBrace)
   ExecType exec{};
 
   // example-begin fill-gen-test-3
-  // Rank-0 fill: an empty {} shape produces a 0D operator with a single
-  // element. Equivalent to passing an explicit cuda::std::array<index_t, 0>.
+  // Rank-0 fill via the empty-brace shape. Note: for plain assignment a
+  // scalar `(t = value).run(exec)` works too; the rank-0 fill form is for
+  // APIs that specifically expect a 0D MatX operator (e.g. sar_bp's
+  // range_to_mcp parameter).
   auto t = make_tensor<TestType>({});
   const TestType value = static_cast<TestType>(17);
   (t = fill<TestType>({}, value)).run(exec);
@@ -499,6 +503,38 @@ TYPED_TEST(BasicGeneratorTestsAll, FillRank0EmptyBrace)
   exec.sync();
 
   EXPECT_TRUE(MatXUtils::MatXTypeCompare(t(), value));
+
+  MATX_EXIT_HANDLER();
+}
+
+// fill() in a slot that requires an actual MatX operator (not a scalar).
+// zipvec is templated on operator types; passing a bare scalar here fails
+// to compile because float has no Rank() / value_type / operator(). fill()
+// is the zero-storage adapter that lets a constant slot into a typed-op
+// position without allocating a tensor of constants.
+TEST(OperatorTests, FillInZipvec)
+{
+  MATX_ENTER_HANDLER();
+  cudaExecutor exec{};
+
+  // example-begin fill-gen-test-2
+  const index_t H = 8, W = 8;
+  auto x = clone<2>(linspace<float>(-1.0f, 1.0f, W), {H, matxKeepDim});
+  auto y = clone<2>(linspace<float>(-1.0f, 1.0f, H), {matxKeepDim, W});
+
+  // matx::zipvec(x, y, 5.0f) does not compile: zipvec expects MatX ops on
+  // every slot, and 5.0f has no Rank() / value_type. fill<float>({H, W}, 5.0f)
+  // is a zero-storage rank-2 op that satisfies the slot without allocating
+  // an H*W tensor of constants.
+  auto voxels = zipvec(x, y, fill<float>({H, W}, 5.0f));
+
+  auto out = make_tensor<float3>({H, W});
+  (out = voxels).run(exec);
+  // example-end fill-gen-test-2
+
+  exec.sync();
+  EXPECT_FLOAT_EQ(out(0, 0).z, 5.0f);
+  EXPECT_FLOAT_EQ(out(H/2, W/2).z, 5.0f);
 
   MATX_EXIT_HANDLER();
 }

--- a/test/00_operators/GeneratorTests.cu
+++ b/test/00_operators/GeneratorTests.cu
@@ -409,6 +409,100 @@ TYPED_TEST(BasicGeneratorTestsAll, Ones)
   MATX_EXIT_HANDLER();
 }
 
+// fill(shape, value) for a rank-1 tensor; verify every element matches the
+// supplied value. Mirrors the Ones/Zeros tests but with a non-trivial value.
+TYPED_TEST(BasicGeneratorTestsAll, Fill)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
+  // example-begin fill-gen-test-1
+  const index_t count = 100;
+  auto t1 = make_tensor<TestType>({count});
+
+  const TestType value = static_cast<TestType>(7);
+  (t1 = fill<TestType>({count}, value)).run(exec);
+  // example-end fill-gen-test-1
+  exec.sync();
+
+  for (index_t i = 0; i < count; i++) {
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), value));
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// fill with the no-shape (NoShape) overload, used as a broadcastable scalar
+// inside an operator expression. The shape is deduced from the surrounding
+// expression, so no shape argument is required.
+TYPED_TEST(BasicGeneratorTestsAll, FillNoShape)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
+  const index_t count = 100;
+  auto t1 = make_tensor<TestType>({count});
+  auto src = make_tensor<TestType>({count});
+  (src = zeros<TestType>({count})).run(exec);
+
+  // example-begin fill-gen-test-2
+  const TestType value = static_cast<TestType>(11);
+  // Shapeless fill() broadcasts as a scalar across `src`. The result's
+  // shape comes from `src`, so fill needs no shape of its own.
+  (t1 = src + fill<TestType>(value)).run(exec);
+  // example-end fill-gen-test-2
+  exec.sync();
+
+  for (index_t i = 0; i < count; i++) {
+    EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), value));
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// fill on a rank-0 tensor (empty shape array); fills the single element.
+TYPED_TEST(BasicGeneratorTestsAll, FillRank0)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
+
+  cuda::std::array<index_t, 0> s{};
+  auto t = make_tensor<TestType>(s);
+
+  const TestType value = static_cast<TestType>(13);
+  (t = fill<TestType>(s, value)).run(exec);
+  exec.sync();
+
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(t(), value));
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(BasicGeneratorTestsAll, FillRank0EmptyBrace)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
+
+  // example-begin fill-gen-test-3
+  // Rank-0 fill: an empty {} shape produces a 0D operator with a single
+  // element. Equivalent to passing an explicit cuda::std::array<index_t, 0>.
+  auto t = make_tensor<TestType>({});
+  const TestType value = static_cast<TestType>(17);
+  (t = fill<TestType>({}, value)).run(exec);
+  // example-end fill-gen-test-3
+  exec.sync();
+
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(t(), value));
+
+  MATX_EXIT_HANDLER();
+}
+
 TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Range)
 {
   MATX_ENTER_HANDLER();


### PR DESCRIPTION
New matx::fill(shape, value) generator that returns an operator that yields the same value at every index. Modeled on ones/zeros, but with a caller-supplied value and no default for T — the type is deduced from value or specified explicitly. This avoids the case of a default type (e.g., int) causing unwanted conversions or truncations of the user-provided value.