### PR TITLE
Improve unit test coverage

### DIFF
--- a/docker/production/matx-production.py
+++ b/docker/production/matx-production.py
@@ -22,20 +22,26 @@ Stage0 = hpccm.Stage()
 Stage0 += baseimage(image='nvidia/cuda:12.6.2-devel-ubuntu22.04', _as='devel', _distro="ubuntu22")
 
 Stage0 += packages(ospackages=[
+    'apt-transport-https',
     'bison',
+    'ca-certificates',
     'clang-tidy',
     'curl',
     'flex',
     'ghostscript',
     'git',
+    'gnupg',
     'libjs-mathjax',
     'liblapacke-dev',    
     'libopenblas64-openmp-dev',
     'lcov',
     'ninja-build',
     'numactl',
-    'python3-pip',
     'python3-dev',
+    'python3-pip',
+    'python3-setuptools',
+    'python3-venv',
+    'python3-wheel',
     'sudo',
     'texlive-font-utils',
     'valgrind',
@@ -57,10 +63,27 @@ Stage0 += pip(pip="pip3", upgrade=True, packages=[
     'sphinx-rtd-theme',
 ])
 
+Stage0 += shell(commands=["python3 -c \"import cupy, numpy, scipy, pybind11\""])
+
 Stage0 += gnu()
 Stage0 += cmake(eula=True, version="3.26.4")
-Stage0 += nsight_compute(eula=True)
-Stage0 += nsight_systems()
+Stage0 += packages(
+    apt_keys=[f"https://developer.download.nvidia.com/devtools/repos/ubuntu2204/{TARGETARCH}/nvidia.pub"],
+    apt_repositories=[f"deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu2204/{TARGETARCH}/ /"],
+    force_add_repo=True,
+    ospackages=[
+        'nsight-compute',
+        'nsight-systems',
+        'nsight-systems-cli',
+    ],
+    _apt_key=False)
+Stage0 += shell(commands=[
+    'ln -sfn "$(find /opt/nvidia/nsight-compute -mindepth 1 -maxdepth 1 -type d -name \'[0-9]*\' | sort -V | tail -n 1)" /opt/nvidia/nsight-compute/latest'
+])
+Stage0 += environment(variables={
+    'NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT': '1',
+    'PATH': '/opt/nvidia/nsight-compute/latest:$PATH',
+})
 
 Stage0 += shell(commands=["wget https://doxygen.nl/files/doxygen-{}.src.tar.gz".format(DOXYGEN_VER),
                           "tar -zxf doxygen-{}.src.tar.gz".format(DOXYGEN_VER),

--- a/docker/production/production.Dockerfile
+++ b/docker/production/production.Dockerfile
@@ -2,12 +2,15 @@ FROM nvidia/cuda:12.6.2-devel-ubuntu22.04 AS devel
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apt-transport-https \
         bison \
+        ca-certificates \
         clang-tidy \
         curl \
         flex \
         ghostscript \
         git \
+        gnupg \
         lcov \
         libjs-mathjax \
         liblapacke-dev \
@@ -16,6 +19,9 @@ RUN apt-get update -y && \
         numactl \
         python3-dev \
         python3-pip \
+        python3-setuptools \
+        python3-venv \
+        python3-wheel \
         sudo \
         texlive-font-utils \
         valgrind \
@@ -31,6 +37,8 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN pip3 --no-cache-dir install --upgrade pip && \
     pip3 --no-cache-dir install breathe cupy-cuda12x hpccm numpy pandas plotly==5.2.1 pybind11 scipy sphinx sphinx_book_theme sphinx-rtd-theme
+
+RUN python3 -c "import cupy, numpy, scipy, pybind11"
 
 # GNU compiler
 RUN apt-get update -y && \
@@ -52,41 +60,21 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     rm -rf /var/tmp/cmake-3.26.4-linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH
 
-# NVIDIA Nsight Compute 2022.4.0
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        apt-transport-https \
-        ca-certificates \
-        gnupg \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /usr/share/keyrings && \
     rm -f /usr/share/keyrings/nvidia.gpg && \
     wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu2204/amd64/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu2204/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        nsight-compute-2022.4.0 && \
+        nsight-compute \
+        nsight-systems \
+        nsight-systems-cli && \
     rm -rf /var/lib/apt/lists/*
-ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1 \
-    PATH=/opt/nvidia/nsight-compute/2022.4.0:$PATH
 
-# NVIDIA Nsight Systems 2022.5.1
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        apt-transport-https \
-        ca-certificates \
-        gnupg \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /usr/share/keyrings && \
-    rm -f /usr/share/keyrings/nvidia.gpg && \
-    wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu2204/amd64/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu2204/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
-    apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        nsight-systems-cli-2022.5.1 && \
-    rm -rf /var/lib/apt/lists/*
+RUN ln -sfn "$(find /opt/nvidia/nsight-compute -mindepth 1 -maxdepth 1 -type d -name '[0-9]*' | sort -V | tail -n 1)" /opt/nvidia/nsight-compute/latest
+
+ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1 \
+    PATH=/opt/nvidia/nsight-compute/latest:$PATH
 
 RUN wget https://doxygen.nl/files/doxygen-1.9.6.src.tar.gz && \
     tar -zxf doxygen-1.9.6.src.tar.gz && \
@@ -102,6 +90,3 @@ RUN curl -L https://coveralls.io/coveralls-linux.tar.gz | tar -xz -C /usr/local/
 
 RUN cd /tmp && wget https://github.com/flame/blis/archive/refs/tags/1.0.tar.gz && tar -zxvf 1.0.tar.gz && cd blis-1.0 && \
     ./configure --enable-threading=openmp --enable-cblas -b 64 auto && sudo make -j install
-
-
-

--- a/docker/production/production.Dockerfile
+++ b/docker/production/production.Dockerfile
@@ -2,15 +2,12 @@ FROM nvidia/cuda:12.6.2-devel-ubuntu22.04 AS devel
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        apt-transport-https \
         bison \
-        ca-certificates \
         clang-tidy \
         curl \
         flex \
         ghostscript \
         git \
-        gnupg \
         lcov \
         libjs-mathjax \
         liblapacke-dev \
@@ -19,9 +16,6 @@ RUN apt-get update -y && \
         numactl \
         python3-dev \
         python3-pip \
-        python3-setuptools \
-        python3-venv \
-        python3-wheel \
         sudo \
         texlive-font-utils \
         valgrind \
@@ -37,8 +31,6 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN pip3 --no-cache-dir install --upgrade pip && \
     pip3 --no-cache-dir install breathe cupy-cuda12x hpccm numpy pandas plotly==5.2.1 pybind11 scipy sphinx sphinx_book_theme sphinx-rtd-theme
-
-RUN python3 -c "import cupy, numpy, scipy, pybind11"
 
 # GNU compiler
 RUN apt-get update -y && \
@@ -60,21 +52,41 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     rm -rf /var/tmp/cmake-3.26.4-linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH
 
+# NVIDIA Nsight Compute 2022.4.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        gnupg \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /usr/share/keyrings && \
     rm -f /usr/share/keyrings/nvidia.gpg && \
     wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu2204/amd64/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu2204/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        nsight-compute \
-        nsight-systems \
-        nsight-systems-cli && \
+        nsight-compute-2022.4.0 && \
     rm -rf /var/lib/apt/lists/*
-
-RUN ln -sfn "$(find /opt/nvidia/nsight-compute -mindepth 1 -maxdepth 1 -type d -name '[0-9]*' | sort -V | tail -n 1)" /opt/nvidia/nsight-compute/latest
-
 ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1 \
-    PATH=/opt/nvidia/nsight-compute/latest:$PATH
+    PATH=/opt/nvidia/nsight-compute/2022.4.0:$PATH
+
+# NVIDIA Nsight Systems 2022.5.1
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        gnupg \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/nvidia.gpg && \
+    wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu2204/amd64/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu2204/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        nsight-systems-cli-2022.5.1 && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN wget https://doxygen.nl/files/doxygen-1.9.6.src.tar.gz && \
     tar -zxf doxygen-1.9.6.src.tar.gz && \
@@ -90,3 +102,6 @@ RUN curl -L https://coveralls.io/coveralls-linux.tar.gz | tar -xz -C /usr/local/
 
 RUN cd /tmp && wget https://github.com/flame/blis/archive/refs/tags/1.0.tar.gz && tar -zxvf 1.0.tar.gz && cd blis-1.0 && \
     ./configure --enable-threading=openmp --enable-cblas -b 64 auto && sudo make -j install
+
+
+

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -448,7 +448,7 @@ template <typename TensorType>
 auto make_tensor( TensorType &tensor,
                   typename TensorType::value_type *ptr) {
   MATX_LOG_DEBUG("make_tensor(tensor&, ptr, 0D): ptr={}", reinterpret_cast<void*>(ptr));
-  auto tmp = make_tensor<typename TensorType::value_type>(ptr, false);
+  auto tmp = make_tensor<typename TensorType::value_type>(ptr, {}, false);
   tensor.Shallow(tmp);
 }
 

--- a/include/matx/core/tensor_desc.h
+++ b/include/matx/core/tensor_desc.h
@@ -385,7 +385,7 @@ public:
    * @param dim Dimension to retrieve
    * @return Size of dimension
    */
-  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) { return shape_[dim]; }
+  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) { return make_shape()[dim]; }
 
   /**
    * @brief Get stride of dimension
@@ -393,7 +393,7 @@ public:
    * @param dim Dimension to retrieve
    * @return Stride of dimension
    */
-  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Stride(int dim) { return stride_[dim]; }
+  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Stride(int dim) { return make_strides()[dim]; }
 
   /**
    * @brief Return strides contaienr of descriptor
@@ -401,7 +401,7 @@ public:
    * @return Strides container
    */
   static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Strides() {
-    return stride_;
+    return make_strides();
   }
 
   /**
@@ -409,14 +409,14 @@ public:
    *
    * @return Descriptor rank
    */
-  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ int Rank() { return shape_.size(); }
+  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ int Rank() { return sizeof...(Is) + 1; }
 
   /**
    * @brief Get underlying shape object
    *
    * @return Shape object
    */
-  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Shape() { return shape_; }
+  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Shape() { return make_shape(); }
 
   /**
    * @brief Get total size of descriptor
@@ -424,27 +424,25 @@ public:
    * @return Product of all sizes
    */
   static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto TotalSize() {
-      return cuda::std::accumulate(shape_.begin(), shape_.end(), static_cast<index_t>(1), cuda::std::multiplies<index_t>());
+      return (I * ... * Is);
   }
 
 private:
-  static constexpr auto make_shape(){
+  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto make_shape(){
       return cuda::std::array{I, Is...};
   }
 
-  static constexpr auto make_strides(){
+  static constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto make_strides(){
       cuda::std::array<index_t, 1 + sizeof...(Is)> m{};
+      const auto shape = make_shape();
       m[m.size()-1] = 1;
       if constexpr (m.size() > 1) {
         for (int i = m.size()-2; i >= 0; i--) {
-            m[i] = m[i+1] * Size(i + 1);
+            m[i] = m[i+1] * shape[i + 1];
         }
       }
       return m;
   }
-
-  static constexpr shape_container shape_ = make_shape();
-  static constexpr stride_container stride_ = make_strides();
 };
 
 /**

--- a/include/matx/executors/cuda_executor_common.h
+++ b/include/matx/executors/cuda_executor_common.h
@@ -157,6 +157,10 @@ namespace detail
   template <typename Op>
   auto create_kernel_provider(const cuda::std::array<index_t, Op::Rank()>& sizes, bool is_jit = false, bool global_kernel = false) {
     return [&, is_jit, global_kernel](ElementsPerThread ept) -> const void* {
+      if (ept == ElementsPerThread::INVALID) {
+        return nullptr;
+      }
+
       dim3 local_blocks = 1;
       dim3 local_threads = 1;
       [[maybe_unused]] bool stride;
@@ -428,4 +432,3 @@ namespace detail
 
 } // namespace detail
 } // namespace matx
-

--- a/include/matx/transforms/ambgfun.h
+++ b/include/matx/transforms/ambgfun.h
@@ -81,7 +81,7 @@ public:
 
   __MATX_DEVICE__ __MATX_INLINE__ __MATX_HOST__ void operator()(index_t idy, index_t idx)
   {
-    return out_.template operator()<ElementsPerThread::ONE>(idy, idx);
+    return this->template operator()<DefaultCapabilities>(idy, idx);
   }
 
   constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) const noexcept
@@ -97,12 +97,20 @@ public:
 
   template <OperatorCapability Cap, typename InType>
   __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
-    // No specific capabilities enforced
     auto self_has_cap = capability_attributes<Cap>::default_value;
-    return combine_capabilities<Cap>(self_has_cap, 
-          detail::get_operator_capability<Cap>(xnorm_, in), 
-          detail::get_operator_capability<Cap>(ynorm_, in),
-          detail::get_operator_capability<Cap>(out_, in));
+    if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
+      const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
+      return combine_capabilities<Cap>(my_cap,
+            detail::get_operator_capability<Cap>(xnorm_, in),
+            detail::get_operator_capability<Cap>(ynorm_, in),
+            detail::get_operator_capability<Cap>(out_, in));
+    }
+    else {
+      return combine_capabilities<Cap>(self_has_cap,
+            detail::get_operator_capability<Cap>(xnorm_, in),
+            detail::get_operator_capability<Cap>(ynorm_, in),
+            detail::get_operator_capability<Cap>(out_, in));
+    }
   }     
 };
 
@@ -135,16 +143,23 @@ public:
 
   __MATX_DEVICE__ inline void operator()(index_t idx)
   {
-    return out_.template operator()<ElementsPerThread::ONE>(idx);
+    return this->template operator()<DefaultCapabilities>(idx);
   } 
 
   template <OperatorCapability Cap, typename InType>
   __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
-    // No specific capabilities enforced
     auto self_has_cap = capability_attributes<Cap>::default_value;
-    return combine_capabilities<Cap>(self_has_cap, 
-          detail::get_operator_capability<Cap>(out_, in), 
-          detail::get_operator_capability<Cap>(x_, in));
+    if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
+      const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
+      return combine_capabilities<Cap>(my_cap,
+            detail::get_operator_capability<Cap>(out_, in),
+            detail::get_operator_capability<Cap>(x_, in));
+    }
+    else {
+      return combine_capabilities<Cap>(self_has_cap,
+            detail::get_operator_capability<Cap>(out_, in),
+            detail::get_operator_capability<Cap>(x_, in));
+    }
   }       
 
   constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) const noexcept
@@ -182,16 +197,23 @@ public:
 
   __MATX_DEVICE__ inline void operator()(index_t idx)
   {
-    return out_.template operator()<ElementsPerThread::ONE>(idx);
+    return this->template operator()<DefaultCapabilities>(idx);
   }
 
   template <OperatorCapability Cap, typename InType>
   __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
-    // No specific capabilities enforced
     auto self_has_cap = capability_attributes<Cap>::default_value;
-    return combine_capabilities<Cap>(self_has_cap, 
-          detail::get_operator_capability<Cap>(out_, in), 
-          detail::get_operator_capability<Cap>(x_, in));
+    if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
+      const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
+      return combine_capabilities<Cap>(my_cap,
+            detail::get_operator_capability<Cap>(out_, in),
+            detail::get_operator_capability<Cap>(x_, in));
+    }
+    else {
+      return combine_capabilities<Cap>(self_has_cap,
+            detail::get_operator_capability<Cap>(out_, in),
+            detail::get_operator_capability<Cap>(x_, in));
+    }
   }           
 
   constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) const noexcept

--- a/test/00_misc/CapabilitiesTests.cu
+++ b/test/00_misc/CapabilitiesTests.cu
@@ -1,0 +1,279 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "matx.h"
+
+#include "gtest/gtest.h"
+
+#include <cuda/std/tuple>
+
+using namespace matx;
+
+namespace {
+
+struct PlainScalarLikeOp {
+  int value;
+};
+
+struct CapabilityTestOp {
+  using emits_jit_str = void;
+
+  bool supports_jit = true;
+  bool async_loads = false;
+  bool global_kernel = true;
+  bool pass_through_threads = false;
+  bool unit_stride_last = true;
+  bool element_wise = true;
+  int max_ept_vec_load = 32;
+  int dyn_shm_size = 0;
+  std::string jit_type;
+  cuda::std::array<detail::ElementsPerThread, 2> ept_range{
+      detail::ElementsPerThread::ONE, detail::ElementsPerThread::MAX};
+  cuda::std::array<int, 2> groups_range{1, 32};
+  cuda::std::array<int, 2> block_range{1, 1024};
+
+  template <detail::OperatorCapability Cap, typename InType>
+  __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType &in) const
+  {
+    if constexpr (Cap == detail::OperatorCapability::SUPPORTS_JIT) {
+      return supports_jit;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::ASYNC_LOADS_REQUESTED) {
+      return async_loads;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::GLOBAL_KERNEL) {
+      return global_kernel;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::PASS_THROUGH_THREADS) {
+      return pass_through_threads;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::UNIT_STRIDE_LAST) {
+      return unit_stride_last;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::ELEMENT_WISE) {
+      return element_wise;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::MAX_EPT_VEC_LOAD) {
+      return max_ept_vec_load;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::DYN_SHM_SIZE) {
+      return dyn_shm_size;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::JIT_TYPE_QUERY) {
+      return jit_type;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::ELEMENTS_PER_THREAD) {
+      return ept_range;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::GROUPS_PER_BLOCK) {
+      return groups_range;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::BLOCK_DIM) {
+      return block_range;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::SET_ELEMENTS_PER_THREAD ||
+                       Cap == detail::OperatorCapability::SET_GROUPS_PER_BLOCK ||
+                       Cap == detail::OperatorCapability::JIT_CLASS_QUERY ||
+                       Cap == detail::OperatorCapability::GENERATE_LTOIR) {
+      return true;
+    }
+    else if constexpr (Cap == detail::OperatorCapability::ALIASED_MEMORY) {
+      return false;
+    }
+    else {
+      return detail::capability_attributes<Cap>::default_value;
+    }
+  }
+};
+
+template <typename T>
+void ExpectRange(const cuda::std::array<T, 2> &actual, T lower, T upper)
+{
+  EXPECT_EQ(actual[0], lower);
+  EXPECT_EQ(actual[1], upper);
+}
+
+void ExpectQueryType(detail::OperatorCapability cap, detail::CapabilityQueryType type)
+{
+  EXPECT_EQ(static_cast<int>(detail::get_query_type(cap)), static_cast<int>(type));
+}
+
+} // namespace
+
+TEST(CapabilitiesTests, DefaultCapabilitiesForNonMatXOps)
+{
+  PlainScalarLikeOp op{42};
+  EXPECT_TRUE(detail::get_operator_capability<detail::OperatorCapability::SUPPORTS_JIT>(op));
+  EXPECT_TRUE(jit_supported(op));
+  EXPECT_FALSE(detail::get_operator_capability<detail::OperatorCapability::ASYNC_LOADS_REQUESTED>(op));
+  EXPECT_TRUE(detail::get_operator_capability<detail::OperatorCapability::GLOBAL_KERNEL>(op));
+  EXPECT_TRUE(detail::get_operator_capability<detail::OperatorCapability::UNIT_STRIDE_LAST>(op));
+  EXPECT_EQ(detail::get_operator_capability<detail::OperatorCapability::MAX_EPT_VEC_LOAD>(op), 32);
+  detail::EPTQueryInput ept_input{false};
+  ExpectRange(detail::get_operator_capability<detail::OperatorCapability::ELEMENTS_PER_THREAD>(op, ept_input),
+              detail::ElementsPerThread::ONE, detail::ElementsPerThread::MAX);
+  EXPECT_FALSE(detail::get_operator_capability<detail::OperatorCapability::JIT_TYPE_QUERY>(op).empty());
+}
+
+TEST(CapabilitiesTests, QueryTypeMappingCoversEveryCapability)
+{
+  ExpectQueryType(detail::OperatorCapability::SUPPORTS_JIT, detail::CapabilityQueryType::AND_QUERY);
+  ExpectQueryType(detail::OperatorCapability::ASYNC_LOADS_REQUESTED, detail::CapabilityQueryType::OR_QUERY);
+  ExpectQueryType(detail::OperatorCapability::GLOBAL_KERNEL, detail::CapabilityQueryType::AND_QUERY);
+  ExpectQueryType(detail::OperatorCapability::ELEMENTS_PER_THREAD, detail::CapabilityQueryType::RANGE_QUERY);
+  ExpectQueryType(detail::OperatorCapability::SET_ELEMENTS_PER_THREAD, detail::CapabilityQueryType::AND_QUERY);
+  ExpectQueryType(detail::OperatorCapability::SET_GROUPS_PER_BLOCK, detail::CapabilityQueryType::AND_QUERY);
+  ExpectQueryType(detail::OperatorCapability::GROUPS_PER_BLOCK, detail::CapabilityQueryType::RANGE_QUERY);
+  ExpectQueryType(detail::OperatorCapability::ALIASED_MEMORY, detail::CapabilityQueryType::OR_QUERY);
+  ExpectQueryType(detail::OperatorCapability::MAX_EPT_VEC_LOAD, detail::CapabilityQueryType::MIN_QUERY);
+  ExpectQueryType(detail::OperatorCapability::JIT_CLASS_QUERY, detail::CapabilityQueryType::AND_QUERY);
+  ExpectQueryType(detail::OperatorCapability::JIT_TYPE_QUERY, detail::CapabilityQueryType::STR_CAT_QUERY);
+  ExpectQueryType(detail::OperatorCapability::DYN_SHM_SIZE, detail::CapabilityQueryType::MAX_QUERY);
+  ExpectQueryType(detail::OperatorCapability::BLOCK_DIM, detail::CapabilityQueryType::RANGE_QUERY);
+  ExpectQueryType(detail::OperatorCapability::GENERATE_LTOIR, detail::CapabilityQueryType::AND_QUERY);
+  ExpectQueryType(detail::OperatorCapability::PASS_THROUGH_THREADS, detail::CapabilityQueryType::OR_QUERY);
+  ExpectQueryType(detail::OperatorCapability::UNIT_STRIDE_LAST, detail::CapabilityQueryType::AND_QUERY);
+  ExpectQueryType(detail::OperatorCapability::NONE, detail::CapabilityQueryType::OR_QUERY);
+}
+
+TEST(CapabilitiesTests, CombinesBoolCapabilities)
+{
+  EXPECT_FALSE(detail::combine_capabilities<detail::OperatorCapability::ASYNC_LOADS_REQUESTED>(false));
+  EXPECT_TRUE(detail::combine_capabilities<detail::OperatorCapability::ASYNC_LOADS_REQUESTED>(false, true, false));
+  EXPECT_TRUE(detail::combine_capabilities<detail::OperatorCapability::SUPPORTS_JIT>(true));
+  EXPECT_TRUE(detail::combine_capabilities<detail::OperatorCapability::SUPPORTS_JIT>(true, true, true));
+  EXPECT_FALSE(detail::combine_capabilities<detail::OperatorCapability::SUPPORTS_JIT>(true, true, false));
+  EXPECT_FALSE(detail::combine_capabilities<detail::OperatorCapability::GLOBAL_KERNEL>(true, true, false));
+  EXPECT_TRUE(detail::combine_capabilities<detail::OperatorCapability::PASS_THROUGH_THREADS>(false, false, true));
+  EXPECT_FALSE(detail::combine_capabilities<detail::OperatorCapability::UNIT_STRIDE_LAST>(true, true, false));
+}
+
+TEST(CapabilitiesTests, CombinesNumericAndStringCapabilities)
+{
+  EXPECT_EQ(detail::combine_capabilities<detail::OperatorCapability::MAX_EPT_VEC_LOAD>(16), 16);
+  EXPECT_EQ(detail::combine_capabilities<detail::OperatorCapability::MAX_EPT_VEC_LOAD>(16, 8, 32), 8);
+  EXPECT_EQ(detail::combine_capabilities<detail::OperatorCapability::DYN_SHM_SIZE>(64), 64);
+  EXPECT_EQ(detail::combine_capabilities<detail::OperatorCapability::DYN_SHM_SIZE>(64, 128, 32), 128);
+  EXPECT_EQ(detail::combine_capabilities<detail::OperatorCapability::JIT_TYPE_QUERY>(
+                std::string("self:"), std::string("child0:"), std::string("child1")),
+            "self:child0:child1");
+}
+
+TEST(CapabilitiesTests, CombinesRangeCapabilities)
+{
+  using detail::ElementsPerThread;
+  using EptRange = cuda::std::array<ElementsPerThread, 2>;
+  using IntRange = cuda::std::array<int, 2>;
+
+  ExpectRange(detail::combine_capabilities<detail::OperatorCapability::ELEMENTS_PER_THREAD>(
+                  EptRange{ElementsPerThread::TWO, ElementsPerThread::SIXTEEN}),
+              ElementsPerThread::TWO, ElementsPerThread::SIXTEEN);
+
+  ExpectRange(detail::combine_capabilities<detail::OperatorCapability::ELEMENTS_PER_THREAD>(
+                  EptRange{ElementsPerThread::TWO, ElementsPerThread::SIXTEEN},
+                  EptRange{ElementsPerThread::FOUR, ElementsPerThread::THIRTY_TWO},
+                  EptRange{ElementsPerThread::ONE, ElementsPerThread::EIGHT}),
+              ElementsPerThread::FOUR, ElementsPerThread::EIGHT);
+
+  ExpectRange(detail::combine_capabilities<detail::OperatorCapability::ELEMENTS_PER_THREAD>(
+                  EptRange{ElementsPerThread::ONE, ElementsPerThread::TWO},
+                  EptRange{ElementsPerThread::FOUR, ElementsPerThread::EIGHT}),
+              ElementsPerThread::INVALID, ElementsPerThread::INVALID);
+
+  ExpectRange(detail::combine_capabilities<detail::OperatorCapability::GROUPS_PER_BLOCK>(
+                  IntRange{2, 16}, IntRange{4, 32}, IntRange{1, 8}),
+              4, 8);
+
+  ExpectRange(detail::combine_capabilities<detail::OperatorCapability::BLOCK_DIM>(
+                  IntRange{128, 1024}, IntRange{256, 512}),
+              256, 512);
+}
+
+TEST(CapabilitiesTests, GetsAndCombinesMatXOperatorCapabilities)
+{
+  using detail::ElementsPerThread;
+
+  CapabilityTestOp op0;
+  op0.supports_jit = true;
+  op0.async_loads = true;
+  op0.global_kernel = true;
+  op0.max_ept_vec_load = 16;
+  op0.dyn_shm_size = 96;
+  op0.jit_type = "op0;";
+  op0.ept_range = {ElementsPerThread::TWO, ElementsPerThread::SIXTEEN};
+  op0.groups_range = {1, 8};
+
+  CapabilityTestOp op1;
+  op1.supports_jit = false;
+  op1.async_loads = false;
+  op1.global_kernel = false;
+  op1.max_ept_vec_load = 8;
+  op1.dyn_shm_size = 192;
+  op1.jit_type = "op1;";
+  op1.ept_range = {ElementsPerThread::FOUR, ElementsPerThread::THIRTY_TWO};
+  op1.groups_range = {4, 16};
+
+  detail::EPTQueryInput ept_input{false};
+  const auto ops = cuda::std::make_tuple(op0, op1);
+
+  EXPECT_TRUE(detail::get_operator_capability<detail::OperatorCapability::ASYNC_LOADS_REQUESTED>(op0));
+  EXPECT_FALSE(detail::get_operator_capability<detail::OperatorCapability::SUPPORTS_JIT>(op1));
+  EXPECT_FALSE(detail::get_combined_ops_capability<detail::OperatorCapability::SUPPORTS_JIT>(ops));
+  EXPECT_TRUE(detail::get_combined_ops_capability<detail::OperatorCapability::ASYNC_LOADS_REQUESTED>(ops));
+  EXPECT_FALSE(detail::get_combined_ops_capability<detail::OperatorCapability::GLOBAL_KERNEL>(ops));
+  EXPECT_EQ(detail::get_combined_ops_capability<detail::OperatorCapability::MAX_EPT_VEC_LOAD>(ops), 8);
+  EXPECT_EQ(detail::get_combined_ops_capability<detail::OperatorCapability::DYN_SHM_SIZE>(ops), 192);
+  EXPECT_EQ(detail::get_combined_ops_capability<detail::OperatorCapability::JIT_TYPE_QUERY>(ops), "op0;op1;");
+  ExpectRange(detail::get_combined_ops_capability<detail::OperatorCapability::ELEMENTS_PER_THREAD>(ept_input, ops),
+              ElementsPerThread::FOUR, ElementsPerThread::SIXTEEN);
+  ExpectRange(detail::get_combined_ops_capability<detail::OperatorCapability::GROUPS_PER_BLOCK>(ops), 4, 8);
+}
+
+TEST(CapabilitiesTests, CapabilityParamsExposeCompileTimeDefaults)
+{
+  using Params = detail::CapabilityParams<detail::ElementsPerThread::FOUR, true, true>;
+
+  static_assert(detail::is_scoped_enum_v<detail::ElementsPerThread>);
+  static_assert(!detail::is_scoped_enum_v<int>);
+  static_assert(detail::DefaultCapabilities::ept == detail::ElementsPerThread::ONE);
+  static_assert(!detail::DefaultCapabilities::jit);
+  static_assert(!detail::DefaultCapabilities::unit_stride_last);
+  static_assert(Params::ept == detail::ElementsPerThread::FOUR);
+  static_assert(Params::jit);
+  static_assert(Params::unit_stride_last);
+  static_assert(Params::osize == 0);
+  static_assert(Params::block_size == 0);
+
+  EXPECT_EQ(Params::ept, detail::ElementsPerThread::FOUR);
+  EXPECT_TRUE(Params::jit);
+  EXPECT_TRUE(Params::unit_stride_last);
+}

--- a/test/00_misc/CudaExecutorCommonTests.cu
+++ b/test/00_misc/CudaExecutorCommonTests.cu
@@ -1,0 +1,177 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "matx.h"
+
+#include "gtest/gtest.h"
+
+#include <cuda/std/tuple>
+
+using namespace matx;
+
+namespace {
+
+bool HasCudaDevice()
+{
+  int device_count = 0;
+  const auto err = cudaGetDeviceCount(&device_count);
+  if (err != cudaSuccess || device_count == 0) {
+    cudaGetLastError();
+    return false;
+  }
+
+  return true;
+}
+
+template <typename KernelProvider>
+void ExpectAllSupportedEPTs(KernelProvider &&provider, bool expect_supported)
+{
+  using detail::ElementsPerThread;
+
+  if (expect_supported) {
+    EXPECT_TRUE(provider(ElementsPerThread::THIRTY_TWO) != nullptr);
+    EXPECT_TRUE(provider(ElementsPerThread::SIXTEEN) != nullptr);
+    EXPECT_TRUE(provider(ElementsPerThread::EIGHT) != nullptr);
+    EXPECT_TRUE(provider(ElementsPerThread::FOUR) != nullptr);
+    EXPECT_TRUE(provider(ElementsPerThread::TWO) != nullptr);
+    EXPECT_TRUE(provider(ElementsPerThread::ONE) != nullptr);
+  }
+  else {
+    EXPECT_EQ(provider(ElementsPerThread::THIRTY_TWO), nullptr);
+    EXPECT_EQ(provider(ElementsPerThread::SIXTEEN), nullptr);
+    EXPECT_EQ(provider(ElementsPerThread::EIGHT), nullptr);
+    EXPECT_EQ(provider(ElementsPerThread::FOUR), nullptr);
+    EXPECT_EQ(provider(ElementsPerThread::TWO), nullptr);
+    EXPECT_EQ(provider(ElementsPerThread::ONE), nullptr);
+  }
+
+  EXPECT_EQ(provider(ElementsPerThread::INVALID), nullptr);
+}
+
+template <typename Op, size_t RANK>
+void ExpectProviderForSizes(const cuda::std::array<index_t, RANK> &sizes, bool is_jit = false, bool global_kernel = false)
+{
+  static_assert(Op::Rank() == static_cast<int>(RANK));
+  auto provider = detail::create_kernel_provider<Op>(sizes, is_jit, global_kernel);
+  ExpectAllSupportedEPTs(provider, RANK <= 4);
+}
+
+} // namespace
+
+TEST(CudaExecutorCommonTests, BaseConstructorsKeepStreamAndRejectUnprofiledTiming)
+{
+  detail::CudaExecutorBase default_exec;
+  EXPECT_EQ(default_exec.getStream(), reinterpret_cast<cudaStream_t>(0));
+  default_exec.start_timer();
+  default_exec.stop_timer();
+  EXPECT_THROW({ default_exec.get_time_ms(); }, detail::matxException);
+
+  detail::CudaExecutorBase int_stream_exec{7};
+  EXPECT_EQ(int_stream_exec.getStream(), reinterpret_cast<cudaStream_t>(7));
+
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(11);
+  detail::CudaExecutorBase stream_exec{stream};
+  EXPECT_EQ(stream_exec.getStream(), stream);
+}
+
+TEST(CudaExecutorCommonTests, ProfiledBaseRecordsElapsedTimeWhenDeviceIsAvailable)
+{
+  if (!HasCudaDevice()) {
+    GTEST_SKIP() << "CUDA device required for profiling event coverage";
+  }
+
+  cudaStream_t stream{};
+  MATX_CUDA_CHECK(cudaStreamCreate(&stream));
+  {
+    detail::CudaExecutorBase exec{stream, true};
+    exec.start_timer();
+    exec.stop_timer();
+    EXPECT_TRUE(exec.get_time_ms() >= 0.0f);
+  }
+  MATX_CUDA_CHECK(cudaStreamDestroy(stream));
+}
+
+TEST(CudaExecutorCommonTests, KernelProviderReturnsRankSpecificPointers)
+{
+  int *ptr = nullptr;
+  auto t0 = make_tensor<int>(ptr, {}, false);
+  auto t1 = make_tensor<int>(ptr, {32}, false);
+  auto t2 = make_tensor<int>(ptr, {8, 32}, false);
+  auto t3 = make_tensor<int>(ptr, {4, 8, 32}, false);
+  auto t4 = make_tensor<int>(ptr, {2, 4, 8, 32}, false);
+  auto t5 = make_tensor<int>(ptr, {2, 2, 2, 2, 2}, false);
+
+  ExpectProviderForSizes<decltype(t0)>(cuda::std::array<index_t, 0>{});
+  ExpectProviderForSizes<decltype(t1)>(cuda::std::array<index_t, 1>{32});
+  ExpectProviderForSizes<decltype(t2)>(cuda::std::array<index_t, 2>{8, 32});
+  ExpectProviderForSizes<decltype(t3)>(cuda::std::array<index_t, 3>{4, 8, 32});
+  ExpectProviderForSizes<decltype(t4)>(cuda::std::array<index_t, 4>{2, 4, 8, 32});
+  ExpectProviderForSizes<decltype(t5)>(cuda::std::array<index_t, 5>{2, 2, 2, 2, 2});
+}
+
+TEST(CudaExecutorCommonTests, KernelProviderCoversStrideAndJitGridPaths)
+{
+  int *ptr = nullptr;
+  auto t2 = make_tensor<int>(ptr, {70000, 2}, false);
+  auto t3 = make_tensor<int>(ptr, {70000, 70000, 2}, false);
+  auto t4 = make_tensor<int>(ptr, {70000, 70000, 2, 2}, false);
+
+  ExpectProviderForSizes<decltype(t2)>(cuda::std::array<index_t, 2>{70000, 2});
+  ExpectProviderForSizes<decltype(t3)>(cuda::std::array<index_t, 3>{70000, 70000, 2});
+  ExpectProviderForSizes<decltype(t4)>(cuda::std::array<index_t, 4>{70000, 70000, 2, 2});
+
+  auto non_global_jit = make_tensor<int>(ptr, {8, 32}, false);
+  ExpectProviderForSizes<decltype(non_global_jit)>(cuda::std::array<index_t, 2>{8, 32}, true, false);
+  ExpectProviderForSizes<decltype(non_global_jit)>(cuda::std::array<index_t, 2>{8, 32}, true, true);
+}
+
+TEST(CudaExecutorCommonTests, FindBestLaunchParamsUsesCompiledKernelAttributes)
+{
+  if (!HasCudaDevice()) {
+    GTEST_SKIP() << "CUDA device required for launch-parameter coverage";
+  }
+
+  int *ptr = nullptr;
+  auto op = make_tensor<int>(ptr, {128}, false);
+  auto provider = detail::create_kernel_provider<decltype(op)>(cuda::std::array<index_t, 1>{128});
+  auto result = detail::find_best_launch_params(op, provider, 256, false);
+
+  const auto ept = cuda::std::get<0>(result);
+  const auto shm_size = cuda::std::get<1>(result);
+  const auto block_size = cuda::std::get<2>(result);
+  const auto groups_per_block = cuda::std::get<3>(result);
+
+  EXPECT_TRUE(static_cast<int>(ept) >= static_cast<int>(detail::ElementsPerThread::ONE));
+  EXPECT_TRUE(shm_size >= 0);
+  EXPECT_TRUE(block_size > 0);
+  EXPECT_TRUE(groups_per_block >= 1);
+}

--- a/test/00_misc/ErrorTests.cu
+++ b/test/00_misc/ErrorTests.cu
@@ -1,0 +1,140 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "matx.h"
+
+#include "gtest/gtest.h"
+
+#include <string>
+
+using namespace matx;
+
+namespace {
+
+struct ShapeChecker {
+  cuda::std::array<index_t, 2> dims;
+
+  static constexpr int Rank()
+  {
+    return 2;
+  }
+
+  index_t Size(int dim) const
+  {
+    return dims[dim];
+  }
+
+  template <typename Op>
+  void Check(Op &op) const
+  {
+    MATX_ASSERT_COMPATIBLE_OP_SIZES(op);
+  }
+};
+
+void ExpectErrorString(matxError_t error, const std::string &expected)
+{
+  EXPECT_EQ(std::string(matxErrorString(error)), expected);
+}
+
+} // namespace
+
+TEST(ErrorTests, ErrorStringCoversAllCodes)
+{
+  ExpectErrorString(matxSuccess, "matxSuccess");
+  ExpectErrorString(matxIOError, "matxIOError");
+  ExpectErrorString(matxOutOfMemory, "matxOutOfMemory");
+  ExpectErrorString(matxNotSupported, "matxNotSupported");
+  ExpectErrorString(matxInvalidParameter, "matxInvalidParameter");
+  ExpectErrorString(matxInvalidDim, "matxInvalidDim");
+  ExpectErrorString(matxInvalidSize, "matxInvalidSize");
+  ExpectErrorString(matxCudaError, "matxCudaError");
+  ExpectErrorString(matxCufftError, "matxCufftError");
+  ExpectErrorString(matxLibMathdxError, "matxLibMathdxError");
+  ExpectErrorString(matxMatMulError, "matxMatMulError");
+  ExpectErrorString(matxAssertError, "matxAssertError");
+  ExpectErrorString(matxInvalidType, "matxInvalidType");
+  ExpectErrorString(matxLUError, "matxLUError");
+  ExpectErrorString(matxInverseError, "matxInverseError");
+  ExpectErrorString(matxSolverError, "matxSolverError");
+  ExpectErrorString(matxcuTensorError, "matxcuTensorError");
+  ExpectErrorString(matxInvalidExecutor, "matxInvalidExecutor");
+  volatile int unknown_error_code = 999;
+  ExpectErrorString(static_cast<matxError_t>(unknown_error_code), "Unknown");
+}
+
+TEST(ErrorTests, ExceptionFormatsCharAndStringMessages)
+{
+  detail::matxException char_msg(matxInvalidParameter, "char message", "char_file.cu", 12);
+  EXPECT_EQ(char_msg.e, matxInvalidParameter);
+  EXPECT_TRUE(std::string(char_msg.what()).find("matxInvalidParameter") != std::string::npos);
+  EXPECT_TRUE(std::string(char_msg.what()).find("char message") != std::string::npos);
+  EXPECT_TRUE(std::string(char_msg.what()).find("char_file.cu:12") != std::string::npos);
+
+  detail::matxException string_msg(matxNotSupported, std::string("string message"), "string_file.cu", 34);
+  EXPECT_EQ(string_msg.e, matxNotSupported);
+  EXPECT_TRUE(std::string(string_msg.what()).find("matxNotSupported") != std::string::npos);
+  EXPECT_TRUE(std::string(string_msg.what()).find("string message") != std::string::npos);
+  EXPECT_TRUE(std::string(string_msg.what()).find("string_file.cu:34") != std::string::npos);
+}
+
+TEST(ErrorTests, ThrowAndAssertMacrosRaise)
+{
+  EXPECT_THROW({ MATX_THROW(matxInvalidType, "manual throw"); }, detail::matxException);
+
+#ifndef NDEBUG
+  EXPECT_THROW({ MATX_ASSERT(false, matxAssertError); }, detail::matxException);
+  EXPECT_THROW({ MATX_ASSERT_STR(false, matxInvalidParameter, "extra context"); }, detail::matxException);
+  EXPECT_THROW({ MATX_ASSERT_STR_EXP(1, 2, matxInvalidSize, "mismatch"); }, detail::matxException);
+#endif
+
+  MATX_ASSERT(true, matxAssertError);
+  MATX_ASSERT_STR(true, matxInvalidParameter, "unused");
+  MATX_ASSERT_STR_EXP(2, 2, matxInvalidSize, "unused");
+}
+
+TEST(ErrorTests, CudaCheckHandlesSuccessAndFailure)
+{
+  MATX_CUDA_CHECK(cudaSuccess);
+  cudaGetLastError();
+  MATX_CUDA_CHECK_LAST_ERROR();
+  EXPECT_THROW({ MATX_CUDA_CHECK(cudaErrorInvalidValue); }, detail::matxException);
+}
+
+TEST(ErrorTests, CompatibleOperatorSizesAreChecked)
+{
+  ShapeChecker checker{{2, 3}};
+  auto compatible = make_tensor<int>({2, 3}, MATX_HOST_MALLOC_MEMORY);
+  auto incompatible = make_tensor<int>({2, 4}, MATX_HOST_MALLOC_MEMORY);
+
+  checker.Check(compatible);
+  EXPECT_THROW({ checker.Check(incompatible); }, detail::matxException);
+}

--- a/test/00_misc/GridDimTests.cu
+++ b/test/00_misc/GridDimTests.cu
@@ -1,0 +1,214 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "matx/core/get_grid_dims.h"
+
+#include "gtest/gtest.h"
+
+using namespace matx;
+
+namespace {
+
+void ExpectDim3(const dim3 &actual, unsigned int x, unsigned int y, unsigned int z)
+{
+  EXPECT_EQ(actual.x, x);
+  EXPECT_EQ(actual.y, y);
+  EXPECT_EQ(actual.z, z);
+}
+
+} // namespace
+
+TEST(GridDimTests, ComputesStandardGridDimsAcrossRanks)
+{
+  dim3 blocks{};
+  dim3 threads{};
+
+  bool stride = detail::get_grid_dims<0>(blocks, threads, cuda::std::array<index_t, 0>{}, 1, 8);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 1, 1);
+  ExpectDim3(threads, 1, 1, 1);
+
+  stride = detail::get_grid_dims<1>(blocks, threads, cuda::std::array<index_t, 1>{17}, 2, 8);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 2, 1, 1);
+  ExpectDim3(threads, 8, 1, 1);
+
+  stride = detail::get_grid_dims<2>(blocks, threads, cuda::std::array<index_t, 2>{7, 4}, 1, 16);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 2, 1);
+  ExpectDim3(threads, 4, 4, 1);
+
+  stride = detail::get_grid_dims<3>(blocks, threads, cuda::std::array<index_t, 3>{5, 1, 1}, 1, 8);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 1, 1);
+  ExpectDim3(threads, 1, 1, 8);
+
+  stride = detail::get_grid_dims<4>(blocks, threads, cuda::std::array<index_t, 4>{5, 3, 2, 4}, 1, 64);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 1, 3);
+  ExpectDim3(threads, 4, 8, 2);
+
+  stride = detail::get_grid_dims<5>(blocks, threads, cuda::std::array<index_t, 5>{2, 3, 4, 5, 6}, 1, 64);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 12, 1, 1);
+  ExpectDim3(threads, 64, 1, 1);
+}
+
+TEST(GridDimTests, ClampsStandardGridDimsAtCudaLimits)
+{
+  dim3 blocks{};
+  dim3 threads{};
+
+  bool stride = detail::get_grid_dims<2>(blocks, threads, cuda::std::array<index_t, 2>{70000, 1}, 1, 1);
+  EXPECT_TRUE(stride);
+  ExpectDim3(blocks, 1, 65535, 1);
+  ExpectDim3(threads, 1, 1, 1);
+
+  stride = detail::get_grid_dims<3>(blocks, threads, cuda::std::array<index_t, 3>{70000, 70000, 1}, 1, 1);
+  EXPECT_TRUE(stride);
+  ExpectDim3(blocks, 1, 65535, 65535);
+  ExpectDim3(threads, 1, 1, 1);
+
+  stride = detail::get_grid_dims<3>(blocks, threads, cuda::std::array<index_t, 3>{1000, 1, 1}, 1, 1024);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 1, 16);
+  ExpectDim3(threads, 1, 1, 64);
+
+  stride = detail::get_grid_dims<4>(blocks, threads, cuda::std::array<index_t, 4>{70000, 70000, 2, 1}, 1, 1);
+  EXPECT_TRUE(stride);
+  ExpectDim3(blocks, 1, 65535, 65535);
+  ExpectDim3(threads, 1, 1, 1);
+
+  stride = detail::get_grid_dims<4>(blocks, threads, cuda::std::array<index_t, 4>{1000, 1, 1, 1}, 1, 1024);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 1, 16);
+  ExpectDim3(threads, 1, 1, 64);
+}
+
+TEST(GridDimTests, ComputesBlockGridDimsAcrossRanks)
+{
+  dim3 blocks{};
+  dim3 threads{};
+
+  bool stride = detail::get_grid_dims_block<0>(blocks, threads, cuda::std::array<index_t, 0>{}, 1, 1, 8);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 1, 1);
+  ExpectDim3(threads, 1, 1, 1);
+
+  stride = detail::get_grid_dims_block<1>(blocks, threads, cuda::std::array<index_t, 1>{17}, 2, 1, 8);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 1, 1);
+  ExpectDim3(threads, 8, 1, 1);
+
+  stride = detail::get_grid_dims_block<1>(blocks, threads, cuda::std::array<index_t, 1>{17}, 2, 1, 128, true);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 1, 1);
+  ExpectDim3(threads, 128, 1, 1);
+
+  stride = detail::get_grid_dims_block<2>(blocks, threads, cuda::std::array<index_t, 2>{8, 17}, 2, 4, 8);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 2, 1, 1);
+  ExpectDim3(threads, 8, 4, 1);
+
+  stride = detail::get_grid_dims_block<2>(blocks, threads, cuda::std::array<index_t, 2>{8, 17}, 2, 1, 8);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 8, 1, 1);
+  ExpectDim3(threads, 8, 1, 1);
+
+  stride = detail::get_grid_dims_block<3>(blocks, threads, cuda::std::array<index_t, 3>{3, 5, 9}, 1, 1, 8);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 5, 3, 1);
+  ExpectDim3(threads, 8, 1, 1);
+
+  stride = detail::get_grid_dims_block<4>(blocks, threads, cuda::std::array<index_t, 4>{3, 4, 5, 9}, 1, 1, 8);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 5, 4, 3);
+  ExpectDim3(threads, 8, 1, 1);
+}
+
+TEST(GridDimTests, ClampsBlockGridDimsAtCudaLimits)
+{
+  dim3 blocks{};
+  dim3 threads{};
+
+  bool stride = detail::get_grid_dims_block<3>(
+      blocks, threads, cuda::std::array<index_t, 3>{70000, 140000, 10}, 1, 2, 8);
+  EXPECT_TRUE(stride);
+  ExpectDim3(blocks, 65535, 65535, 1);
+  ExpectDim3(threads, 8, 2, 1);
+
+  stride = detail::get_grid_dims_block<4>(
+      blocks, threads, cuda::std::array<index_t, 4>{70000, 70000, 140000, 10}, 1, 2, 8);
+  EXPECT_TRUE(stride);
+  ExpectDim3(blocks, 65535, 65535, 65535);
+  ExpectDim3(threads, 8, 2, 1);
+}
+
+TEST(GridDimTests, ComputesBlock2DGridDims)
+{
+  dim3 blocks{};
+  dim3 threads{};
+
+  bool stride = detail::get_grid_dims_block_2d<2>(blocks, threads, cuda::std::array<index_t, 2>{8, 16}, 32);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 1, 1, 1);
+  ExpectDim3(threads, 32, 1, 1);
+
+  stride = detail::get_grid_dims_block_2d<3>(blocks, threads, cuda::std::array<index_t, 3>{7, 8, 16}, 64);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 7, 1, 1);
+  ExpectDim3(threads, 64, 1, 1);
+
+  stride = detail::get_grid_dims_block_2d<4>(blocks, threads, cuda::std::array<index_t, 4>{3, 5, 8, 16}, 128);
+  EXPECT_FALSE(stride);
+  ExpectDim3(blocks, 5, 3, 1);
+  ExpectDim3(threads, 128, 1, 1);
+}
+
+TEST(GridDimTests, RejectsInvalidBlockGridDims)
+{
+#ifndef NDEBUG
+  auto invalid_groups_per_block = []() {
+    dim3 blocks{};
+    dim3 threads{};
+    detail::get_grid_dims_block<2>(blocks, threads, cuda::std::array<index_t, 2>{7, 17}, 1, 4, 8);
+  };
+  EXPECT_THROW(invalid_groups_per_block(), matx::detail::matxException);
+#endif
+
+  auto oversized_batch_dim = []() {
+    dim3 blocks{};
+    dim3 threads{};
+    detail::get_grid_dims_block_2d<3>(blocks, threads, cuda::std::array<index_t, 3>{70000, 8, 16}, 32);
+  };
+  EXPECT_THROW(oversized_batch_dim(), matx::detail::matxException);
+}

--- a/test/00_operators/ReductionTests.cu
+++ b/test/00_operators/ReductionTests.cu
@@ -810,6 +810,43 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, Percentile)
   MATX_EXIT_HANDLER();
 }
 
+TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, PercentileMethodsAndBounds)
+{
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  MATX_ENTER_HANDLER();
+  {
+    auto t1 = make_tensor<TestType>({5});
+    auto t0 = make_tensor<TestType>({});
+    t1.SetVals({0, 10, 20, 30, 40});
+
+    auto expect_percentile = [&](uint8_t q, PercentileMethod method, double expected) {
+      (t0 = percentile(t1, q, method)).run(exec);
+      exec.sync();
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(t0(), static_cast<TestType>(expected), 0.01));
+    };
+
+    expect_percentile(0, PercentileMethod::LINEAR, 0.0);
+    expect_percentile(100, PercentileMethod::LINEAR, 40.0);
+    expect_percentile(25, PercentileMethod::HAZEN, 7.5);
+    expect_percentile(25, PercentileMethod::WEIBULL, 5.0);
+    expect_percentile(25, PercentileMethod::MEDIAN_UNBIASED, 6.6666666667);
+    expect_percentile(25, PercentileMethod::NORMAL_UNBIASED, 6.875);
+    expect_percentile(25, PercentileMethod::MIDPOINT, 15.0);
+    expect_percentile(25, PercentileMethod::NEAREST, 10.0);
+
+#ifndef NDEBUG
+    EXPECT_THROW({ (t0 = percentile(t1, 50, static_cast<PercentileMethod>(99))).run(exec); },
+                 detail::matxException);
+#endif
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
 TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, Median)
 {
   MATX_ENTER_HANDLER();
@@ -1758,5 +1795,3 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, Trace)
   ASSERT_EQ(t0(), count);
   MATX_EXIT_HANDLER();
 }
-
-

--- a/test/00_operators/ReductionTests.cu
+++ b/test/00_operators/ReductionTests.cu
@@ -839,7 +839,7 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, PercentileMethodsAndBou
     expect_percentile(25, PercentileMethod::NEAREST, 10.0);
 
 #ifndef NDEBUG
-    EXPECT_THROW({ (t0 = percentile(t1, 50, static_cast<PercentileMethod>(99))).run(exec); },
+    EXPECT_THROW({ detail::percentile_impl(t0, t1, 50, static_cast<PercentileMethod>(99), exec); },
                  detail::matxException);
 #endif
   }

--- a/test/00_solver/SVD.cu
+++ b/test/00_solver/SVD.cu
@@ -85,6 +85,36 @@ class SVDPISolverTestNonHalfTypes : public SVDTest<TensorType> {
 TYPED_TEST_SUITE(SVDSolverTestNonHalfTypes, MatXFloatNonHalfTypesAllExecs);
 TYPED_TEST_SUITE(SVDPISolverTestNonHalfTypes, MatXFloatNonHalfTypesCUDAExec);
 
+template <typename T>
+T MakeSVDTestValue(double value)
+{
+  using SType = typename inner_op_type_t<T>::type;
+  if constexpr (is_complex_v<T>) {
+    return T{static_cast<SType>(value), static_cast<SType>(0)};
+  }
+  else {
+    return static_cast<T>(value);
+  }
+}
+
+TEST(SVDInternalTests, CUDASelectsExpectedSVDMethods)
+{
+  float *ptr = nullptr;
+  auto matrix = make_tensor<float>(ptr, {8, 4}, false);
+  auto small_batched = make_tensor<float>(ptr, {2, 4, 4}, false);
+  auto large_batched = make_tensor<float>(ptr, {2, 64, 64}, false);
+  auto generated_batched = ones<float>({2, 4, 4});
+
+  EXPECT_EQ(static_cast<int>(detail::GetCUDASVDMethod(matrix)),
+            static_cast<int>(detail::SVDMethod::GESVD));
+  EXPECT_EQ(static_cast<int>(detail::GetCUDASVDMethod(small_batched)),
+            static_cast<int>(detail::SVDMethod::GESVDJ_BATCHED));
+  EXPECT_EQ(static_cast<int>(detail::GetCUDASVDMethod(large_batched)),
+            static_cast<int>(detail::SVDMethod::GESVD));
+  EXPECT_EQ(static_cast<int>(detail::GetCUDASVDMethod(generated_batched)),
+            static_cast<int>(detail::SVDMethod::GESVDJ_BATCHED));
+}
+
 TYPED_TEST(SVDSolverTestNonHalfTypes, SVDBasic)
 {
   MATX_ENTER_HANDLER();
@@ -737,6 +767,41 @@ TYPED_TEST(SVDPISolverTestNonHalfTypes, SVDBPI)
   svdbpi_test<TestType>({5,5,4,4}, this->exec);
   svdbpi_test<TestType>({5,5,4,16}, this->exec);
   svdbpi_test<TestType>({5,5,16,4}, this->exec);
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(SVDPISolverTestNonHalfTypes, SVDBPIToleranceCheck)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using SType = typename inner_op_type_t<TestType>::type;
+
+  tensor_t<TestType, 2> A2{{2, 2}};
+  tensor_t<TestType, 2> U2{{2, 2}};
+  tensor_t<SType, 1> S2{{2}};
+  tensor_t<TestType, 2> VT2{{2, 2}};
+
+  const auto zero = MakeSVDTestValue<TestType>(0);
+  const auto one = MakeSVDTestValue<TestType>(1);
+  const auto two = MakeSVDTestValue<TestType>(2);
+  A2(0, 0) = one;
+  A2(0, 1) = zero;
+  A2(1, 0) = zero;
+  A2(1, 1) = two;
+  (mtie(U2, S2, VT2) = svdbpi(A2, 2, 1.0e9f)).run(this->exec);
+
+  tensor_t<TestType, 3> A3{{1, 2, 2}};
+  tensor_t<TestType, 3> U3{{1, 2, 2}};
+  tensor_t<SType, 2> S3{{1, 2}};
+  tensor_t<TestType, 3> VT3{{1, 2, 2}};
+
+  A3(0, 0, 0) = one;
+  A3(0, 0, 1) = zero;
+  A3(0, 1, 0) = zero;
+  A3(0, 1, 1) = two;
+  (mtie(U3, S3, VT3) = svdbpi(A3, 2, 1.0e9f)).run(this->exec);
+  this->exec.sync();
 
   MATX_EXIT_HANDLER();
 }

--- a/test/00_tensor/CUBTests.cu
+++ b/test/00_tensor/CUBTests.cu
@@ -323,24 +323,30 @@ TEST(TensorStats, InternalCubPlansRejectInvalidOperations)
   EXPECT_THROW(create_dual_plan(), detail::matxException);
 }
 
-TEST(TensorStats, EmptyFindAndUniqueHost)
+TEST(TensorStats, NoMatchesFindAndUniqueHost)
 {
   MATX_ENTER_HANDLER();
 
   HostExecutor exec{};
-  tensor_t<float, 1> empty({0});
-  tensor_t<float, 1> out({1});
-  tensor_t<int, 1> idx({1});
+  tensor_t<float, 1> in({3});
+  tensor_t<float, 1> out({3});
+  tensor_t<int, 1> idx({3});
   tensor_t<int, 0> num_found{{}};
 
-  (mtie(out, num_found) = find(empty, GT{0.0f})).run(exec);
+  in.SetVals({1, 2, 3});
+
+  (mtie(out, num_found) = find(in, GT{10.0f})).run(exec);
   ASSERT_EQ(num_found(), 0);
 
-  (mtie(idx, num_found) = find_idx(empty, GT{0.0f})).run(exec);
+  (mtie(idx, num_found) = find_idx(in, GT{10.0f})).run(exec);
   ASSERT_EQ(num_found(), 0);
 
-  (mtie(out, num_found) = unique(empty)).run(exec);
-  ASSERT_EQ(num_found(), 0);
+  in.SetVals({1, 1, 2});
+
+  (mtie(out, num_found) = unique(in)).run(exec);
+  ASSERT_EQ(num_found(), 2);
+  ASSERT_EQ(out(0), 1.0f);
+  ASSERT_EQ(out(1), 2.0f);
 
   MATX_EXIT_HANDLER();
 }

--- a/test/00_tensor/CUBTests.cu
+++ b/test/00_tensor/CUBTests.cu
@@ -132,6 +132,219 @@ TEST(TensorStats, Hist)
   MATX_EXIT_HANDLER();
 }
 
+TEST(TensorStats, HistNonContiguousInput)
+{
+  MATX_ENTER_HANDLER();
+
+  constexpr int levels = 4;
+  tensor_t<float, 1> inv_storage({12});
+  tensor_t<int, 1> outv({levels - 1});
+
+  inv_storage.SetVals({0, 99, 1, 99, 2, 99, 0, 99, 1, 99, 2, 99});
+
+  cudaExecutor exec{};
+  const index_t hist_shape[1] = {6};
+  const index_t hist_strides[1] = {2};
+  auto inv_strided = make_tensor(inv_storage.Data(), hist_shape, hist_strides);
+  (outv = hist(inv_strided, 0.0f, 3.0f, levels)).run(exec);
+  exec.sync();
+
+  for (index_t i = 0; i < outv.Size(0); i++) {
+    ASSERT_EQ(outv(i), 2);
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+TEST(TensorStats, CumsumNonContiguousInput)
+{
+  MATX_ENTER_HANDLER();
+
+  tensor_t<int, 2> inv({3, 4});
+  tensor_t<int, 2> outv({4, 3});
+
+  inv.SetVals({{1, 2, 3, 4},
+               {10, 20, 30, 40},
+               {100, 200, 300, 400}});
+
+  cudaExecutor exec{};
+  auto invp = inv.Permute({1, 0});
+  (outv = cumsum(invp)).run(exec);
+  exec.sync();
+
+  for (index_t i = 0; i < outv.Size(0); i++) {
+    int running = 0;
+    for (index_t j = 0; j < outv.Size(1); j++) {
+      running += invp(i, j);
+      ASSERT_EQ(outv(i, j), running);
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+TEST(TensorStats, SortLegacyRank2AndOversizedGuards)
+{
+  MATX_ENTER_HANDLER();
+
+  cudaExecutor exec{};
+  tensor_t<int, 2> inv({2, cubSegmentCuttoff});
+  auto outv = make_tensor<int>(inv.Shape());
+
+  for (index_t i = 0; i < inv.Size(0); i++) {
+    for (index_t j = 0; j < inv.Size(1); j++) {
+      inv(i, j) = static_cast<int>(inv.Size(1) - j + i);
+    }
+  }
+
+  (outv = matx::sort(inv, SORT_DIR_ASC)).run(exec);
+  exec.sync();
+  for (index_t i = 0; i < outv.Size(0); i++) {
+    ASSERT_EQ(outv(i, 0), static_cast<int>(i + 1));
+    ASSERT_EQ(outv(i, outv.Size(1) - 1), static_cast<int>(outv.Size(1) + i));
+  }
+
+  (outv = matx::sort(inv, SORT_DIR_DESC)).run(exec);
+  exec.sync();
+  for (index_t i = 0; i < outv.Size(0); i++) {
+    ASSERT_EQ(outv(i, 0), static_cast<int>(outv.Size(1) + i));
+    ASSERT_EQ(outv(i, outv.Size(1) - 1), static_cast<int>(i + 1));
+  }
+
+  int *ptr = nullptr;
+  index_t *idx_ptr = nullptr;
+  auto huge_in = make_tensor<int>(ptr, {2048, 2048, 1024}, false);
+  auto huge_out = make_tensor<int>(ptr, {2048, 2048, 1024}, false);
+  auto huge_idx_in = make_tensor<index_t>(idx_ptr, {2048, 2048, 1024}, false);
+  auto huge_idx_out = make_tensor<index_t>(idx_ptr, {2048, 2048, 1024}, false);
+
+  EXPECT_THROW({ detail::sort_impl_inner(huge_out, huge_in, SORT_DIR_ASC, exec); },
+               detail::matxException);
+  EXPECT_THROW({ detail::sort_pairs_impl_inner(huge_idx_out, huge_idx_in, huge_out, huge_in, SORT_DIR_ASC, exec); },
+               detail::matxException);
+
+  tensor_t<int, 2> noncontig_base({2, 3});
+  tensor_t<int, 2> noncontig_out({3, 2});
+  auto noncontig_view = noncontig_base.Permute({1, 0});
+  detail::SortParams_t sort_params{SORT_DIR_ASC};
+  using NonContigSortPlan = detail::matxCubPlan_t<decltype(noncontig_out),
+                                                  decltype(noncontig_view),
+                                                  detail::CUB_OP_RADIX_SORT,
+                                                  detail::SortParams_t>;
+  auto create_noncontig_sort_plan = [&]() {
+    NonContigSortPlan plan(noncontig_out, noncontig_view, sort_params, exec.getStream());
+    (void)plan;
+  };
+  EXPECT_THROW(create_noncontig_sort_plan(), detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}
+
+TEST(TensorStats, NonContiguousFindUniqueAndArgReduceOutputs)
+{
+  MATX_ENTER_HANDLER();
+
+  cudaExecutor exec{};
+  tensor_t<float, 2> inv({2, 4});
+  inv.SetVals({{1, 1, 2, 2},
+               {1, 1, 2, 2}});
+  auto invp = inv.Permute({1, 0});
+
+  tensor_t<float, 1> found({8});
+  tensor_t<int, 1> found_idx({8});
+  tensor_t<int, 0> num_found{{}};
+
+  (mtie(found, num_found) = find(invp, GT{1.5f})).run(exec);
+  exec.sync();
+  ASSERT_EQ(num_found(), 4);
+  for (index_t i = 0; i < num_found(); i++) {
+    ASSERT_EQ(found(i), 2.0f);
+  }
+
+  (mtie(found_idx, num_found) = find_idx(invp, GT{1.5f})).run(exec);
+  exec.sync();
+  ASSERT_EQ(num_found(), 4);
+  for (index_t i = 0; i < num_found(); i++) {
+    ASSERT_EQ(found_idx(i), i + 4);
+  }
+
+  tensor_t<float, 1> unique_out({8});
+  auto unique_params = detail::UniqueParams_t<decltype(num_found)>{num_found};
+  auto unique_plan = detail::matxCubPlan_t<decltype(unique_out),
+                                           decltype(invp),
+                                           detail::CUB_OP_UNIQUE,
+                                           decltype(unique_params)>{unique_out, invp, unique_params, exec.getStream()};
+  unique_plan.ExecUnique(unique_out, invp, exec.getStream());
+  exec.sync();
+  ASSERT_EQ(num_found(), 2);
+  ASSERT_EQ(unique_out(0), 1.0f);
+  ASSERT_EQ(unique_out(1), 2.0f);
+
+  tensor_t<float, 2> arg_in({2, 3});
+  tensor_t<float, 1> arg_out({2});
+  tensor_t<index_t, 1> arg_idx({2});
+  arg_in.SetVals({{1, 5, 2},
+                  {4, 3, 6}});
+
+  (mtie(arg_out, arg_idx) = argmax(arg_in, {1})).run(exec);
+  exec.sync();
+  ASSERT_EQ(arg_out(0), 5.0f);
+  ASSERT_EQ(arg_idx(0), 1);
+  ASSERT_EQ(arg_out(1), 6.0f);
+  ASSERT_EQ(arg_idx(1), 5);
+
+  MATX_EXIT_HANDLER();
+}
+
+TEST(TensorStats, InternalCubPlansRejectInvalidOperations)
+{
+  int *ptr = nullptr;
+  index_t *idx_ptr = nullptr;
+  auto in = make_tensor<int>(ptr, {4}, false);
+  auto out = make_tensor<int>(ptr, {}, false);
+  auto idx = make_tensor<index_t>(idx_ptr, {}, false);
+  using SingleParams = detail::ReduceParams_t<detail::CustomArgMaxCmp, cuda::std::tuple<index_t, int>>;
+  using DualParams = detail::ReduceParams_t<detail::CustomArgMinMaxCmp, cuda::std::tuple<index_t, int, index_t, int>>;
+  SingleParams single_params{detail::CustomArgMaxCmp{}, cuda::std::make_tuple(index_t{0}, int{})};
+  DualParams dual_params{detail::CustomArgMinMaxCmp{}, cuda::std::make_tuple(index_t{0}, int{}, index_t{0}, int{})};
+
+  using SinglePlan = detail::matxCubSingleArgPlan_t<decltype(out), decltype(idx), decltype(in), SingleParams>;
+  using DualPlan = detail::matxCubDualArgPlan_t<decltype(out), decltype(idx), decltype(in), DualParams>;
+  auto create_single_plan = [&]() {
+    SinglePlan plan(out, idx, in, detail::CUB_OP_REDUCE, single_params, 0);
+    (void)plan;
+  };
+  auto create_dual_plan = [&]() {
+    DualPlan plan(out, idx, out, idx, in, detail::CUB_OP_REDUCE, dual_params, 0);
+    (void)plan;
+  };
+
+  EXPECT_THROW(create_single_plan(), detail::matxException);
+  EXPECT_THROW(create_dual_plan(), detail::matxException);
+}
+
+TEST(TensorStats, EmptyFindAndUniqueHost)
+{
+  MATX_ENTER_HANDLER();
+
+  HostExecutor exec{};
+  tensor_t<float, 1> empty({0});
+  tensor_t<float, 1> out({1});
+  tensor_t<int, 1> idx({1});
+  tensor_t<int, 0> num_found{{}};
+
+  (mtie(out, num_found) = find(empty, GT{0.0f})).run(exec);
+  ASSERT_EQ(num_found(), 0);
+
+  (mtie(idx, num_found) = find_idx(empty, GT{0.0f})).run(exec);
+  ASSERT_EQ(num_found(), 0);
+
+  (mtie(out, num_found) = unique(empty)).run(exec);
+  ASSERT_EQ(num_found(), 0);
+
+  MATX_EXIT_HANDLER();
+}
+
 TYPED_TEST(CUBTestsNumericNonComplexAllExecs, CumSum)
 {
   MATX_ENTER_HANDLER();

--- a/test/00_tensor/DLPackTests.cu
+++ b/test/00_tensor/DLPackTests.cu
@@ -312,6 +312,9 @@ TYPED_TEST(DLPackTestsFloatNonComplex, VersionedReadOnlyRequiresConstType)
 {
   MATX_ENTER_HANDLER();
 
+#ifdef NDEBUG
+  GTEST_SKIP() << "Read-only DLPack validation uses MATX_ASSERT and is disabled in release builds";
+#else
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   int mutable_deleter_calls = 0;
   int const_deleter_calls = 0;
@@ -332,6 +335,7 @@ TYPED_TEST(DLPackTestsFloatNonComplex, VersionedReadOnlyRequiresConstType)
     ASSERT_EQ(const_deleter_calls, 0);
   }
   ASSERT_EQ(const_deleter_calls, 1);
+#endif
 
   MATX_EXIT_HANDLER();
 }
@@ -393,6 +397,9 @@ TEST(DLPackVectorTests, ImportVectorLaneMismatchThrows)
 {
   MATX_ENTER_HANDLER();
 
+#ifdef NDEBUG
+  GTEST_SKIP() << "DLPack dtype validation uses MATX_ASSERT and is disabled in release builds";
+#else
   int deleter_calls = 0;
   auto *dl = MakeManagedTensorForOwningImportTest<float4>(&deleter_calls, 8);
   dl->dl_tensor.dtype.lanes = 2;
@@ -401,6 +408,7 @@ TEST(DLPackVectorTests, ImportVectorLaneMismatchThrows)
     ASSERT_THROW({ make_tensor(t, dl); }, matx::detail::matxException);
   }
   ASSERT_EQ(deleter_calls, 1);
+#endif
 
   MATX_EXIT_HANDLER();
 }
@@ -409,6 +417,9 @@ TEST(DLPackVectorTests, ImportVectorBaseTypeMismatchThrows)
 {
   MATX_ENTER_HANDLER();
 
+#ifdef NDEBUG
+  GTEST_SKIP() << "DLPack dtype validation uses MATX_ASSERT and is disabled in release builds";
+#else
   int deleter_calls = 0;
   auto *dl = MakeManagedTensorForOwningImportTest<float4>(&deleter_calls, 8);
   dl->dl_tensor.dtype.code = kDLInt;
@@ -417,6 +428,7 @@ TEST(DLPackVectorTests, ImportVectorBaseTypeMismatchThrows)
     ASSERT_THROW({ make_tensor(t, dl); }, matx::detail::matxException);
   }
   ASSERT_EQ(deleter_calls, 1);
+#endif
 
   MATX_EXIT_HANDLER();
 }

--- a/test/00_tensor/MakeTensorTests.cu
+++ b/test/00_tensor/MakeTensorTests.cu
@@ -1,0 +1,296 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "matx.h"
+#include "gtest/gtest.h"
+
+#include <cuda/std/array>
+#include <cstdlib>
+#include <memory>
+
+using namespace matx;
+
+namespace {
+
+struct CountingAllocator {
+  static inline size_t allocations = 0;
+  static inline size_t deallocations = 0;
+  static inline size_t active_bytes = 0;
+
+  static void Reset()
+  {
+    allocations = 0;
+    deallocations = 0;
+    active_bytes = 0;
+  }
+
+  void *allocate(size_t bytes)
+  {
+    allocations++;
+    active_bytes += bytes;
+    return std::malloc(bytes);
+  }
+
+  void deallocate(void *ptr, size_t bytes)
+  {
+    deallocations++;
+    active_bytes -= bytes;
+    std::free(ptr);
+  }
+};
+
+template <typename TensorType>
+void ExpectShape2(const TensorType &tensor, index_t dim0, index_t dim1)
+{
+  EXPECT_EQ(tensor.Rank(), 2);
+  EXPECT_EQ(tensor.Size(0), dim0);
+  EXPECT_EQ(tensor.Size(1), dim1);
+  EXPECT_EQ(tensor.TotalSize(), dim0 * dim1);
+}
+
+} // namespace
+
+TEST(MakeTensorTests, CreatesAllocatedAndPlacementTensors)
+{
+  MATX_ENTER_HANDLER();
+
+  index_t shape2[2] = {2, 3};
+
+  auto c_array_tensor = make_tensor<int, 2>(shape2, MATX_HOST_MALLOC_MEMORY);
+  ExpectShape2(c_array_tensor, 2, 3);
+  c_array_tensor(1, 2) = 12;
+  EXPECT_EQ(c_array_tensor(1, 2), 12);
+
+  tensor_t<int, 2> placed_c_array;
+  make_tensor(placed_c_array, shape2, MATX_HOST_MALLOC_MEMORY);
+  ExpectShape2(placed_c_array, 2, 3);
+  placed_c_array(1, 1) = 11;
+  EXPECT_EQ(placed_c_array(1, 1), 11);
+
+  std::unique_ptr<tensor_t<int, 2>> c_array_ptr(
+      make_tensor_p<int, 2>(shape2, MATX_HOST_MALLOC_MEMORY));
+  ExpectShape2(*c_array_ptr, 2, 3);
+
+  auto shape3 = cuda::std::array<index_t, 3>{2, 3, 4};
+  auto container_tensor = make_tensor<int>(shape3, MATX_HOST_MALLOC_MEMORY);
+  EXPECT_EQ(container_tensor.Rank(), 3);
+  EXPECT_EQ(container_tensor.Size(0), 2);
+  EXPECT_EQ(container_tensor.Size(1), 3);
+  EXPECT_EQ(container_tensor.Size(2), 4);
+
+  tensor_t<int, 3> placed_container;
+  make_tensor(placed_container, cuda::std::array<index_t, 3>{2, 3, 4},
+              MATX_HOST_MALLOC_MEMORY);
+  EXPECT_EQ(placed_container.Size(0), 2);
+  EXPECT_EQ(placed_container.Size(1), 3);
+  EXPECT_EQ(placed_container.Size(2), 4);
+
+  std::unique_ptr<tensor_t<int, 1>> container_ptr(
+      make_tensor_p<int>(cuda::std::array<index_t, 1>{6},
+                         MATX_HOST_MALLOC_MEMORY));
+  EXPECT_EQ(container_ptr->Size(0), 6);
+
+  auto scalar_tensor = make_tensor<int>({}, MATX_HOST_MALLOC_MEMORY);
+  scalar_tensor() = 7;
+  EXPECT_EQ(scalar_tensor(), 7);
+
+  tensor_t<int, 0> placed_scalar;
+  make_tensor(placed_scalar, MATX_HOST_MALLOC_MEMORY);
+  placed_scalar() = 9;
+  EXPECT_EQ(placed_scalar(), 9);
+
+  std::unique_ptr<tensor_t<int, 0>> scalar_ptr(
+      make_tensor_p<int>({}, MATX_HOST_MALLOC_MEMORY));
+  (*scalar_ptr)() = 13;
+  EXPECT_EQ((*scalar_ptr)(), 13);
+
+  auto static_tensor = make_tensor<int, 2, 3>();
+  ExpectShape2(static_tensor, 2, 3);
+  static_tensor(1, 2) = 15;
+  EXPECT_EQ(static_tensor(1, 2), 15);
+
+  MATX_EXIT_HANDLER();
+}
+
+TEST(MakeTensorTests, CreatesPointerBackedViews)
+{
+  MATX_ENTER_HANDLER();
+
+  int data[8] = {};
+  index_t shape2[2] = {2, 3};
+  index_t strides2[2] = {3, 1};
+
+  Storage<int> storage(data, 6);
+  auto storage_tensor =
+      make_tensor(std::move(storage), cuda::std::array<index_t, 2>{2, 3});
+  ExpectShape2(storage_tensor, 2, 3);
+  storage_tensor(1, 2) = 17;
+  EXPECT_EQ(data[5], 17);
+
+  auto c_array_view = make_tensor(data, shape2);
+  ExpectShape2(c_array_view, 2, 3);
+  c_array_view(1, 1) = 21;
+  EXPECT_EQ(data[4], 21);
+  EXPECT_EQ(c_array_view.Data(), data);
+
+  tensor_t<int, 2> placed_c_array_view;
+  make_tensor(placed_c_array_view, data, shape2);
+  ExpectShape2(placed_c_array_view, 2, 3);
+  placed_c_array_view(0, 2) = 22;
+  EXPECT_EQ(data[2], 22);
+
+  auto container_view =
+      make_tensor(data, cuda::std::array<index_t, 2>{2, 3});
+  ExpectShape2(container_view, 2, 3);
+  container_view(0, 1) = 23;
+  EXPECT_EQ(data[1], 23);
+
+  tensor_t<int, 2> placed_container_view;
+  make_tensor(placed_container_view, data,
+              cuda::std::array<index_t, 2>{2, 3});
+  ExpectShape2(placed_container_view, 2, 3);
+  placed_container_view(0, 0) = 24;
+  EXPECT_EQ(data[0], 24);
+
+  int scalar = 3;
+  auto scalar_view = make_tensor(&scalar, {});
+  EXPECT_EQ(scalar_view.Data(), &scalar);
+  scalar_view() = 31;
+  EXPECT_EQ(scalar, 31);
+
+  tensor_t<int, 0> placed_scalar_view;
+  make_tensor(placed_scalar_view, &scalar);
+  EXPECT_EQ(placed_scalar_view.Data(), &scalar);
+  placed_scalar_view() = 32;
+  EXPECT_EQ(scalar, 32);
+
+  std::unique_ptr<tensor_t<int, 2>> pointer_view_ptr(
+      make_tensor_p(data, cuda::std::array<index_t, 2>{2, 3}));
+  ExpectShape2(*pointer_view_ptr, 2, 3);
+  (*pointer_view_ptr)(1, 0) = 33;
+  EXPECT_EQ(data[3], 33);
+
+  auto strided_view = make_tensor(data, shape2, strides2);
+  ExpectShape2(strided_view, 2, 3);
+  strided_view(1, 1) = 41;
+  EXPECT_EQ(data[4], 41);
+
+  tensor_t<int, 2> placed_strided_view;
+  make_tensor(placed_strided_view, data, shape2, strides2);
+  ExpectShape2(placed_strided_view, 2, 3);
+  placed_strided_view(1, 2) = 42;
+  EXPECT_EQ(data[5], 42);
+
+  MATX_EXIT_HANDLER();
+}
+
+TEST(MakeTensorTests, CreatesDescriptorBackedTensors)
+{
+  MATX_ENTER_HANDLER();
+
+  int data[6] = {};
+  auto shape = cuda::std::array<index_t, 2>{2, 3};
+  DefaultDescriptor<2> desc{shape};
+
+  auto allocated = make_tensor<int>(desc, MATX_HOST_MALLOC_MEMORY);
+  ExpectShape2(allocated, 2, 3);
+  allocated(1, 2) = 51;
+  EXPECT_EQ(allocated(1, 2), 51);
+
+  auto view = make_tensor(data, desc);
+  ExpectShape2(view, 2, 3);
+  view(1, 2) = 52;
+  EXPECT_EQ(data[5], 52);
+
+  tensor_t<int, 2> placed_view;
+  make_tensor(placed_view, data,
+              DefaultDescriptor<2>{cuda::std::array<index_t, 2>{2, 3}});
+  ExpectShape2(placed_view, 2, 3);
+  placed_view(1, 1) = 53;
+  EXPECT_EQ(data[4], 53);
+
+  tensor_t<int, 2> placed_allocated;
+  make_tensor(std::move(placed_allocated),
+              DefaultDescriptor<2>{cuda::std::array<index_t, 2>{2, 3}},
+              MATX_HOST_MALLOC_MEMORY);
+  ExpectShape2(placed_allocated, 2, 3);
+  placed_allocated(0, 2) = 54;
+  EXPECT_EQ(placed_allocated(0, 2), 54);
+
+  MATX_EXIT_HANDLER();
+}
+
+TEST(MakeTensorTests, CreatesCustomAllocatorTensors)
+{
+  MATX_ENTER_HANDLER();
+
+  CountingAllocator::Reset();
+
+  {
+    index_t shape1[1] = {4};
+    index_t shape2[2] = {2, 3};
+
+    auto c_array_tensor = make_tensor<int>(shape1, CountingAllocator{});
+    EXPECT_EQ(c_array_tensor.Size(0), 4);
+    c_array_tensor(3) = 61;
+    EXPECT_EQ(c_array_tensor(3), 61);
+
+    auto container_tensor =
+        make_tensor<int>(cuda::std::array<index_t, 2>{2, 3},
+                         CountingAllocator{});
+    ExpectShape2(container_tensor, 2, 3);
+    container_tensor(1, 2) = 62;
+    EXPECT_EQ(container_tensor(1, 2), 62);
+
+    tensor_t<int, 2> placed_c_array;
+    make_tensor(placed_c_array, shape2, CountingAllocator{});
+    ExpectShape2(placed_c_array, 2, 3);
+    placed_c_array(1, 1) = 63;
+    EXPECT_EQ(placed_c_array(1, 1), 63);
+
+    tensor_t<int, 2> placed_container;
+    make_tensor(placed_container, cuda::std::array<index_t, 2>{2, 3},
+                CountingAllocator{});
+    ExpectShape2(placed_container, 2, 3);
+    placed_container(0, 2) = 64;
+    EXPECT_EQ(placed_container(0, 2), 64);
+
+    EXPECT_EQ(CountingAllocator::allocations, 4);
+    EXPECT_EQ(CountingAllocator::active_bytes,
+              (4 + 6 + 6 + 6) * sizeof(int));
+  }
+
+  EXPECT_EQ(CountingAllocator::allocations, CountingAllocator::deallocations);
+  EXPECT_EQ(CountingAllocator::active_bytes, 0);
+
+  MATX_EXIT_HANDLER();
+}

--- a/test/00_tensor/MakeTensorTests.cu
+++ b/test/00_tensor/MakeTensorTests.cu
@@ -239,7 +239,7 @@ TEST(MakeTensorTests, CreatesDescriptorBackedTensors)
   EXPECT_EQ(data[4], 53);
 
   tensor_t<int, 2> placed_allocated;
-  make_tensor(std::move(placed_allocated),
+  make_tensor(placed_allocated,
               DefaultDescriptor<2>{cuda::std::array<index_t, 2>{2, 3}},
               MATX_HOST_MALLOC_MEMORY);
   ExpectShape2(placed_allocated, 2, 3);

--- a/test/01_radar/ambgfun.cu
+++ b/test/01_radar/ambgfun.cu
@@ -42,12 +42,15 @@ class RadarAmbiguityFunction : public ::testing::Test {
 protected:
   void SetUp() override
   {
-
+#ifdef CUPY_INSTALLED
     pb = std::make_unique<detail::MatXPybind>();
     pb->InitAndRunTVGenerator<complex>("01_radar", "ambgfun", "run",
                                        {sig_size});
 
     pb->NumpyToTensorView(xv, "x");
+#else
+    GTEST_SKIP() << "CuPy is required to generate ambgfun reference data";
+#endif
   }
 
   void TearDown() override { pb.reset(); }
@@ -57,11 +60,7 @@ protected:
   std::unique_ptr<detail::MatXPybind> pb;
 };
 
-//#ifdef CUPY_INSTALLED
-//TEST_F(RadarAmbiguityFunction, Cut2D)
-//#else
-TEST_F(RadarAmbiguityFunction, DISABLED_Cut2D)
-//#endif
+TEST_F(RadarAmbiguityFunction, Cut2D)
 {
   MATX_ENTER_HANDLER();
 
@@ -75,11 +74,7 @@ TEST_F(RadarAmbiguityFunction, DISABLED_Cut2D)
   MATX_EXIT_HANDLER();
 }
 
-//#ifdef CUPY_INSTALLED
-//TEST_F(RadarAmbiguityFunction, CutDelay)
-//#else
-TEST_F(RadarAmbiguityFunction, DISABLED_CutDelay)
-//#endif
+TEST_F(RadarAmbiguityFunction, CutDelay)
 {
   MATX_ENTER_HANDLER();
 
@@ -96,11 +91,7 @@ TEST_F(RadarAmbiguityFunction, DISABLED_CutDelay)
   MATX_EXIT_HANDLER();
 }
 
-//#ifdef CUPY_INSTALLED
-//TEST_F(RadarAmbiguityFunction, CutDoppler)
-//#else
-TEST_F(RadarAmbiguityFunction, DISABLED_CutDoppler)
-//#endif
+TEST_F(RadarAmbiguityFunction, CutDoppler)
 {
   MATX_ENTER_HANDLER();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,13 +5,18 @@ list(TRANSFORM OPERATOR_TEST_FILES PREPEND "00_operators/")
 
 set (test_sources
     00_misc/AllocatorTests.cu
+    00_misc/CapabilitiesTests.cu
     00_misc/ClearCacheTests.cu
+    00_misc/CudaExecutorCommonTests.cu
+    00_misc/ErrorTests.cu
     00_misc/FloatFloatTests.cu
+    00_misc/GridDimTests.cu
     00_misc/ProfilingTests.cu
     00_misc/PropertyTests.cu
     00_misc/TensorAccessorTests.cu
     00_tensor/BasicTensorTests.cu
     00_tensor/DLPackTests.cu
+    00_tensor/MakeTensorTests.cu
     00_tensor/CUBTests.cu
     00_tensor/Storage.cu
     00_tensor/ViewTests.cu

--- a/test/test_vectors/generators/01_radar.py
+++ b/test/test_vectors/generators/01_radar.py
@@ -155,7 +155,7 @@ class ambgfun:
             }
             """,
             "_new_ynorm_kernel",
-            options=("-std=c++11",),
+            options=("-std=c++17",),
         )
 
         cut = 'delay'


### PR DESCRIPTION
Unit test coverage was missing on several operators and kernel launch functions. This adds in coverage for those plus a few minor fixes that were exposed along the way.