### PR TITLE
PermuteOp: Verify remapped axes and prevent maybe-uninitialized warnings

### DIFF
--- a/examples/sarbp/sarbp.cu
+++ b/examples/sarbp/sarbp.cu
@@ -98,16 +98,6 @@
 
 using namespace matx;
 
-#define CUDA_CHECK(call)                                                       \
-  do {                                                                         \
-    cudaError_t err = (call);                                                  \
-    if (err != cudaSuccess) {                                                  \
-      std::cerr << "CUDA error at " << __FILE__ << ":" << __LINE__ << " - "   \
-                << cudaGetErrorString(err) << std::endl;                       \
-      std::exit(1);                                                            \
-    }                                                                          \
-  } while (0)
-
 // ---------------------------------------------------------------------------
 // .sarbp file header (matches Python writer)
 // ---------------------------------------------------------------------------
@@ -321,20 +311,20 @@ int main(int argc, char **argv) {
   complex_t *h_range_profiles = nullptr;
   int16_t *h_range_profiles_i16 = nullptr;
 
-  CUDA_CHECK(cudaHostAlloc(&h_positions,
+  MATX_CUDA_CHECK(cudaHostAlloc(&h_positions,
       static_cast<size_t>(num_pulses) * sizeof(double3), cudaHostAllocDefault));
-  CUDA_CHECK(cudaHostAlloc(&h_range_to_mcp,
+  MATX_CUDA_CHECK(cudaHostAlloc(&h_range_to_mcp,
       static_cast<size_t>(num_pulses) * sizeof(double), cudaHostAllocDefault));
 
   if (is_int16_mode) {
-    CUDA_CHECK(cudaHostAlloc(&h_ampsf,
+    MATX_CUDA_CHECK(cudaHostAlloc(&h_ampsf,
         static_cast<size_t>(num_pulses) * sizeof(float), cudaHostAllocDefault));
     // int16 pairs: num_range_bins * 2 int16 per pulse
-    CUDA_CHECK(cudaHostAlloc(&h_range_profiles_i16,
+    MATX_CUDA_CHECK(cudaHostAlloc(&h_range_profiles_i16,
         static_cast<size_t>(num_pulses) * static_cast<size_t>(num_range_bins) * 2 * sizeof(int16_t),
         cudaHostAllocDefault));
   } else {
-    CUDA_CHECK(cudaHostAlloc(&h_range_profiles,
+    MATX_CUDA_CHECK(cudaHostAlloc(&h_range_profiles,
         static_cast<size_t>(num_pulses) * static_cast<size_t>(num_range_bins) * sizeof(complex_t),
         cudaHostAllocDefault));
   }
@@ -469,7 +459,7 @@ int main(int argc, char **argv) {
   std::cout << "BP precision     : " << precision_type << std::endl;
 
   cudaStream_t stream;
-  CUDA_CHECK(cudaStreamCreate(&stream));
+  MATX_CUDA_CHECK(cudaStreamCreate(&stream));
   cudaExecutor exec{stream};
 
   // Pre-allocate GPU block buffers (sized for largest block)
@@ -565,24 +555,24 @@ int main(int argc, char **argv) {
   const size_t num_pixels =
       static_cast<size_t>(image_height) * static_cast<size_t>(image_width);
   complex_t *h_image = nullptr;
-  CUDA_CHECK(cudaHostAlloc(&h_image, num_pixels * sizeof(complex_t), cudaHostAllocDefault));
+  MATX_CUDA_CHECK(cudaHostAlloc(&h_image, num_pixels * sizeof(complex_t), cudaHostAllocDefault));
 
   std::cout << "Running backprojection (" << output_range_bins << " range bins, del_r="
             << del_r << " m)..." << std::endl;
 
   cudaEvent_t ev_start, ev_stop;
-  CUDA_CHECK(cudaEventCreate(&ev_start));
-  CUDA_CHECK(cudaEventCreate(&ev_stop));
+  MATX_CUDA_CHECK(cudaEventCreate(&ev_start));
+  MATX_CUDA_CHECK(cudaEventCreate(&ev_stop));
 
   std::vector<cudaEvent_t> ev_bp_start(num_blocks);
   std::vector<cudaEvent_t> ev_bp_stop(num_blocks);
   for (index_t blk = 0; blk < num_blocks; blk++) {
-    CUDA_CHECK(cudaEventCreate(&ev_bp_start[blk]));
-    CUDA_CHECK(cudaEventCreate(&ev_bp_stop[blk]));
+    MATX_CUDA_CHECK(cudaEventCreate(&ev_bp_start[blk]));
+    MATX_CUDA_CHECK(cudaEventCreate(&ev_bp_stop[blk]));
   }
 
   cudaProfilerStart();
-  CUDA_CHECK(cudaEventRecord(ev_start, stream));
+  MATX_CUDA_CHECK(cudaEventRecord(ev_start, stream));
 
   for (index_t blk = 0; blk < num_blocks; blk++) {
     const index_t p0 = blk * block_size;
@@ -595,11 +585,11 @@ int main(int argc, char **argv) {
     auto cur_rtm       = matx::slice(blk_rtm,       {0},    {npulses});
 
     // Upload platform positions and range_to_mcp for this block
-    CUDA_CHECK(cudaMemcpyAsync(cur_positions.Data(),
+    MATX_CUDA_CHECK(cudaMemcpyAsync(cur_positions.Data(),
                     h_positions + p0,
                     static_cast<size_t>(npulses) * sizeof(double3),
                     cudaMemcpyHostToDevice, stream));
-    CUDA_CHECK(cudaMemcpyAsync(cur_rtm.Data(),
+    MATX_CUDA_CHECK(cudaMemcpyAsync(cur_rtm.Data(),
                     h_range_to_mcp + p0,
                     static_cast<size_t>(npulses) * sizeof(double),
                     cudaMemcpyHostToDevice, stream));
@@ -611,11 +601,11 @@ int main(int argc, char **argv) {
         // Upload int16 I/Q pairs and per-pulse scale
         auto cur_fx_i16 = matx::slice(blk_fx_i16, {0, 0}, {npulses, num_samples_raw * 2});
         auto cur_ampsf = matx::slice(blk_ampsf, {0}, {npulses});
-        CUDA_CHECK(cudaMemcpyAsync(cur_fx_i16.Data(),
+        MATX_CUDA_CHECK(cudaMemcpyAsync(cur_fx_i16.Data(),
                         h_range_profiles_i16 + p0 * num_samples_raw * 2,
                         static_cast<size_t>(npulses) * static_cast<size_t>(num_samples_raw) * 2 * sizeof(int16_t),
                         cudaMemcpyHostToDevice, stream));
-        CUDA_CHECK(cudaMemcpyAsync(cur_ampsf.Data(),
+        MATX_CUDA_CHECK(cudaMemcpyAsync(cur_ampsf.Data(),
                         h_ampsf + p0,
                         static_cast<size_t>(npulses) * sizeof(float),
                         cudaMemcpyHostToDevice, stream));
@@ -641,21 +631,21 @@ int main(int argc, char **argv) {
         }
       } else {
         // Upload complex64 samples directly
-        CUDA_CHECK(cudaMemcpyAsync(cur_fx.Data(),
+        MATX_CUDA_CHECK(cudaMemcpyAsync(cur_fx.Data(),
                         h_range_profiles + p0 * num_samples_raw,
                         static_cast<size_t>(npulses) * static_cast<size_t>(num_samples_raw) * sizeof(complex_t),
                         cudaMemcpyHostToDevice, stream));
 
         if (apply_window) {
           (cur_fx = cur_fx * matx::hamming<1>({npulses, num_samples_raw})).run(exec);
-          CUDA_CHECK(cudaGetLastError());
+          MATX_CUDA_CHECK(cudaGetLastError());
         }
       }
 
       // Zero only the padding region (middle of each row after ifftshift)
       const index_t pad_size = fft_size - num_samples_raw;
       if (pad_size > 0) {
-        CUDA_CHECK(cudaMemset2DAsync(
+        MATX_CUDA_CHECK(cudaMemset2DAsync(
             cur_profiles.Data() + (num_samples_raw - ifft_shift),
             static_cast<size_t>(fft_size) * sizeof(complex_t),
             0,
@@ -665,7 +655,7 @@ int main(int argc, char **argv) {
       }
 
       // Second half of spectrum (indices shift..N-1) -> start of padded row
-      CUDA_CHECK(cudaMemcpy2DAsync(
+      MATX_CUDA_CHECK(cudaMemcpy2DAsync(
           cur_profiles.Data(),
           static_cast<size_t>(fft_size) * sizeof(complex_t),
           cur_fx.Data() + ifft_shift,
@@ -675,7 +665,7 @@ int main(int argc, char **argv) {
           cudaMemcpyDeviceToDevice, stream));
 
       // First half of spectrum (indices 0..shift-1) -> end of padded row
-      CUDA_CHECK(cudaMemcpy2DAsync(
+      MATX_CUDA_CHECK(cudaMemcpy2DAsync(
           cur_profiles.Data() + (fft_size - ifft_shift),
           static_cast<size_t>(fft_size) * sizeof(complex_t),
           cur_fx.Data(),
@@ -696,19 +686,19 @@ int main(int argc, char **argv) {
       (cur_profiles = matx::fftshift1D(cur_compressed)).run(exec);
     } else {
       // Pre-compressed: simple copy
-      CUDA_CHECK(cudaMemcpyAsync(cur_profiles.Data(),
+      MATX_CUDA_CHECK(cudaMemcpyAsync(cur_profiles.Data(),
                       h_range_profiles + p0 * num_range_bins,
                       static_cast<size_t>(npulses) * static_cast<size_t>(num_range_bins) * sizeof(complex_t),
                       cudaMemcpyHostToDevice, stream));
     }
 
     // Backprojection - accumulates this block's pulses into image
-    CUDA_CHECK(cudaEventRecord(ev_bp_start[blk], stream));
+    MATX_CUDA_CHECK(cudaEventRecord(ev_bp_start[blk], stream));
     (image = matx::experimental::sar_bp(image, cur_profiles,
                                          cur_positions, voxel_locations,
                                          cur_rtm, params))
         .run(exec);
-    CUDA_CHECK(cudaEventRecord(ev_bp_stop[blk], stream));
+    MATX_CUDA_CHECK(cudaEventRecord(ev_bp_stop[blk], stream));
 
     if (num_blocks > 1) {
       std::cout << "\r  Block " << (blk + 1) << " / " << num_blocks << std::flush;
@@ -716,22 +706,22 @@ int main(int argc, char **argv) {
   }
 
   // Copy result to pinned host buffer (included in timed region)
-  CUDA_CHECK(cudaMemcpyAsync(h_image, image.Data(), num_pixels * sizeof(complex_t),
+  MATX_CUDA_CHECK(cudaMemcpyAsync(h_image, image.Data(), num_pixels * sizeof(complex_t),
              cudaMemcpyDeviceToHost, stream));
 
-  CUDA_CHECK(cudaEventRecord(ev_stop, stream));
+  MATX_CUDA_CHECK(cudaEventRecord(ev_stop, stream));
 
   exec.sync();
   cudaProfilerStop();
 
   float elapsed_ms = 0;
-  CUDA_CHECK(cudaEventElapsedTime(&elapsed_ms, ev_start, ev_stop));
+  MATX_CUDA_CHECK(cudaEventElapsedTime(&elapsed_ms, ev_start, ev_stop));
   if (num_blocks > 1) std::cout << std::endl;
 
   float bp_elapsed_ms = 0;
   for (index_t blk = 0; blk < num_blocks; blk++) {
     float blk_ms = 0;
-    CUDA_CHECK(cudaEventElapsedTime(&blk_ms, ev_bp_start[blk], ev_bp_stop[blk]));
+    MATX_CUDA_CHECK(cudaEventElapsedTime(&blk_ms, ev_bp_start[blk], ev_bp_stop[blk]));
     bp_elapsed_ms += blk_ms;
   }
 
@@ -749,11 +739,11 @@ int main(int argc, char **argv) {
             << num_blocks << " block" << (num_blocks > 1 ? "s" : "") << ")" << std::endl;
   std::cout << "  Rate                : " << bp_gbp_per_sec << " Gbp/s" << std::endl;
 
-  CUDA_CHECK(cudaEventDestroy(ev_start));
-  CUDA_CHECK(cudaEventDestroy(ev_stop));
+  MATX_CUDA_CHECK(cudaEventDestroy(ev_start));
+  MATX_CUDA_CHECK(cudaEventDestroy(ev_stop));
   for (index_t blk = 0; blk < num_blocks; blk++) {
-    CUDA_CHECK(cudaEventDestroy(ev_bp_start[blk]));
-    CUDA_CHECK(cudaEventDestroy(ev_bp_stop[blk]));
+    MATX_CUDA_CHECK(cudaEventDestroy(ev_bp_start[blk]));
+    MATX_CUDA_CHECK(cudaEventDestroy(ev_bp_stop[blk]));
   }
 
   // -------------------------------------------------------------------
@@ -773,14 +763,14 @@ int main(int argc, char **argv) {
   std::cout << "Wrote " << image_height << " x " << image_width
             << " complex<float> image to " << output_file << std::endl;
 
-  CUDA_CHECK(cudaFreeHost(h_positions));
-  CUDA_CHECK(cudaFreeHost(h_range_to_mcp));
-  if (h_range_profiles) CUDA_CHECK(cudaFreeHost(h_range_profiles));
-  if (h_range_profiles_i16) CUDA_CHECK(cudaFreeHost(h_range_profiles_i16));
-  if (h_ampsf) CUDA_CHECK(cudaFreeHost(h_ampsf));
-  CUDA_CHECK(cudaFreeHost(h_image));
+  MATX_CUDA_CHECK(cudaFreeHost(h_positions));
+  MATX_CUDA_CHECK(cudaFreeHost(h_range_to_mcp));
+  if (h_range_profiles) MATX_CUDA_CHECK(cudaFreeHost(h_range_profiles));
+  if (h_range_profiles_i16) MATX_CUDA_CHECK(cudaFreeHost(h_range_profiles_i16));
+  if (h_ampsf) MATX_CUDA_CHECK(cudaFreeHost(h_ampsf));
+  MATX_CUDA_CHECK(cudaFreeHost(h_image));
   matx::ClearCachesAndAllocations();
-  CUDA_CHECK(cudaStreamDestroy(stream));
+  MATX_CUDA_CHECK(cudaStreamDestroy(stream));
   MATX_EXIT_HANDLER();
 
   return 0;

--- a/include/matx/executors/jit_cuda.h
+++ b/include/matx/executors/jit_cuda.h
@@ -185,15 +185,27 @@ namespace matx
                 "Please break up your operator statement into multiple executions to limit the size of the parameters");
           }
 
-          cuda::std::array<index_t, RANK> sizes;
-          for (int i = 0; i < RANK; i++) {
+          // The dynamic-rank dispatch in Exec() instantiates ExecWithRank for
+          // every switch arm, so this template is compiled for RANK values
+          // that exceed Op::Rank() (dead arms — never reached at runtime,
+          // since the dynamic source's runtime rank must match Op::Rank()).
+          // Cap both copies at min(RANK, Op::Rank()) so the dead instantiations
+          // don't read past op.Size() bounds or write past op_sizes, which
+          // trips -Werror=aggressive-loop-optimizations on older GCC. The
+          // unfilled slots stay zero from `{}`-init; in the live arm this is
+          // a no-op (RANK == Op::Rank()), and in the genuine dynamic case
+          // (Op::Rank() > RANK) the trailing zeros were already the intent.
+          constexpr int kSizeCount =
+              (RANK < static_cast<int>(Op::Rank())) ? RANK : static_cast<int>(Op::Rank());
+
+          cuda::std::array<index_t, RANK> sizes{};
+          for (int i = 0; i < kSizeCount; i++) {
             sizes[i] = op.Size(i);
           }
 
-          // For dynamic tensors, Op::Rank() may differ from RANK.
           // create_kernel_provider requires an Op::Rank()-sized array.
           cuda::std::array<index_t, Op::Rank()> op_sizes{};
-          for (int i = 0; i < RANK; i++) {
+          for (int i = 0; i < kSizeCount; i++) {
             op_sizes[i] = sizes[i];
           }
 

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -104,18 +104,24 @@ namespace matx
                 detail::array_to_string(out_dims_, actual_rank) + " };\n" +
                 "  constexpr static cuda::std::array<int32_t, Rank_> dims_ = " + dims_array + ";\n" +
                 "  typename detail::inner_storage_or_self_t<detail::base_type_t<T>> op_;\n" +
+                "  template <size_t K, typename Dims, typename Inds>\n" +
+                "  static __MATX_INLINE__ __MATX_DEVICE__ index_t lookup_for_axis_(const Dims &dims, const Inds &inds) {\n" +
+                "    index_t result = 0;\n" +
+                "    for(int32_t j = 0; j < Rank_; j++) {\n" +
+                "      if(dims[j] == static_cast<int32_t>(K)) result = inds[j];\n" +
+                "    }\n" +
+                "    return result;\n" +
+                "  }\n" +
+                "  template <typename CapType, typename Op, typename Dims, typename Inds, size_t... K>\n" +
+                "  static __MATX_INLINE__ __MATX_DEVICE__ decltype(auto) apply_permuted_(Op &&op, const Dims &dims, const Inds &inds, cuda::std::index_sequence<K...>) {\n" +
+                "    return get_value<CapType>(cuda::std::forward<Op>(op), cuda::std::array<index_t, Rank_>{lookup_for_axis_<K>(dims, inds)...});\n" +
+                "  }\n" +
                 "  template <typename CapType, typename... Is>\n" +
                 "  __MATX_INLINE__ __MATX_DEVICE__ decltype(auto) operator()(Is... indices) const\n" +
                 "  {\n" +
                 "    if constexpr (CapType::ept == ElementsPerThread::ONE) {\n" +
-                "      cuda::std::array<index_t, Rank_> inds{indices...};\n" +
-                "      cuda::std::array<index_t, Rank_> ind;\n" +
-                "      for(int32_t i = 0; i < Rank_; i++) {\n" +
-                "        for(int32_t j = 0; j < Rank_; j++) {\n" +
-                "          if(dims_[j] == i) ind[i] = inds[j];\n" +
-                "        }\n" +
-                "      }\n" +
-                "      return get_value<CapType>(op_, ind);\n" +
+                "      const cuda::std::array<index_t, Rank_> inds{indices...};\n" +
+                "      return apply_permuted_<CapType>(op_, dims_, inds, cuda::std::make_index_sequence<Rank_>{});\n" +
                 "    } else {\n" +
                 "      return Vector<value_type, static_cast<index_t>(CapType::ept)>{};\n" +
                 "    }\n" +
@@ -136,11 +142,11 @@ namespace matx
 
         static_assert(Rank() > 0, "PermuteOp: Rank of operator must be greater than 0.");
 
-	      __MATX_INLINE__ PermuteOp(const T &op, const cuda::std::array<int32_t, T::Rank()> &dims) : op_(op) {
+        __MATX_INLINE__ PermuteOp(const T &op, const cuda::std::array<int32_t, T::Rank()> &dims) : op_(op) {
 
-          [[maybe_unused]] cuda::std::array<bool, Rank()> seen{};
+          cuda::std::array<bool, Rank()> seen{};
           for(int32_t i = 0; i < Rank(); i++) {
-            [[maybe_unused]] int32_t dim = dims[i];
+            const int32_t dim = dims[i];
             MATX_ASSERT_STR(dim < Rank() && dim >= 0, matxInvalidDim, "PermuteOp:  Invalid permute index.");
             MATX_ASSERT_STR(!seen[dim], matxInvalidDim, "PermuteOp:  Duplicate permute index.");
             seen[dim] = true;

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -138,13 +138,53 @@ namespace matx
 
 	      __MATX_INLINE__ PermuteOp(const T &op, const cuda::std::array<int32_t, T::Rank()> &dims) : op_(op) {
 
+          [[maybe_unused]] cuda::std::array<bool, Rank()> seen{};
           for(int32_t i = 0; i < Rank(); i++) {
             [[maybe_unused]] int32_t dim = dims[i];
             MATX_ASSERT_STR(dim < Rank() && dim >= 0, matxInvalidDim, "PermuteOp:  Invalid permute index.");
+            MATX_ASSERT_STR(!seen[dim], matxInvalidDim, "PermuteOp:  Duplicate permute index.");
+            seen[dim] = true;
 
             dims_[i] = dims[i];
           }
           MATX_LOG_TRACE("{} constructor: rank={}", str(), Rank());
+        }
+
+        // For permuted-output axis K, find the input axis j with dims[j]==K
+        // and return inds[j]. The accumulator form with a conditional store
+        // (rather than an early return) is intentional: ptxas keeps `result`
+        // in a register and the unrolled loop becomes a predicated chain. An
+        // early-return inside the unrolled loop spills the inds array to
+        // local memory because each iteration becomes a real exit edge that
+        // inhibits the optimization. With the constructor's range +
+        // uniqueness checks, exactly one j matches per K.
+        template <size_t K, typename Dims, typename Inds>
+        static __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ index_t
+        lookup_for_axis_(const Dims &dims, const Inds &inds)
+        {
+          index_t result = 0;
+          MATX_LOOP_UNROLL
+          for (int32_t j = 0; j < Rank(); j++) {
+            if (dims[j] == static_cast<int32_t>(K)) {
+              result = inds[j];
+            }
+          }
+          return result;
+        }
+
+        // Aggregate-initialize the permuted-index array via the parameter pack
+        // expansion of lookup_for_axis_<K>(...) and forward it to op. Avoids a
+        // mutable local array, which was the source of register spills (when
+        // built via direct indexed store) and warnings (when conditionally
+        // written in a double loop).
+        template <typename CapType, typename Op, typename Dims, typename Inds, size_t... K>
+        static __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto)
+        apply_permuted_(Op &&op, const Dims &dims, const Inds &inds,
+                        cuda::std::index_sequence<K...>)
+        {
+          return get_value<CapType>(cuda::std::forward<Op>(op),
+                                    cuda::std::array<index_t, Rank()>{
+                                        lookup_for_axis_<K>(dims, inds)...});
         }
 
         template <typename CapType, typename Op, typename Dims, typename... Is>
@@ -154,31 +194,10 @@ namespace matx
             static_assert(sizeof...(Is)==Rank());
             static_assert((std::is_convertible_v<Is, index_t> && ... ));
 
-            // convert variadic type to tuple so we can read/update
-            cuda::std::array<index_t, Rank()> inds{indices...};
-MATX_IGNORE_WARNING_PUSH_GCC("-Wmaybe-uninitialized")
-            cuda::std::array<index_t, Rank()> ind;
-MATX_IGNORE_WARNING_POP_GCC
-
-#if 0
-    //This causes register spills but might be faster if Rank is large
-MATX_LOOP_UNROLL
-            for(int32_t i = 0; i < Rank(); i++) {
-              ind[dims_[i]] = inds[i];
-            }
-#else
-MATX_LOOP_UNROLL
-      // use double loop to avoid register spills
-            for(int32_t i = 0; i < Rank(); i++) {
-MATX_LOOP_UNROLL
-              for(int32_t j = 0; j < Rank(); j++) {
-                if(dims[j] == i) {
-                  ind[i] = inds[j];
-                }
-              }
-            }
-#endif
-            return get_value<CapType>(cuda::std::forward<Op>(op), ind);
+            const cuda::std::array<index_t, Rank()> inds{indices...};
+            return apply_permuted_<CapType>(cuda::std::forward<Op>(op),
+                                            dims, inds,
+                                            cuda::std::make_index_sequence<Rank()>{});
           } else {
             return Vector<value_type, static_cast<index_t>(CapType::ept)>{};
           }


### PR DESCRIPTION
Verify in the PermuteOp constructor that each tensor axis appears in the index list exactly once. Previously, an axis could be duplicated, which would result in another axis being uninitialized.

A stack array of size Rank() was previously uninitialized prior to populating it with the remapped version of the user-provided indices. This could result in maybe-uninitialized compiler warnings, even though the constructor validated that all array entries would be initialized. Switch to an index-sequence-based fold expression as an alternative to avoid the local array. I verified that this approach matches the original in terms of having no associated stack and the same register usage.