### PR TITLE
Fix compute capability encoding for mathDx

### DIFF
--- a/include/matx/core/utils.h
+++ b/include/matx/core/utils.h
@@ -66,7 +66,7 @@ __MATX_INLINE__ int GetComputeCapabilityMinor() {
 }
 
 __MATX_INLINE__ int GetComputeCapability() {
-    return GetComputeCapabilityMajor() * 100 + GetComputeCapabilityMinor();
+    return GetComputeCapabilityMajor() * 100 + GetComputeCapabilityMinor() * 10;
 }
 
 __MATX_INLINE__ bool IsHopperOrAbove() {
@@ -700,4 +700,3 @@ __MATX_INLINE__ std::string make_jit_tensor_struct_str(
 
 }
 }
-

--- a/include/matx/operators/fft.h
+++ b/include/matx/operators/fft.h
@@ -189,7 +189,7 @@ namespace matx
             cudaGetDevice(&device);            
             cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device);
             cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device);
-            int cc = major * 100 + minor;          
+            int cc = major * 100 + minor * 10;
             dx_fft_helper_.set_fft_size(fft_size_);
             dx_fft_helper_.set_fft_type(DeduceFFTTransformType<typename scalar_to_complex<typename OpA::value_type>::ctype, value_type>());
             dx_fft_helper_.set_direction(Direction);

--- a/include/matx/operators/matmul.h
+++ b/include/matx/operators/matmul.h
@@ -189,7 +189,7 @@ namespace matx
           cudaGetDevice(&device);
           cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device);
           cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device);
-          int cc = major * 100 + minor;  // Compute capability as three digits (e.g., 890 for SM 8.9)
+          int cc = major * 100 + minor * 10;  // Compute capability as __CUDA_ARCH__ digits (e.g., 890 for SM 8.9)
           
           dx_gemm_helper_.set_m(a_.Size(OpA::Rank() - 2));
           dx_gemm_helper_.set_n(b_.Size(OpB::Rank() - 1));


### PR DESCRIPTION
This was getting computed incorrectly (e.g. 809 instead of 890)