### PR TITLE
Add dense solve operator support

### DIFF
--- a/docs_input/api/linalg/other/solve.rst
+++ b/docs_input/api/linalg/other/solve.rst
@@ -9,4 +9,14 @@ Solves the system of equations AX=Y, where X is the unknown.
 
 .. doxygenfunction:: solve(const OpA &A, const OpB &B)
 
-Currently only supported for sparse matrix A, please see :ref:`sparse_tensor_api`.
+For dense ``A``, ``A`` must have shape ``... x n x n``. ``B`` may have shape
+``... x n`` for a vector right-hand side or ``... x n x nrhs`` for one or more
+matrix right-hand sides. Dense batch dimensions must match exactly; they are not
+broadcast. The output shape matches ``B``. Dense solve uses cuSolver/cuBLAS with
+CUDA executors and LAPACK with host executors when CPU solver support is
+configured.
+
+For sparse ``A``, ``solve`` preserves the legacy sparse solve layout where
+right-hand sides are stacked by row and the operation solves ``A X^T = B^T``.
+Sparse direct solve support depends on the sparse format and may require cuDSS;
+please see :ref:`sparse_tensor_api`.

--- a/include/matx/operators/set.h
+++ b/include/matx/operators/set.h
@@ -400,7 +400,7 @@ public:
   // InnerPreRun on it to call any nested PreRun calls, then output directly into the LHS
   // tensor.
   template <typename ShapeType, typename Executor>
-  void TransformExec(ShapeType &&shape, Executor &&ex) const noexcept {
+  void TransformExec(ShapeType &&shape, Executor &&ex) const {
     op_.InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
     op_.Exec(cuda::std::make_tuple(out_), std::forward<Executor>(ex));
     op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));

--- a/include/matx/operators/solve.h
+++ b/include/matx/operators/solve.h
@@ -132,7 +132,7 @@ public:
   template <typename ShapeType, typename Executor>
   __MATX_INLINE__ void
   InnerPreRun([[maybe_unused]] ShapeType &&shape,
-              [[maybe_unused]] Executor &&ex) const noexcept {
+              [[maybe_unused]] Executor &&ex) const {
     if constexpr (is_matx_op<OpA>()) {
       a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
     }
@@ -143,7 +143,7 @@ public:
 
   template <typename ShapeType, typename Executor>
   __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape,
-                              [[maybe_unused]] Executor &&ex) const noexcept {
+                              [[maybe_unused]] Executor &&ex) const {
     if (prerun_done_) {
       return;
     }
@@ -157,7 +157,7 @@ public:
 
   template <typename ShapeType, typename Executor>
   __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape,
-                               [[maybe_unused]] Executor &&ex) const noexcept {
+                               [[maybe_unused]] Executor &&ex) const {
     if constexpr (is_matx_op<OpA>()) {
       a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
     }

--- a/include/matx/operators/solve.h
+++ b/include/matx/operators/solve.h
@@ -35,7 +35,11 @@
 
 #include "matx/core/type_utils.h"
 #include "matx/operators/base_operator.h"
+#include "matx/transforms/solve/solve_cuda.h"
 #include "matx/transforms/solve/solve_cusparse.h"
+#ifdef MATX_EN_CPU_SOLVER
+#include "matx/transforms/solve/solve_lapack.h"
+#endif
 #ifdef MATX_EN_CUDSS
 #include "matx/transforms/solve/solve_cudss.h"
 #endif
@@ -121,8 +125,7 @@ public:
 #endif
       }
     } else {
-      MATX_THROW(matxNotSupported,
-                 "Direct solver currently only supports sparse system");
+      dense_solve_impl(cuda::std::get<0>(out), a_, b_, ex);
     }
   }
 
@@ -130,8 +133,9 @@ public:
   __MATX_INLINE__ void
   InnerPreRun([[maybe_unused]] ShapeType &&shape,
               [[maybe_unused]] Executor &&ex) const noexcept {
-    static_assert(is_sparse_tensor_v<OpA>,
-                  "Direct solver currently only supports sparse system");
+    if constexpr (is_matx_op<OpA>()) {
+      a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+    }
     if constexpr (is_matx_op<OpB>()) {
       b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
     }
@@ -154,8 +158,9 @@ public:
   template <typename ShapeType, typename Executor>
   __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape,
                                [[maybe_unused]] Executor &&ex) const noexcept {
-    static_assert(is_sparse_tensor_v<OpA>,
-                  "Direct solver currently only supports sparse system");
+    if constexpr (is_matx_op<OpA>()) {
+      a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+    }
     if constexpr (is_matx_op<OpB>()) {
       b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
     }
@@ -166,21 +171,21 @@ public:
 } // end namespace detail
 
 /**
- * Running X = solve(A, B) solves the system A X^T = B^T for
- * an unknown X given the rhs B. The transposition is used so
- * that the different rhs vectors and solutions are stacked by
- * row (another way to think about this is that X and B are
- * presented using column-major storage). Currently, this
- * operation is only implemented for solving a linear system
- * with a very **sparse** matrix A in CSR or DIA format.
+ * Running X = solve(A, B) solves the system A X = B for dense A, where A has
+ * shape `... x n x n` and B has shape `... x n` for a vector right-hand side
+ * or `... x n x nrhs` for one or more matrix right-hand sides. Dense batch
+ * dimensions must match exactly and are not broadcast.
+ *
+ * For sparse A, solve preserves the legacy sparse API: B and X stack different
+ * right-hand sides by row and the operation solves A X^T = B^T.
  *
  * @tparam OpA
- *    Data type of A tensor (sparse)
+ *    Data type of A tensor
  * @tparam OpB
  *    Data type of B tensor
  *
  * @param A
- *   A Sparse tensor with system coefficients
+ *   A tensor with system coefficients
  * @param B
  *   B Dense tensor of known values
  *

--- a/include/matx/transforms/solve/solve_common.h
+++ b/include/matx/transforms/solve/solve_common.h
@@ -37,11 +37,44 @@
 #include "matx/core/type_utils.h"
 #include "matx/transforms/solver_common.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
 namespace matx {
 namespace detail {
+
+template <typename T>
+class DenseSolveAllocGuard {
+public:
+  DenseSolveAllocGuard() = default;
+  DenseSolveAllocGuard(const DenseSolveAllocGuard &) = delete;
+  DenseSolveAllocGuard &operator=(const DenseSolveAllocGuard &) = delete;
+
+  ~DenseSolveAllocGuard() noexcept
+  {
+    try {
+      matxFree(ptr_);
+    }
+    catch (...) {
+    }
+  }
+
+  void Alloc(size_t bytes,
+             matxMemorySpace_t space,
+             cudaStream_t stream = cudaStreamDefault)
+  {
+    matxAlloc(reinterpret_cast<void **>(&ptr_), bytes, space, stream);
+  }
+
+  __MATX_INLINE__ T *get() const noexcept
+  {
+    return ptr_;
+  }
+
+private:
+  T *ptr_ = nullptr;
+};
 
 template <typename T>
 inline constexpr bool is_dense_solve_supported_type_v =

--- a/include/matx/transforms/solve/solve_common.h
+++ b/include/matx/transforms/solve/solve_common.h
@@ -1,0 +1,150 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx/core/error.h"
+#include "matx/core/type_utils.h"
+#include "matx/transforms/solver_common.h"
+
+#include <string>
+#include <vector>
+
+namespace matx {
+namespace detail {
+
+template <typename T>
+inline constexpr bool is_dense_solve_supported_type_v =
+    std::is_same_v<T, float> ||
+    std::is_same_v<T, double> ||
+    std::is_same_v<T, cuda::std::complex<float>> ||
+    std::is_same_v<T, cuda::std::complex<double>>;
+
+template <typename ATensor, typename BTensor>
+static constexpr bool IsDenseSolveVectorRHS()
+{
+  return remove_cvref_t<BTensor>::Rank() == remove_cvref_t<ATensor>::Rank() - 1;
+}
+
+template <typename OutputTensor, typename ATensor, typename BTensor>
+__MATX_INLINE__ void ValidateDenseSolve(OutputTensor &&out,
+                                        const ATensor &a,
+                                        const BTensor &b)
+{
+  using OutTensor_t = remove_cvref_t<OutputTensor>;
+  using ATensor_t = remove_cvref_t<ATensor>;
+  using BTensor_t = remove_cvref_t<BTensor>;
+  using T = typename ATensor_t::value_type;
+
+  constexpr int ARANK = ATensor_t::Rank();
+  constexpr int BRANK = BTensor_t::Rank();
+  constexpr int ORANK = OutTensor_t::Rank();
+
+  static_assert(ARANK >= 2, "Dense solve A must have rank 2 or higher");
+  static_assert(BRANK == ARANK || BRANK == ARANK - 1,
+                "Dense solve B must have rank A.Rank() or A.Rank() - 1");
+  static_assert(ORANK == BRANK,
+                "Dense solve output rank must match B rank");
+  static_assert(std::is_same_v<T, typename BTensor_t::value_type>,
+                "Dense solve A and B value types must match");
+  static_assert(std::is_same_v<T, typename OutTensor_t::value_type>,
+                "Dense solve output value type must match A and B");
+  static_assert(is_dense_solve_supported_type_v<T>,
+                "Dense solve supports float, double, complex<float>, and complex<double>");
+
+  MATX_ASSERT_STR(a.Size(ARANK - 1) == a.Size(ARANK - 2),
+                  matxInvalidSize,
+                  "Dense solve A must be square");
+
+  for (int i = 0; i < ORANK; i++) {
+    MATX_ASSERT_STR(out.Size(i) == b.Size(i), matxInvalidSize,
+                    "Dense solve output shape must match B");
+  }
+
+  if constexpr (IsDenseSolveVectorRHS<ATensor_t, BTensor_t>()) {
+    for (int i = 0; i < BRANK - 1; i++) {
+      MATX_ASSERT_STR(a.Size(i) == b.Size(i), matxInvalidSize,
+                      "Dense solve A and B batch dimensions must match");
+    }
+    MATX_ASSERT_STR(b.Size(BRANK - 1) == a.Size(ARANK - 1), matxInvalidSize,
+                    "Dense solve vector RHS length must match A");
+  }
+  else {
+    for (int i = 0; i < ARANK - 2; i++) {
+      MATX_ASSERT_STR(a.Size(i) == b.Size(i), matxInvalidSize,
+                      "Dense solve A and B batch dimensions must match");
+    }
+    MATX_ASSERT_STR(b.Size(BRANK - 2) == a.Size(ARANK - 1), matxInvalidSize,
+                    "Dense solve matrix RHS row count must match A");
+  }
+}
+
+template <typename ATensor, typename BTensor>
+__MATX_INLINE__ index_t GetDenseSolveNumRhs(const BTensor &b)
+{
+  if constexpr (IsDenseSolveVectorRHS<ATensor, BTensor>()) {
+    return 1;
+  }
+  else {
+    return b.Size(remove_cvref_t<BTensor>::Rank() - 1);
+  }
+}
+
+__MATX_INLINE__ void CheckDenseSolveInfo(const int info,
+                                         const char *provider,
+                                         const char *routine)
+{
+  if (info < 0) {
+    MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+      ("Parameter " + std::to_string(-info) + " had an illegal value in " +
+       provider + " " + routine).c_str());
+  }
+  else {
+    MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
+      ("Singular matrix in " + std::string(provider) + " " + routine +
+       ": U(" + std::to_string(info) + "," + std::to_string(info) +
+       ") = 0").c_str());
+  }
+}
+
+__MATX_INLINE__ void CheckDenseSolveInfos(const std::vector<int> &infos,
+                                          const char *provider,
+                                          const char *routine)
+{
+  for (const auto info : infos) {
+    CheckDenseSolveInfo(info, provider, routine);
+  }
+}
+
+} // end namespace detail
+} // end namespace matx

--- a/include/matx/transforms/solve/solve_cuda.h
+++ b/include/matx/transforms/solve/solve_cuda.h
@@ -42,7 +42,10 @@
 #include "matx/core/tensor.h"
 #include "matx/transforms/solve/solve_common.h"
 
+#include <any>
 #include <limits>
+#include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace matx {
@@ -129,76 +132,345 @@ __MATX_INLINE__ bool DenseSolveCanUseCublasBatched(const ATensor &a,
          batches <= static_cast<uint32_t>(std::numeric_limits<int>::max());
 }
 
+struct DenseSolveCUDAParams_t {
+  int64_t n;
+  int64_t nrhs;
+  uint32_t batch_size;
+  MatXDataType_t dtype;
+  cudaStream_t stream;
+};
+
+template <typename ATensor, typename BTensor>
+__MATX_INLINE__ DenseSolveCUDAParams_t
+GetDenseSolveCUDAParams(const ATensor &a, const BTensor &b,
+                        const cudaExecutor &exec)
+{
+  DenseSolveCUDAParams_t params;
+  params.n = static_cast<int64_t>(a.Size(remove_cvref_t<ATensor>::Rank() - 1));
+  params.nrhs = static_cast<int64_t>(GetDenseSolveNumRhs<ATensor, BTensor>(b));
+  params.batch_size = GetNumBatches(a);
+  params.dtype = TypeToInt<typename remove_cvref_t<ATensor>::value_type>();
+  params.stream = exec.getStream();
+  return params;
+}
+
+struct DenseSolveCUDAParamsKeyHash {
+  std::size_t operator()(const DenseSolveCUDAParams_t &k) const noexcept
+  {
+    return (std::hash<uint64_t>()(static_cast<uint64_t>(k.n))) +
+           (std::hash<uint64_t>()(static_cast<uint64_t>(k.nrhs))) +
+           (std::hash<uint64_t>()(static_cast<uint64_t>(k.batch_size))) +
+           (std::hash<uintptr_t>()(reinterpret_cast<uintptr_t>(k.stream))) +
+           (std::hash<int>()(static_cast<int>(k.dtype)));
+  }
+};
+
+struct DenseSolveCUDAParamsKeyEq {
+  bool operator()(const DenseSolveCUDAParams_t &l,
+                  const DenseSolveCUDAParams_t &r) const noexcept
+  {
+    return l.n == r.n &&
+           l.nrhs == r.nrhs &&
+           l.batch_size == r.batch_size &&
+           l.dtype == r.dtype &&
+           l.stream == r.stream;
+  }
+};
+
+class DenseSolveCublasHandleGuard {
+public:
+  DenseSolveCublasHandleGuard() = default;
+  DenseSolveCublasHandleGuard(const DenseSolveCublasHandleGuard &) = delete;
+  DenseSolveCublasHandleGuard &operator=(const DenseSolveCublasHandleGuard &) = delete;
+
+  ~DenseSolveCublasHandleGuard()
+  {
+    if (handle_ != nullptr) {
+      cublasDestroy(handle_);
+    }
+  }
+
+  void Create()
+  {
+    const auto ret = cublasCreate(&handle_);
+    MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
+  }
+
+  __MATX_INLINE__ cublasHandle_t get() const noexcept
+  {
+    return handle_;
+  }
+
+private:
+  cublasHandle_t handle_ = nullptr;
+};
+
+class DenseSolveCusolverHandleGuard {
+public:
+  DenseSolveCusolverHandleGuard() = default;
+  DenseSolveCusolverHandleGuard(const DenseSolveCusolverHandleGuard &) = delete;
+  DenseSolveCusolverHandleGuard &operator=(const DenseSolveCusolverHandleGuard &) = delete;
+
+  ~DenseSolveCusolverHandleGuard()
+  {
+    if (handle_ != nullptr) {
+      cusolverDnDestroy(handle_);
+    }
+  }
+
+  void Create()
+  {
+    const auto ret = cusolverDnCreate(&handle_);
+    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+  }
+
+  __MATX_INLINE__ cusolverDnHandle_t get() const noexcept
+  {
+    return handle_;
+  }
+
+private:
+  cusolverDnHandle_t handle_ = nullptr;
+};
+
+class DenseSolveCusolverParamsGuard {
+public:
+  DenseSolveCusolverParamsGuard() = default;
+  DenseSolveCusolverParamsGuard(const DenseSolveCusolverParamsGuard &) = delete;
+  DenseSolveCusolverParamsGuard &operator=(const DenseSolveCusolverParamsGuard &) = delete;
+
+  ~DenseSolveCusolverParamsGuard()
+  {
+    if (params_ != nullptr) {
+      cusolverDnDestroyParams(params_);
+    }
+  }
+
+  void Create()
+  {
+    const auto ret = cusolverDnCreateParams(&params_);
+    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+  }
+
+  __MATX_INLINE__ cusolverDnParams_t get() const noexcept
+  {
+    return params_;
+  }
+
+private:
+  cusolverDnParams_t params_ = nullptr;
+};
+
+template <typename T>
+class DenseSolveCublasBatchedPlan_t {
+public:
+  DenseSolveCublasBatchedPlan_t(const DenseSolveCUDAParams_t &params,
+                                const cudaExecutor &exec)
+      : params_(params)
+  {
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+    handle_.Create();
+
+    const auto stream = exec.getStream();
+    const auto batch_size = static_cast<size_t>(params_.batch_size);
+    d_a_array_.Alloc(batch_size * sizeof(T *), MATX_ASYNC_DEVICE_MEMORY,
+                     stream);
+    d_b_array_.Alloc(batch_size * sizeof(T *), MATX_ASYNC_DEVICE_MEMORY,
+                     stream);
+    d_piv_.Alloc(static_cast<size_t>(params_.n) * batch_size * sizeof(int),
+                 MATX_ASYNC_DEVICE_MEMORY, stream);
+    d_info_.Alloc(batch_size * sizeof(int), MATX_ASYNC_DEVICE_MEMORY, stream);
+  }
+
+  template <typename ATensor, typename BTensor>
+  void Exec(ATensor &a_col, BTensor &b_col, const cudaExecutor &exec)
+  {
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    const auto stream = exec.getStream();
+    const int n = static_cast<int>(params_.n);
+    const int nrhs = static_cast<int>(params_.nrhs);
+    const int batch_size = static_cast<int>(params_.batch_size);
+
+    std::vector<T *> h_a_array;
+    std::vector<T *> h_b_array;
+    SetBatchPointers<BatchType::MATRIX>(a_col, h_a_array);
+    if constexpr (IsDenseSolveVectorRHS<ATensor, BTensor>()) {
+      SetBatchPointers<BatchType::VECTOR>(b_col, h_b_array);
+    }
+    else {
+      SetBatchPointers<BatchType::MATRIX>(b_col, h_b_array);
+    }
+
+    cudaMemcpyAsync(d_a_array_.get(), h_a_array.data(),
+                    h_a_array.size() * sizeof(T *), cudaMemcpyHostToDevice,
+                    stream);
+    cudaMemcpyAsync(d_b_array_.get(), h_b_array.data(),
+                    h_b_array.size() * sizeof(T *), cudaMemcpyHostToDevice,
+                    stream);
+
+    auto ret = cublasSetStream(handle_.get(), stream);
+    MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
+
+    ret = DenseSolveGetrfBatched(handle_.get(), n, d_a_array_.get(), n,
+                                 d_piv_.get(), d_info_.get(), batch_size);
+    MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
+
+    std::vector<int> h_info(batch_size);
+    cudaMemcpyAsync(h_info.data(), d_info_.get(), sizeof(int) * batch_size,
+                    cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
+    CheckDenseSolveInfos(h_info, "cuBLAS", "getrfBatched");
+
+    int h_getrs_info = 0;
+    ret = DenseSolveGetrsBatched(handle_.get(), n, nrhs, d_a_array_.get(), n,
+                                 d_piv_.get(), d_b_array_.get(), n,
+                                 &h_getrs_info, batch_size);
+    MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
+    CheckDenseSolveInfo(h_getrs_info, "cuBLAS", "getrsBatched");
+  }
+
+private:
+  DenseSolveCUDAParams_t params_;
+  DenseSolveCublasHandleGuard handle_;
+  DenseSolveAllocGuard<T *> d_a_array_;
+  DenseSolveAllocGuard<T *> d_b_array_;
+  DenseSolveAllocGuard<int> d_piv_;
+  DenseSolveAllocGuard<int> d_info_;
+};
+
+template <typename T>
+class DenseSolveCusolverLoopPlan_t {
+public:
+  template <typename ATensor>
+  DenseSolveCusolverLoopPlan_t(const DenseSolveCUDAParams_t &params,
+                               const ATensor &a_col,
+                               const cudaExecutor &exec)
+      : params_(params)
+  {
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    const auto stream = exec.getStream();
+    handle_.Create();
+    dn_params_.Create();
+
+    auto ret = cusolverDnSetStream(handle_.get(), stream);
+    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+
+    ret = cusolverDnXgetrf_bufferSize(
+        handle_.get(), dn_params_.get(), params_.n, params_.n,
+        MatXTypeToCudaType<T>(), a_col.Data(), params_.n,
+        MatXTypeToCudaType<T>(), &dspace_, &hspace_);
+    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+
+    const auto batch_size = static_cast<size_t>(params_.batch_size);
+    if (dspace_ > 0) {
+      d_workspace_.Alloc(batch_size * dspace_, MATX_ASYNC_DEVICE_MEMORY,
+                         stream);
+      cudaMemsetAsync(d_workspace_.get(), 0, batch_size * dspace_, stream);
+    }
+    if (hspace_ > 0) {
+      h_workspace_.Alloc(batch_size * hspace_, MATX_HOST_MEMORY);
+    }
+    d_piv_.Alloc(static_cast<size_t>(params_.n) * batch_size * sizeof(int64_t),
+                 MATX_ASYNC_DEVICE_MEMORY, stream);
+    d_info_.Alloc(batch_size * sizeof(int), MATX_ASYNC_DEVICE_MEMORY, stream);
+  }
+
+  template <typename ATensor, typename BTensor>
+  void Exec(ATensor &a_col, BTensor &b_col, const cudaExecutor &exec)
+  {
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
+
+    const auto stream = exec.getStream();
+    auto ret = cusolverDnSetStream(handle_.get(), stream);
+    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+
+    std::vector<T *> h_a_array;
+    std::vector<T *> h_b_array;
+    SetBatchPointers<BatchType::MATRIX>(a_col, h_a_array);
+    if constexpr (IsDenseSolveVectorRHS<ATensor, BTensor>()) {
+      SetBatchPointers<BatchType::VECTOR>(b_col, h_b_array);
+    }
+    else {
+      SetBatchPointers<BatchType::MATRIX>(b_col, h_b_array);
+    }
+
+    for (uint32_t i = 0; i < params_.batch_size; i++) {
+      auto *d_work = dspace_ > 0 ? d_workspace_.get() + i * dspace_ : nullptr;
+      auto *h_work = hspace_ > 0 ? h_workspace_.get() + i * hspace_ : nullptr;
+      ret = cusolverDnXgetrf(
+          handle_.get(), dn_params_.get(), params_.n, params_.n,
+          MatXTypeToCudaType<T>(), h_a_array[i], params_.n,
+          d_piv_.get() + static_cast<size_t>(i) * params_.n,
+          MatXTypeToCudaType<T>(), d_work, dspace_, h_work, hspace_,
+          d_info_.get() + i);
+      MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+    }
+
+    std::vector<int> h_info(params_.batch_size);
+    cudaMemcpyAsync(h_info.data(), d_info_.get(),
+                    sizeof(int) * params_.batch_size, cudaMemcpyDeviceToHost,
+                    stream);
+    cudaStreamSynchronize(stream);
+    CheckDenseSolveInfos(h_info, "cuSolver", "Xgetrf");
+
+    for (uint32_t i = 0; i < params_.batch_size; i++) {
+      ret = cusolverDnXgetrs(
+          handle_.get(), dn_params_.get(), CUBLAS_OP_N, params_.n,
+          params_.nrhs, MatXTypeToCudaType<T>(), h_a_array[i], params_.n,
+          d_piv_.get() + static_cast<size_t>(i) * params_.n,
+          MatXTypeToCudaType<T>(), h_b_array[i], params_.n,
+          d_info_.get() + i);
+      MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+    }
+
+    cudaMemcpyAsync(h_info.data(), d_info_.get(),
+                    sizeof(int) * params_.batch_size, cudaMemcpyDeviceToHost,
+                    stream);
+    cudaStreamSynchronize(stream);
+    CheckDenseSolveInfos(h_info, "cuSolver", "Xgetrs");
+  }
+
+private:
+  DenseSolveCUDAParams_t params_;
+  DenseSolveCusolverHandleGuard handle_;
+  DenseSolveCusolverParamsGuard dn_params_;
+  DenseSolveAllocGuard<uint8_t> d_workspace_;
+  DenseSolveAllocGuard<uint8_t> h_workspace_;
+  DenseSolveAllocGuard<int64_t> d_piv_;
+  DenseSolveAllocGuard<int> d_info_;
+  size_t dspace_ = 0;
+  size_t hspace_ = 0;
+};
+
+using dense_solve_cublas_cuda_cache_t =
+    std::unordered_map<DenseSolveCUDAParams_t, std::any,
+                       DenseSolveCUDAParamsKeyHash, DenseSolveCUDAParamsKeyEq>;
+using dense_solve_cusolver_cuda_cache_t =
+    std::unordered_map<DenseSolveCUDAParams_t, std::any,
+                       DenseSolveCUDAParamsKeyHash, DenseSolveCUDAParamsKeyEq>;
+
 template <typename ATensor, typename BTensor>
 void DenseSolveCublasBatched(ATensor &a_col,
                              BTensor &b_col,
                              const cudaExecutor &exec)
 {
   using T = typename remove_cvref_t<ATensor>::value_type;
-  constexpr int ARANK = remove_cvref_t<ATensor>::Rank();
-
-  const auto stream = exec.getStream();
-  const int n = static_cast<int>(a_col.Size(ARANK - 1));
-  const int nrhs = static_cast<int>(GetDenseSolveNumRhs<ATensor, BTensor>(b_col));
-  const int batch_size = static_cast<int>(GetNumBatches(a_col));
-
-  std::vector<T *> h_a_array;
-  std::vector<T *> h_b_array;
-  SetBatchPointers<BatchType::MATRIX>(a_col, h_a_array);
-  if constexpr (IsDenseSolveVectorRHS<ATensor, BTensor>()) {
-    SetBatchPointers<BatchType::VECTOR>(b_col, h_b_array);
-  }
-  else {
-    SetBatchPointers<BatchType::MATRIX>(b_col, h_b_array);
-  }
-
-  T **d_a_array = nullptr;
-  T **d_b_array = nullptr;
-  int *d_piv = nullptr;
-  int *d_info = nullptr;
-  matxAlloc(reinterpret_cast<void **>(&d_a_array),
-            h_a_array.size() * sizeof(T *), MATX_ASYNC_DEVICE_MEMORY, stream);
-  matxAlloc(reinterpret_cast<void **>(&d_b_array),
-            h_b_array.size() * sizeof(T *), MATX_ASYNC_DEVICE_MEMORY, stream);
-  matxAlloc(reinterpret_cast<void **>(&d_piv),
-            static_cast<size_t>(n) * batch_size * sizeof(int),
-            MATX_ASYNC_DEVICE_MEMORY, stream);
-  matxAlloc(reinterpret_cast<void **>(&d_info),
-            static_cast<size_t>(batch_size) * sizeof(int),
-            MATX_ASYNC_DEVICE_MEMORY, stream);
-
-  cudaMemcpyAsync(d_a_array, h_a_array.data(), h_a_array.size() * sizeof(T *),
-                  cudaMemcpyHostToDevice, stream);
-  cudaMemcpyAsync(d_b_array, h_b_array.data(), h_b_array.size() * sizeof(T *),
-                  cudaMemcpyHostToDevice, stream);
-
-  cublasHandle_t handle;
-  auto ret = cublasCreate(&handle);
-  MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
-  ret = cublasSetStream(handle, stream);
-  MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
-
-  ret = DenseSolveGetrfBatched(handle, n, d_a_array, n, d_piv, d_info,
-                               batch_size);
-  MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
-
-  std::vector<int> h_info(batch_size);
-  cudaMemcpyAsync(h_info.data(), d_info, sizeof(int) * batch_size,
-                  cudaMemcpyDeviceToHost, stream);
-  cudaStreamSynchronize(stream);
-  CheckDenseSolveInfos(h_info, "cuBLAS", "getrfBatched");
-
-  int h_getrs_info = 0;
-  ret = DenseSolveGetrsBatched(handle, n, nrhs, d_a_array, n, d_piv,
-                               d_b_array, n, &h_getrs_info, batch_size);
-  MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
-  CheckDenseSolveInfo(h_getrs_info, "cuBLAS", "getrsBatched");
-
-  cublasDestroy(handle);
-  matxFree(d_a_array);
-  matxFree(d_b_array);
-  matxFree(d_piv);
-  matxFree(d_info);
+  auto params = GetDenseSolveCUDAParams(a_col, b_col, exec);
+  using cache_val_type = DenseSolveCublasBatchedPlan_t<T>;
+  auto cache_id = GetCacheIdFromType<dense_solve_cublas_cuda_cache_t>();
+  MATX_LOG_DEBUG("Dense solve cuBLAS transform: cache_id={}", cache_id);
+  GetCache().LookupAndExec<dense_solve_cublas_cuda_cache_t>(
+      cache_id,
+      params,
+      [&]() {
+        return std::make_shared<cache_val_type>(params, exec);
+      },
+      [&](std::shared_ptr<cache_val_type> ctype) {
+        ctype->Exec(a_col, b_col, exec);
+      },
+      exec);
 }
 
 template <typename ATensor, typename BTensor>
@@ -207,93 +479,20 @@ void DenseSolveCusolverLoop(ATensor &a_col,
                             const cudaExecutor &exec)
 {
   using T = typename remove_cvref_t<ATensor>::value_type;
-  constexpr int ARANK = remove_cvref_t<ATensor>::Rank();
-
-  const auto stream = exec.getStream();
-  const int64_t n = static_cast<int64_t>(a_col.Size(ARANK - 1));
-  const int64_t nrhs = static_cast<int64_t>(GetDenseSolveNumRhs<ATensor, BTensor>(b_col));
-  const auto batch_size = GetNumBatches(a_col);
-
-  std::vector<T *> h_a_array;
-  std::vector<T *> h_b_array;
-  SetBatchPointers<BatchType::MATRIX>(a_col, h_a_array);
-  if constexpr (IsDenseSolveVectorRHS<ATensor, BTensor>()) {
-    SetBatchPointers<BatchType::VECTOR>(b_col, h_b_array);
-  }
-  else {
-    SetBatchPointers<BatchType::MATRIX>(b_col, h_b_array);
-  }
-
-  cusolverDnHandle_t handle;
-  cusolverDnParams_t dn_params;
-  auto ret = cusolverDnCreate(&handle);
-  MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
-  ret = cusolverDnCreateParams(&dn_params);
-  MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
-  ret = cusolverDnSetStream(handle, stream);
-  MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
-
-  size_t dspace = 0;
-  size_t hspace = 0;
-  ret = cusolverDnXgetrf_bufferSize(handle, dn_params, n, n,
-                                    MatXTypeToCudaType<T>(), h_a_array[0], n,
-                                    MatXTypeToCudaType<T>(), &dspace, &hspace);
-  MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
-
-  void *d_workspace = nullptr;
-  void *h_workspace = nullptr;
-  int64_t *d_piv = nullptr;
-  int *d_info = nullptr;
-  if (dspace > 0) {
-    matxAlloc(&d_workspace, batch_size * dspace, MATX_ASYNC_DEVICE_MEMORY,
-              stream);
-    cudaMemsetAsync(d_workspace, 0, batch_size * dspace, stream);
-  }
-  if (hspace > 0) {
-    matxAlloc(&h_workspace, batch_size * hspace, MATX_HOST_MEMORY);
-  }
-  matxAlloc(reinterpret_cast<void **>(&d_piv),
-            static_cast<size_t>(n) * batch_size * sizeof(int64_t),
-            MATX_ASYNC_DEVICE_MEMORY, stream);
-  matxAlloc(reinterpret_cast<void **>(&d_info),
-            static_cast<size_t>(batch_size) * sizeof(int),
-            MATX_ASYNC_DEVICE_MEMORY, stream);
-
-  for (uint32_t i = 0; i < batch_size; i++) {
-    ret = cusolverDnXgetrf(
-        handle, dn_params, n, n, MatXTypeToCudaType<T>(), h_a_array[i], n,
-        d_piv + static_cast<size_t>(i) * n, MatXTypeToCudaType<T>(),
-        reinterpret_cast<uint8_t *>(d_workspace) + i * dspace, dspace,
-        reinterpret_cast<uint8_t *>(h_workspace) + i * hspace, hspace,
-        d_info + i);
-    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
-  }
-
-  std::vector<int> h_info(batch_size);
-  cudaMemcpyAsync(h_info.data(), d_info, sizeof(int) * batch_size,
-                  cudaMemcpyDeviceToHost, stream);
-  cudaStreamSynchronize(stream);
-  CheckDenseSolveInfos(h_info, "cuSolver", "Xgetrf");
-
-  for (uint32_t i = 0; i < batch_size; i++) {
-    ret = cusolverDnXgetrs(
-        handle, dn_params, CUBLAS_OP_N, n, nrhs, MatXTypeToCudaType<T>(),
-        h_a_array[i], n, d_piv + static_cast<size_t>(i) * n,
-        MatXTypeToCudaType<T>(), h_b_array[i], n, d_info + i);
-    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
-  }
-
-  cudaMemcpyAsync(h_info.data(), d_info, sizeof(int) * batch_size,
-                  cudaMemcpyDeviceToHost, stream);
-  cudaStreamSynchronize(stream);
-  CheckDenseSolveInfos(h_info, "cuSolver", "Xgetrs");
-
-  cusolverDnDestroyParams(dn_params);
-  cusolverDnDestroy(handle);
-  matxFree(d_workspace);
-  matxFree(h_workspace);
-  matxFree(d_piv);
-  matxFree(d_info);
+  auto params = GetDenseSolveCUDAParams(a_col, b_col, exec);
+  using cache_val_type = DenseSolveCusolverLoopPlan_t<T>;
+  auto cache_id = GetCacheIdFromType<dense_solve_cusolver_cuda_cache_t>();
+  MATX_LOG_DEBUG("Dense solve cuSolver transform: cache_id={}", cache_id);
+  GetCache().LookupAndExec<dense_solve_cusolver_cuda_cache_t>(
+      cache_id,
+      params,
+      [&]() {
+        return std::make_shared<cache_val_type>(params, a_col, exec);
+      },
+      [&](std::shared_ptr<cache_val_type> ctype) {
+        ctype->Exec(a_col, b_col, exec);
+      },
+      exec);
 }
 
 } // end namespace detail
@@ -327,17 +526,15 @@ void dense_solve_impl(OutputTensor &&out,
 
   const auto stream = exec.getStream();
 
-  T *a_ptr = nullptr;
-  matxAlloc(reinterpret_cast<void **>(&a_ptr), a_new.Bytes(),
-            MATX_ASYNC_DEVICE_MEMORY, stream);
-  auto a_work_t = detail::TransposeCopy(a_ptr, a_new, exec);
+  detail::DenseSolveAllocGuard<T> a_ptr;
+  a_ptr.Alloc(a_new.Bytes(), MATX_ASYNC_DEVICE_MEMORY, stream);
+  auto a_work_t = detail::TransposeCopy(a_ptr.get(), a_new, exec);
   auto a_col = a_work_t.PermuteMatrix();
 
   if constexpr (detail::IsDenseSolveVectorRHS<decltype(a_new), decltype(b_new)>()) {
-    T *b_ptr = nullptr;
-    matxAlloc(reinterpret_cast<void **>(&b_ptr), b_new.Bytes(),
-              MATX_ASYNC_DEVICE_MEMORY, stream);
-    auto b_work = make_tensor<T>(b_ptr, b_new.Shape());
+    detail::DenseSolveAllocGuard<T> b_ptr;
+    b_ptr.Alloc(b_new.Bytes(), MATX_ASYNC_DEVICE_MEMORY, stream);
+    auto b_work = make_tensor<T>(b_ptr.get(), b_new.Shape());
     (b_work = b_new).run(exec);
 
     if (detail::DenseSolveCanUseCublasBatched<decltype(a_col), decltype(b_work)>(a_col, b_work)) {
@@ -348,13 +545,11 @@ void dense_solve_impl(OutputTensor &&out,
     }
 
     matx::copy(out, b_work, exec);
-    matxFree(b_ptr);
   }
   else {
-    T *b_ptr = nullptr;
-    matxAlloc(reinterpret_cast<void **>(&b_ptr), b_new.Bytes(),
-              MATX_ASYNC_DEVICE_MEMORY, stream);
-    auto b_work_t = detail::TransposeCopy(b_ptr, b_new, exec);
+    detail::DenseSolveAllocGuard<T> b_ptr;
+    b_ptr.Alloc(b_new.Bytes(), MATX_ASYNC_DEVICE_MEMORY, stream);
+    auto b_work_t = detail::TransposeCopy(b_ptr.get(), b_new, exec);
     auto b_col = b_work_t.PermuteMatrix();
 
     if (detail::DenseSolveCanUseCublasBatched<decltype(a_col), decltype(b_col)>(a_col, b_col)) {
@@ -365,10 +560,7 @@ void dense_solve_impl(OutputTensor &&out,
     }
 
     matx::copy(out, b_work_t.PermuteMatrix(), exec);
-    matxFree(b_ptr);
   }
-
-  matxFree(a_ptr);
 }
 
 } // end namespace matx

--- a/include/matx/transforms/solve/solve_cuda.h
+++ b/include/matx/transforms/solve/solve_cuda.h
@@ -1,0 +1,374 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cublas_v2.h>
+#include <cusolverDn.h>
+
+#include "matx/core/cache.h"
+#include "matx/core/error.h"
+#include "matx/core/nvtx.h"
+#include "matx/core/tensor.h"
+#include "matx/transforms/solve/solve_common.h"
+
+#include <limits>
+#include <vector>
+
+namespace matx {
+namespace detail {
+
+template <typename T>
+__MATX_INLINE__ cublasStatus_t DenseSolveGetrfBatched(cublasHandle_t handle,
+                                                      int n,
+                                                      T **a_array,
+                                                      int lda,
+                                                      int *piv,
+                                                      int *info,
+                                                      int batch_size)
+{
+  if constexpr (std::is_same_v<T, float>) {
+    return cublasSgetrfBatched(handle, n, a_array, lda, piv, info, batch_size);
+  }
+  else if constexpr (std::is_same_v<T, double>) {
+    return cublasDgetrfBatched(handle, n, a_array, lda, piv, info, batch_size);
+  }
+  else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+    return cublasCgetrfBatched(handle, n,
+                               reinterpret_cast<cuComplex *const *>(a_array),
+                               lda, piv, info, batch_size);
+  }
+  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+    return cublasZgetrfBatched(handle, n,
+                               reinterpret_cast<cuDoubleComplex *const *>(a_array),
+                               lda, piv, info, batch_size);
+  }
+  else {
+    return CUBLAS_STATUS_NOT_SUPPORTED;
+  }
+}
+
+template <typename T>
+__MATX_INLINE__ cublasStatus_t DenseSolveGetrsBatched(cublasHandle_t handle,
+                                                      int n,
+                                                      int nrhs,
+                                                      T **a_array,
+                                                      int lda,
+                                                      int *piv,
+                                                      T **b_array,
+                                                      int ldb,
+                                                      int *info,
+                                                      int batch_size)
+{
+  if constexpr (std::is_same_v<T, float>) {
+    return cublasSgetrsBatched(handle, CUBLAS_OP_N, n, nrhs, a_array, lda,
+                               piv, b_array, ldb, info, batch_size);
+  }
+  else if constexpr (std::is_same_v<T, double>) {
+    return cublasDgetrsBatched(handle, CUBLAS_OP_N, n, nrhs, a_array, lda,
+                               piv, b_array, ldb, info, batch_size);
+  }
+  else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+    return cublasCgetrsBatched(
+        handle, CUBLAS_OP_N, n, nrhs,
+        reinterpret_cast<const cuComplex *const *>(a_array), lda, piv,
+        reinterpret_cast<cuComplex *const *>(b_array), ldb, info, batch_size);
+  }
+  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+    return cublasZgetrsBatched(
+        handle, CUBLAS_OP_N, n, nrhs,
+        reinterpret_cast<const cuDoubleComplex *const *>(a_array), lda, piv,
+        reinterpret_cast<cuDoubleComplex *const *>(b_array), ldb, info,
+        batch_size);
+  }
+  else {
+    return CUBLAS_STATUS_NOT_SUPPORTED;
+  }
+}
+
+template <typename ATensor, typename BTensor>
+__MATX_INLINE__ bool DenseSolveCanUseCublasBatched(const ATensor &a,
+                                                  const BTensor &b)
+{
+  const auto n = a.Size(remove_cvref_t<ATensor>::Rank() - 1);
+  const auto nrhs = GetDenseSolveNumRhs<ATensor, BTensor>(b);
+  const auto batches = GetNumBatches(a);
+  return batches > 1 &&
+         n <= std::numeric_limits<int>::max() &&
+         nrhs <= std::numeric_limits<int>::max() &&
+         batches <= static_cast<uint32_t>(std::numeric_limits<int>::max());
+}
+
+template <typename ATensor, typename BTensor>
+void DenseSolveCublasBatched(ATensor &a_col,
+                             BTensor &b_col,
+                             const cudaExecutor &exec)
+{
+  using T = typename remove_cvref_t<ATensor>::value_type;
+  constexpr int ARANK = remove_cvref_t<ATensor>::Rank();
+
+  const auto stream = exec.getStream();
+  const int n = static_cast<int>(a_col.Size(ARANK - 1));
+  const int nrhs = static_cast<int>(GetDenseSolveNumRhs<ATensor, BTensor>(b_col));
+  const int batch_size = static_cast<int>(GetNumBatches(a_col));
+
+  std::vector<T *> h_a_array;
+  std::vector<T *> h_b_array;
+  SetBatchPointers<BatchType::MATRIX>(a_col, h_a_array);
+  if constexpr (IsDenseSolveVectorRHS<ATensor, BTensor>()) {
+    SetBatchPointers<BatchType::VECTOR>(b_col, h_b_array);
+  }
+  else {
+    SetBatchPointers<BatchType::MATRIX>(b_col, h_b_array);
+  }
+
+  T **d_a_array = nullptr;
+  T **d_b_array = nullptr;
+  int *d_piv = nullptr;
+  int *d_info = nullptr;
+  matxAlloc(reinterpret_cast<void **>(&d_a_array),
+            h_a_array.size() * sizeof(T *), MATX_ASYNC_DEVICE_MEMORY, stream);
+  matxAlloc(reinterpret_cast<void **>(&d_b_array),
+            h_b_array.size() * sizeof(T *), MATX_ASYNC_DEVICE_MEMORY, stream);
+  matxAlloc(reinterpret_cast<void **>(&d_piv),
+            static_cast<size_t>(n) * batch_size * sizeof(int),
+            MATX_ASYNC_DEVICE_MEMORY, stream);
+  matxAlloc(reinterpret_cast<void **>(&d_info),
+            static_cast<size_t>(batch_size) * sizeof(int),
+            MATX_ASYNC_DEVICE_MEMORY, stream);
+
+  cudaMemcpyAsync(d_a_array, h_a_array.data(), h_a_array.size() * sizeof(T *),
+                  cudaMemcpyHostToDevice, stream);
+  cudaMemcpyAsync(d_b_array, h_b_array.data(), h_b_array.size() * sizeof(T *),
+                  cudaMemcpyHostToDevice, stream);
+
+  cublasHandle_t handle;
+  auto ret = cublasCreate(&handle);
+  MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
+  ret = cublasSetStream(handle, stream);
+  MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
+
+  ret = DenseSolveGetrfBatched(handle, n, d_a_array, n, d_piv, d_info,
+                               batch_size);
+  MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
+
+  std::vector<int> h_info(batch_size);
+  cudaMemcpyAsync(h_info.data(), d_info, sizeof(int) * batch_size,
+                  cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
+  CheckDenseSolveInfos(h_info, "cuBLAS", "getrfBatched");
+
+  int h_getrs_info = 0;
+  ret = DenseSolveGetrsBatched(handle, n, nrhs, d_a_array, n, d_piv,
+                               d_b_array, n, &h_getrs_info, batch_size);
+  MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxSolverError);
+  CheckDenseSolveInfo(h_getrs_info, "cuBLAS", "getrsBatched");
+
+  cublasDestroy(handle);
+  matxFree(d_a_array);
+  matxFree(d_b_array);
+  matxFree(d_piv);
+  matxFree(d_info);
+}
+
+template <typename ATensor, typename BTensor>
+void DenseSolveCusolverLoop(ATensor &a_col,
+                            BTensor &b_col,
+                            const cudaExecutor &exec)
+{
+  using T = typename remove_cvref_t<ATensor>::value_type;
+  constexpr int ARANK = remove_cvref_t<ATensor>::Rank();
+
+  const auto stream = exec.getStream();
+  const int64_t n = static_cast<int64_t>(a_col.Size(ARANK - 1));
+  const int64_t nrhs = static_cast<int64_t>(GetDenseSolveNumRhs<ATensor, BTensor>(b_col));
+  const auto batch_size = GetNumBatches(a_col);
+
+  std::vector<T *> h_a_array;
+  std::vector<T *> h_b_array;
+  SetBatchPointers<BatchType::MATRIX>(a_col, h_a_array);
+  if constexpr (IsDenseSolveVectorRHS<ATensor, BTensor>()) {
+    SetBatchPointers<BatchType::VECTOR>(b_col, h_b_array);
+  }
+  else {
+    SetBatchPointers<BatchType::MATRIX>(b_col, h_b_array);
+  }
+
+  cusolverDnHandle_t handle;
+  cusolverDnParams_t dn_params;
+  auto ret = cusolverDnCreate(&handle);
+  MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+  ret = cusolverDnCreateParams(&dn_params);
+  MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+  ret = cusolverDnSetStream(handle, stream);
+  MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+
+  size_t dspace = 0;
+  size_t hspace = 0;
+  ret = cusolverDnXgetrf_bufferSize(handle, dn_params, n, n,
+                                    MatXTypeToCudaType<T>(), h_a_array[0], n,
+                                    MatXTypeToCudaType<T>(), &dspace, &hspace);
+  MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+
+  void *d_workspace = nullptr;
+  void *h_workspace = nullptr;
+  int64_t *d_piv = nullptr;
+  int *d_info = nullptr;
+  if (dspace > 0) {
+    matxAlloc(&d_workspace, batch_size * dspace, MATX_ASYNC_DEVICE_MEMORY,
+              stream);
+    cudaMemsetAsync(d_workspace, 0, batch_size * dspace, stream);
+  }
+  if (hspace > 0) {
+    matxAlloc(&h_workspace, batch_size * hspace, MATX_HOST_MEMORY);
+  }
+  matxAlloc(reinterpret_cast<void **>(&d_piv),
+            static_cast<size_t>(n) * batch_size * sizeof(int64_t),
+            MATX_ASYNC_DEVICE_MEMORY, stream);
+  matxAlloc(reinterpret_cast<void **>(&d_info),
+            static_cast<size_t>(batch_size) * sizeof(int),
+            MATX_ASYNC_DEVICE_MEMORY, stream);
+
+  for (uint32_t i = 0; i < batch_size; i++) {
+    ret = cusolverDnXgetrf(
+        handle, dn_params, n, n, MatXTypeToCudaType<T>(), h_a_array[i], n,
+        d_piv + static_cast<size_t>(i) * n, MatXTypeToCudaType<T>(),
+        reinterpret_cast<uint8_t *>(d_workspace) + i * dspace, dspace,
+        reinterpret_cast<uint8_t *>(h_workspace) + i * hspace, hspace,
+        d_info + i);
+    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+  }
+
+  std::vector<int> h_info(batch_size);
+  cudaMemcpyAsync(h_info.data(), d_info, sizeof(int) * batch_size,
+                  cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
+  CheckDenseSolveInfos(h_info, "cuSolver", "Xgetrf");
+
+  for (uint32_t i = 0; i < batch_size; i++) {
+    ret = cusolverDnXgetrs(
+        handle, dn_params, CUBLAS_OP_N, n, nrhs, MatXTypeToCudaType<T>(),
+        h_a_array[i], n, d_piv + static_cast<size_t>(i) * n,
+        MatXTypeToCudaType<T>(), h_b_array[i], n, d_info + i);
+    MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
+  }
+
+  cudaMemcpyAsync(h_info.data(), d_info, sizeof(int) * batch_size,
+                  cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
+  CheckDenseSolveInfos(h_info, "cuSolver", "Xgetrs");
+
+  cusolverDnDestroyParams(dn_params);
+  cusolverDnDestroy(handle);
+  matxFree(d_workspace);
+  matxFree(h_workspace);
+  matxFree(d_piv);
+  matxFree(d_info);
+}
+
+} // end namespace detail
+
+template <typename OutputTensor, typename ATensor, typename BTensor>
+void dense_solve_impl(OutputTensor &&out,
+                      const ATensor &a,
+                      const BTensor &b,
+                      const cudaExecutor &exec)
+{
+  MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+
+  using T = typename remove_cvref_t<OutputTensor>::value_type;
+
+  detail::ValidateDenseSolve(out, a, b);
+
+  auto a_new = OpToTensor(a, exec);
+  auto b_new = OpToTensor(b, exec);
+
+  if constexpr (!is_matx_transform_op<ATensor>()) {
+    if (!a_new.isSameView(a)) {
+      (a_new = a).run(exec);
+    }
+  }
+
+  if constexpr (!is_matx_transform_op<BTensor>()) {
+    if (!b_new.isSameView(b)) {
+      (b_new = b).run(exec);
+    }
+  }
+
+  const auto stream = exec.getStream();
+
+  T *a_ptr = nullptr;
+  matxAlloc(reinterpret_cast<void **>(&a_ptr), a_new.Bytes(),
+            MATX_ASYNC_DEVICE_MEMORY, stream);
+  auto a_work_t = detail::TransposeCopy(a_ptr, a_new, exec);
+  auto a_col = a_work_t.PermuteMatrix();
+
+  if constexpr (detail::IsDenseSolveVectorRHS<decltype(a_new), decltype(b_new)>()) {
+    T *b_ptr = nullptr;
+    matxAlloc(reinterpret_cast<void **>(&b_ptr), b_new.Bytes(),
+              MATX_ASYNC_DEVICE_MEMORY, stream);
+    auto b_work = make_tensor<T>(b_ptr, b_new.Shape());
+    (b_work = b_new).run(exec);
+
+    if (detail::DenseSolveCanUseCublasBatched<decltype(a_col), decltype(b_work)>(a_col, b_work)) {
+      detail::DenseSolveCublasBatched(a_col, b_work, exec);
+    }
+    else {
+      detail::DenseSolveCusolverLoop(a_col, b_work, exec);
+    }
+
+    matx::copy(out, b_work, exec);
+    matxFree(b_ptr);
+  }
+  else {
+    T *b_ptr = nullptr;
+    matxAlloc(reinterpret_cast<void **>(&b_ptr), b_new.Bytes(),
+              MATX_ASYNC_DEVICE_MEMORY, stream);
+    auto b_work_t = detail::TransposeCopy(b_ptr, b_new, exec);
+    auto b_col = b_work_t.PermuteMatrix();
+
+    if (detail::DenseSolveCanUseCublasBatched<decltype(a_col), decltype(b_col)>(a_col, b_col)) {
+      detail::DenseSolveCublasBatched(a_col, b_col, exec);
+    }
+    else {
+      detail::DenseSolveCusolverLoop(a_col, b_col, exec);
+    }
+
+    matx::copy(out, b_work_t.PermuteMatrix(), exec);
+    matxFree(b_ptr);
+  }
+
+  matxFree(a_ptr);
+}
+
+} // end namespace matx

--- a/include/matx/transforms/solve/solve_lapack.h
+++ b/include/matx/transforms/solve/solve_lapack.h
@@ -134,36 +134,29 @@ void dense_solve_impl([[maybe_unused]] OutputTensor &&out,
     }
   }
 
-  T *a_ptr = nullptr;
-  matxAlloc(reinterpret_cast<void **>(&a_ptr), a_new.Bytes(),
-            MATX_HOST_MALLOC_MEMORY);
-  auto a_work_t = detail::TransposeCopy(a_ptr, a_new, exec);
+  detail::DenseSolveAllocGuard<T> a_ptr;
+  a_ptr.Alloc(a_new.Bytes(), MATX_HOST_MALLOC_MEMORY);
+  auto a_work_t = detail::TransposeCopy(a_ptr.get(), a_new, exec);
   auto a_col = a_work_t.PermuteMatrix();
 
   if constexpr (detail::IsDenseSolveVectorRHS<decltype(a_new), decltype(b_new)>()) {
-    T *b_ptr = nullptr;
-    matxAlloc(reinterpret_cast<void **>(&b_ptr), b_new.Bytes(),
-              MATX_HOST_MALLOC_MEMORY);
-    auto b_work = make_tensor<T>(b_ptr, b_new.Shape());
+    detail::DenseSolveAllocGuard<T> b_ptr;
+    b_ptr.Alloc(b_new.Bytes(), MATX_HOST_MALLOC_MEMORY);
+    auto b_work = make_tensor<T>(b_ptr.get(), b_new.Shape());
     (b_work = b_new).run(exec);
 
     detail::DenseSolveLapackLoop(a_col, b_work, exec);
     matx::copy(out, b_work, exec);
-    matxFree(b_ptr);
   }
   else {
-    T *b_ptr = nullptr;
-    matxAlloc(reinterpret_cast<void **>(&b_ptr), b_new.Bytes(),
-              MATX_HOST_MALLOC_MEMORY);
-    auto b_work_t = detail::TransposeCopy(b_ptr, b_new, exec);
+    detail::DenseSolveAllocGuard<T> b_ptr;
+    b_ptr.Alloc(b_new.Bytes(), MATX_HOST_MALLOC_MEMORY);
+    auto b_work_t = detail::TransposeCopy(b_ptr.get(), b_new, exec);
     auto b_col = b_work_t.PermuteMatrix();
 
     detail::DenseSolveLapackLoop(a_col, b_col, exec);
     matx::copy(out, b_work_t.PermuteMatrix(), exec);
-    matxFree(b_ptr);
   }
-
-  matxFree(a_ptr);
 #endif
 }
 

--- a/include/matx/transforms/solve/solve_lapack.h
+++ b/include/matx/transforms/solve/solve_lapack.h
@@ -1,0 +1,170 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx/core/error.h"
+#include "matx/core/nvtx.h"
+#include "matx/core/tensor.h"
+#include "matx/executors/host.h"
+#include "matx/executors/support.h"
+#include "matx/transforms/solve/solve_common.h"
+
+#include <vector>
+
+namespace matx {
+namespace detail {
+
+#if MATX_EN_CPU_SOLVER
+template <typename T>
+__MATX_INLINE__ void DenseSolveGesvDispatch(lapack_int_t *n,
+                                            lapack_int_t *nrhs,
+                                            T *a,
+                                            lapack_int_t *lda,
+                                            lapack_int_t *piv,
+                                            T *b,
+                                            lapack_int_t *ldb,
+                                            lapack_int_t *info)
+{
+  if constexpr (std::is_same_v<T, float>) {
+    LAPACK_CALL(sgesv)(n, nrhs, a, lda, piv, b, ldb, info);
+  }
+  else if constexpr (std::is_same_v<T, double>) {
+    LAPACK_CALL(dgesv)(n, nrhs, a, lda, piv, b, ldb, info);
+  }
+  else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+    LAPACK_CALL(cgesv)(n, nrhs, a, lda, piv, b, ldb, info);
+  }
+  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+    LAPACK_CALL(zgesv)(n, nrhs, a, lda, piv, b, ldb, info);
+  }
+}
+
+template <typename ATensor, typename BTensor, ThreadsMode MODE>
+void DenseSolveLapackLoop(ATensor &a_col,
+                          BTensor &b_col,
+                          [[maybe_unused]] const HostExecutor<MODE> &exec)
+{
+  using T = typename remove_cvref_t<ATensor>::value_type;
+  constexpr int ARANK = remove_cvref_t<ATensor>::Rank();
+
+  lapack_int_t n = static_cast<lapack_int_t>(a_col.Size(ARANK - 1));
+  lapack_int_t nrhs = static_cast<lapack_int_t>(GetDenseSolveNumRhs<ATensor, BTensor>(b_col));
+  lapack_int_t info = 0;
+  const auto batch_size = GetNumBatches(a_col);
+
+  std::vector<T *> a_ptrs;
+  std::vector<T *> b_ptrs;
+  SetBatchPointers<BatchType::MATRIX>(a_col, a_ptrs);
+  if constexpr (IsDenseSolveVectorRHS<ATensor, BTensor>()) {
+    SetBatchPointers<BatchType::VECTOR>(b_col, b_ptrs);
+  }
+  else {
+    SetBatchPointers<BatchType::MATRIX>(b_col, b_ptrs);
+  }
+
+  std::vector<lapack_int_t> piv(static_cast<size_t>(n));
+  for (uint32_t i = 0; i < batch_size; i++) {
+    DenseSolveGesvDispatch(&n, &nrhs, a_ptrs[i], &n, piv.data(), b_ptrs[i],
+                           &n, &info);
+    CheckDenseSolveInfo(static_cast<int>(info), "LAPACK", "gesv");
+  }
+}
+#endif
+
+} // end namespace detail
+
+template <typename OutputTensor, typename ATensor, typename BTensor,
+          ThreadsMode MODE>
+void dense_solve_impl([[maybe_unused]] OutputTensor &&out,
+                      [[maybe_unused]] const ATensor &a,
+                      [[maybe_unused]] const BTensor &b,
+                      [[maybe_unused]] const HostExecutor<MODE> &exec)
+{
+  MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+  MATX_ASSERT_STR(MATX_EN_CPU_SOLVER, matxInvalidExecutor,
+    "Trying to run a host Solver executor but host Solver support is not configured");
+#if MATX_EN_CPU_SOLVER
+  using T = typename remove_cvref_t<OutputTensor>::value_type;
+
+  detail::ValidateDenseSolve(out, a, b);
+
+  auto a_new = OpToTensor(a, exec);
+  auto b_new = OpToTensor(b, exec);
+
+  if constexpr (!is_matx_transform_op<ATensor>()) {
+    if (!a_new.isSameView(a)) {
+      (a_new = a).run(exec);
+    }
+  }
+
+  if constexpr (!is_matx_transform_op<BTensor>()) {
+    if (!b_new.isSameView(b)) {
+      (b_new = b).run(exec);
+    }
+  }
+
+  T *a_ptr = nullptr;
+  matxAlloc(reinterpret_cast<void **>(&a_ptr), a_new.Bytes(),
+            MATX_HOST_MALLOC_MEMORY);
+  auto a_work_t = detail::TransposeCopy(a_ptr, a_new, exec);
+  auto a_col = a_work_t.PermuteMatrix();
+
+  if constexpr (detail::IsDenseSolveVectorRHS<decltype(a_new), decltype(b_new)>()) {
+    T *b_ptr = nullptr;
+    matxAlloc(reinterpret_cast<void **>(&b_ptr), b_new.Bytes(),
+              MATX_HOST_MALLOC_MEMORY);
+    auto b_work = make_tensor<T>(b_ptr, b_new.Shape());
+    (b_work = b_new).run(exec);
+
+    detail::DenseSolveLapackLoop(a_col, b_work, exec);
+    matx::copy(out, b_work, exec);
+    matxFree(b_ptr);
+  }
+  else {
+    T *b_ptr = nullptr;
+    matxAlloc(reinterpret_cast<void **>(&b_ptr), b_new.Bytes(),
+              MATX_HOST_MALLOC_MEMORY);
+    auto b_work_t = detail::TransposeCopy(b_ptr, b_new, exec);
+    auto b_col = b_work_t.PermuteMatrix();
+
+    detail::DenseSolveLapackLoop(a_col, b_col, exec);
+    matx::copy(out, b_work_t.PermuteMatrix(), exec);
+    matxFree(b_ptr);
+  }
+
+  matxFree(a_ptr);
+#endif
+}
+
+} // end namespace matx

--- a/test/00_solver/SolveDense.cu
+++ b/test/00_solver/SolveDense.cu
@@ -118,6 +118,30 @@ TYPED_TEST(DenseSolveTestFloatTypes, SolveMatrixRHS)
   MATX_EXIT_HANDLER();
 }
 
+TYPED_TEST(DenseSolveTestFloatTypes, SolveInExpression)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  constexpr index_t n = 8;
+  auto A = make_tensor<TestType>({n, n});
+  auto B = make_tensor<TestType>({n});
+  auto C = make_tensor<TestType>({n});
+  auto X = make_tensor<TestType>({n});
+
+  this->pb->template InitAndRunTVGenerator<TestType>(
+      "00_solver", "solve", "run_vector_expression", {n});
+  this->pb->NumpyToTensorView(A, "A");
+  this->pb->NumpyToTensorView(B, "B");
+  this->pb->NumpyToTensorView(C, "C");
+
+  (X = solve(A, B) * C).run(this->exec);
+  this->exec.sync();
+
+  MATX_TEST_ASSERT_COMPARE(this->pb, X, "X", this->thresh);
+  MATX_EXIT_HANDLER();
+}
+
 TYPED_TEST(DenseSolveTestFloatTypes, SolveBatchedVectorRHS)
 {
   MATX_ENTER_HANDLER();

--- a/test/00_solver/SolveDense.cu
+++ b/test/00_solver/SolveDense.cu
@@ -1,0 +1,257 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "assert.h"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+#include "gtest/gtest.h"
+
+using namespace matx;
+
+template <typename T> class DenseSolveTest : public ::testing::Test {
+protected:
+  using GTestType = cuda::std::tuple_element_t<0, T>;
+  using GExecType = cuda::std::tuple_element_t<1, T>;
+
+  void SetUp() override
+  {
+    if constexpr (!detail::CheckSolverSupport<GExecType>()) {
+      GTEST_SKIP();
+    }
+
+    if constexpr (is_select_threads_host_executor_v<GExecType>) {
+      HostExecParams params{4};
+      exec = SelectThreadsHostExecutor{params};
+    }
+
+    pb = std::make_unique<detail::MatXPybind>();
+  }
+
+  void TearDown() override { pb.reset(); }
+
+  GExecType exec{};
+  std::unique_ptr<detail::MatXPybind> pb;
+  float thresh = 0.001f;
+};
+
+template <typename T>
+class DenseSolveTestFloatTypes : public DenseSolveTest<T> {
+};
+
+TYPED_TEST_SUITE(DenseSolveTestFloatTypes, MatXFloatNonHalfTypesAllExecs);
+
+TYPED_TEST(DenseSolveTestFloatTypes, SolveVectorRHS)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  constexpr index_t n = 8;
+  auto A = make_tensor<TestType>({n, n});
+  auto B = make_tensor<TestType>({n});
+  auto X = make_tensor<TestType>({n});
+
+  this->pb->template InitAndRunTVGenerator<TestType>(
+      "00_solver", "solve", "run_vector", {n});
+  this->pb->NumpyToTensorView(A, "A");
+  this->pb->NumpyToTensorView(B, "B");
+
+  // example-begin solve-test-1
+  (X = solve(A, B)).run(this->exec);
+  // example-end solve-test-1
+  this->exec.sync();
+
+  MATX_TEST_ASSERT_COMPARE(this->pb, X, "X", this->thresh);
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(DenseSolveTestFloatTypes, SolveMatrixRHS)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  constexpr index_t n = 8;
+  constexpr index_t nrhs = 3;
+  auto A = make_tensor<TestType>({n, n});
+  auto B = make_tensor<TestType>({n, nrhs});
+  auto X = make_tensor<TestType>({n, nrhs});
+
+  this->pb->template InitAndRunTVGenerator<TestType>(
+      "00_solver", "solve", "run_matrix", {n, nrhs});
+  this->pb->NumpyToTensorView(A, "A");
+  this->pb->NumpyToTensorView(B, "B");
+
+  (X = solve(A, B)).run(this->exec);
+  this->exec.sync();
+
+  MATX_TEST_ASSERT_COMPARE(this->pb, X, "X", this->thresh);
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(DenseSolveTestFloatTypes, SolveBatchedVectorRHS)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  constexpr index_t batches = 5;
+  constexpr index_t n = 8;
+  auto A = make_tensor<TestType>({batches, n, n});
+  auto B = make_tensor<TestType>({batches, n});
+  auto X = make_tensor<TestType>({batches, n});
+
+  this->pb->template InitAndRunTVGenerator<TestType>(
+      "00_solver", "solve", "run_batched_vector", {batches, n});
+  this->pb->NumpyToTensorView(A, "A");
+  this->pb->NumpyToTensorView(B, "B");
+
+  (X = solve(A, B)).run(this->exec);
+  this->exec.sync();
+
+  MATX_TEST_ASSERT_COMPARE(this->pb, X, "X", this->thresh);
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(DenseSolveTestFloatTypes, SolveBatchedMatrixRHS)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  constexpr index_t batches = 5;
+  constexpr index_t n = 8;
+  constexpr index_t nrhs = 3;
+  auto A = make_tensor<TestType>({batches, n, n});
+  auto B = make_tensor<TestType>({batches, n, nrhs});
+  auto X = make_tensor<TestType>({batches, n, nrhs});
+
+  this->pb->template InitAndRunTVGenerator<TestType>(
+      "00_solver", "solve", "run_batched_matrix", {batches, n, nrhs});
+  this->pb->NumpyToTensorView(A, "A");
+  this->pb->NumpyToTensorView(B, "B");
+
+  (X = solve(A, B)).run(this->exec);
+  this->exec.sync();
+
+  MATX_TEST_ASSERT_COMPARE(this->pb, X, "X", this->thresh);
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(DenseSolveTestFloatTypes, SolveInPlaceRHS)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  constexpr index_t n = 8;
+  constexpr index_t nrhs = 3;
+  auto A = make_tensor<TestType>({n, n});
+  auto B = make_tensor<TestType>({n, nrhs});
+
+  this->pb->template InitAndRunTVGenerator<TestType>(
+      "00_solver", "solve", "run_matrix", {n, nrhs});
+  this->pb->NumpyToTensorView(A, "A");
+  this->pb->NumpyToTensorView(B, "B");
+
+  (B = solve(A, B)).run(this->exec);
+  this->exec.sync();
+
+  MATX_TEST_ASSERT_COMPARE(this->pb, B, "X", this->thresh);
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(DenseSolveTestFloatTypes, SolveOperatorInputs)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  constexpr index_t batches = 5;
+  constexpr index_t n = 8;
+  constexpr index_t nrhs = 3;
+  auto Afull = make_tensor<TestType>({batches, n, n + 1});
+  auto Bfull = make_tensor<TestType>({batches, n, nrhs + 1});
+  auto A = slice(Afull, {0, 0, 0}, {matxEnd, matxEnd, n});
+  auto B = slice(Bfull, {0, 0, 0}, {matxEnd, matxEnd, nrhs});
+  auto X = make_tensor<TestType>({batches, n, nrhs});
+
+  this->pb->template InitAndRunTVGenerator<TestType>(
+      "00_solver", "solve", "run_batched_matrix", {batches, n, nrhs});
+  this->pb->NumpyToTensorView(A, "A");
+  this->pb->NumpyToTensorView(B, "B");
+
+  (X = solve(A, B)).run(this->exec);
+  this->exec.sync();
+
+  MATX_TEST_ASSERT_COMPARE(this->pb, X, "X", this->thresh);
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(DenseSolveTestFloatTypes, SolveInvalidShape)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  constexpr index_t n = 8;
+  auto A = make_tensor<TestType>({n, n});
+  auto B = make_tensor<TestType>({n + 1});
+  auto X = make_tensor<TestType>({n + 1});
+
+  ASSERT_THROW({
+    (X = solve(A, B)).run(this->exec);
+    this->exec.sync();
+  }, matx::detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(DenseSolveTestFloatTypes, SolveSingularMatrix)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+
+  constexpr index_t n = 4;
+  auto A = make_tensor<TestType>({n, n});
+  auto B = make_tensor<TestType>({n});
+  auto X = make_tensor<TestType>({n});
+
+  for (index_t i = 0; i < n; i++) {
+    B(i) = static_cast<TestType>(1);
+    for (index_t j = 0; j < n; j++) {
+      A(i, j) = static_cast<TestType>(0);
+    }
+  }
+
+  ASSERT_THROW({
+    (X = solve(A, B)).run(this->exec);
+    this->exec.sync();
+  }, matx::detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set (test_sources
     00_solver/Eigen.cu
     00_solver/Det.cu
     00_solver/Inverse.cu
+    00_solver/SolveDense.cu
     00_solver/Pinv.cu
     00_operators/PythonEmbed.cu
     00_io/FileIOTests.cu

--- a/test/test_vectors/generators/00_solver.py
+++ b/test/test_vectors/generators/00_solver.py
@@ -36,6 +36,67 @@ class inv:
         }
 
 
+class solve:
+    def __init__(self, dtype: str, size: List[int]):
+        self.size = size
+        self.dtype = dtype
+        np.random.seed(1234)
+
+    def _make_a(self, shape):
+        n = shape[-1]
+        A = matx_common.randn_ndarray(shape, self.dtype)
+        A = A + n * np.eye(n, dtype=A.dtype)
+        return A
+
+    def run_vector(self):
+        n = self.size[-1]
+        A = self._make_a((n, n))
+        B = matx_common.randn_ndarray((n,), self.dtype)
+        X = np.linalg.solve(A, B)
+
+        return {
+            'A': A,
+            'B': B,
+            'X': X,
+        }
+
+    def run_matrix(self):
+        n, nrhs = self.size[-2:]
+        A = self._make_a((n, n))
+        B = matx_common.randn_ndarray((n, nrhs), self.dtype)
+        X = np.linalg.solve(A, B)
+
+        return {
+            'A': A,
+            'B': B,
+            'X': X,
+        }
+
+    def run_batched_vector(self):
+        batch_size, n = self.size[-2:]
+        A = self._make_a((batch_size, n, n))
+        B = matx_common.randn_ndarray((batch_size, n), self.dtype)
+        X = np.linalg.solve(A, B[..., np.newaxis])[..., 0]
+
+        return {
+            'A': A,
+            'B': B,
+            'X': X,
+        }
+
+    def run_batched_matrix(self):
+        batch_size, n, nrhs = self.size[-3:]
+        A = self._make_a((batch_size, n, n))
+        B = matx_common.randn_ndarray((batch_size, n, nrhs), self.dtype)
+        X = np.linalg.solve(A, B)
+
+        return {
+            'A': A,
+            'B': B,
+            'X': X,
+        }
+
+
 class cholesky:
     def __init__(self, dtype: str, size: List[int]):
         self.size = size

--- a/test/test_vectors/generators/00_solver.py
+++ b/test/test_vectors/generators/00_solver.py
@@ -60,6 +60,20 @@ class solve:
             'X': X,
         }
 
+    def run_vector_expression(self):
+        n = self.size[-1]
+        A = self._make_a((n, n))
+        B = matx_common.randn_ndarray((n,), self.dtype)
+        C = matx_common.randn_ndarray((n,), self.dtype)
+        X = np.linalg.solve(A, B) * C
+
+        return {
+            'A': A,
+            'B': B,
+            'C': C,
+            'X': X,
+        }
+
     def run_matrix(self):
         n, nrhs = self.size[-2:]
         A = self._make_a((n, n))


### PR DESCRIPTION
Implement dense solve dispatch for CUDA and host executors, including batched RHS handling and NumPy-backed tests. Preserve existing sparse solve behavior and document the dense and sparse shape semantics. Currently we try to use the same algorithms/kernels as the linalg.numpy version.

Closes #664 