### PR TITLE
Adopt TensorAccessor for resample_poly; uplift of up to 19%

### DIFF
--- a/bench/00_misc/fltflt_arithmetic.cu
+++ b/bench/00_misc/fltflt_arithmetic.cu
@@ -50,6 +50,26 @@ static constexpr int ILP_FACTOR = 8;
 // Unroll factor for the inner loop
 static constexpr int ITER_UNROLL_FACTOR = 16;
 
+// Per-row GOPS/s summary so downstream tooling reads throughput straight off
+// the nvbench table/CSV. Each kernel does ILP_FACTOR ops per inner iteration
+// per element, with `iterations` outer iterations, on `size` elements:
+//   total_ops_per_call = size * iterations * ILP_FACTOR * ops_per_op
+// `ops_per_op` lets compound ops (FMA = 2, norm3d = 5, etc.) self-report.
+static void add_gops_per_sec_summary(nvbench::state &state, double ops_per_op = 1.0)
+{
+  const double seconds = state.get_summary("Batch GPU").get_float64("value");
+  const int64_t size = state.get_int64("Array Size");
+  const int64_t iterations = state.get_int64("Iterations");
+  const double total_ops = static_cast<double>(size) * static_cast<double>(iterations)
+                         * static_cast<double>(ILP_FACTOR) * ops_per_op;
+
+  auto &s = state.add_summary("matx/fltflt/gops_per_sec");
+  s.set_string("name", "Gops/s");
+  s.set_string("hint", "item_rate");
+  s.set_string("description", "Giga-operations per second (per-row throughput)");
+  s.set_float64("value", total_ops / seconds / 1e9);
+}
+
 template <typename T>
 __global__ void iterative_add_kernel(T* __restrict__ result, int64_t size, int32_t iterations)
 {
@@ -283,6 +303,7 @@ void fltflt_bench_add(nvbench::state &state, nvbench::type_list<PrecisionType>)
     iterative_add_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_add, NVBENCH_TYPE_AXES(precision_types))
@@ -313,6 +334,7 @@ void fltflt_bench_sub(nvbench::state &state, nvbench::type_list<PrecisionType>)
     iterative_sub_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_sub, NVBENCH_TYPE_AXES(precision_types))
@@ -343,6 +365,7 @@ void fltflt_bench_mul(nvbench::state &state, nvbench::type_list<PrecisionType>)
     iterative_mul_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_mul, NVBENCH_TYPE_AXES(precision_types))
@@ -373,6 +396,7 @@ void fltflt_bench_div(nvbench::state &state, nvbench::type_list<PrecisionType>)
     iterative_div_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_div, NVBENCH_TYPE_AXES(precision_types))
@@ -403,6 +427,7 @@ void fltflt_bench_sqrt(nvbench::state &state, nvbench::type_list<PrecisionType>)
     iterative_sqrt_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_sqrt, NVBENCH_TYPE_AXES(precision_types))
@@ -473,6 +498,7 @@ void fltflt_bench_sqrt_fast(nvbench::state &state, nvbench::type_list<PrecisionT
     iterative_sqrt_fast_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_sqrt_fast, NVBENCH_TYPE_AXES(precision_types))
@@ -554,6 +580,8 @@ void fltflt_bench_norm3d(nvbench::state &state, nvbench::type_list<PrecisionType
     iterative_norm3d_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  // 3 muls + 2 adds + 1 sqrt + 1 sub + 1 add = 8 ops per inner iteration.
+  add_gops_per_sec_summary(state, /*ops_per_op=*/8.0);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_norm3d, NVBENCH_TYPE_AXES(precision_types))
@@ -584,6 +612,7 @@ void fltflt_bench_abs(nvbench::state &state, nvbench::type_list<PrecisionType>)
     iterative_abs_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_abs, NVBENCH_TYPE_AXES(precision_types))
@@ -614,6 +643,7 @@ void fltflt_bench_fma(nvbench::state &state, nvbench::type_list<PrecisionType>)
     iterative_fma_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state, /*ops_per_op=*/2.0);  // FMA = 1 mul + 1 add
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_fma, NVBENCH_TYPE_AXES(precision_types))
@@ -680,6 +710,7 @@ void fltflt_bench_madd(nvbench::state &state, nvbench::type_list<PrecisionType>)
     iterative_madd_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state, /*ops_per_op=*/2.0);  // separate mul + add
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_madd, NVBENCH_TYPE_AXES(precision_types))
@@ -753,6 +784,7 @@ void fltflt_bench_round(nvbench::state &state, nvbench::type_list<PrecisionType>
     iterative_round_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_round, NVBENCH_TYPE_AXES(precision_types))
@@ -834,6 +866,7 @@ void fltflt_bench_fmod(nvbench::state &state, nvbench::type_list<PrecisionType>)
     iterative_fmod_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_fmod, NVBENCH_TYPE_AXES(precision_types))
@@ -910,6 +943,7 @@ void fltflt_bench_trunc(nvbench::state &state, nvbench::type_list<PrecisionType>
     iterative_trunc_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_trunc, NVBENCH_TYPE_AXES(precision_types))
@@ -986,6 +1020,7 @@ void fltflt_bench_floor(nvbench::state &state, nvbench::type_list<PrecisionType>
     iterative_floor_kernel<<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_floor, NVBENCH_TYPE_AXES(precision_types))
@@ -1048,6 +1083,7 @@ void fltflt_bench_cast2dbl(nvbench::state &state, nvbench::type_list<PrecisionTy
     iterative_cast2dbl_kernel<PrecisionType><<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_cast2dbl, NVBENCH_TYPE_AXES(precision_types))
@@ -1110,6 +1146,7 @@ void fltflt_bench_cast2fltflt(nvbench::state &state, nvbench::type_list<Precisio
     iterative_cast2fltflt_kernel<PrecisionType><<<grid_size, block_size, 0, (cudaStream_t)launch.get_stream()>>>(
       result.Data(), size, iterations);
   });
+  add_gops_per_sec_summary(state);
 }
 
 NVBENCH_BENCH_TYPES(fltflt_bench_cast2fltflt, NVBENCH_TYPE_AXES(precision_types))

--- a/bench/00_transform/resample_poly.cu
+++ b/bench/00_transform/resample_poly.cu
@@ -40,19 +40,11 @@ using namespace matx;
 using resample_poly_types =
     nvbench::type_list<cuda::std::complex<float>, cuda::std::complex<double>, float, double>;
 
-// 1D polyphase resampler.
-//
-// Axes (defaults can be overriden on the command line, e.g.
-//   --axis "Up=[2,3,4,5]" --axis "Down=[1,2,3]" --axis "Signal Size=[131072,524288]"
-// ):
-//   - Up           : upsample factor (default 4)
-//   - Down         : downsample factor (default 5)
-//   - Signal Size  : input length in samples (default 512000)
-//   - Filter Size  : filter length, or 0 to auto-compute as
-//                    2 * 10 * max(up, down) + 1 (default: 0)
-template <typename ValueType>
-void resample_poly_1d(nvbench::state &state,
-                     nvbench::type_list<ValueType>)
+// Shared body for the 1D polyphase resampler benchmarks. Templated on signal
+// and filter types separately so we can cover real-filter / complex-signal
+// pipelines (common in radar/SDR) in addition to the matched-type case.
+template <typename SignalType, typename FilterType>
+static void resample_poly_1d_run(nvbench::state &state)
 {
   cudaExecutor exec{0};
 
@@ -69,14 +61,14 @@ void resample_poly_1d(nvbench::state &state,
   //   out_len = ceil(signal_len * up / down)
   const index_t out_len = (signal_len * up + down - 1) / down;
 
-  auto in     = make_tensor<ValueType>({signal_len});
-  auto filter = make_tensor<ValueType>({filter_len});
-  auto out    = make_tensor<ValueType>({out_len});
+  auto in     = make_tensor<SignalType>({signal_len});
+  auto filter = make_tensor<FilterType>({filter_len});
+  auto out    = make_tensor<SignalType>({out_len});
 
   // Populate inputs with deterministic random data so first-run timing
   // doesn't get charged for page faults on the unified-memory fast path.
-  (in     = random<ValueType>({signal_len}, NORMAL)).run(exec);
-  (filter = random<ValueType>({filter_len}, NORMAL)).run(exec);
+  (in     = random<SignalType>({signal_len}, NORMAL)).run(exec);
+  (filter = random<FilterType>({filter_len}, NORMAL)).run(exec);
 
   in.PrefetchDevice(0);
   filter.PrefetchDevice(0);
@@ -110,6 +102,23 @@ void resample_poly_1d(nvbench::state &state,
   thr.set_string("description", "Million input samples per second");
   thr.set_float64("value", static_cast<double>(signal_len) / seconds / 1e6);
 }
+
+// 1D polyphase resampler with matched signal/filter element types.
+//
+// Axes (defaults can be overriden on the command line, e.g.
+//   --axis "Up=[2,3,4,5]" --axis "Down=[1,2,3]" --axis "Signal Size=[131072,524288]"
+// ):
+//   - Up           : upsample factor (default 4)
+//   - Down         : downsample factor (default 5)
+//   - Signal Size  : input length in samples (default 512000)
+//   - Filter Size  : filter length, or 0 to auto-compute as
+//                    2 * 10 * max(up, down) + 1 (default: 0)
+template <typename ValueType>
+void resample_poly_1d(nvbench::state &state,
+                     nvbench::type_list<ValueType>)
+{
+  resample_poly_1d_run<ValueType, ValueType>(state);
+}
 NVBENCH_BENCH_TYPES(resample_poly_1d, NVBENCH_TYPE_AXES(resample_poly_types))
     .add_int64_axis("Up",          {4})
     .add_int64_axis("Down",        {5})
@@ -117,4 +126,24 @@ NVBENCH_BENCH_TYPES(resample_poly_1d, NVBENCH_TYPE_AXES(resample_poly_types))
     // Filter Size = 0 (or any value <= 0) is a sentinel meaning "auto-compute
     // from up/down via 2*10*max(up,down)+1". The actual filter length used
     // shows up in the "Eff. Filter" summary column on every row.
+    .add_int64_axis("Filter Size", {0});
+
+using resample_poly_complex_types =
+    nvbench::type_list<cuda::std::complex<float>, cuda::std::complex<double>>;
+
+// 1D polyphase resampler, complex signal with real-valued filter. Real
+// filters on complex I/Q data are the common case in radar/SDR pipelines,
+// and exercise a different mixed-type code path than the matched variant.
+template <typename ValueType>
+void resample_poly_1d_real_filter(nvbench::state &state,
+                                  nvbench::type_list<ValueType>)
+{
+  using filter_t = typename ValueType::value_type;
+  resample_poly_1d_run<ValueType, filter_t>(state);
+}
+NVBENCH_BENCH_TYPES(resample_poly_1d_real_filter,
+                    NVBENCH_TYPE_AXES(resample_poly_complex_types))
+    .add_int64_axis("Up",          {4})
+    .add_int64_axis("Down",        {5})
+    .add_int64_axis("Signal Size", {512000})
     .add_int64_axis("Filter Size", {0});

--- a/bench/00_transform/resample_poly.cu
+++ b/bench/00_transform/resample_poly.cu
@@ -1,0 +1,120 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "matx.h"
+#include <nvbench/nvbench.cuh>
+#include "matx/core/half_complex.h"
+#include "matx/core/nvtx.h"
+
+using namespace matx;
+
+using resample_poly_types =
+    nvbench::type_list<cuda::std::complex<float>, cuda::std::complex<double>, float, double>;
+
+// 1D polyphase resampler.
+//
+// Axes (defaults can be overriden on the command line, e.g.
+//   --axis "Up=[2,3,4,5]" --axis "Down=[1,2,3]" --axis "Signal Size=[131072,524288]"
+// ):
+//   - Up           : upsample factor (default 4)
+//   - Down         : downsample factor (default 5)
+//   - Signal Size  : input length in samples (default 512000)
+//   - Filter Size  : filter length, or 0 to auto-compute as
+//                    2 * 10 * max(up, down) + 1 (default: 0)
+template <typename ValueType>
+void resample_poly_1d(nvbench::state &state,
+                     nvbench::type_list<ValueType>)
+{
+  cudaExecutor exec{0};
+
+  const index_t up         = static_cast<index_t>(state.get_int64("Up"));
+  const index_t down       = static_cast<index_t>(state.get_int64("Down"));
+  const index_t signal_len = static_cast<index_t>(state.get_int64("Signal Size"));
+  index_t       filter_len = static_cast<index_t>(state.get_int64("Filter Size"));
+  if (filter_len <= 0) {
+    const index_t half_len = 10 * std::max(up, down);
+    filter_len = 2 * half_len + 1;
+  }
+
+  // Output length matches the one-shot resample_poly_impl convention:
+  //   out_len = ceil(signal_len * up / down)
+  const index_t out_len = (signal_len * up + down - 1) / down;
+
+  auto in     = make_tensor<ValueType>({signal_len});
+  auto filter = make_tensor<ValueType>({filter_len});
+  auto out    = make_tensor<ValueType>({out_len});
+
+  // Populate inputs with deterministic random data so first-run timing
+  // doesn't get charged for page faults on the unified-memory fast path.
+  (in     = random<ValueType>({signal_len}, NORMAL)).run(exec);
+  (filter = random<ValueType>({filter_len}, NORMAL)).run(exec);
+
+  in.PrefetchDevice(0);
+  filter.PrefetchDevice(0);
+  out.PrefetchDevice(0);
+
+  // Warmup.
+  (out = resample_poly(in, filter, up, down)).run(exec);
+  exec.sync();
+
+  MATX_NVTX_START_RANGE("resample_poly_1d", matx_nvxtLogLevels::MATX_NVTX_LOG_ALL, 1)
+  state.exec(
+      [&out, &in, &filter, up, down](nvbench::launch &launch) {
+        (out = resample_poly(in, filter, up, down))
+            .run(cudaExecutor(launch.get_stream()));
+      });
+  MATX_NVTX_END_RANGE(1)
+
+  // Show the effective filter length (after the 0=auto sentinel resolves) and
+  // throughput in input-samples/sec as native columns, so downstream tooling
+  // can read them straight off the nvbench table/CSV without re-deriving.
+  auto seconds = state.get_summary("Batch GPU").get_float64("value");
+
+  auto &eff_fl = state.add_summary("matx/resample_poly/effective_filter_size");
+  eff_fl.set_string("name", "Eff. Filter");
+  eff_fl.set_string("description", "Effective filter length (resolves 0=auto)");
+  eff_fl.set_int64("value", filter_len);
+
+  auto &thr = state.add_summary("matx/resample_poly/in_msamp_per_sec");
+  thr.set_string("name", "In Msamp/s");
+  thr.set_string("hint", "item_rate");
+  thr.set_string("description", "Million input samples per second");
+  thr.set_float64("value", static_cast<double>(signal_len) / seconds / 1e6);
+}
+NVBENCH_BENCH_TYPES(resample_poly_1d, NVBENCH_TYPE_AXES(resample_poly_types))
+    .add_int64_axis("Up",          {4})
+    .add_int64_axis("Down",        {5})
+    .add_int64_axis("Signal Size", {512000})
+    // Filter Size = 0 (or any value <= 0) is a sentinel meaning "auto-compute
+    // from up/down via 2*10*max(up,down)+1". The actual filter length used
+    // shows up in the "Eff. Filter" summary column on every row.
+    .add_int64_axis("Filter Size", {0});

--- a/bench/00_transform/sarbp.cu
+++ b/bench/00_transform/sarbp.cu
@@ -39,6 +39,22 @@ using namespace matx;
 
 const std::vector<ssize_t> PROBLEM_SIZES = {2000};
 
+// Gigabackprojections per second derived metric. Operations per launch =
+// num_pulses * image_width * image_height = problem_size^3. Reading this
+// straight off the nvbench table/CSV beats parsing the table in Python.
+static void add_gproj_per_sec_summary(nvbench::state &state)
+{
+  const double seconds = state.get_summary("Batch GPU").get_float64("value");
+  const int64_t ps = state.get_int64("Problem Size");
+  const double ops = static_cast<double>(ps) * static_cast<double>(ps) * static_cast<double>(ps);
+
+  auto &s = state.add_summary("matx/sarbp/gproj_per_sec");
+  s.set_string("name", "Gproj/s");
+  s.set_string("hint", "item_rate");
+  s.set_string("description", "Gigabackprojections per second (problem_size^3 / time)");
+  s.set_float64("value", ops / seconds / 1e9);
+}
+
 /* Float precision benchmark */
 void sarbp_float(nvbench::state &state)
 {
@@ -103,6 +119,7 @@ void sarbp_float(nvbench::state &state)
         .run(cudaExecutor(launch.get_stream()));
   });
 
+  add_gproj_per_sec_summary(state);
   matx::ClearCachesAndAllocations();
 }
 
@@ -173,6 +190,7 @@ void sarbp_double(nvbench::state &state)
         .run(cudaExecutor(launch.get_stream()));
   });
 
+  add_gproj_per_sec_summary(state);
   matx::ClearCachesAndAllocations();
 }
 
@@ -244,6 +262,7 @@ void sarbp_mixed(nvbench::state &state)
         .run(cudaExecutor(launch.get_stream()));
   });
 
+  add_gproj_per_sec_summary(state);
   matx::ClearCachesAndAllocations();
 }
 
@@ -316,6 +335,7 @@ void sarbp_fltflt(nvbench::state &state)
         .run(cudaExecutor(launch.get_stream()));
   });
 
+  add_gproj_per_sec_summary(state);
   matx::ClearCachesAndAllocations();
 }
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -8,6 +8,7 @@ set(bench_sources
     00_transform/cub.cu
     00_transform/einsum.cu
     00_transform/sarbp.cu
+    00_transform/resample_poly.cu
     00_transform/svd_power.cu
     00_transform/qr.cu
     00_operators/operators.cu

--- a/include/matx/kernels/resample_poly.cuh
+++ b/include/matx/kernels/resample_poly.cuh
@@ -53,6 +53,7 @@ namespace cg = cooperative_groups;
 #include "matx/core/utils.h"
 #include "matx/core/type_utils.h"
 #include "matx/core/tensor_utils.h"
+#include "matx/kernels/tensor_accessor.h"
 
 namespace matx {
 
@@ -66,7 +67,7 @@ static constexpr int MATX_RESAMPLE_POLY_MAX_NUM_THREADS = 256;
 static constexpr size_t MATX_RESAMPLE_POLY_MAX_SMEM_BYTES = 11*1024;
 
 #ifdef __CUDACC__ 
-template <int THREADS, typename OutType, typename InType, typename FilterType, typename index_t>
+template <int THREADS, bool IsUnitStride, typename OutType, typename InType, typename FilterType, typename index_t>
 __launch_bounds__(MATX_RESAMPLE_POLY_MAX_NUM_THREADS)
 __global__ void ResamplePoly1D_PhaseBlock(OutType output, InType input, FilterType filter,
                     index_t up, index_t down, index_t elems_per_thread)
@@ -95,9 +96,20 @@ __global__ void ResamplePoly1D_PhaseBlock(OutType output, InType input, FilterTy
     const int tid = threadIdx.x;
     const index_t filter_len_half = filter_len/2;
 
-    // All but the last dim are batch indices
+    // Wrap input/output/filter in TensorAccessor and bind the leading Rank-1
+    // batch dims once. After binding, per-access calls supply only the inner
+    // element index. On the fast path this collapses to base_ptr[idx]
+    // arithmetic; on the slow path it forwards to operator(). Output and
+    // input share the same batch shape (asserted by resample_poly_impl), so
+    // a single BlockToIdx call feeds both bind_first_n calls.
     const int batch_idx = blockIdx.x;
-    auto bdims = BlockToIdx(output, batch_idx, 1);
+    detail::TensorAccessor<InType,     IsUnitStride> input_acc(input);
+    detail::TensorAccessor<OutType,    IsUnitStride> output_acc(output);
+    detail::TensorAccessor<FilterType, IsUnitStride> filter_acc(filter);
+
+    const auto batch_idx_arr = BlockToIdx(output, batch_idx, 1);
+    auto input_b  = detail::bind_first_n<Rank - 1>(input_acc,  batch_idx_arr);
+    auto output_b = detail::bind_first_n<Rank - 1>(output_acc, batch_idx_arr);
 
     // We assume odd-length filters in the below index calculations. If the filter
     // is even-length, then it has had a single zero logically prepended to it to
@@ -148,10 +160,7 @@ __global__ void ResamplePoly1D_PhaseBlock(OutType output, InType input, FilterTy
     // overlaps with zero-filled samples from the upsampling operation.
     if (last_filter_ind < 0) {
         for (index_t out_ind = phase_ind + tid * up; out_ind < output_len; out_ind += THREADS * up) {
-            bdims[Rank - 1] = out_ind;
-            cuda::std::apply([&output](auto &&...args) {
-                output.operator()(args...) = 0;
-            }, bdims);
+            output_b(out_ind) = 0;
         }
         return;
     }
@@ -167,13 +176,13 @@ __global__ void ResamplePoly1D_PhaseBlock(OutType output, InType input, FilterTy
         for (index_t t = tid; t < this_phase_len; t += THREADS) {
             const index_t ind = t * up + first_filter_ind;
             const index_t smem_ind = this_phase_len - 1 - t;
-            s_filter[smem_ind] = (ind > 0) ? scale * filter.operator()(ind-1) : static_cast<filter_t>(0);
+            s_filter[smem_ind] = (ind > 0) ? scale * filter_acc(ind-1) : static_cast<filter_t>(0);
         }
     } else {
         for (index_t t = tid; t < this_phase_len; t += THREADS) {
             const index_t ind = t * up + first_filter_ind;
             const index_t smem_ind = this_phase_len - 1 - t;
-            s_filter[smem_ind] = scale * filter.operator()(ind);
+            s_filter[smem_ind] = scale * filter_acc(ind);
         }
     }
 
@@ -217,43 +226,47 @@ __global__ void ResamplePoly1D_PhaseBlock(OutType output, InType input, FilterTy
         index_t x_ind = input_ind - prologue;
         index_t h_ind = left_h_ind - prologue;
         output_t accum {};
-        input_t in_val;
         for (index_t j = 0; j < n; j++) {
-            bdims[Rank - 1] = x_ind++;
-            cuda::std::apply([&in_val, &input](auto &&...args) {
-                in_val = input.operator()(args...);
-            }, bdims);
+            const input_t in_val = input_b(x_ind++);
             accum += s_filter[h_ind++] * in_val;
         }
 
-        bdims[Rank - 1] = out_ind;
-        cuda::std::apply([&accum, &output](auto &&...args) {
-            output.operator()(args...) = accum;
-        }, bdims);
+        output_b(out_ind) = accum;
     }
 }
 
-template <int THREADS, typename FilterType>
-__device__ inline void ResamplePoly1D_LoadFilter(typename FilterType::value_type *s_filter, const FilterType &filter)
+template <int THREADS, typename FilterAcc>
+__device__ inline void ResamplePoly1D_LoadFilter(typename FilterAcc::value_type *s_filter,
+                                                  const FilterAcc &filter_acc, index_t filter_len)
 {
-    const index_t filter_len = filter.Size(0);
+    // FilterAcc is a TensorAccessor / BoundAccessor wrapping the filter
+    // operator; both expose `value_type` aliased from the underlying op's
+    // value_type. The static_assert documents that contract so a refactor
+    // that drops `value_type` from those wrappers fails here at the helper
+    // site rather than silently breaking smem-filter loads.
+    using filter_value_t = typename FilterAcc::value_type;
+    static_assert(cuda::std::is_arithmetic_v<filter_value_t> ||
+                  is_complex_v<filter_value_t> ||
+                  is_matx_type_v<filter_value_t>,
+                  "ResamplePoly1D_LoadFilter requires FilterAcc::value_type "
+                  "to be a MatX-supported numeric scalar/complex type");
     const int tid = threadIdx.x;
     if (filter_len % 2 == 0) {
         for (int t = tid; t < filter_len; t += THREADS) {
-            s_filter[t+1] = filter.operator()(t);
+            s_filter[t+1] = filter_acc(t);
         }
         if (tid == 0) {
-            s_filter[0] = static_cast<typename FilterType::value_type>(0);
+            s_filter[0] = static_cast<filter_value_t>(0);
         }
     } else {
         for (int t = tid; t < filter_len; t += THREADS) {
-            s_filter[t] = filter.operator()(t);
+            s_filter[t] = filter_acc(t);
         }
     }
     __syncthreads();    
 }
 
-template <int THREADS, typename OutType, typename InType, typename FilterType, typename index_t>
+template <int THREADS, bool IsUnitStride, typename OutType, typename InType, typename FilterType, typename index_t>
 __launch_bounds__(MATX_RESAMPLE_POLY_MAX_NUM_THREADS)
 __global__ void ResamplePoly1D_ElemBlock(OutType output, InType input, FilterType filter,
                     index_t up, index_t down, index_t elems_per_thread)
@@ -277,16 +290,24 @@ __global__ void ResamplePoly1D_ElemBlock(OutType output, InType input, FilterTyp
     const int tid = threadIdx.x;
     // const int THREADS = blockDim.x;
 
+    // TensorAccessors with per-block batch binding (see ResamplePoly1D_PhaseBlock).
+    detail::TensorAccessor<InType,     IsUnitStride> input_acc(input);
+    detail::TensorAccessor<OutType,    IsUnitStride> output_acc(output);
+    detail::TensorAccessor<FilterType, IsUnitStride> filter_acc(filter);
+
     if (load_filter_to_smem) {
-        ResamplePoly1D_LoadFilter<THREADS, FilterType>(s_filter, filter);
+        ResamplePoly1D_LoadFilter<THREADS>(s_filter, filter_acc, filter_len);
         if (filter_len % 2 == 0) {
             filter_len++;
         }
     }
 
-    // All but the last dim are batch indices
+    // Bind the leading Rank-1 batch dims into both accessors. Input and
+    // output share their batch shape, so a single BlockToIdx call feeds both.
     const int batch_idx = blockIdx.x;
-    auto bdims = BlockToIdx(output, batch_idx, 1);
+    const auto batch_idx_arr = BlockToIdx(output, batch_idx, 1);
+    auto input_b  = detail::bind_first_n<Rank - 1>(input_acc,  batch_idx_arr);
+    auto output_b = detail::bind_first_n<Rank - 1>(output_acc, batch_idx_arr);
 
     // Scale the filter coefficients by up to match scipy's convention
     const filter_t scale = static_cast<filter_t>(up);
@@ -316,21 +337,17 @@ __global__ void ResamplePoly1D_ElemBlock(OutType output, InType input, FilterTyp
             int h_ind = static_cast<int>(filter_central_tap + (up_ind - up*x_start));
 
             output_t accum {};
-            input_t in_val;
+            // Cap the inner-loop unroll at 8; unroll=16 can saturate the MIO
+            // pipeline and reduce performance.
+            #pragma unroll 8
             for (index_t i = x_start; i <= x_end; i++) {
-                bdims[Rank - 1] = i;
-                cuda::std::apply([&in_val, &input](auto &&...args) {
-                    in_val = input.operator()(args...);
-                }, bdims);
+                const input_t in_val = input_b(i);
                 accum += in_val * s_filter[h_ind];
                 h_ind -= up;
             }
 
             accum *= scale;
-            bdims[Rank - 1] = out_ind;
-            cuda::std::apply([&accum, &output](auto &&...args) {
-                output.operator()(args...) = accum;
-            }, bdims);
+            output_b(out_ind) = accum;
         }
     } else {
         for (index_t out_ind = start_ind; out_ind <= last_ind; out_ind += THREADS) {
@@ -345,27 +362,20 @@ __global__ void ResamplePoly1D_ElemBlock(OutType output, InType input, FilterTyp
             }
 
             output_t accum {};
-            input_t in_val;
             for (index_t i = x_start; i <= x_end; i++) {
-                bdims[Rank - 1] = i;
-                cuda::std::apply([&in_val, &input](auto &&...args) {
-                    in_val = input.operator()(args...);
-                }, bdims);
-                accum += in_val * filter.operator()(h_ind);
+                const input_t in_val = input_b(i);
+                accum += in_val * filter_acc(h_ind);
                 h_ind -= up;
             }
 
             accum *= scale;
-            bdims[Rank - 1] = out_ind;
-            cuda::std::apply([&accum, &output](auto &&...args) {
-                output.operator()(args...) = accum;
-            }, bdims);
+            output_b(out_ind) = accum;
         }
     }
 
 }
 
-template <int THREADS, typename OutType, typename InType, typename FilterType, typename index_t>
+template <int THREADS, bool IsUnitStride, typename OutType, typename InType, typename FilterType, typename index_t>
 __launch_bounds__(MATX_RESAMPLE_POLY_MAX_NUM_THREADS)
 __global__ void ResamplePoly1D_WarpCentric(OutType output, InType input, FilterType filter,
                     index_t up, index_t down, index_t elems_per_warp)
@@ -393,16 +403,24 @@ __global__ void ResamplePoly1D_WarpCentric(OutType output, InType input, FilterT
 
     const int elem_block = blockIdx.z;
 
+    // TensorAccessors with per-block batch binding (see ResamplePoly1D_PhaseBlock).
+    detail::TensorAccessor<InType,     IsUnitStride> input_acc(input);
+    detail::TensorAccessor<OutType,    IsUnitStride> output_acc(output);
+    detail::TensorAccessor<FilterType, IsUnitStride> filter_acc(filter);
+
     if (load_filter_to_smem) {
-        ResamplePoly1D_LoadFilter<THREADS, FilterType>(s_filter, filter);
+        ResamplePoly1D_LoadFilter<THREADS>(s_filter, filter_acc, filter_len);
         if (filter_len % 2 == 0) {
             filter_len++;
         }        
     }
 
-    // All but the last dim are batch indices
+    // Bind the leading Rank-1 batch dims into both accessors. Input and
+    // output share their batch shape, so a single BlockToIdx call feeds both.
     const int batch_idx = blockIdx.x;
-    auto bdims = BlockToIdx(output, batch_idx, 1);
+    const auto batch_idx_arr = BlockToIdx(output, batch_idx, 1);
+    auto input_b  = detail::bind_first_n<Rank - 1>(input_acc,  batch_idx_arr);
+    auto output_b = detail::bind_first_n<Rank - 1>(output_acc, batch_idx_arr);
 
     // Scale the filter coefficients by up to match scipy's convention
     const filter_t scale = static_cast<filter_t>(up);
@@ -423,12 +441,8 @@ __global__ void ResamplePoly1D_WarpCentric(OutType output, InType input, FilterT
             int h_ind = static_cast<int>(filter_central_tap + (up_ind - up*x_start)) - lane_id*up;
 
             output_t accum {};
-            input_t in_val;
             for (index_t i = x_start+lane_id; i <= x_end; i += WARP_SIZE) {
-                bdims[Rank - 1] = i;
-                cuda::std::apply([&in_val, &input](auto &&...args) {
-                    in_val = input.operator()(args...);
-                }, bdims);
+                const input_t in_val = input_b(i);
                 accum += in_val * s_filter[h_ind];
                 h_ind -= up * WARP_SIZE;
             }
@@ -442,10 +456,7 @@ __global__ void ResamplePoly1D_WarpCentric(OutType output, InType input, FilterT
                 accum = cg::reduce(tile, accum, cg::plus<output_t>());
             }
             if (lane_id == 0) {
-                bdims[Rank - 1] = out_ind;
-                cuda::std::apply([&accum, &output](auto &&...args) {
-                    output.operator()(args...) = accum;
-                }, bdims);
+                output_b(out_ind) = accum;
             }
         }
     } else {
@@ -462,13 +473,9 @@ __global__ void ResamplePoly1D_WarpCentric(OutType output, InType input, FilterT
             h_ind -= lane_id*up;
 
             output_t accum {};
-            input_t in_val;
             for (index_t i = x_start+lane_id; i <= x_end; i += WARP_SIZE) {
-                bdims[Rank - 1] = i;
-                cuda::std::apply([&in_val, &input](auto &&...args) {
-                    in_val = input.operator()(args...);
-                }, bdims);
-                accum += in_val * filter.operator()(h_ind);
+                const input_t in_val = input_b(i);
+                accum += in_val * filter_acc(h_ind);
                 h_ind -= up * WARP_SIZE;
             }
 
@@ -481,10 +488,7 @@ __global__ void ResamplePoly1D_WarpCentric(OutType output, InType input, FilterT
                 accum = cg::reduce(tile, accum, cg::plus<output_t>());
             }
             if (lane_id == 0) {
-                bdims[Rank - 1] = out_ind;
-                cuda::std::apply([&accum, &output](auto &&...args) {
-                    output.operator()(args...) = accum;
-                }, bdims);
+                output_b(out_ind) = accum;
             }
         }
     }

--- a/include/matx/kernels/tensor_accessor.h
+++ b/include/matx/kernels/tensor_accessor.h
@@ -116,15 +116,15 @@ struct TensorAccessor {
     }
 
     // Rank-0 access.
-    template <int R = Rank, cuda::std::enable_if_t<R == 0, int> = 0>
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
-    decltype(auto) operator()() const { return op_(); }
+    decltype(auto) operator()() const requires (Rank == 0) { return op_(); }
 
-    // Rank >= 1 access; SFINAE enforces arity == Rank.
-    template <typename... Is,
-              cuda::std::enable_if_t<(Rank >= 1) && sizeof...(Is) == Rank, int> = 0>
+    // Rank >= 1 access; arity must match Rank.
+    template <typename... Is>
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
-    decltype(auto) operator()(Is... is) const {
+    decltype(auto) operator()(Is... is) const
+        requires (Rank >= 1 && sizeof...(Is) == Rank)
+    {
         if constexpr (FastPath) {
             const index_t idx_arr[] = { static_cast<index_t>(is)... };
             // Last-dim stride is 1 under IsUnitStride.
@@ -143,11 +143,11 @@ struct TensorAccessor {
 
     // Bind the first sizeof...(Leading) dimensions. Returns a BoundAccessor
     // with (Rank - sizeof...(Leading)) remaining dims.
-    template <typename... Leading,
-              cuda::std::enable_if_t<(sizeof...(Leading) > 0) &&
-                               (sizeof...(Leading) <= Rank), int> = 0>
+    template <typename... Leading>
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
-    auto bind(Leading... leading) const {
+    auto bind(Leading... leading) const
+        requires (sizeof...(Leading) > 0 && sizeof...(Leading) <= Rank)
+    {
         return BoundAccessor<Op, IsUnitStride, sizeof...(Leading)>(
             *this, static_cast<index_t>(leading)...);
     }
@@ -224,9 +224,8 @@ struct BoundAccessor {
     }
 
     // Rank-0 remainder: nullary.
-    template <int R = Rank, cuda::std::enable_if_t<R == 0, int> = 0>
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
-    decltype(auto) operator()() const {
+    decltype(auto) operator()() const requires (Rank == 0) {
         if constexpr (FastPath) {
             return base_[0];
         } else {
@@ -235,10 +234,11 @@ struct BoundAccessor {
     }
 
     // Rank >= 1 remainder: variadic, arity == Rank.
-    template <typename... Is,
-              cuda::std::enable_if_t<(Rank >= 1) && sizeof...(Is) == Rank, int> = 0>
+    template <typename... Is>
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
-    decltype(auto) operator()(Is... is) const {
+    decltype(auto) operator()(Is... is) const
+        requires (Rank >= 1 && sizeof...(Is) == Rank)
+    {
         if constexpr (FastPath) {
             const index_t idx_arr[] = { static_cast<index_t>(is)... };
             index_t offset = idx_arr[Rank - 1];

--- a/include/matx/transforms/resample_poly.h
+++ b/include/matx/transforms/resample_poly.h
@@ -118,50 +118,77 @@ inline void matxResamplePoly1DInternal(OutType &o, const InType &i,
     return (max_outlen_per_cta + cta_comp_unit_count * grid.z - 1) / (cta_comp_unit_count * grid.z);
   };
 
+  // Unit-stride fast path: only viable when every hot tensor is a tensor view
+  // (Data()/Stride() callable) AND each one's last-dim stride is 1. The
+  // TensorAccessor in the kernel takes the fast pointer-arithmetic path when
+  // IsUnitStride is true; otherwise it forwards to operator() and works for
+  // any MatX op (computed ops included).
+  constexpr bool fast_path_eligible =
+      is_tensor_view_v<OutType> &&
+      is_tensor_view_v<InType> &&
+      is_tensor_view_v<FilterType>;
+
+  bool is_unit_stride = false;
+  if constexpr (fast_path_eligible) {
+    is_unit_stride =
+        o.Stride(OutType::Rank() - 1) == 1 &&
+        i.Stride(InType::Rank() - 1) == 1 &&
+        filter.Stride(FilterType::Rank() - 1) == 1;
+  }
+
   constexpr int THREADS = MATX_RESAMPLE_POLY_MAX_NUM_THREADS;
-  if (kernel == ResampleKernel::PhaseBlock) {
-    const size_t smemBytes = (sizeof(filter_t) * max_phase_len <= MATX_RESAMPLE_POLY_MAX_SMEM_BYTES) ?
-      sizeof(filter_t) * max_phase_len : 0;
-    const index_t max_output_len_per_phase = (output_len + up - 1) / up;
-    grid.y = static_cast<int>(up);
-    const index_t elems_per_thread = compute_elems_per_comp_unit(max_output_len_per_phase, THREADS);
-    if (downcast_to_32b_index()) {
-      ResamplePoly1D_PhaseBlock<THREADS, OutType, InType, FilterType, int32_t><<<grid, THREADS, smemBytes, stream>>>(
-        o, i, filter, static_cast<int32_t>(up), static_cast<int32_t>(down),
-        static_cast<int32_t>(elems_per_thread));
-    } else {
-      ResamplePoly1D_PhaseBlock<THREADS, OutType, InType, FilterType, index_t><<<grid, THREADS, smemBytes, stream>>>(
-        o, i, filter, up, down, elems_per_thread);
-    }
-  } else if (kernel == ResampleKernel::ElemBlock) {
-    const size_t filter_sz_bytes = (filter_len % 2 == 0) ? sizeof(filter_t)*(filter_len+1) : sizeof(filter_t)*filter_len;
-    const size_t smemBytes = (filter_sz_bytes <= MATX_RESAMPLE_POLY_MAX_SMEM_BYTES) ? filter_sz_bytes : 0;
-    const index_t elems_per_thread = compute_elems_per_comp_unit(output_len, THREADS);
-    if (downcast_to_32b_index()) {
-      ResamplePoly1D_ElemBlock<THREADS, OutType, InType, FilterType, int32_t><<<grid, THREADS, smemBytes, stream>>>(
-        o, i, filter, static_cast<int32_t>(up), static_cast<int32_t>(down),
-        static_cast<int32_t>(elems_per_thread));
-    } else {
-      ResamplePoly1D_ElemBlock<THREADS, OutType, InType, FilterType, index_t><<<grid, THREADS, smemBytes, stream>>>(
-        o, i, filter, up, down, elems_per_thread);
-    }
-  } else {
-    // We only select the WarpCentric kernel for trivially copyable types, but we need this
-    // constexpr if to avoid instantiating the kernel with inappropriate types.
-    if constexpr (std::is_trivially_copyable_v<output_t>) {
+  auto dispatch_kernel = [&](auto is_unit_c) {
+    constexpr bool IsUnitStride = decltype(is_unit_c)::value;
+    if (kernel == ResampleKernel::PhaseBlock) {
+      const size_t smemBytes = (sizeof(filter_t) * max_phase_len <= MATX_RESAMPLE_POLY_MAX_SMEM_BYTES) ?
+        sizeof(filter_t) * max_phase_len : 0;
+      const index_t max_output_len_per_phase = (output_len + up - 1) / up;
+      grid.y = static_cast<int>(up);
+      const index_t elems_per_thread = compute_elems_per_comp_unit(max_output_len_per_phase, THREADS);
+      if (downcast_to_32b_index()) {
+        ResamplePoly1D_PhaseBlock<THREADS, IsUnitStride, OutType, InType, FilterType, int32_t><<<grid, THREADS, smemBytes, stream>>>(
+          o, i, filter, static_cast<int32_t>(up), static_cast<int32_t>(down),
+          static_cast<int32_t>(elems_per_thread));
+      } else {
+        ResamplePoly1D_PhaseBlock<THREADS, IsUnitStride, OutType, InType, FilterType, index_t><<<grid, THREADS, smemBytes, stream>>>(
+          o, i, filter, up, down, elems_per_thread);
+      }
+    } else if (kernel == ResampleKernel::ElemBlock) {
       const size_t filter_sz_bytes = (filter_len % 2 == 0) ? sizeof(filter_t)*(filter_len+1) : sizeof(filter_t)*filter_len;
       const size_t smemBytes = (filter_sz_bytes <= MATX_RESAMPLE_POLY_MAX_SMEM_BYTES) ? filter_sz_bytes : 0;
-      static_assert(THREADS % WARP_SIZE == 0);
-      const index_t elems_per_warp = compute_elems_per_comp_unit(output_len, THREADS/WARP_SIZE);
+      const index_t elems_per_thread = compute_elems_per_comp_unit(output_len, THREADS);
       if (downcast_to_32b_index()) {
-        ResamplePoly1D_WarpCentric<THREADS, OutType, InType, FilterType, int32_t><<<grid, THREADS, smemBytes, stream>>>(
+        ResamplePoly1D_ElemBlock<THREADS, IsUnitStride, OutType, InType, FilterType, int32_t><<<grid, THREADS, smemBytes, stream>>>(
           o, i, filter, static_cast<int32_t>(up), static_cast<int32_t>(down),
-          static_cast<int32_t>(elems_per_warp));
+          static_cast<int32_t>(elems_per_thread));
       } else {
-        ResamplePoly1D_WarpCentric<THREADS, OutType, InType, FilterType, index_t><<<grid, THREADS, smemBytes, stream>>>(
-          o, i, filter, up, down, elems_per_warp);
+        ResamplePoly1D_ElemBlock<THREADS, IsUnitStride, OutType, InType, FilterType, index_t><<<grid, THREADS, smemBytes, stream>>>(
+          o, i, filter, up, down, elems_per_thread);
+      }
+    } else {
+      // We only select the WarpCentric kernel for trivially copyable types, but we need this
+      // constexpr if to avoid instantiating the kernel with inappropriate types.
+      if constexpr (std::is_trivially_copyable_v<output_t>) {
+        const size_t filter_sz_bytes = (filter_len % 2 == 0) ? sizeof(filter_t)*(filter_len+1) : sizeof(filter_t)*filter_len;
+        const size_t smemBytes = (filter_sz_bytes <= MATX_RESAMPLE_POLY_MAX_SMEM_BYTES) ? filter_sz_bytes : 0;
+        static_assert(THREADS % WARP_SIZE == 0);
+        const index_t elems_per_warp = compute_elems_per_comp_unit(output_len, THREADS/WARP_SIZE);
+        if (downcast_to_32b_index()) {
+          ResamplePoly1D_WarpCentric<THREADS, IsUnitStride, OutType, InType, FilterType, int32_t><<<grid, THREADS, smemBytes, stream>>>(
+            o, i, filter, static_cast<int32_t>(up), static_cast<int32_t>(down),
+            static_cast<int32_t>(elems_per_warp));
+        } else {
+          ResamplePoly1D_WarpCentric<THREADS, IsUnitStride, OutType, InType, FilterType, index_t><<<grid, THREADS, smemBytes, stream>>>(
+            o, i, filter, up, down, elems_per_warp);
+        }
       }
     }
+  };
+
+  if (is_unit_stride) {
+    dispatch_kernel(cuda::std::bool_constant<true>{});
+  } else {
+    dispatch_kernel(cuda::std::bool_constant<false>{});
   }
 #endif
 }


### PR DESCRIPTION
Adopt the TensorAccessor class for the resample_poly kernels. Also add new resample_poly benchmarks and convert TensorAccessor to use concepts/requires instead of SFINAE.

Performance improvements from the TensorAccessor vary from -1%-19% over a variety of test cases. The regression cases seem to generally be related to different compiler-chosen unrolling factors (normally higher with the adoption of TensorAccessor).