### PR TITLE
Various compiler fixes for nightly compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ option(MATX_EN_EXTENDED_LAMBDA "Enable extended lambda support for device/host l
 option(MATX_EN_JIT "Enable CUDA JIT compilation support via NVRTC" OFF)
 option(MATX_EN_MATHDX "Enable MathDx support for kernel fusion" OFF)
 option(MATX_EN_UNSAFE_ALIAS_DETECTION "Enable aliased memory detection" OFF)
-option(MATX_CHECK_NARROWING_CONVERSIONS "Enable compile-time checks for narrowing assignment conversions" ON)
+option(MATX_CHECK_NARROWING_CONVERSIONS "Enable compile-time checks for narrowing assignment conversions" OFF)
 option(MATX_DISABLE_EXCEPTIONS "Disable C++ exceptions and log errors instead" OFF)
 
 set(MATX_EN_PYBIND11 OFF CACHE BOOL "Enable pybind11 support")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ option(MATX_EN_EXTENDED_LAMBDA "Enable extended lambda support for device/host l
 option(MATX_EN_JIT "Enable CUDA JIT compilation support via NVRTC" OFF)
 option(MATX_EN_MATHDX "Enable MathDx support for kernel fusion" OFF)
 option(MATX_EN_UNSAFE_ALIAS_DETECTION "Enable aliased memory detection" OFF)
+option(MATX_CHECK_NARROWING_CONVERSIONS "Enable compile-time checks for narrowing assignment conversions" ON)
 option(MATX_DISABLE_EXCEPTIONS "Disable C++ exceptions and log errors instead" OFF)
 
 set(MATX_EN_PYBIND11 OFF CACHE BOOL "Enable pybind11 support")
@@ -228,6 +229,9 @@ endif()
 if (MATX_EN_UNSAFE_ALIAS_DETECTION)
     target_compile_definitions(matx INTERFACE MATX_EN_UNSAFE_ALIAS_DETECTION)
 endif()
+
+target_compile_definitions(matx INTERFACE
+    MATX_CHECK_NARROWING_CONVERSIONS=$<BOOL:${MATX_CHECK_NARROWING_CONVERSIONS}>)
 
 # Host support
 if (MATX_EN_NVPL OR MATX_EN_X86_FFTW OR MATX_EN_BLIS OR MATX_EN_OPENBLAS)

--- a/bench/00_sparse/SpMM.cu
+++ b/bench/00_sparse/SpMM.cu
@@ -22,10 +22,19 @@ void pow2_SpMM_bench(nvbench::state &state, nvbench::type_list<ValueType>)
   auto B = make_tensor<ValueType, 2>({K, N}, MATX_DEVICE_MEMORY);
   auto C = make_tensor<ValueType, 2>({M, N}, MATX_DEVICE_MEMORY);
 
-  (A = diag(1.0)).run(exec);  // very simple sparse matrix
-                              // with density = min(m,k) / m*k
-  (B = ones()).run(exec);
-  (C = zeros()).run(exec);
+  if constexpr (is_complex_v<ValueType>) {
+    using DiagType = typename ValueType::value_type;
+    (A = diag<DiagType>(DiagType{1})).run(exec);  // very simple sparse matrix
+  }
+  else if constexpr (cuda::std::is_same_v<ValueType, double>) {
+    (A = diag<double>(1.0)).run(exec);  // very simple sparse matrix
+  }
+  else {
+    (A = diag<float>(1.0f)).run(exec);  // very simple sparse matrix
+  }
+  // with density = min(m,k) / m*k
+  (B = ones<ValueType>()).run(exec);
+  (C = zeros<ValueType>()).run(exec);
 
   auto Acoo = experimental::make_zero_tensor_coo<ValueType, index_t>({M, K}, MATX_DEVICE_MEMORY);
   (Acoo = dense2sparse(A)).run(exec);

--- a/bench/00_transform/svd_power.cu
+++ b/bench/00_transform/svd_power.cu
@@ -33,9 +33,9 @@ void svdpi_batch(nvbench::state &state,
 
   (A = random<float>({batch, m, n}, NORMAL)).run(exec);
 
-  (U = 0).run(exec);
-  (S = 0).run(exec);
-  (VT = 0).run(exec);
+  (U = AType{0}).run(exec);
+  (S = SType{0}).run(exec);
+  (VT = AType{0}).run(exec);
   auto x0 = random<float>({batch, r}, NORMAL);
 
   // warm up
@@ -81,9 +81,9 @@ void svdbpi_batch(nvbench::state &state,
 
   (A = random<float>({batch, m, n}, NORMAL)).run(exec);
 
-  (U = 0).run(exec);
-  (S = 0).run(exec);
-  (VT = 0).run(exec);
+  (U = AType{0}).run(exec);
+  (S = SType{0}).run(exec);
+  (VT = AType{0}).run(exec);
 
   // warm up
   nvtxRangePushA("Warmup");
@@ -102,4 +102,3 @@ NVBENCH_BENCH_TYPES(svdbpi_batch, NVBENCH_TYPE_AXES(svd_types))
   .add_int64_axis("cols", {4, 16, 64})
   .add_int64_axis("rows", {4})
   .add_int64_axis("batch", {3000});
-

--- a/docs_input/build.rst
+++ b/docs_input/build.rst
@@ -182,6 +182,8 @@ By default, all of these options are OFF.
     - ``-DMATX_EN_COVERAGE=ON``
   * - Complex Operations NaN/Inf Handling
     - ``-DMATX_EN_COMPLEX_OP_NAN_CHECKS=ON``
+  * - Narrowing Assignment Conversion Checks
+    - ``-DMATX_CHECK_NARROWING_CONVERSIONS=ON``
   * - CUDA Line Info
     - ``-DMATX_EN_CUDA_LINEINFO=ON``
   * - cuTENSOR Support
@@ -262,6 +264,14 @@ the ``cuda::std::complex`` implementation supports this extra handling for multi
 yields the semantics of the direct implementation above.
 Using the ``-DMATX_EN_COMPLEX_OP_NAN_CHECKS=ON`` CMake option or otherwise defining the ``MATX_EN_COMPLEX_OP_NAN_CHECKS``
 macro will enable these additional checks. Enabling this option introduces extra cost in complex multiplication and division.
+
+Narrowing Assignment Conversion Checks
+--------------------------------------
+
+Using the ``-DMATX_CHECK_NARROWING_CONVERSIONS=ON`` CMake option or otherwise defining the ``MATX_CHECK_NARROWING_CONVERSIONS``
+macro to ``1`` enables additional compile-time diagnostics for assignments that may require narrowing implicit conversions.
+This can help find cases where an expression, literal, or generator produces a wider or different type than the destination
+tensor. The checks are disabled by default.
 
 CUDA Line Info
 --------------
@@ -368,6 +378,5 @@ and building on the offline system.
 
     
 - Build your MatX project per your standard process, CPM will automatically use the cache
-
 
 

--- a/examples/channelize_poly_bench.cu
+++ b/examples/channelize_poly_bench.cu
@@ -171,7 +171,9 @@ struct ScalarType<cuda::std::complex<T>> { using type = T; };
 template <typename InType, typename FilterType>
 void DispatchBench(const BenchConfig &cfg) {
   using in_scalar = typename ScalarType<InType>::type;
-  using OutType = cuda::std::complex<in_scalar>;
+  using filter_scalar = typename ScalarType<FilterType>::type;
+  using out_scalar = cuda::std::common_type_t<in_scalar, filter_scalar>;
+  using OutType = cuda::std::complex<out_scalar>;
 
   printf("Input: %-16s  Filter: %-16s  Output: %-16s\n",
       TypeName<InType>(), TypeName<FilterType>(), TypeName<OutType>());

--- a/examples/sarbp/sarbp.cu
+++ b/examples/sarbp/sarbp.cu
@@ -517,7 +517,7 @@ int main(int argc, char **argv) {
           // Warmup int16 -> complex<float> conversion kernel
           auto cur_fx_i16 = matx::slice(blk_fx_i16, {0, 0}, {npulses, num_samples_raw * 2});
           auto cur_ampsf = matx::slice(blk_ampsf, {0}, {npulses});
-          (cur_fx_i16 = 0).run(exec);
+          (cur_fx_i16 = static_cast<int16_t>(0)).run(exec);
           (cur_ampsf = 1.0f).run(exec);
           auto i_vals = matx::slice(cur_fx_i16, {0, 0},
                                     {npulses, num_samples_raw * 2}, {1, 2});

--- a/examples/simple_radar_pipeline.h
+++ b/examples/simple_radar_pipeline.h
@@ -90,7 +90,8 @@ public:
       typename I1::type xpow = xpow_(idz, idy, idx);
       typename I2::type ba = ba_(idz, idy, idx);
       typename I2::type norm = norm_(idz, idy, idx);
-      typename I2::type alpha = norm * (cuda::std::powf(pfa_, -1.0f / norm) - 1.f);
+      using calc_type = typename I2::type;
+      calc_type alpha = norm * (cuda::std::pow(static_cast<calc_type>(pfa_), calc_type(-1) / norm) - calc_type(1));
       out_(idz, idy, idx) = (xpow > alpha * ba) ? 1 : 0;
 
     }

--- a/examples/svd_power.cu
+++ b/examples/svd_power.cu
@@ -104,9 +104,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 
     printf("iterations: %d\n", iterations);
 
-    (U = 0).run(exec);
-    (S = 0).run(exec);
-    (VT = 0).run(exec);
+    (U = static_cast<AType>(0)).run(exec);
+    (S = static_cast<SType>(0)).run(exec);
+    (VT = static_cast<AType>(0)).run(exec);
 
     (mtie(U, S, VT) = svdpi(A, x0, iterations, k)).run(exec);
 
@@ -161,9 +161,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
   // Same as above but with svdbpi
   {
 
-    (U = 0).run(exec);
-    (S = 0).run(exec);
-    (VT = 0).run(exec);
+    (U = static_cast<AType>(0)).run(exec);
+    (S = static_cast<SType>(0)).run(exec);
+    (VT = static_cast<AType>(0)).run(exec);
     // TODO add k
     (mtie(U, S, VT) = svdbpi(A, iterations, tol)).run(exec);
 

--- a/include/matx/core/dynamic_tensor.h
+++ b/include/matx/core/dynamic_tensor.h
@@ -295,7 +295,8 @@ public:
       if constexpr (sizeof(T) != detail::alignment_by_type<T>()) {
         return cuda::std::array<detail::ElementsPerThread, 2>{detail::ElementsPerThread::ONE, detail::ElementsPerThread::ONE};
       } else {
-        int width = in.jit ? 32 : MAX_VEC_WIDTH_BYTES / sizeof(T);
+        const int type_width_bytes = static_cast<int>(sizeof(T));
+        int width = in.jit ? 32 : MAX_VEC_WIDTH_BYTES / type_width_bytes;
         index_t lsize = shape_[rank_ - 1];
         while (width > 1) {
           if (((lsize % width) == 0) &&
@@ -308,7 +309,8 @@ public:
       }
     }
     else if constexpr (Cap == detail::OperatorCapability::MAX_EPT_VEC_LOAD) {
-      int vec = MAX_VEC_WIDTH_BYTES / sizeof(T);
+      const int type_width_bytes = static_cast<int>(sizeof(T));
+      int vec = MAX_VEC_WIDTH_BYTES / type_width_bytes;
       int power = 1;
       while (power * 2 <= vec) { power *= 2; }
       return power;

--- a/include/matx/core/half_complex.h
+++ b/include/matx/core/half_complex.h
@@ -1057,7 +1057,7 @@ using matxBf16Complex = matxHalfComplex<matxBf16>; ///< Alias for a MatXbf16 com
 
 struct matxFp16ComplexPlanar : public matxFp16Complex {
   using matxFp16Complex::matxFp16Complex;
-  __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxFp16ComplexPlanar() = default;
+  __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxFp16ComplexPlanar() : matxFp16Complex(0.0f, 0.0f) {}
   __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxFp16ComplexPlanar(const matxFp16Complex &rhs) : matxFp16Complex(rhs) {}
   __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxFp16ComplexPlanar &operator=(const matxFp16Complex &rhs)
   {
@@ -1069,7 +1069,7 @@ struct matxFp16ComplexPlanar : public matxFp16Complex {
 
 struct matxBf16ComplexPlanar : public matxBf16Complex {
   using matxBf16Complex::matxBf16Complex;
-  __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxBf16ComplexPlanar() = default;
+  __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxBf16ComplexPlanar() : matxBf16Complex(0.0f, 0.0f) {}
   __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxBf16ComplexPlanar(const matxBf16Complex &rhs) : matxBf16Complex(rhs) {}
   __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ matxBf16ComplexPlanar &operator=(const matxBf16Complex &rhs)
   {

--- a/include/matx/core/operator_utils.h
+++ b/include/matx/core/operator_utils.h
@@ -158,13 +158,13 @@ namespace matx {
     template <typename CapType, typename T, typename Func>
     __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto ApplyGeneratorVecFunc(const Func &func, index_t index) {
       if constexpr (CapType::ept == ElementsPerThread::ONE) {
-        return func(index);
+        return static_cast<T>(func(index));
       } else {
 
         Vector<T, static_cast<index_t>(CapType::ept)> result;
         MATX_LOOP_UNROLL
         for (int i = 0; i < static_cast<index_t>(CapType::ept); i++) {
-          result.data[i] = func(index * static_cast<index_t>(CapType::ept) + i);
+          result.data[i] = static_cast<T>(func(index * static_cast<index_t>(CapType::ept) + i));
         }
         return result;
       }
@@ -173,12 +173,12 @@ namespace matx {
     template <typename CapType, typename OutType, typename Func, typename... Vals>
     __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto ApplyVecFunc(const Func &func, const Vals &...vals) {
       if constexpr (CapType::ept == ElementsPerThread::ONE) {
-        return func(vals...);
+        return static_cast<OutType>(func(vals...));
       } else {
         Vector<OutType, static_cast<index_t>(CapType::ept)> result;
         MATX_LOOP_UNROLL
         for (int i = 0; i < static_cast<index_t>(CapType::ept); i++) {
-          result.data[i] = func(vals.data[i]...);
+          result.data[i] = static_cast<OutType>(func(vals.data[i]...));
         }
         return result;
       }
@@ -432,4 +432,3 @@ namespace matx {
     }    
   }
 }
-

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -1353,7 +1353,8 @@ MATX_IGNORE_WARNING_POP_GCC
           // Host dispatch may select 32B width on CC100+, but 256b instructions are only
           // generated when the binary contains an sm_100+ device image.
           const int max_vec_width_bytes = (detail::GetComputeCapability() >= 1000) ? 32 : MAX_VEC_WIDTH_BYTES;
-          int width = in.jit ? 32 : max_vec_width_bytes / sizeof(T);
+          const int type_width_bytes = static_cast<int>(sizeof(T));
+          int width = in.jit ? 32 : max_vec_width_bytes / type_width_bytes;
           while (width > 1) {
             if (((Lsize() % width) == 0) &&                                       // Last dim is a multiple of vector load size
               ((reinterpret_cast<uintptr_t>(data_.ldata_) % (sizeof(T) * width)) == 0)) {
@@ -1370,7 +1371,8 @@ MATX_IGNORE_WARNING_POP_GCC
         // Same caveat as above: runtime selection can prefer 32B, while actual instruction
         // width depends on whether sm_100+ code was compiled into the binary.
         const int max_vec_width_bytes = (detail::GetComputeCapability() >= 1000) ? 32 : MAX_VEC_WIDTH_BYTES;
-        int vec = max_vec_width_bytes / sizeof(T);
+        const int type_width_bytes = static_cast<int>(sizeof(T));
+        int vec = max_vec_width_bytes / type_width_bytes;
         // Round down to next lower power of two
         // (if already a power of two, remains unchanged)
         // For vec = 0, will stay zero (avoid infinite loop)

--- a/include/matx/generators/chirp.h
+++ b/include/matx/generators/chirp.h
@@ -242,8 +242,9 @@ namespace matx
                 "      if (method_ == ChirpMethod::CHIRP_METHOD_LINEAR) {{\n"
                 "        const FreqType tval = static_cast<FreqType>(sop_(idx));\n"
                 "        const FreqType phase = FreqType(2) * static_cast<FreqType>(M_PI) * (f0_ * tval + FreqType(0.5) * ((f1_ - f0_) / static_cast<FreqType>(t1_)) * tval * tval);\n"
+                "        const FreqType quadrature_offset = FreqType(2) * static_cast<FreqType>(M_PI) * FreqType(90.0 / 360.0);\n"
                 "        FreqType real = static_cast<FreqType>(cuda::std::cos(phase));\n"
-                "        FreqType imag = static_cast<FreqType>(-cuda::std::cos(phase + FreqType(90.0 / 360.0)));\n"
+                "        FreqType imag = static_cast<FreqType>(-cuda::std::cos(phase + quadrature_offset));\n"
                 "        return cuda::std::complex<FreqType>{{real, imag}};\n"
                 "      }}\n"
                 "      return cuda::std::complex<FreqType>{{0, 0}};\n"
@@ -320,8 +321,9 @@ namespace matx
               const FreqType tval = static_cast<FreqType>(sop_(idx));
               const FreqType phase = FreqType(2) * static_cast<FreqType>(M_PI) *
                   (f0_ * tval + FreqType(0.5) * ((f1_ - f0_) / static_cast<FreqType>(t1_)) * tval * tval);
+              const FreqType quadrature_offset = FreqType(2) * static_cast<FreqType>(M_PI) * FreqType(90.0 / 360.0);
               FreqType real = static_cast<FreqType>(cuda::std::cos(phase));
-              FreqType imag = static_cast<FreqType>(-cuda::std::cos(phase + FreqType(90.0 / 360.0)));
+              FreqType imag = static_cast<FreqType>(-cuda::std::cos(phase + quadrature_offset));
               return cuda::std::complex<FreqType>{real, imag};
             }
 

--- a/include/matx/generators/chirp.h
+++ b/include/matx/generators/chirp.h
@@ -95,9 +95,11 @@ namespace matx
                 "  {{\n"
                 "    return detail::ApplyGeneratorVecFunc<CapType, FreqType>([this](index_t idx) {{\n"
                 "      if (method_ == ChirpMethod::CHIRP_METHOD_LINEAR) {{\n"
-                "        return cuda::std::cos(2.0f * M_PI * (f0_ * sop_(idx) + 0.5f * ((f1_ - f0_) / t1_) * sop_(idx) * sop_(idx)));\n"
+                "        const FreqType tval = static_cast<FreqType>(sop_(idx));\n"
+                "        const FreqType phase = FreqType(2) * static_cast<FreqType>(M_PI) * (f0_ * tval + FreqType(0.5) * ((f1_ - f0_) / static_cast<FreqType>(t1_)) * tval * tval);\n"
+                "        return static_cast<FreqType>(cuda::std::cos(phase));\n"
                 "      }}\n"
-                "      return 0.0;\n"
+                "      return FreqType(0);\n"
                 "    }}, i);\n"
                 "  }}\n"
                 "  static __MATX_INLINE__ constexpr __MATX_DEVICE__ int32_t Rank() {{ return 1; }}\n"
@@ -168,10 +170,13 @@ namespace matx
         {
           return detail::ApplyGeneratorVecFunc<CapType, FreqType>([this](index_t idx) { 
             if (method_ == ChirpMethod::CHIRP_METHOD_LINEAR) {
-              return cuda::std::cos(2.0f * M_PI * (f0_ * sop_(idx) + 0.5f * ((f1_ - f0_) / t1_) * sop_(idx) * sop_(idx)));
+              const FreqType tval = static_cast<FreqType>(sop_(idx));
+              const FreqType phase = FreqType(2) * static_cast<FreqType>(M_PI) *
+                  (f0_ * tval + FreqType(0.5) * ((f1_ - f0_) / static_cast<FreqType>(t1_)) * tval * tval);
+              return static_cast<FreqType>(cuda::std::cos(phase));
             }
 
-            return 0.0; 
+            return FreqType(0); 
           }, i);
         }
 
@@ -235,8 +240,10 @@ namespace matx
                 "  {{\n"
                 "    return detail::ApplyGeneratorVecFunc<CapType, value_type>([this](index_t idx) {{\n"
                 "      if (method_ == ChirpMethod::CHIRP_METHOD_LINEAR) {{\n"
-                "        FreqType real = cuda::std::cos(2.0f * M_PI * (f0_ * sop_(idx) + 0.5f * ((f1_ - f0_) / t1_) * sop_(idx) * sop_(idx)));\n"
-                "        FreqType imag = -cuda::std::cos(2.0f * M_PI * (f0_ * sop_(idx) + 0.5f * ((f1_ - f0_) / t1_) * sop_(idx) * sop_(idx) + 90.0/360.0));\n"
+                "        const FreqType tval = static_cast<FreqType>(sop_(idx));\n"
+                "        const FreqType phase = FreqType(2) * static_cast<FreqType>(M_PI) * (f0_ * tval + FreqType(0.5) * ((f1_ - f0_) / static_cast<FreqType>(t1_)) * tval * tval);\n"
+                "        FreqType real = static_cast<FreqType>(cuda::std::cos(phase));\n"
+                "        FreqType imag = static_cast<FreqType>(-cuda::std::cos(phase + FreqType(90.0 / 360.0)));\n"
                 "        return cuda::std::complex<FreqType>{{real, imag}};\n"
                 "      }}\n"
                 "      return cuda::std::complex<FreqType>{{0, 0}};\n"
@@ -310,8 +317,11 @@ namespace matx
         {
           return detail::ApplyGeneratorVecFunc<CapType, value_type>([this](index_t idx) { 
             if (method_ == ChirpMethod::CHIRP_METHOD_LINEAR) {
-              FreqType real = cuda::std::cos(2.0f * M_PI * (f0_ * sop_(idx) + 0.5f * ((f1_ - f0_) / t1_) * sop_(idx) * sop_(idx)));
-              FreqType imag = -cuda::std::cos(2.0f * M_PI * (f0_ * sop_(idx) + 0.5f * ((f1_ - f0_) / t1_) * sop_(idx) * sop_(idx) + 90.0/360.0));
+              const FreqType tval = static_cast<FreqType>(sop_(idx));
+              const FreqType phase = FreqType(2) * static_cast<FreqType>(M_PI) *
+                  (f0_ * tval + FreqType(0.5) * ((f1_ - f0_) / static_cast<FreqType>(t1_)) * tval * tval);
+              FreqType real = static_cast<FreqType>(cuda::std::cos(phase));
+              FreqType imag = static_cast<FreqType>(-cuda::std::cos(phase + FreqType(90.0 / 360.0)));
               return cuda::std::complex<FreqType>{real, imag};
             }
 

--- a/include/matx/generators/flattop.h
+++ b/include/matx/generators/flattop.h
@@ -85,7 +85,8 @@ namespace matx
                 "  __MATX_INLINE__ __MATX_DEVICE__ auto operator()(index_t i) const\n" +
                 "  {\n" +
                 "    return detail::ApplyGeneratorVecFunc<CapType, T>([](index_t idx) {\n" +
-                "      return a0 - a1 * cuda::std::cos(2*cuda::std::numbers::pi*idx / (size_ - 1)) + a2 * cuda::std::cos(4*cuda::std::numbers::pi*idx / (size_ - 1)) - a3 * cuda::std::cos(6*cuda::std::numbers::pi*idx / (size_ - 1)) + a4 * cuda::std::cos(8*cuda::std::numbers::pi*idx / (size_ - 1));\n" +
+                "      static constexpr T tmp_pi = cuda::std::numbers::pi;\n" +
+                "      return a0 - a1 * cuda::std::cos(static_cast<T>(2) * tmp_pi * idx / (size_ - 1)) + a2 * cuda::std::cos(static_cast<T>(4) * tmp_pi * idx / (size_ - 1)) - a3 * cuda::std::cos(static_cast<T>(6) * tmp_pi * idx / (size_ - 1)) + a4 * cuda::std::cos(static_cast<T>(8) * tmp_pi * idx / (size_ - 1));\n" +
                 "    }, i);\n" +
                 "  }\n" +
                 "  static __MATX_INLINE__ constexpr __MATX_DEVICE__ int32_t Rank() { return 1; }\n" +
@@ -107,11 +108,12 @@ namespace matx
         inline __MATX_HOST__ __MATX_DEVICE__ auto operator()(index_t i) const
         {
           return detail::ApplyGeneratorVecFunc<CapType, T>([this](index_t idx) {
+            static constexpr T tmp_pi = cuda::std::numbers::pi;
             return  a0  
-              - a1 * cuda::std::cos(2*M_PI*idx / (size_ - 1))
-              + a2 * cuda::std::cos(4*M_PI*idx / (size_ - 1))
-              - a3 * cuda::std::cos(6*M_PI*idx / (size_ - 1))
-              + a4 * cuda::std::cos(8*M_PI*idx / (size_ - 1));
+              - a1 * cuda::std::cos(static_cast<T>(2)*tmp_pi*idx / (size_ - 1))
+              + a2 * cuda::std::cos(static_cast<T>(4)*tmp_pi*idx / (size_ - 1))
+              - a3 * cuda::std::cos(static_cast<T>(6)*tmp_pi*idx / (size_ - 1))
+              + a4 * cuda::std::cos(static_cast<T>(8)*tmp_pi*idx / (size_ - 1));
           }, i);
         }
 

--- a/include/matx/generators/random.h
+++ b/include/matx/generators/random.h
@@ -66,16 +66,20 @@ __global__ void curand_setup_kernel(Gen *states, uint64_t seed, index_t size)
  * @param min min of the range to generate
  * @param max max of the range to generate
  */
-template <typename T, typename Gen>
-__MATX_INLINE__ __MATX_DEVICE__ void get_randomi(T &val, Gen *state, double min, double max)
+template <typename T, typename Gen, typename FloatT>
+__MATX_INLINE__ __MATX_DEVICE__ void get_randomi(T &val, Gen *state, FloatT min, FloatT max)
 {
+  FloatT norm;
 
-  double normFloat = curand_uniform(state);
+  if constexpr (cuda::std::is_same_v<FloatT, double>) {
+    norm = curand_uniform_double(state);
+  }
+  else {
+    norm = curand_uniform(state);
+  }
 
-  // Scale to the provided min and max range
-  val = static_cast<T>(normFloat * (max - min)+ min);
-
-};
+  val = static_cast<T>(norm * (max - min) + min);
+}
 
 /**
  * @brief Get a random number
@@ -417,11 +421,18 @@ namespace detail {
                     std::is_same_v<T,  int64_t>
           )
           {
+            using rand_scale_t =
+              cuda::std::conditional_t<(sizeof(T) > sizeof(uint32_t)), double, float>;
             if constexpr (sizeof...(indices) == 0) {
-              get_randomi(val.data[i], &states_[0], iParams_.min_, iParams_.max_);
+              get_randomi(val.data[i], 
+                &states_[0], 
+                static_cast<rand_scale_t>(iParams_.min_), 
+                static_cast<rand_scale_t>(iParams_.max_));
             }
             else {
-              get_randomi(val.data[i], &states_[static_cast<int>(CapType::ept) * GetValC<0, Is...>(cuda::std::make_tuple(indices...)) + i], iParams_.min_, iParams_.max_);
+              get_randomi(val.data[i], 
+                &states_[static_cast<int>(CapType::ept) * GetValC<0, Is...>(cuda::std::make_tuple(indices...)) + i], 
+                static_cast<rand_scale_t>(iParams_.min_), static_cast<rand_scale_t>(iParams_.max_));
             }          
           }
         }

--- a/include/matx/kernels/channelize_poly.cuh
+++ b/include/matx/kernels/channelize_poly.cuh
@@ -952,17 +952,17 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
     for (int t = tid; t < NUM_CHAN*NUM_CHAN; t += THREADS) {
         const int i = t / NUM_CHAN;
         const int j = t % NUM_CHAN;
-        if constexpr (std::is_same_v<output_t, std::complex<double>> || std::is_same_v<output_t, cuda::std::complex<double>>) {
+        if constexpr (std::is_same_v<AccumType, double>) {
             const double arg = 2.0 * M_PI * j * i / NUM_CHAN;
             double sinx, cosx;
             sincos(arg, &sinx, &cosx);
-            complex_accum_t eij { cosx, sinx };
+            complex_accum_t eij { static_cast<AccumType>(cosx), static_cast<AccumType>(sinx) };
             smem_eij[i][j] = eij;
         } else {
             const float arg = 2.0f * static_cast<float>(M_PI) * j * i / NUM_CHAN;
             float sinx, cosx;
             sincosf(arg, &sinx, &cosx);
-            complex_accum_t eij { cosx, sinx };
+            complex_accum_t eij { static_cast<AccumType>(cosx), static_cast<AccumType>(sinx) };
             smem_eij[i][j] = eij;
         }
     }

--- a/include/matx/kernels/conv.cuh
+++ b/include/matx/kernels/conv.cuh
@@ -47,8 +47,8 @@ __global__ void Conv1D(OutType d_out, InType d_in, FilterType d_filter,
   using ftype_strip = typename FilterType::value_type;
   using intype_strip = typename InType::value_type;
   using outtype_strip = typename OutType::value_type;
-  uint32_t filter_len = d_filter.Size(Rank-1);
-  uint32_t full_len = signal_len + filter_len - 1;
+  uint32_t filter_len = static_cast<uint32_t>(d_filter.Size(Rank - 1));
+  uint32_t full_len = static_cast<uint32_t>(signal_len + filter_len - 1);
 
   int batch_idx = blockIdx.x;
 
@@ -73,7 +73,8 @@ __global__ void Conv1D(OutType d_out, InType d_in, FilterType d_filter,
   }
 
   // number of chunks in the signal, number of output elements / chunk size rounded up
-  uint32_t num_chunks = (signal_len + filter_len -1 + CONV1D_ELEMENTS_PER_BLOCK - 1) / CONV1D_ELEMENTS_PER_BLOCK;
+  uint32_t num_chunks = static_cast<uint32_t>(
+      (signal_len + filter_len - 1 + CONV1D_ELEMENTS_PER_BLOCK - 1) / CONV1D_ELEMENTS_PER_BLOCK);
 
   // number of chunks per Y block, rounded up
   num_chunks = (num_chunks + gridDim.y - 1) / gridDim.y;
@@ -88,7 +89,8 @@ __global__ void Conv1D(OutType d_out, InType d_in, FilterType d_filter,
       __syncthreads();
 
     // load signal,  pad extra elements with zeros
-    for (int32_t lidx = threadIdx.x, gidx  = chunk_idx * CONV1D_ELEMENTS_PER_BLOCK - filter_len + 1 + threadIdx.x;
+    for (int32_t lidx = threadIdx.x,
+                 gidx = static_cast<int32_t>(chunk_idx * CONV1D_ELEMENTS_PER_BLOCK - filter_len + 1 + threadIdx.x);
         gidx < static_cast<int32_t>((chunk_idx+1) * CONV1D_ELEMENTS_PER_BLOCK) ;
         gidx += THREADS, lidx += THREADS) {
 
@@ -168,7 +170,7 @@ MATX_LOOP_UNROLL
 MATX_LOOP_UNROLL
     for (uint32_t i = 0; i < EPT; i++) {
       // index for the computation
-      uint32_t idx = chunk_idx * CONV1D_ELEMENTS_PER_BLOCK + i * THREADS + threadIdx.x;
+      uint32_t idx = static_cast<uint32_t>(chunk_idx * CONV1D_ELEMENTS_PER_BLOCK + i * THREADS + threadIdx.x);
       // output index is shifted by start
       int32_t gidx = idx - start;
 
@@ -251,8 +253,8 @@ __global__ void Conv2D(OutType d_out, InType1 d_in1, InType2 d_in2,
   int dy = 0, dx = 0;
 
   if( mode == MATX_C_MODE_SAME) {
-    dy = i2N / 2;
-    dx = i2M / 2;
+    dy = static_cast<int>(i2N / 2);
+    dx = static_cast<int>(i2M / 2);
 #if 0
     // uncomment this to match matlab
     if(i2N % 2 == 0) dy--;
@@ -260,8 +262,8 @@ __global__ void Conv2D(OutType d_out, InType1 d_in1, InType2 d_in2,
 #endif
 
   } else if ( mode == MATX_C_MODE_FULL) {
-    dy = i2N - 1;
-    dx = i2M - 1;
+    dy = static_cast<int>(i2N - 1);
+    dx = static_cast<int>(i2M - 1);
   }
 
   // grid stride loop over batches

--- a/include/matx/kernels/resample_poly.cuh
+++ b/include/matx/kernels/resample_poly.cuh
@@ -79,9 +79,9 @@ __global__ void ResamplePoly1D_PhaseBlock(OutType output, InType input, FilterTy
     filter_t *s_filter = reinterpret_cast<filter_t *>(smem_filter);
 
     constexpr int Rank = OutType::Rank();
-    const index_t output_len = output.Size(Rank-1);
-    index_t filter_len = filter.Size(0);
-    const index_t input_len = input.Size(Rank-1);
+    const index_t output_len = static_cast<index_t>(output.Size(Rank-1));
+    index_t filter_len = static_cast<index_t>(filter.Size(0));
+    const index_t input_len = static_cast<index_t>(input.Size(Rank-1));
 
     // We assume odd-length filters below. In the case of an even-length filter,
     // logically prepend the filter with a single zero to make its length odd.
@@ -266,9 +266,9 @@ __global__ void ResamplePoly1D_ElemBlock(OutType output, InType input, FilterTyp
     filter_t *s_filter = reinterpret_cast<filter_t *>(smem_filter);
 
     constexpr int Rank = OutType::Rank();
-    const index_t output_len = output.Size(Rank-1);
-    index_t filter_len = filter.Size(0);
-    const index_t input_len = input.Size(Rank-1);
+    const index_t output_len = static_cast<index_t>(output.Size(Rank-1));
+    index_t filter_len = static_cast<index_t>(filter.Size(0));
+    const index_t input_len = static_cast<index_t>(input.Size(Rank-1));
 
     const size_t filter_sz_bytes = (filter_len % 2 == 0) ? sizeof(filter_t)*(filter_len+1) : sizeof(filter_t)*filter_len;
     const bool load_filter_to_smem = (filter_sz_bytes <= MATX_RESAMPLE_POLY_MAX_SMEM_BYTES);
@@ -384,9 +384,9 @@ __global__ void ResamplePoly1D_WarpCentric(OutType output, InType input, FilterT
     filter_t *s_filter = reinterpret_cast<filter_t *>(smem_filter);
 
     constexpr int Rank = OutType::Rank();
-    const index_t output_len = output.Size(Rank-1);
-    index_t filter_len = filter.Size(0);
-    const index_t input_len = input.Size(Rank-1);
+    const index_t output_len = static_cast<index_t>(output.Size(Rank-1));
+    index_t filter_len = static_cast<index_t>(filter.Size(0));
+    const index_t input_len = static_cast<index_t>(input.Size(Rank-1));    
 
     const size_t filter_sz_bytes = (filter_len % 2 == 0) ? sizeof(filter_t)*(filter_len+1) : sizeof(filter_t)*filter_len;
     const bool load_filter_to_smem = (filter_sz_bytes <= MATX_RESAMPLE_POLY_MAX_SMEM_BYTES);
@@ -420,7 +420,7 @@ __global__ void ResamplePoly1D_WarpCentric(OutType output, InType input, FilterT
             const index_t x_start = (up_start + up - 1) / up;
             index_t x_end = up_end / up;
             // Since the filter is in shared memory, we can narrow the index type to 32 bits
-            int h_ind = static_cast<int>(filter_central_tap + (up_ind - up*x_start)) - lane_id*up;
+            int h_ind = static_cast<int>(filter_central_tap + (up_ind - up*x_start)) - static_cast<int>(lane_id*up);
 
             output_t accum {};
             input_t in_val;

--- a/include/matx/kernels/sar_bp.cuh
+++ b/include/matx/kernels/sar_bp.cuh
@@ -257,9 +257,9 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     // one-shot cost of its operator() is negligible and its layout is free to
     // be anything the caller wants without blocking fast-path eligibility.
     const voxel_loc_t voxel_loc = is_valid ? voxel_locations(iy, ix) : voxel_loc_t{};
-    const loose_compute_t py = voxel_loc.y;
-    const loose_compute_t px = voxel_loc.x;
-    const loose_compute_t pz = voxel_loc.z;
+    const loose_compute_t py = static_cast<loose_compute_t>(voxel_loc.y);
+    const loose_compute_t px = static_cast<loose_compute_t>(voxel_loc.x);
+    const loose_compute_t pz = static_cast<loose_compute_t>(voxel_loc.z);
 
     // TensorAccessor wraps each hot tensor and picks the fast pointer path
     // when IsUnitStride && is_tensor_view_v<Op>, otherwise forwards to
@@ -286,8 +286,13 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     const auto get_reference_phase = [&phase_lut, &phase_correction_partial, &phase_correction_partial_loose](strict_or_ff_compute_t diffR, index_t bin_floor_int, loose_compute_t w) -> loose_complex_compute_t {
         if constexpr (PhaseLUT) {
             const loose_complex_compute_t base_phase = phase_lut[bin_floor_int];
-            float incr_sinx, incr_cosx;
-            __sincosf(phase_correction_partial_loose * w, &incr_sinx, &incr_cosx);
+            loose_compute_t incr_sinx, incr_cosx;
+            if constexpr (cuda::std::is_same_v<loose_compute_t, double>) {
+                ::sincos(phase_correction_partial_loose * w, &incr_sinx, &incr_cosx);
+            } else {
+                __sincosf(phase_correction_partial_loose * w, &incr_sinx, &incr_cosx);
+            }
+
             return loose_complex_compute_t{
                 base_phase.real() * incr_cosx - base_phase.imag() * incr_sinx,
                 base_phase.real() * incr_sinx + base_phase.imag() * incr_cosx
@@ -311,14 +316,17 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     loose_complex_compute_t accum{};
     const loose_compute_t bin_offset = static_cast<loose_compute_t>(0.5) * static_cast<loose_compute_t>(num_range_bins-1);
 
-    const int num_pulse_blocks = (num_pulses + PULSE_BLOCK_SIZE - 1) / PULSE_BLOCK_SIZE;
+    const int num_pulse_blocks = static_cast<int>(
+        (num_pulses + static_cast<index_t>(PULSE_BLOCK_SIZE) - 1) / static_cast<index_t>(PULSE_BLOCK_SIZE));
     for (int block = 0; block < num_pulse_blocks; ++block) {
-        const int num_pulses_in_block = num_pulses - block * PULSE_BLOCK_SIZE < PULSE_BLOCK_SIZE ?
-            num_pulses - block * PULSE_BLOCK_SIZE : PULSE_BLOCK_SIZE;
+        const index_t pulse_base = static_cast<index_t>(block) * static_cast<index_t>(PULSE_BLOCK_SIZE);
+        const index_t pulses_remaining = num_pulses - pulse_base;
+        const index_t num_pulses_in_block =
+            (pulses_remaining < static_cast<index_t>(PULSE_BLOCK_SIZE)) ? pulses_remaining : static_cast<index_t>(PULSE_BLOCK_SIZE);
         if constexpr (UseSharedPreamble) {
             __syncthreads();
             for (index_t ip = tid; ip < num_pulses_in_block; ip += blockDim.x * blockDim.y) {
-                const int p = block * PULSE_BLOCK_SIZE + ip;
+                const index_t p = pulse_base + ip;
                 // Accessor does the IsUnitStride / rank dispatch internally,
                 // so we just ask for (apx, apy, apz) uniformly.
                 auto load_xyz = [&]() {
@@ -359,7 +367,7 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
         }
         #pragma unroll 4
         for (index_t ip = 0; ip < num_pulses_in_block; ++ip) {
-            const int p = block * PULSE_BLOCK_SIZE + ip;
+            const index_t p = pulse_base + ip;
             strict_or_ff_compute_t diffR;
             loose_compute_t w;
             index_t bin_floor_int;
@@ -468,9 +476,13 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
         // and non-unit-stride output layouts do not disqualify the fast path
         // for the hot tensors (range_profiles, platform_positions, rtm).
         const initial_image_t initial_image_voxel = initial_image.operator()(iy, ix);
-        const image_t voxel_contribution {
-            initial_image_voxel.real() + accum.real(), initial_image_voxel.imag() + accum.imag() };
-        output.operator()(iy, ix) = voxel_contribution;
+        using out_value_t = typename OutImageType::value_type;
+        using out_scalar_t = typename out_value_t::value_type;
+
+        output(iy, ix) = out_value_t{
+            static_cast<out_scalar_t>(initial_image_voxel.real() + accum.real()),
+            static_cast<out_scalar_t>(initial_image_voxel.imag() + accum.imag())
+        };
     }
 }
 

--- a/include/matx/operators/set.h
+++ b/include/matx/operators/set.h
@@ -41,6 +41,10 @@
 #include "matx/core/capabilities.h"
 #include "matx/core/operator_utils.h"
 
+#ifndef MATX_CHECK_NARROWING_CONVERSIONS
+#define MATX_CHECK_NARROWING_CONVERSIONS 1
+#endif
+
 namespace matx {
 template <typename T, int RANK, typename Desc> class tensor_t; ///< Tensor detail type
 template <typename T> class BaseOp; ///< Base operator type
@@ -48,6 +52,57 @@ template <typename T> class BaseOp; ///< Base operator type
 namespace detail {
 
 template <typename T, int RANK, typename Desc, typename Data> class tensor_impl_t; ///< Tensor implementation type
+
+#if MATX_CHECK_NARROWING_CONVERSIONS
+// Brace initialization rejects arithmetic narrowing, giving set() a shorter
+// diagnostic than a kernel instantiation.
+template <typename From, typename To>
+struct set_assignment_conversion_may_narrow {
+private:
+  using from_type = remove_cvref_t<From>;
+  using to_type = remove_cvref_t<To>;
+
+  template <typename F, typename U>
+  static constexpr bool compute()
+  {
+    if constexpr (std::is_void_v<F> || std::is_void_v<U> || std::is_same_v<F, U>) {
+      return false;
+    }
+    else if constexpr (is_vector_v<F>) {
+      return set_assignment_conversion_may_narrow<typename F::value_type, U>::value;
+    }
+    else if constexpr (is_vector_v<U>) {
+      return set_assignment_conversion_may_narrow<F, typename U::value_type>::value;
+    }
+    else if constexpr (is_complex_v<F> && is_complex_v<U>) {
+      return set_assignment_conversion_may_narrow<typename F::value_type, typename U::value_type>::value;
+    }
+    else if constexpr (!is_complex_v<F> && is_complex_v<U>) {
+      return set_assignment_conversion_may_narrow<F, typename U::value_type>::value;
+    }
+    else if constexpr (is_complex_v<F> && !is_complex_v<U>) {
+      return false;
+    }
+    else if constexpr (!std::is_assignable_v<U &, F>) {
+      return false;
+    }
+    else {
+      // List initialization will reject narrowing conversions, so we can check if the conversion is narrowing by 
+      // testing if F can be list-initialized into U. We also check that the types are not the same, as some 
+      // types (e.g. half) have non-narrowing implicit conversions to the same type that are not accepted by list initialization.
+      return !requires(F from) { U{from}; };
+    }
+  }
+
+public:
+  static constexpr bool value = compute<from_type, to_type>();
+};
+
+template <typename From, typename To>
+inline constexpr bool set_assignment_conversion_may_narrow_v =
+  set_assignment_conversion_may_narrow<From, To>::value;
+
+#endif
 
 
 /**
@@ -67,6 +122,19 @@ class set : public BaseOp<set<T, Op>> {
 private:
   mutable typename detail::base_type_t<T> out_;
   mutable typename detail::base_type_t<Op> op_;
+
+#if MATX_CHECK_NARROWING_CONVERSIONS
+  template <typename RhsValueType>
+  static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ void CheckNarrowingAssignment()
+  {
+    using lhs_value_type = remove_cvref_t<typename T::value_type>;
+    using rhs_value_type = remove_cvref_t<RhsValueType>;
+    static_assert(
+      !set_assignment_conversion_may_narrow_v<rhs_value_type, lhs_value_type>,
+      "MatX assignment may require a narrowing implicit conversion. Cast the RHS or use a typed generator, "
+      "for example tensor = T{value}, ones<T>(), zeros<T>(), or as_type<T>(op).");
+  }
+#endif
 
 public:
   // Type specifier for reflection on class
@@ -122,11 +190,17 @@ public:
     if constexpr (is_planar_complex_v<typename T::value_type>) {
       const auto r = detail::get_value<detail::DefaultCapabilities>(
           static_cast<const decltype(op_)&>(op_), args...);
+#if MATX_CHECK_NARROWING_CONVERSIONS
+      CheckNarrowingAssignment<decltype(r)>();
+#endif
       out_.template operator()<detail::DefaultCapabilities>(args...) = r;
       return r;
     }
     else {
       const auto r = detail::get_value<CapType>(static_cast<const decltype(op_)&>(op_), args...);
+#if MATX_CHECK_NARROWING_CONVERSIONS
+      CheckNarrowingAssignment<decltype(r)>();
+#endif
       out_.template operator()<CapType>(args...) = r;
       return r;
     }
@@ -149,12 +223,19 @@ public:
     if constexpr (is_planar_complex_v<typename T::value_type>) {
       const auto in_val = detail::get_value<detail::DefaultCapabilities>(
           static_cast<const decltype(op_)&>(op_), indices...);
+#if MATX_CHECK_NARROWING_CONVERSIONS
+      CheckNarrowingAssignment<decltype(in_val)>();
+#endif
       out_.template operator()<detail::DefaultCapabilities>(indices...) = in_val;
       return in_val;
     }
     else {
       const auto in_val = detail::get_value<CapType>(static_cast<const decltype(op_)&>(op_), indices...);
       using out_type = decltype(out_.template operator()<CapType>(indices...));
+
+#if MATX_CHECK_NARROWING_CONVERSIONS
+      CheckNarrowingAssignment<decltype(in_val)>();
+#endif
       
       if constexpr (!is_vector_v<decltype(in_val)> && is_vector_v<out_type>) {
         Vector<remove_cvref_t<decltype(in_val)>, static_cast<size_t>(CapType::ept)> vec{in_val};

--- a/include/matx/operators/set.h
+++ b/include/matx/operators/set.h
@@ -42,7 +42,7 @@
 #include "matx/core/operator_utils.h"
 
 #ifndef MATX_CHECK_NARROWING_CONVERSIONS
-#define MATX_CHECK_NARROWING_CONVERSIONS 1
+#define MATX_CHECK_NARROWING_CONVERSIONS 0
 #endif
 
 namespace matx {

--- a/include/matx/operators/shift.h
+++ b/include/matx/operators/shift.h
@@ -166,7 +166,8 @@ namespace matx
             Is... indices)
         {
           if constexpr (CapType::ept == ElementsPerThread::ONE) {
-            cuda::std::array idx{indices...};
+            cuda::std::array<index_t, sizeof...(Is)> idx{
+                static_cast<index_t>(indices)...};
 
             index_t shift;
             if constexpr (shift_rank_ == 1) {

--- a/include/matx/transforms/ambgfun.h
+++ b/include/matx/transforms/ambgfun.h
@@ -251,7 +251,7 @@ void ambgfun_impl(AMFTensor &amf, XTensor &x,
     auto fullfft = make_tensor<T1>({(len_seq - 1), nfreq}, MATX_ASYNC_DEVICE_MEMORY, stream);
     auto partfft = slice(fullfft, {0, 0}, {(len_seq - 1), xlen});
 
-    (fullfft = 0).run(stream);
+    (fullfft = T1{0}).run(stream);
     matx::copy(partfft, new_ynorm_v, stream);
 
     ifft_impl(fullfft, fullfft, 0, FFTNorm::BACKWARD, stream);
@@ -266,7 +266,7 @@ void ambgfun_impl(AMFTensor &amf, XTensor &x,
   else if (cut == ::matx::AMBGFUN_CUT_TYPE_DELAY) {
     auto fullfft_x = make_tensor<T1>({nfreq}, MATX_ASYNC_DEVICE_MEMORY, stream);
     auto partfft_x = slice(fullfft_x, {0}, {xlen});
-    (fullfft_x = 0).run(stream);
+    (fullfft_x = T1{0}).run(stream);
     matx::copy(partfft_x, x_normdiv_v, stream);
 
     fft_impl(fullfft_x, fullfft_x, 0, FFTNorm::BACKWARD, stream);
@@ -274,7 +274,7 @@ void ambgfun_impl(AMFTensor &amf, XTensor &x,
     ifft_impl(fullfft_x, fullfft_x, 0, FFTNorm::BACKWARD, stream);
 
     auto fullfft_y = make_tensor<T1>({nfreq}, MATX_ASYNC_DEVICE_MEMORY, stream);
-    (fullfft_y = 0).run(stream);
+    (fullfft_y = T1{0}).run(stream);
 
     auto partfft_y = slice(fullfft_y, {0}, {xlen});
     matx::copy(partfft_y, y_normdiv_v, stream);
@@ -295,12 +295,12 @@ void ambgfun_impl(AMFTensor &amf, XTensor &x,
     auto fullfft_y = make_tensor<T1>({len_seq - 1}, MATX_ASYNC_DEVICE_MEMORY, stream);
     auto partfft_y = slice(fullfft_y, {0}, {y_normdiv_v.Size(0)});
 
-    (fullfft_y = 0).run(stream);
+    (fullfft_y = T1{0}).run(stream);
     matx::copy(partfft_y, y_normdiv_v, stream);
     fft_impl(fullfft_y, fullfft_y, 0, FFTNorm::BACKWARD, stream);
 
     auto fullfft_x = make_tensor<T1>({len_seq - 1}, MATX_ASYNC_DEVICE_MEMORY, stream);
-    (fullfft_x = 0).run(stream);
+    (fullfft_x = T1{0}).run(stream);
 
     cuda::std::array<index_t, 1> xnd_size = {x_normdiv_v.Size(0)};
     auto partfft_x = make_tensor(fullfft_x.GetStorage(), xnd_size);

--- a/include/matx/transforms/conv.h
+++ b/include/matx/transforms/conv.h
@@ -214,7 +214,7 @@ inline void matxDirectConv1DInternal(OutputType &o, const InType &i,
 
   dim3 gsize(grid_size, num_blocks);
   constexpr int EPT = 4;
-  constexpr int THREADS = CONV1D_ELEMENTS_PER_BLOCK / EPT;
+  constexpr int THREADS = static_cast<int>(CONV1D_ELEMENTS_PER_BLOCK / EPT);
   static_assert(CONV1D_ELEMENTS_PER_BLOCK % EPT == 0);
 
   Conv1D<THREADS, EPT><<<gsize, THREADS, shmsize, stream>>>(

--- a/include/matx/transforms/cov.h
+++ b/include/matx/transforms/cov.h
@@ -113,7 +113,7 @@ public:
     make_tensor(devsT, tmp, MATX_ASYNC_DEVICE_MEMORY, stream);
 
     // Populate our ones matrix
-    (onesM = ones()).run(stream);
+    (onesM = ones<T1>()).run(stream);
   }
 
   static CovParams_t GetCovParams([[maybe_unused]] TensorTypeC &c, const TensorTypeA &a, cudaStream_t stream = 0)

--- a/include/matx/transforms/cub.h
+++ b/include/matx/transforms/cub.h
@@ -993,7 +993,7 @@ inline void ExecSort(OutputTensor &a_out,
 #ifdef __CUDACC__
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
-    if (!has_index_cmp_op_v<decltype(cparams_.op)>) {
+    if constexpr (!has_index_cmp_op_v<decltype(cparams_.op)>) {
       if constexpr (is_tensor_view_v<InputOperator>) {
         if (a.IsContiguous()) {
           cub::DeviceSelect::If(d_temp,

--- a/include/matx/transforms/svd/svd_cuda.h
+++ b/include/matx/transforms/svd/svd_cuda.h
@@ -439,7 +439,8 @@ inline void svdbpi_impl(UType &U, SType &S, VTType &VT, const AType &A, int max_
     matmul_impl(AT, A, conj(transpose_matrix(A)), exec);
   }
 
-  auto e2 = eye({d,d});
+  using q_value_t = typename decltype(Q)::value_type;
+  auto e2 = eye<q_value_t>({d, d});
   auto cShape = A.Shape();
   cShape[RANK-1] = matxKeepDim;
   cShape[RANK-2] = matxKeepDim;

--- a/test/00_operators/GeneratorTests.cu
+++ b/test/00_operators/GeneratorTests.cu
@@ -212,7 +212,7 @@ TYPED_TEST(BasicGeneratorTestsAll, Diag)
       delta(0) = static_cast<TestType>(1.0);
       exec.sync();
 
-      (td = 0).run(exec);
+      (td = TestType{0}).run(exec);
       (td = diag(conv1d(tc, delta, MATX_C_MODE_SAME))).run(exec);
       exec.sync();
 
@@ -366,7 +366,7 @@ TYPED_TEST(BasicGeneratorTestsAll, Zeros)
   cuda::std::array<index_t, 1> s({count});
   auto t1 = make_tensor<TestType>(s);
 
-  (t1 = zeros()).run(exec);
+  (t1 = zeros<TestType>()).run(exec);
   // example-end zeros-gen-test-1
 
   exec.sync();
@@ -393,7 +393,7 @@ TYPED_TEST(BasicGeneratorTestsAll, Ones)
   cuda::std::array<index_t, 1> s({count});
   auto t1 = make_tensor<TestType>(s);
 
-  (t1 = ones()).run(exec);
+  (t1 = ones<TestType>()).run(exec);
   // example-end ones-gen-test-1    
   exec.sync();
 
@@ -454,7 +454,12 @@ TYPED_TEST(BasicGeneratorTestsAll, FillNoShape)
   const TestType value = static_cast<TestType>(11);
   // Shapeless fill() broadcasts as a scalar across `src`. The result's
   // shape comes from `src`, so fill needs no shape of its own.
-  (t1 = src + fill<TestType>(value)).run(exec);
+  if constexpr (std::is_same_v<TestType, bool>) {
+    (t1 = src || fill<TestType>(value)).run(exec);
+  }
+  else {
+    (t1 = src + fill<TestType>(value)).run(exec);
+  }
   exec.sync();
 
   for (index_t i = 0; i < count; i++) {
@@ -551,7 +556,7 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Range)
   tensor_t<TestType, 1> t1{{count}};
 
   // Generate a sequence of 100 numbers starting at 1 and spaced by 1
-  (t1 = range<0>(t1.Shape(), 1, 1)).run(exec);
+  (t1 = range<0>(t1.Shape(), static_cast<TestType>(1), static_cast<TestType>(1))).run(exec);
   // example-end range-gen-test-1  
   exec.sync();
 
@@ -634,8 +639,10 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
 
     for (int row = 0; row < ls.Size(0); row++) {
       for (int col = 0; col < ls.Size(1); col++) {
-        TestType step = (stops[col] - starts[col]) / (count - 1);
-        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), starts[col] + step * row));
+        const TestType step =
+            static_cast<TestType>((stops[col] - starts[col]) / static_cast<TestType>(count - 1));
+        const TestType expected = static_cast<TestType>(starts[col] + step * static_cast<TestType>(row));
+        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), expected));
       }
     }
   }
@@ -652,8 +659,10 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
 
     for (int row = 0; row < ls.Size(0); row++) {
       for (int col = 0; col < ls.Size(1); col++) {
-        TestType step = (stops[row] - starts[row]) / (count - 1);
-        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), starts[row] + step * col));
+        const TestType step =
+            static_cast<TestType>((stops[row] - starts[row]) / static_cast<TestType>(count - 1));
+        const TestType expected = static_cast<TestType>(starts[row] + step * static_cast<TestType>(col));
+        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), expected));
       }
     }
   }    
@@ -711,8 +720,10 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
 
     for (int row = 0; row < ls.Size(0); row++) {
       for (int col = 0; col < ls.Size(1); col++) {
-        TestType step = (stops[col] - starts[col]) / (count - 1);
-        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), starts[col] + step * row));
+        const TestType step =
+            static_cast<TestType>((stops[col] - starts[col]) / static_cast<TestType>(count - 1));
+        const TestType expected = static_cast<TestType>(starts[col] + step * static_cast<TestType>(row));
+        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), expected));
       }
     }
   }
@@ -730,8 +741,10 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
 
     for (int row = 0; row < ls.Size(0); row++) {
       for (int col = 0; col < ls.Size(1); col++) {
-        TestType step = (stops[row] - starts[row]) / (count - 1);
-        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), starts[row] + step * col));
+        const TestType step =
+            static_cast<TestType>((stops[row] - starts[row]) / static_cast<TestType>(count - 1));
+        const TestType expected = static_cast<TestType>(starts[row] + step * static_cast<TestType>(col));
+        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), expected));
       }
     }
   }
@@ -749,8 +762,10 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
 
     for (int row = 0; row < ls.Size(0); row++) {
       for (int col = 0; col < ls.Size(1); col++) {
-        TestType step = (stops[col] - starts[col]) / (count - 1);
-        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), starts[col] + step * row));
+        const TestType step =
+            static_cast<TestType>((stops[col] - starts[col]) / static_cast<TestType>(count - 1));
+        const TestType expected = static_cast<TestType>(starts[col] + step * static_cast<TestType>(row));
+        EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), expected));
       }
     }
   }
@@ -784,21 +799,14 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Logspace)
                 static_cast<double>(s[s.size() - 1] - 1);
 
   for (index_t i = 0; i < count; i++) {
+    const double expected = cuda::std::pow(
+        10.0, static_cast<double>(start) + step * static_cast<double>(i));
+
     if constexpr (IsHalfType<TestType>()) {
-      EXPECT_TRUE(MatXUtils::MatXTypeCompare(
-          t1(i),
-          cuda::std::powf(10, static_cast<double>(start) +
-                                  static_cast<double>(step) *
-                                      static_cast<double>(i)),
-          2));
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), expected, 2));
     }
     else {
-      EXPECT_TRUE(MatXUtils::MatXTypeCompare(
-          t1(i),
-          cuda::std::powf(10, static_cast<double>(start) +
-                                  static_cast<double>(step) *
-                                      static_cast<double>(i)),
-          0.01));
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t1(i), expected, 0.01));
     }
   }
 
@@ -988,5 +996,3 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplexNonHalf, CChirp)
   pb.reset();
   MATX_EXIT_HANDLER();
 }
-
-

--- a/test/00_operators/abs2_test.cu
+++ b/test/00_operators/abs2_test.cu
@@ -35,10 +35,16 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Abs2)
     exec.sync();
     ASSERT_NEAR(y(), 8.0, 1.0e-6);
   } else {
-    x() = 2.0;
+    x() = static_cast<TestType>(2);
     (y = abs2(x)).run(exec);
     exec.sync();
-    ASSERT_NEAR(y(), 4.0, 1.0e-6);
+    if constexpr (std::is_integral_v<inner_type>) {
+      ASSERT_EQ(y(), static_cast<inner_type>(4));
+    }
+    else {
+      ASSERT_NEAR(y(), static_cast<inner_type>(4), 1.0e-6);
+    }
+
 
     // Test with higher rank tensor
     auto x3 = make_tensor<TestType>({3,3,3});
@@ -58,7 +64,12 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Abs2)
       for (int j = 0; j < 3; j++) {
         for (int k = 0; k < 3; k++) {
           TestType v = static_cast<TestType>(i*9 + j*3 + k);
-          ASSERT_NEAR(y3(i,j,k), v*v, 1.0e-6);
+          if constexpr (std::is_integral_v<inner_type>) {
+            ASSERT_EQ(y3(i,j,k), static_cast<inner_type>(v*v));
+          }
+          else {
+            ASSERT_NEAR(y3(i,j,k), static_cast<inner_type>(v*v), 1.0e-6);
+          }          
         }
       }
     }

--- a/test/00_operators/advanced_remap_test.cu
+++ b/test/00_operators/advanced_remap_test.cu
@@ -48,7 +48,7 @@ TEST(OperatorTestsAdvanced, AdvancedRemapOp)
     }
   }
 
-  (B = 0).run(exec);
+  (B = static_cast<complex>(0)).run(exec);
 
   auto rop = remap<1>(A, idx);
   auto lop = lcollapse<3>(rop);
@@ -121,10 +121,10 @@ TEST(OperatorTestsAdvanced, AdvancedRemapOp)
   auto cop = C.Clone<4>({matxKeepDim, M, matxKeepDim, matxKeepDim});
   auto rcop = lcollapse<3>(remap<1>(cop, idx));
 
-  (O1 = 1).run(exec);
-  (O2 = 2).run(exec);
-  (O3 = 3).run(exec);
-  (O4 = 4).run(exec);
+  (O1 = complex{1.0f, 0.0f}).run(exec);
+  (O2 = complex{2.0f, 0.0f}).run(exec);
+  (O3 = complex{3.0f, 0.0f}).run(exec);
+  (O4 = complex{4.0f, 0.0f}).run(exec);
   
   (B = lop).run(exec);
   (D = rcop).run(exec);

--- a/test/00_operators/cast_test.cu
+++ b/test/00_operators/cast_test.cu
@@ -12,7 +12,7 @@ TEST(OperatorTests, Cast)
   index_t count0 = 4;
   auto t = make_tensor<int8_t>({count0});
   auto t2 = make_tensor<int8_t>({count0});
-  auto to = make_tensor<float>({count0});
+  auto to = make_tensor<int8_t>({count0});
 
   cudaExecutor exec{};
 
@@ -25,7 +25,7 @@ TEST(OperatorTests, Cast)
   exec.sync();
 
   for (int i = 0; i < t.Size(0); i++) {
-    ASSERT_EQ(to(i), -4); // -4 from 126 + 126 wrap-around
+    ASSERT_EQ(to(i), static_cast<int8_t>(-4)); // -4 from 126 + 126 wrap-around
   }
 
   // example-begin as_int8-test-1
@@ -34,7 +34,7 @@ TEST(OperatorTests, Cast)
   exec.sync();
   
   for (int i = 0; i < t.Size(0); i++) {
-    ASSERT_EQ(to(i), -4); // -4 from 126 + 126 wrap-around
+    ASSERT_EQ(to(i), static_cast<int8_t>(-4)); // -4 from 126 + 126 wrap-around
   }  
 
   // example-begin as_complex_float-test-1

--- a/test/00_operators/cast_test.cu
+++ b/test/00_operators/cast_test.cu
@@ -12,7 +12,7 @@ TEST(OperatorTests, Cast)
   index_t count0 = 4;
   auto t = make_tensor<int8_t>({count0});
   auto t2 = make_tensor<int8_t>({count0});
-  auto to = make_tensor<int8_t>({count0});
+  auto to = make_tensor<float>({count0});
 
   cudaExecutor exec{};
 
@@ -20,21 +20,21 @@ TEST(OperatorTests, Cast)
   t2.SetVals({126, 126, 126, 126});
   
   // example-begin as_type-test-1
-  (to = as_type<int8_t>(t + t2)).run(exec);
+  (to = as_float(as_type<int8_t>(t + t2))).run(exec);
   // example-end as_type-test-1
   exec.sync();
 
   for (int i = 0; i < t.Size(0); i++) {
-    ASSERT_EQ(to(i), static_cast<int8_t>(-4)); // -4 from 126 + 126 wrap-around
+    ASSERT_EQ(to(i), -4.0f); // -4 from 126 + 126 wrap-around
   }
 
   // example-begin as_int8-test-1
-  (to = as_int8(t + t2)).run(exec);
+  (to = as_float(as_int8(t + t2))).run(exec);
   // example-end as_int8-test-1
   exec.sync();
   
   for (int i = 0; i < t.Size(0); i++) {
-    ASSERT_EQ(to(i), static_cast<int8_t>(-4)); // -4 from 126 + 126 wrap-around
+    ASSERT_EQ(to(i), -4.0f); // -4 from 126 + 126 wrap-around
   }  
 
   // example-begin as_complex_float-test-1

--- a/test/00_operators/concat_test.cu
+++ b/test/00_operators/concat_test.cu
@@ -42,9 +42,9 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Concatenate)
   // Test contcat with nested transforms
   if constexpr (is_cuda_non_jit_executor<ExecType> && (std::is_same_v<TestType, float> || std::is_same_v<TestType, double>)) {
     auto delta = make_tensor<TestType>({1});
-    delta.SetVals({1.0});
+    delta.SetVals({static_cast<TestType>(1)});
 
-    (t1o = 0).run(exec);
+    (t1o = static_cast<TestType>(0)).run(exec);
     (t1o = concat(0, conv1d(t11, delta, MATX_C_MODE_SAME), conv1d(t12, delta, MATX_C_MODE_SAME))).run(exec);
 
     exec.sync();

--- a/test/00_operators/square_copy_transpose_test.cu
+++ b/test/00_operators/square_copy_transpose_test.cu
@@ -19,6 +19,9 @@ TYPED_TEST(OperatorTestsNumericNoHalfAllExecs, SquareCopyTranspose)
   index_t count = 512;
   tensor_t<TestType, 2> t2({count, count});
   tensor_t<TestType, 2> t2t({count, count});
+  auto expected_value = [](index_t value) {
+    return TestType{static_cast<detail::value_promote_t<TestType>>(value)};
+  };
 
   for (index_t i = 0; i < count; i++) {
     for (index_t j = 0; j < count; j++) {
@@ -32,7 +35,7 @@ TYPED_TEST(OperatorTestsNumericNoHalfAllExecs, SquareCopyTranspose)
 
   for (index_t i = 0; i < count; i++) {
     for (index_t j = 0; j < count; j++) {
-      ASSERT_EQ(t2t(i, j), TestType(i * count + (double)j));
+      ASSERT_EQ(t2t(i, j), expected_value(i * count + j));
     }
   }
 
@@ -43,9 +46,9 @@ TYPED_TEST(OperatorTestsNumericNoHalfAllExecs, SquareCopyTranspose)
   for (index_t i = 0; i < count; i++) {
     for (index_t j = 0; j < count; j++) {
       EXPECT_TRUE(MatXUtils::MatXTypeCompare(t2(i, j),
-                                             TestType(i * count + (double)j)));
+                                             expected_value(i * count + j)));
       EXPECT_TRUE(
-          MatXUtils::MatXTypeCompare(t2t(j, i), TestType(i * count + j)));
+          MatXUtils::MatXTypeCompare(t2t(j, i), expected_value(i * count + j)));
     }
   }
   MATX_EXIT_HANDLER();
@@ -62,6 +65,9 @@ TYPED_TEST(OperatorTestsNumericNoHalfAllExecs, NonSquareTranspose)
   index_t count1 = 200, count2 = 100;
   tensor_t<TestType, 2> t2({count1, count2});
   tensor_t<TestType, 2> t2t({count2, count1});
+  auto expected_value = [](index_t value) {
+    return TestType{static_cast<detail::value_promote_t<TestType>>(value)};
+  };
 
   for (index_t i = 0; i < count1; i++) {
     for (index_t j = 0; j < count2; j++) {
@@ -75,9 +81,9 @@ TYPED_TEST(OperatorTestsNumericNoHalfAllExecs, NonSquareTranspose)
   for (index_t i = 0; i < count1; i++) {
     for (index_t j = 0; j < count2; j++) {
       EXPECT_TRUE(MatXUtils::MatXTypeCompare(t2(i, j),
-                                             TestType(i * count + (double)j)));
+                                             expected_value(i * count + j)));
       EXPECT_TRUE(MatXUtils::MatXTypeCompare(t2t(j, i),
-                                             TestType(i * count + (double)j)));
+                                             expected_value(i * count + j)));
     }
   }
   MATX_EXIT_HANDLER();

--- a/test/00_solver/SVD.cu
+++ b/test/00_solver/SVD.cu
@@ -510,9 +510,9 @@ void svdpi_test( const index_t (&AshapeA)[RANK], Executor exec) {
   (A = random<AType>(AshapeA, NORMAL)).run(exec);
   auto x0 = random<SType>(std::move(Sshape), NORMAL);
 
-  (U = 0).run(exec);
-  (S = 0).run(exec);
-  (VT = 0).run(exec);
+  (U = AType{0}).run(exec);
+  (S = SType{0}).run(exec);
+  (VT = AType{0}).run(exec);
 
   (mtie(U, S, VT) = svdpi(A, x0, iterations, r)).run(exec);
   // example-end svdpi-test-1
@@ -642,9 +642,9 @@ void svdbpi_test( const index_t (&AshapeA)[RANK], Executor exec) {
   (A = random<AType>(std::move(Ashape), NORMAL)).run(exec);
 
 
-  (U = 0).run(exec);
-  (S = 0).run(exec);
-  (VT = 0).run(exec);
+  (U = AType{0}).run(exec);
+  (S = SType{0}).run(exec);
+  (VT = AType{0}).run(exec);
 
   (mtie(U, S, VT) = svdbpi(A, iterations)).run(exec);
   // example-end svdbpi-test-1

--- a/test/00_tensor/BasicTensorTests.cu
+++ b/test/00_tensor/BasicTensorTests.cu
@@ -466,7 +466,7 @@ TYPED_TEST(BasicTensorTestsIntegral, StridedKernels)
     auto tb = make_tensor<TestType>({70000 * 1024, 1});
     auto tc = make_tensor<TestType>({70000 * 1024, 1});
 
-    (ta = 1, tb = 2).run();
+    (ta = TestType{1}, tb = TestType{2}).run();
     (tc = ta + tb).run();
 
     cudaStreamSynchronize(0);
@@ -481,7 +481,7 @@ TYPED_TEST(BasicTensorTestsIntegral, StridedKernels)
     auto tb = make_tensor<TestType>({70000 * 1024, 1, 1});
     auto tc = make_tensor<TestType>({70000 * 1024, 1, 1});
 
-    (ta = 1, tb = 2).run();
+    (ta = TestType{1}, tb = TestType{2}).run();
     (tc = ta + tb).run();
 
     cudaStreamSynchronize(0);
@@ -496,7 +496,7 @@ TYPED_TEST(BasicTensorTestsIntegral, StridedKernels)
     auto tb = make_tensor<TestType>({70000 * 1024, 1, 1, 1});
     auto tc = make_tensor<TestType>({70000 * 1024, 1, 1, 1});
 
-    (ta = 1, tb = 2).run();
+    (ta = TestType{1}, tb = TestType{2}).run();
     (tc = ta + tb).run();
 
     cudaStreamSynchronize(0);
@@ -516,7 +516,7 @@ TYPED_TEST(BasicTensorTestsAll, Print)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
 
   auto t = make_tensor<TestType>({3});
-  (t = ones()).run(this->exec);
+  (t = ones<TestType>()).run(this->exec);
   print(t);
 
   MATX_EXIT_HANDLER();
@@ -528,9 +528,8 @@ TYPED_TEST(BasicTensorTestsAll, DevicePrint)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>; 
 
   auto t = make_tensor<TestType>({3}, MATX_DEVICE_MEMORY);
-  (t = ones()).run(this->exec);
+  (t = ones<TestType>()).run(this->exec);
   print(t);
 
   MATX_EXIT_HANDLER();
 }
-

--- a/test/00_tensor/EinsumTests.cu
+++ b/test/00_tensor/EinsumTests.cu
@@ -166,8 +166,8 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Dot)
   auto a1 = make_tensor<TestType>({60});
   auto b1 = make_tensor<TestType>({60});
   auto c0 = make_tensor<TestType>({});
-  (a1 = ones(a1.Shape()) * 2).run(exec);
-  (b1 = ones(b1.Shape()) * 2).run(exec); 
+  (a1 = ones<TestType>(a1.Shape()) * 2).run(exec);
+  (b1 = ones<TestType>(b1.Shape()) * 2).run(exec);
 
   // Perform a dot product of b1 with itself and store in a1
   (c0 = cutensor::einsum("i,i->", a1, b1)).run(exec);
@@ -192,8 +192,8 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, GEMM)
   auto b2 = make_tensor<TestType>({20,10});
   auto c2 = make_tensor<TestType>({10,10});    
   auto c22 = make_tensor<TestType>({10,10});   
-  (a2 = ones()).run(exec);
-  (b2 = ones()).run(exec); 
+  (a2 = ones<TestType>()).run(exec);
+  (b2 = ones<TestType>()).run(exec);
 
   // Perform a GEMM of a2 * b2. Compare results to traditional matmul call
   (c2 = cutensor::einsum("mk,kn->mn", a2, b2)).run(exec);
@@ -222,8 +222,8 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, GEMMTranspose)
   auto b2 = make_tensor<TestType>({20,10});
   auto c2 = make_tensor<TestType>({10,5});    
   auto c22 = make_tensor<TestType>({5,10});   
-  (a2 = ones()).run(exec);
-  (b2 = ones()).run(exec); 
+  (a2 = ones<TestType>()).run(exec);
+  (b2 = ones<TestType>()).run(exec);
 
   // Perform a GEMM of a2 * b2 and store the results transposed
   (c2 = cutensor::einsum("mk,kn->nm", a2, b2)).run(exec);
@@ -251,8 +251,8 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Permute)
   auto a = make_tensor<TestType>({5,20,4,3});
   auto b = make_tensor<TestType>({20,3,4,5});
   auto b2 = make_tensor<TestType>({20,3,4,5});
-  (a = ones()).run(exec);
-  (b = ones()).run(exec);
+  (a = ones<TestType>()).run(exec);
+  (b = ones<TestType>()).run(exec);
 
   // Permute a 4D tensor. This gives the same output as Permute, but is much faster
   (b = cutensor::einsum("ijkl->jlki", a)).run(exec);
@@ -313,7 +313,7 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Trace)
   auto a2 = make_tensor<TestType>({10,10});
   auto c0_0 = make_tensor<TestType>({});
   auto c0_1 = make_tensor<TestType>({});
-  (a2 = ones()).run(exec);
+  (a2 = ones<TestType>()).run(exec);
 
   // Perform a GEMM of a2 * b2. Compare results to traditional matmul call
   (c0_0 = cutensor::einsum("ii->", a2)).run(exec);

--- a/test/00_tensor/EinsumTests.cu
+++ b/test/00_tensor/EinsumTests.cu
@@ -166,8 +166,8 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Dot)
   auto a1 = make_tensor<TestType>({60});
   auto b1 = make_tensor<TestType>({60});
   auto c0 = make_tensor<TestType>({});
-  (a1 = ones<TestType>(a1.Shape()) * 2).run(exec);
-  (b1 = ones<TestType>(b1.Shape()) * 2).run(exec);
+  (a1 = ones<TestType>(a1.Shape()) * TestType{2}).run(exec);
+  (b1 = ones<TestType>(b1.Shape()) * TestType{2}).run(exec);
 
   // Perform a dot product of b1 with itself and store in a1
   (c0 = cutensor::einsum("i,i->", a1, b1)).run(exec);

--- a/test/00_tensor/TensorCreationTests.cu
+++ b/test/00_tensor/TensorCreationTests.cu
@@ -302,11 +302,17 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic)
 
   (a = ones<TestType>()).run(exec);
   (b = ones<TestType>()).run(exec);
-  (c = a + b).run(exec);
+  if constexpr (std::is_same_v<TestType, bool>) {
+    (c = a || b).run(exec);
+  }
+  else {
+    (c = a + b).run(exec);
+  }
   exec.sync();
 
+  const TestType expected = std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
   for (index_t i = 0; i < 4; i++) {
-    ASSERT_EQ(c(i), TestType(2));
+    ASSERT_EQ(c(i), expected);
   }
 }
 
@@ -322,12 +328,18 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic2D)
 
   (a = ones<TestType>()).run(exec);
   (b = ones<TestType>()).run(exec);
-  (c = a + b).run(exec);
+  if constexpr (std::is_same_v<TestType, bool>) {
+    (c = a || b).run(exec);
+  }
+  else {
+    (c = a + b).run(exec);
+  }
   exec.sync();
 
+  const TestType expected = std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
   for (index_t i = 0; i < 3; i++) {
     for (index_t j = 0; j < 4; j++) {
-      ASSERT_EQ(c(i, j), TestType(2));
+      ASSERT_EQ(c(i, j), expected);
     }
   }
 }
@@ -344,13 +356,19 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic3D)
 
   (a = ones<TestType>()).run(exec);
   (b = ones<TestType>()).run(exec);
-  (c = a + b).run(exec);
+  if constexpr (std::is_same_v<TestType, bool>) {
+    (c = a || b).run(exec);
+  }
+  else {
+    (c = a + b).run(exec);
+  }
   exec.sync();
 
+  const TestType expected = std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
   for (index_t i = 0; i < 2; i++) {
     for (index_t j = 0; j < 3; j++) {
       for (index_t k = 0; k < 4; k++) {
-        ASSERT_EQ(c(i, j, k), TestType(2));
+        ASSERT_EQ(c(i, j, k), expected);
       }
     }
   }
@@ -368,14 +386,20 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic4D)
 
   (a = ones<TestType>()).run(exec);
   (b = ones<TestType>()).run(exec);
-  (c = a + b).run(exec);
+  if constexpr (std::is_same_v<TestType, bool>) {
+    (c = a || b).run(exec);
+  }
+  else {
+    (c = a + b).run(exec);
+  }
   exec.sync();
 
+  const TestType expected = std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
   for (index_t i = 0; i < 2; i++) {
     for (index_t j = 0; j < 3; j++) {
       for (index_t k = 0; k < 4; k++) {
         for (index_t l = 0; l < 5; l++) {
-          ASSERT_EQ(c(i, j, k, l), TestType(2));
+          ASSERT_EQ(c(i, j, k, l), expected);
         }
       }
     }

--- a/test/00_transform/ResamplePoly.cu
+++ b/test/00_transform/ResamplePoly.cu
@@ -359,7 +359,7 @@ TYPED_TEST(ResamplePolyTestNonHalfFloatTypes, Batched)
     // Now use a full 4D tensor rather than just a cloned tensor as input
     auto full = make_tensor<TestType>({nA, nB, nC, a_len});
     (full = ac).run(this->exec);
-    (b = 0).run(this->exec);
+    (b = TestType{0}).run(this->exec);
 
     this->exec.sync();
 
@@ -398,7 +398,7 @@ TYPED_TEST(ResamplePolyTestNonHalfFloatTypes, Identity)
   };
 
   auto zero = make_tensor<TestType>({1});
-  (zero = 0).run(this->exec);
+  (zero = TestType{0}).run(this->exec);
   this->exec.sync();
 
   for (size_t i = 0; i < sizeof(test_cases)/sizeof(test_cases[0]); i++) {
@@ -441,7 +441,7 @@ TYPED_TEST(ResamplePolyTestNonHalfFloatTypes, Downsample)
   };
 
   auto seven = make_tensor<TestType>({1});
-  (seven = 7).run(this->exec);
+  (seven = TestType{static_cast<typename inner_op_type_t<TestType>::type>(7)}).run(this->exec);
   this->exec.sync();
 
   for (size_t i = 0; i < sizeof(test_cases)/sizeof(test_cases[0]); i++) {
@@ -479,6 +479,7 @@ TYPED_TEST(ResamplePolyTestNonHalfFloatTypes, Upsample)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using InnerType = typename inner_op_type_t<TestType>::type;
 
   struct {
     index_t a_len;
@@ -500,7 +501,8 @@ TYPED_TEST(ResamplePolyTestNonHalfFloatTypes, Upsample)
 
     // The resample kernel scales the filter by up, so we use 1/up to get an
     // effective filter of 1.
-    (f = 1.0/static_cast<double>(up)).run(this->exec);
+    const auto filter_scale = static_cast<InnerType>(1) / static_cast<InnerType>(up);
+    (f = TestType{filter_scale}).run(this->exec);
     this->exec.sync();
 
     auto a = make_tensor<TestType>({a_len});


### PR DESCRIPTION
Nightly nvcc with the latest gcc/clang/nvhpc have many errors mostly related to narrowing conversions. This PR fixes the warnings/errors and adds a conversion checker in set.h that's disabled by default.