### PR TITLE
Use Thrust for multithreaded host algorithms

### DIFF
--- a/examples/simple_radar_pipeline.h
+++ b/examples/simple_radar_pipeline.h
@@ -240,10 +240,6 @@ public:
                            {1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1},
                            {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}});
 
-    // Pre-process CFAR convolution
-    (normT = conv2d(ones({numChannels, numPulsesRnd, numCompressedSamples}),
-           cfarMaskView, matxConvCorrMode_t::MATX_C_MODE_FULL)).run(exec);
-
     cancelMask.PrefetchDevice(stream);
     ba.PrefetchDevice(stream);
     normT.PrefetchDevice(stream);
@@ -397,6 +393,8 @@ public:
    */
   void CFARDetections()
   {
+    ComputeCFARNorm();
+
     (xPow = abs2(tpcView)).run(exec);
 
     // Estimate the background average power in each cell
@@ -477,9 +475,22 @@ public:
    * 
    * @return tensor_t view 
    */
-  auto GetnormT() { return normT; }
+  auto GetnormT()
+  {
+    ComputeCFARNorm();
+    return normT;
+  }
 
 private:
+  void ComputeCFARNorm()
+  {
+    if (!cfarNormReady) {
+      (normT = conv2d(ones({numChannels, numPulsesRnd, numCompressedSamples}),
+             cfarMaskView, matxConvCorrMode_t::MATX_C_MODE_FULL)).run(exec);
+      cfarNormReady = true;
+    }
+  }
+
   index_t numPulses;
   index_t numSamples;
   index_t waveformLength;
@@ -505,4 +516,5 @@ private:
 
   cudaStream_t stream;
   cudaExecutor exec;
+  bool cfarNormReady = false;
 };

--- a/include/matx/core/iterator.h
+++ b/include/matx/core/iterator.h
@@ -53,7 +53,7 @@ struct RandomOperatorIterator {
   //                         index_t>;
   using stride_type = index_t;
   using pointer = value_type*;
-  using reference = value_type&;
+  using reference = value_type;
   using iterator_category = cuda::std::random_access_iterator_tag;
   using difference_type = index_t;
   using OperatorBaseType = typename detail::base_type_t<OperatorType>;
@@ -151,6 +151,17 @@ struct RandomOperatorIterator {
       return *this;
   }
 
+  [[nodiscard]] __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ self_type operator-(difference_type offset) const
+  {
+      return self_type{t_, offset_ - offset};
+  }
+
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ self_type& operator--()
+  {
+      --offset_;
+      return *this;
+  }
+
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ friend bool operator!=(const self_type &a, const self_type &b)
   {
     return a.offset_ != b.offset_;
@@ -159,6 +170,22 @@ struct RandomOperatorIterator {
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ friend bool operator==(const self_type &a, const self_type &b)
   {
     return a.offset_ == b.offset_;
+  }
+
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ friend bool operator<(const self_type &a, const self_type &b) {
+    return a.offset_ < b.offset_;
+  }
+
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ friend bool operator>(const self_type &a, const self_type &b) {
+    return a.offset_ > b.offset_;
+  }
+
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ friend bool operator<=(const self_type &a, const self_type &b) {
+    return a.offset_ <= b.offset_;
+  }
+
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ friend bool operator>=(const self_type &a, const self_type &b) {
+    return a.offset_ >= b.offset_;
   }
 
   static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() {
@@ -218,17 +245,17 @@ struct RandomOperatorOutputIterator {
     requires (!cuda::std::is_same_v<T, OperatorBaseType>)
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorOutputIterator(OperatorBaseType &&t, stride_type offset) : t_(t), offset_(offset) {}
 
-  [[nodiscard]] __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ reference operator*()
+  [[nodiscard]] __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ reference operator*() const
   {
     if constexpr (OperatorType::Rank() == 0) {
-      auto &tmp = t_.operator()();
+      auto &tmp = const_cast<OperatorBaseType&>(t_).operator()();
       return tmp;
     }
     else {
       auto arrs = detail::GetIdxFromAbs(t_, offset_);
 
       return cuda::std::apply([&](auto &&...args) -> reference {
-          auto &tmp = t_.operator()(args...);
+          auto &tmp = const_cast<OperatorBaseType&>(t_).operator()(args...);
           return tmp;
         }, arrs);
     }

--- a/include/matx/transforms/cub.h
+++ b/include/matx/transforms/cub.h
@@ -49,6 +49,7 @@
 #include "matx/core/operator_utils.h"
 #include "matx/core/type_utils_both.h"
 #include "matx/transforms/cccl_iterators.h"
+#include "matx/transforms/host_algorithms.h"
 
 
 namespace matx {
@@ -2260,7 +2261,7 @@ void argsort_impl(OutputTensor &idx_out, const InputOperator &a,
 template <typename OutputTensor, typename InputOperator, ThreadsMode MODE>
 void argsort_impl(OutputTensor &idx_out, const InputOperator &a,
           const SortDirection_t dir,
-          [[maybe_unused]] const HostExecutor<MODE> &exec)
+          const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
@@ -2271,25 +2272,23 @@ void argsort_impl(OutputTensor &idx_out, const InputOperator &a,
 
   if constexpr (RANK == 1) {
     if (dir == SORT_DIR_ASC) {
-      std::sort(
-          lout, lout + idx_out.Size(0),
-          [&a](index_t i, index_t j) { return a(i) < a(j); });
+      detail::host_sort(exec, lout, lout + idx_out.Size(0),
+                        [&a](index_t i, index_t j) { return a(i) < a(j); });
     }
     else {
-      std::sort(
-          lout, lout + idx_out.Size(0),
-          [&a](index_t i, index_t j) { return a(i) > a(j); });
+      detail::host_sort(exec, lout, lout + idx_out.Size(0),
+                        [&a](index_t i, index_t j) { return a(i) > a(j); });
     }
   }
   else if constexpr (RANK == 2) {
     for (index_t b = 0; b < lout.Size(0); b++) {
       if (dir == SORT_DIR_ASC) {
-        std::sort( lout + b*a.Size(1), lout + (b+1)*a.Size(1),
-                  [&a, b](index_t i, index_t j) { return a(b,i) < a(b,j); });
+        detail::host_sort(exec, lout + b*a.Size(1), lout + (b+1)*a.Size(1),
+                          [&a, b](index_t i, index_t j) { return a(b,i) < a(b,j); });
       }
       else {
-        std::sort( lout + b*a.Size(1), lout + (b+1)*a.Size(1),
-                  [&a, b](index_t i, index_t j) { return a(b,i) > a(b,j); });
+        detail::host_sort(exec, lout + b*a.Size(1), lout + (b+1)*a.Size(1),
+                          [&a, b](index_t i, index_t j) { return a(b,i) > a(b,j); });
       }
     }
   }
@@ -2301,7 +2300,7 @@ void argsort_impl(OutputTensor &idx_out, const InputOperator &a,
 template <typename OutputTensor, typename InputOperator, ThreadsMode MODE>
 void sort_impl(OutputTensor &a_out, const InputOperator &a,
           const SortDirection_t dir,
-          [[maybe_unused]] const HostExecutor<MODE> &exec)
+          const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
@@ -2312,33 +2311,37 @@ void sort_impl(OutputTensor &a_out, const InputOperator &a,
 
   if constexpr (InputOperator::Rank() == 1) {
     if (dir == SORT_DIR_ASC) {
-      std::partial_sort_copy( lin,
-                              lin  + a.Size(0),
-                              lout,
-                              lout + a_out.Size(0));
+      detail::host_sort_copy(exec,
+                             lin,
+                             lin  + a.Size(0),
+                             lout,
+                             lout + a_out.Size(0));
     }
     else {
-      std::partial_sort_copy( lin,
-                              lin  + a.Size(0),
-                              lout,
-                              lout + a_out.Size(0),
-                              std::greater<typename InputOperator::value_type>());
+      detail::host_sort_copy(exec,
+                             lin,
+                             lin  + a.Size(0),
+                             lout,
+                             lout + a_out.Size(0),
+                             std::greater<typename InputOperator::value_type>());
     }
   }
   else {
     for (index_t b = 0; b < lout.Size(0); b++) {
       if (dir == SORT_DIR_ASC) {
-        std::partial_sort_copy( lin  + b*a.Size(1),
-                                lin  + (b+1)*a.Size(1),
-                                lout + b*a.Size(1),
-                                lout + (b+1)*a.Size(1));
+        detail::host_sort_copy(exec,
+                               lin  + b*a.Size(1),
+                               lin  + (b+1)*a.Size(1),
+                               lout + b*a.Size(1),
+                               lout + (b+1)*a.Size(1));
       }
       else {
-        std::partial_sort_copy( lin  + b*a.Size(1),
-                                lin  + (b+1)*a.Size(1),
-                                lout + b*a.Size(1),
-                                lout + (b+1)*a.Size(1),
-                                std::greater<typename InputOperator::value_type>());
+        detail::host_sort_copy(exec,
+                               lin  + b*a.Size(1),
+                               lin  + (b+1)*a.Size(1),
+                               lout + b*a.Size(1),
+                               lout + (b+1)*a.Size(1),
+                               std::greater<typename InputOperator::value_type>());
       }
     }
   }
@@ -2399,7 +2402,7 @@ void cumsum_impl(OutputTensor &a_out, const InputOperator &a,
 
 template <typename OutputTensor, typename InputOperator, ThreadsMode MODE>
 void cumsum_impl(OutputTensor &a_out, const InputOperator &a,
-            [[maybe_unused]] const HostExecutor<MODE> &exec)
+            const HostExecutor<MODE> &exec)
 {
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
@@ -2409,15 +2412,17 @@ void cumsum_impl(OutputTensor &a_out, const InputOperator &a,
   auto lout = matx::RandomOperatorOutputIterator{out_base};
 
   if constexpr (OutputTensor::Rank() == 1) {
-    std::partial_sum( lin,
-                      lin  + a.Size(0),
-                      lout);
+    detail::host_inclusive_scan(exec,
+                                lin,
+                                lin  + a.Size(0),
+                                lout);
   }
   else if constexpr (InputOperator::Rank() == 2) {
     for (index_t b = 0; b < a.Size(0); b++) {
-      std::partial_sum( lin  + b     * a.Size(1),
-                        lin  + (b+1) * a.Size(1),
-                        lout + b     * a.Size(1));
+      detail::host_inclusive_scan(exec,
+                                  lin  + b     * a.Size(1),
+                                  lin  + (b+1) * a.Size(1),
+                                  lout + b     * a.Size(1));
     }
   }
   else {
@@ -2834,7 +2839,7 @@ void unique_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperato
  *   Single thread executor
  */
 template <typename CountTensor, typename OutputTensor, typename InputOperator, ThreadsMode MODE>
-void unique_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperator &a, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void unique_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperator &a, const HostExecutor<MODE> &exec)
 {
 #ifdef __CUDACC__
   static_assert(CountTensor::Rank() == 0, "Num found output tensor rank must be 0");
@@ -2845,8 +2850,8 @@ void unique_impl(OutputTensor &a_out, CountTensor &num_found, const InputOperato
     return;
   }
 
-  std::partial_sort_copy(cbegin(a), cend(a), begin(a_out), end(a_out));
-  auto last = std::unique(begin(a_out), end(a_out));
+  detail::host_sort_copy(exec, cbegin(a), cend(a), begin(a_out), end(a_out));
+  auto last = detail::host_unique(exec, begin(a_out), end(a_out));
   num_found() = static_cast<int>(last - begin(a_out));
 #endif
 }

--- a/include/matx/transforms/host_algorithms.h
+++ b/include/matx/transforms/host_algorithms.h
@@ -33,7 +33,9 @@
 #pragma once
 
 #include <algorithm>
+#include <cstddef>
 #include <functional>
+#include <iterator>
 #include <numeric>
 
 #include "matx/executors/host.h"
@@ -50,6 +52,10 @@
 #endif
 
 namespace matx::detail {
+
+inline constexpr std::ptrdiff_t HostThrustMinReductionElements = 16 * 1024;
+inline constexpr std::ptrdiff_t HostThrustMinScanElements = 16 * 1024;
+inline constexpr std::ptrdiff_t HostThrustMinSortElements = 1024;
 
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
 class ScopedOmpNumThreads {
@@ -88,13 +94,27 @@ __MATX_INLINE__ int get_parallel_host_thrust_threads(const HostExecutor<MODE> &e
   return 0;
 }
 
+template <typename InputIt, ThreadsMode MODE>
+__MATX_INLINE__ int get_parallel_host_thrust_threads(const HostExecutor<MODE> &exec,
+                                                     InputIt first,
+                                                     InputIt last,
+                                                     const std::ptrdiff_t min_elements)
+{
+  const int threads = get_parallel_host_thrust_threads(exec);
+  if (threads == 0 || std::distance(first, last) < min_elements) {
+    return 0;
+  }
+
+  return threads;
+}
+
 template <typename InputIt, typename T, typename BinaryOp, ThreadsMode MODE>
 __MATX_INLINE__ T host_reduce(const HostExecutor<MODE> &exec, InputIt first, InputIt last, T init, BinaryOp op)
 {
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinReductionElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       return thrust::reduce(thrust::omp::par, first, last, init, op);
@@ -111,7 +131,7 @@ __MATX_INLINE__ T host_reduce(const HostExecutor<MODE> &exec, InputIt first, Inp
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinReductionElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       return thrust::reduce(thrust::omp::par, first, last, init);
@@ -128,7 +148,7 @@ __MATX_INLINE__ void host_sort(const HostExecutor<MODE> &exec, RandomIt first, R
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinSortElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       thrust::sort(thrust::omp::par, first, last, comp);
@@ -146,7 +166,7 @@ __MATX_INLINE__ void host_sort(const HostExecutor<MODE> &exec, RandomIt first, R
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinSortElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       thrust::sort(thrust::omp::par, first, last);
@@ -170,7 +190,7 @@ __MATX_INLINE__ void host_sort_copy(const HostExecutor<MODE> &exec,
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   // Thrust does not provide partial_sort_copy; copy+sort is equivalent only when ranges match.
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinSortElements);
     if (((last - first) == (out_last - out_first)) && threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       thrust::copy(thrust::omp::par, first, last, out_first);
@@ -194,7 +214,7 @@ __MATX_INLINE__ void host_sort_copy(const HostExecutor<MODE> &exec,
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   // Thrust does not provide partial_sort_copy; copy+sort is equivalent only when ranges match.
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinSortElements);
     if (((last - first) == (out_last - out_first)) && threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       thrust::copy(thrust::omp::par, first, last, out_first);
@@ -216,7 +236,7 @@ __MATX_INLINE__ void host_inclusive_scan(const HostExecutor<MODE> &exec,
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinScanElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       thrust::inclusive_scan(thrust::omp::par, first, last, out);
@@ -234,7 +254,7 @@ __MATX_INLINE__ ForwardIt host_max_element(const HostExecutor<MODE> &exec, Forwa
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinReductionElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       return thrust::max_element(thrust::omp::par, first, last);
@@ -251,7 +271,7 @@ __MATX_INLINE__ ForwardIt host_min_element(const HostExecutor<MODE> &exec, Forwa
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinReductionElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       return thrust::min_element(thrust::omp::par, first, last);
@@ -268,7 +288,7 @@ __MATX_INLINE__ bool host_any_of(const HostExecutor<MODE> &exec, InputIt first, 
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinReductionElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       return thrust::any_of(thrust::omp::par, first, last, pred);
@@ -285,7 +305,7 @@ __MATX_INLINE__ bool host_all_of(const HostExecutor<MODE> &exec, InputIt first, 
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinReductionElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       return thrust::all_of(thrust::omp::par, first, last, pred);
@@ -302,7 +322,7 @@ __MATX_INLINE__ ForwardIt host_unique(const HostExecutor<MODE> &exec, ForwardIt 
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    const int threads = get_parallel_host_thrust_threads(exec);
+    const int threads = get_parallel_host_thrust_threads(exec, first, last, HostThrustMinSortElements);
     if (threads > 0) {
       ScopedOmpNumThreads thread_guard{threads};
       return thrust::unique(thrust::omp::par, first, last);

--- a/include/matx/transforms/host_algorithms.h
+++ b/include/matx/transforms/host_algorithms.h
@@ -1,0 +1,298 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+
+#include "matx/executors/host.h"
+
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+#include <thrust/copy.h>
+#include <thrust/extrema.h>
+#include <thrust/logical.h>
+#include <thrust/reduce.h>
+#include <thrust/scan.h>
+#include <thrust/sort.h>
+#include <thrust/system/omp/execution_policy.h>
+#include <thrust/unique.h>
+#endif
+
+namespace matx::detail {
+
+template <ThreadsMode MODE>
+__MATX_INLINE__ bool use_parallel_host_thrust(const HostExecutor<MODE> &exec)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    const int threads = exec.GetNumThreads();
+    if (threads > 1) {
+      omp_set_num_threads(threads);
+      return true;
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  return false;
+}
+
+template <typename InputIt, typename T, typename BinaryOp, ThreadsMode MODE>
+__MATX_INLINE__ T host_reduce(const HostExecutor<MODE> &exec, InputIt first, InputIt last, T init, BinaryOp op)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      return thrust::reduce(thrust::omp::par, first, last, init, op);
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  return std::accumulate(first, last, init, op);
+}
+
+template <typename InputIt, typename T, ThreadsMode MODE>
+__MATX_INLINE__ T host_reduce(const HostExecutor<MODE> &exec, InputIt first, InputIt last, T init)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      return thrust::reduce(thrust::omp::par, first, last, init);
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  return std::accumulate(first, last, init);
+}
+
+template <typename RandomIt, typename Compare, ThreadsMode MODE>
+__MATX_INLINE__ void host_sort(const HostExecutor<MODE> &exec, RandomIt first, RandomIt last, Compare comp)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      thrust::sort(thrust::omp::par, first, last, comp);
+      return;
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  std::sort(first, last, comp);
+}
+
+template <typename RandomIt, ThreadsMode MODE>
+__MATX_INLINE__ void host_sort(const HostExecutor<MODE> &exec, RandomIt first, RandomIt last)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      thrust::sort(thrust::omp::par, first, last);
+      return;
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  std::sort(first, last);
+}
+
+template <typename InputIt, typename OutputIt, typename Compare, ThreadsMode MODE>
+__MATX_INLINE__ void host_sort_copy(const HostExecutor<MODE> &exec,
+                                    InputIt first,
+                                    InputIt last,
+                                    OutputIt out_first,
+                                    OutputIt out_last,
+                                    Compare comp)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  // Thrust does not provide partial_sort_copy; copy+sort is equivalent only when ranges match.
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (((last - first) == (out_last - out_first)) && use_parallel_host_thrust(exec)) {
+      thrust::copy(thrust::omp::par, first, last, out_first);
+      thrust::sort(thrust::omp::par, out_first, out_last, comp);
+      return;
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  std::partial_sort_copy(first, last, out_first, out_last, comp);
+}
+
+template <typename InputIt, typename OutputIt, ThreadsMode MODE>
+__MATX_INLINE__ void host_sort_copy(const HostExecutor<MODE> &exec,
+                                    InputIt first,
+                                    InputIt last,
+                                    OutputIt out_first,
+                                    OutputIt out_last)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  // Thrust does not provide partial_sort_copy; copy+sort is equivalent only when ranges match.
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (((last - first) == (out_last - out_first)) && use_parallel_host_thrust(exec)) {
+      thrust::copy(thrust::omp::par, first, last, out_first);
+      thrust::sort(thrust::omp::par, out_first, out_last);
+      return;
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  std::partial_sort_copy(first, last, out_first, out_last);
+}
+
+template <typename InputIt, typename OutputIt, ThreadsMode MODE>
+__MATX_INLINE__ void host_inclusive_scan(const HostExecutor<MODE> &exec,
+                                         InputIt first,
+                                         InputIt last,
+                                         OutputIt out)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      thrust::inclusive_scan(thrust::omp::par, first, last, out);
+      return;
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  std::partial_sum(first, last, out);
+}
+
+template <typename ForwardIt, ThreadsMode MODE>
+__MATX_INLINE__ ForwardIt host_max_element(const HostExecutor<MODE> &exec, ForwardIt first, ForwardIt last)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      return thrust::max_element(thrust::omp::par, first, last);
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  return std::max_element(first, last);
+}
+
+template <typename ForwardIt, ThreadsMode MODE>
+__MATX_INLINE__ ForwardIt host_min_element(const HostExecutor<MODE> &exec, ForwardIt first, ForwardIt last)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      return thrust::min_element(thrust::omp::par, first, last);
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  return std::min_element(first, last);
+}
+
+template <typename InputIt, typename UnaryPredicate, ThreadsMode MODE>
+__MATX_INLINE__ bool host_any_of(const HostExecutor<MODE> &exec, InputIt first, InputIt last, UnaryPredicate pred)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      return thrust::any_of(thrust::omp::par, first, last, pred);
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  return std::any_of(first, last, pred);
+}
+
+template <typename InputIt, typename UnaryPredicate, ThreadsMode MODE>
+__MATX_INLINE__ bool host_all_of(const HostExecutor<MODE> &exec, InputIt first, InputIt last, UnaryPredicate pred)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      return thrust::all_of(thrust::omp::par, first, last, pred);
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  return std::all_of(first, last, pred);
+}
+
+template <typename ForwardIt, ThreadsMode MODE>
+__MATX_INLINE__ ForwardIt host_unique(const HostExecutor<MODE> &exec, ForwardIt first, ForwardIt last)
+{
+  static_cast<void>(exec);
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+  if constexpr (MODE != ThreadsMode::SINGLE) {
+    if (use_parallel_host_thrust(exec)) {
+      return thrust::unique(thrust::omp::par, first, last);
+    }
+  }
+#else
+  static_cast<void>(exec);
+#endif
+
+  return std::unique(first, last);
+}
+
+} // namespace matx::detail

--- a/include/matx/transforms/host_algorithms.h
+++ b/include/matx/transforms/host_algorithms.h
@@ -51,23 +51,41 @@
 
 namespace matx::detail {
 
+#if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
+class ScopedOmpNumThreads {
+public:
+  explicit ScopedOmpNumThreads(const int threads) : previous_threads_(omp_get_max_threads())
+  {
+    omp_set_num_threads(threads);
+  }
+
+  ScopedOmpNumThreads(const ScopedOmpNumThreads &) = delete;
+  ScopedOmpNumThreads &operator=(const ScopedOmpNumThreads &) = delete;
+
+  ~ScopedOmpNumThreads()
+  {
+    omp_set_num_threads(previous_threads_);
+  }
+
+private:
+  int previous_threads_;
+};
+#endif
+
 template <ThreadsMode MODE>
-__MATX_INLINE__ bool use_parallel_host_thrust(const HostExecutor<MODE> &exec)
+__MATX_INLINE__ int get_parallel_host_thrust_threads(const HostExecutor<MODE> &exec)
 {
-  static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
     const int threads = exec.GetNumThreads();
-    if (threads > 1) {
-      omp_set_num_threads(threads);
-      return true;
+    if (threads > 1 && !omp_in_parallel()) {
+      return threads;
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
-  return false;
+  static_cast<void>(exec);
+  return 0;
 }
 
 template <typename InputIt, typename T, typename BinaryOp, ThreadsMode MODE>
@@ -76,12 +94,12 @@ __MATX_INLINE__ T host_reduce(const HostExecutor<MODE> &exec, InputIt first, Inp
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       return thrust::reduce(thrust::omp::par, first, last, init, op);
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   return std::accumulate(first, last, init, op);
@@ -93,12 +111,12 @@ __MATX_INLINE__ T host_reduce(const HostExecutor<MODE> &exec, InputIt first, Inp
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       return thrust::reduce(thrust::omp::par, first, last, init);
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   return std::accumulate(first, last, init);
@@ -110,13 +128,13 @@ __MATX_INLINE__ void host_sort(const HostExecutor<MODE> &exec, RandomIt first, R
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       thrust::sort(thrust::omp::par, first, last, comp);
       return;
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   std::sort(first, last, comp);
@@ -128,13 +146,13 @@ __MATX_INLINE__ void host_sort(const HostExecutor<MODE> &exec, RandomIt first, R
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       thrust::sort(thrust::omp::par, first, last);
       return;
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   std::sort(first, last);
@@ -152,14 +170,14 @@ __MATX_INLINE__ void host_sort_copy(const HostExecutor<MODE> &exec,
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   // Thrust does not provide partial_sort_copy; copy+sort is equivalent only when ranges match.
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (((last - first) == (out_last - out_first)) && use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (((last - first) == (out_last - out_first)) && threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       thrust::copy(thrust::omp::par, first, last, out_first);
       thrust::sort(thrust::omp::par, out_first, out_last, comp);
       return;
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   std::partial_sort_copy(first, last, out_first, out_last, comp);
@@ -176,14 +194,14 @@ __MATX_INLINE__ void host_sort_copy(const HostExecutor<MODE> &exec,
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   // Thrust does not provide partial_sort_copy; copy+sort is equivalent only when ranges match.
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (((last - first) == (out_last - out_first)) && use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (((last - first) == (out_last - out_first)) && threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       thrust::copy(thrust::omp::par, first, last, out_first);
       thrust::sort(thrust::omp::par, out_first, out_last);
       return;
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   std::partial_sort_copy(first, last, out_first, out_last);
@@ -198,13 +216,13 @@ __MATX_INLINE__ void host_inclusive_scan(const HostExecutor<MODE> &exec,
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       thrust::inclusive_scan(thrust::omp::par, first, last, out);
       return;
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   std::partial_sum(first, last, out);
@@ -216,12 +234,12 @@ __MATX_INLINE__ ForwardIt host_max_element(const HostExecutor<MODE> &exec, Forwa
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       return thrust::max_element(thrust::omp::par, first, last);
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   return std::max_element(first, last);
@@ -233,12 +251,12 @@ __MATX_INLINE__ ForwardIt host_min_element(const HostExecutor<MODE> &exec, Forwa
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       return thrust::min_element(thrust::omp::par, first, last);
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   return std::min_element(first, last);
@@ -250,12 +268,12 @@ __MATX_INLINE__ bool host_any_of(const HostExecutor<MODE> &exec, InputIt first, 
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       return thrust::any_of(thrust::omp::par, first, last, pred);
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   return std::any_of(first, last, pred);
@@ -267,12 +285,12 @@ __MATX_INLINE__ bool host_all_of(const HostExecutor<MODE> &exec, InputIt first, 
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       return thrust::all_of(thrust::omp::par, first, last, pred);
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   return std::all_of(first, last, pred);
@@ -284,12 +302,12 @@ __MATX_INLINE__ ForwardIt host_unique(const HostExecutor<MODE> &exec, ForwardIt 
   static_cast<void>(exec);
 #if defined(MATX_EN_OMP) && !defined(__CUDACC_RTC__)
   if constexpr (MODE != ThreadsMode::SINGLE) {
-    if (use_parallel_host_thrust(exec)) {
+    const int threads = get_parallel_host_thrust_threads(exec);
+    if (threads > 0) {
+      ScopedOmpNumThreads thread_guard{threads};
       return thrust::unique(thrust::omp::par, first, last);
     }
   }
-#else
-  static_cast<void>(exec);
 #endif
 
   return std::unique(first, last);

--- a/include/matx/transforms/reduce.h
+++ b/include/matx/transforms/reduce.h
@@ -45,6 +45,7 @@
 #include "matx/core/cache.h"
 #include "matx/core/nvtx.h"
 #include "matx/transforms/cub.h"
+#include "matx/transforms/host_algorithms.h"
 #include "matx/transforms/copy.h"
 #include "matx/core/reduce_utils.h"
 #include "matx/core/half.h"
@@ -312,7 +313,7 @@ void __MATX_INLINE__ mean_impl(OutType dest, const InType &in,
  *   Single thread host executor
  */
 template <typename OutType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ mean_impl(OutType dest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ mean_impl(OutType dest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("mean_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
 
@@ -322,11 +323,11 @@ void __MATX_INLINE__ mean_impl(OutType dest, const InType &in, [[maybe_unused]] 
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
       auto ts = TotalSize(in);
-      *lout = std::accumulate(lin, lin + ts, static_cast<typename InType::value_type>(0)) / static_cast<inner_type>(ts);
+      *lout = detail::host_reduce(exec, lin, lin + ts, static_cast<typename InType::value_type>(0)) / static_cast<inner_type>(ts);
     }
     else {
       for (index_t b = 0; b < lin.Size(0); b++) {
-        *(lout + b) = std::accumulate(lin + lbegin[b], lin + lend[b], static_cast<typename InType::value_type>(0)) / static_cast<inner_type>(lin.Size(1));
+        *(lout + b) = detail::host_reduce(exec, lin + lbegin[b], lin + lend[b], static_cast<typename InType::value_type>(0)) / static_cast<inner_type>(lin.Size(1));
       }
     }
   };
@@ -577,17 +578,18 @@ void __MATX_INLINE__ median_impl(OutType dest,
  *   Single thread host executor
  */
 template <typename OutType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ median_impl(OutType dest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ median_impl(OutType dest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("median_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
       auto insize = TotalSize(in);
       auto tin = new typename InType::value_type[insize];
-      std::partial_sort_copy( lin,
-                              lin + insize,
-                              tin,
-                              tin + insize);
+      detail::host_sort_copy(exec,
+                             lin,
+                             lin + insize,
+                             tin,
+                             tin + insize);
       if ((insize % 2) == 0) {
         *lout = (tin[insize / 2] + tin[insize / 2 - 1]) / 2.0f;
       }
@@ -601,10 +603,11 @@ void __MATX_INLINE__ median_impl(OutType dest, const InType &in, [[maybe_unused]
       auto insize = lin.Size(1);
       auto tin = new typename InType::value_type[insize];
       for (index_t b = 0; b < lin.Size(0); b++) {
-        std::partial_sort_copy( lin + lbegin[b],
-                                lin + lend[b],
-                                tin,
-                                tin + insize);
+        detail::host_sort_copy(exec,
+                               lin + lbegin[b],
+                               lin + lend[b],
+                               tin,
+                               tin + insize);
 
         if ((insize % 2) == 0) {
           *(lout + b) = (tin[insize / 2] + tin[insize / 2 - 1]) / 2.0f;
@@ -669,16 +672,16 @@ void __MATX_INLINE__ sum_impl(OutType dest, const InType &in, const cudaExecutor
  *   Single thread host executor
  */
 template <typename OutType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ sum_impl(OutType dest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ sum_impl(OutType dest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("sum_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
-      *lout = std::accumulate(lin, lin + lin.Size(0), static_cast<typename InType::value_type>(0));
+      *lout = detail::host_reduce(exec, lin, lin + TotalSize(in), static_cast<typename InType::value_type>(0));
     }
     else {
       for (index_t b = 0; b < lin.Size(0); b++) {
-        auto f = std::accumulate(lin + lbegin[b], lin + lend[b], static_cast<typename InType::value_type>(0));
+        auto f = detail::host_reduce(exec, lin + lbegin[b], lin + lend[b], static_cast<typename InType::value_type>(0));
         *(lout + b) = f;
       }
     }
@@ -736,22 +739,24 @@ void __MATX_INLINE__ prod_impl(OutType dest, const InType &in, const cudaExecuto
  *   Single thread host executor
  */
 template <typename OutType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ prod_impl(OutType dest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ prod_impl(OutType dest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("prod_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
-      *lout = std::accumulate(lin,
-                              lin + TotalSize(in),
-                              static_cast<typename InType::value_type>(1),
-                              std::multiplies<typename InType::value_type>());
+      *lout = detail::host_reduce(exec,
+                                  lin,
+                                  lin + TotalSize(in),
+                                  static_cast<typename InType::value_type>(1),
+                                  std::multiplies<typename InType::value_type>());
     }
     else {
       for (index_t b = 0; b < lin.Size(0); b++) {
-        *(lout + b) = std::accumulate(lin + lbegin[b],
-                                      lin + lend[b],
-                                      static_cast<typename InType::value_type>(1),
-                                      std::multiplies<typename InType::value_type>());
+        *(lout + b) = detail::host_reduce(exec,
+                                          lin + lbegin[b],
+                                          lin + lend[b],
+                                          static_cast<typename InType::value_type>(1),
+                                          std::multiplies<typename InType::value_type>());
       }
     }
   };
@@ -807,18 +812,18 @@ void __MATX_INLINE__ max_impl(OutType dest, const InType &in, const cudaExecutor
  *   Single threaded host executor
  */
 template <typename OutType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ max_impl(OutType dest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ max_impl(OutType dest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("max_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
 
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
-      *lout = *std::max_element(lin, lin + TotalSize(in));
+      *lout = *detail::host_max_element(exec, lin, lin + TotalSize(in));
     }
     else {
       const index_t BATCHES = TotalSize(dest);
       for (index_t b = 0; b < BATCHES; b++) {
-        lout[b] = *std::max_element(lin + lbegin[b], lin + lend[b]);
+        lout[b] = *detail::host_max_element(exec, lin + lbegin[b], lin + lend[b]);
       }
     }
   };
@@ -885,18 +890,18 @@ void __MATX_INLINE__ argmax_impl(OutType dest, TensorIndexType &idest, const InT
  *   Single threaded host executor
  */
 template <typename OutType, typename TensorIndexType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ argmax_impl(OutType dest, TensorIndexType &idest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ argmax_impl(OutType dest, TensorIndexType &idest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("argmax_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
 
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
-      *lout = static_cast<index_t>(cuda::std::max_element(lin, lin + TotalSize(in)) - lin);
+      *lout = static_cast<index_t>(detail::host_max_element(exec, lin, lin + TotalSize(in)) - lin);
     }
     else {
       const index_t BATCHES = TotalSize(dest);
       for (index_t b = 0; b < BATCHES; b++) {
-        lout[b] = static_cast<index_t>(cuda::std::max_element(lin + lbegin[b], lin + lend[b]) - lin);
+        lout[b] = static_cast<index_t>(detail::host_max_element(exec, lin + lbegin[b], lin + lend[b]) - lin);
       }
     }
   };
@@ -955,17 +960,17 @@ void __MATX_INLINE__ min_impl(OutType dest, const InType &in, const cudaExecutor
  *   Single threaded host executor
  */
 template <typename OutType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ min_impl(OutType dest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ min_impl(OutType dest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("min_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
-      *lout = *std::min_element(lin, lin + TotalSize(in));
+      *lout = *detail::host_min_element(exec, lin, lin + TotalSize(in));
     }
     else {
       const index_t BATCHES = TotalSize(dest);
       for (index_t b = 0; b < BATCHES; b++) {
-        lout[b] = *std::min_element(lin + lbegin[b], lin + lend[b]);
+        lout[b] = *detail::host_min_element(exec, lin + lbegin[b], lin + lend[b]);
       }
     }
   };
@@ -1035,18 +1040,18 @@ void __MATX_INLINE__ argmin_impl(OutType dest, TensorIndexType &idest, const InT
  *   Single host executor
  */
 template <typename OutType, typename TensorIndexType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ argmin_impl(OutType dest, TensorIndexType &idest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ argmin_impl(OutType dest, TensorIndexType &idest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("argmin_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
 
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
-      *lout = static_cast<index_t>(cuda::std::min_element(lin, lin + TotalSize(in)) - lin);
+      *lout = static_cast<index_t>(detail::host_min_element(exec, lin, lin + TotalSize(in)) - lin);
     }
     else {
       const index_t BATCHES = TotalSize(dest);
       for (index_t b = 0; b < BATCHES; b++) {
-        lout[b] = static_cast<index_t>(cuda::std::min_element(lin + lbegin[b], lin + lend[b]) - lin);
+        lout[b] = static_cast<index_t>(detail::host_min_element(exec, lin + lbegin[b], lin + lend[b]) - lin);
       }
     }
   };
@@ -1192,19 +1197,19 @@ void __MATX_INLINE__ any_impl(OutType dest, const InType &in, const cudaExecutor
  *   Single threaded host executor
  */
 template <typename OutType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ any_impl(OutType dest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ any_impl(OutType dest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("any_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
 
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
-      *lout = std::any_of(lin, lin + TotalSize(in), [](typename InType::value_type vin) {
+      *lout = detail::host_any_of(exec, lin, lin + TotalSize(in), [](typename InType::value_type vin) {
           return vin != static_cast<typename InType::value_type>(0);
         });
     }
     else {
       for (index_t b = 0; b < lin.Size(0); b++) {
-        lout[b] = std::any_of(lin + lbegin[b], lin + lend[b], [](typename InType::value_type vin) {
+        lout[b] = detail::host_any_of(exec, lin + lbegin[b], lin + lend[b], [](typename InType::value_type vin) {
           return vin != static_cast<typename InType::value_type>(0);
         });
       }
@@ -1265,19 +1270,19 @@ void __MATX_INLINE__ all_impl(OutType dest, const InType &in, const cudaExecutor
  *   Single threaded host executor
  */
 template <typename OutType, typename InType, ThreadsMode MODE>
-void __MATX_INLINE__ all_impl(OutType dest, const InType &in, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ all_impl(OutType dest, const InType &in, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("all_impl(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
 
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
     if constexpr (OutType::Rank() == 0) {
-      *lout = std::all_of(lin, lin + TotalSize(in), [](typename InType::value_type vin) {
+      *lout = detail::host_all_of(exec, lin, lin + TotalSize(in), [](typename InType::value_type vin) {
           return vin != static_cast<typename InType::value_type>(0);
         });
     }
     else {
       for (index_t b = 0; b < lin.Size(0); b++) {
-        lout[b] = std::all_of(lin + lbegin[b], lin + lend[b], [](typename InType::value_type vin) {
+        lout[b] = detail::host_all_of(exec, lin + lbegin[b], lin + lend[b], [](typename InType::value_type vin) {
           return vin != static_cast<typename InType::value_type>(0);
         });
       }
@@ -1351,7 +1356,7 @@ void __MATX_INLINE__ allclose(OutType dest, const InType1 &in1, const InType2 &i
  *   Single threaded host executor
  */
 template <typename OutType, typename InType1, typename InType2, ThreadsMode MODE>
-void __MATX_INLINE__ allclose(OutType dest, const InType1 &in1, const InType2 &in2, double rtol, double atol, [[maybe_unused]] const HostExecutor<MODE> &exec)
+void __MATX_INLINE__ allclose(OutType dest, const InType1 &in1, const InType2 &in2, double rtol, double atol, const HostExecutor<MODE> &exec)
 {
   MATX_NVTX_START("allclose(" + get_type_str(in1) + ", " + get_type_str(in2) + ")", matx::MATX_NVTX_LOG_API)
   static_assert(OutType::Rank() == 0, "allclose output must be rank 0");
@@ -1359,7 +1364,7 @@ void __MATX_INLINE__ allclose(OutType dest, const InType1 &in1, const InType2 &i
   auto isc = isclose(in1, in2, rtol, atol);
 
   auto ft = [&](auto &&lin, auto &&lout, [[maybe_unused]] auto &&lbegin, [[maybe_unused]] auto &&lend) {
-    *lout = std::all_of(lin, lin + TotalSize(in1), [](int vin) {
+    *lout = detail::host_all_of(exec, lin, lin + TotalSize(in1), [](int vin) {
         return vin != 0;
       });
   };

--- a/test/01_radar/MultiChannelRadarPipeline.cu
+++ b/test/01_radar/MultiChannelRadarPipeline.cu
@@ -41,7 +41,9 @@ template <typename T> class MultiChannelRadarPipeline : public ::testing::Test {
 protected:
   using GTestType = cuda::std::tuple_element_t<0, T>;
   using GExecType = cuda::std::tuple_element_t<1, T>;
-  void SetUp() override
+
+public:
+  static void SetUpTestSuite()
   {
     assert(numSamples > waveformLength);
 
@@ -56,15 +58,17 @@ protected:
     pb->RunTVGenerator("run");
   }
 
-  void TearDown() override { pb.reset(); }
-  uint32_t iterations = 100;
-  index_t numChannels = 16;
-  index_t numPulses = 128;
-  index_t numSamples = 9000;
-  index_t waveformLength = 1000;
-  index_t numSamplesRnd = 16384;
-  index_t numCompressedSamples = numSamples - waveformLength + 1;
-  std::unique_ptr<detail::MatXPybind> pb;
+  static void TearDownTestSuite() { pb.reset(); }
+
+protected:
+  static constexpr uint32_t iterations = 100;
+  static constexpr index_t numChannels = 16;
+  static constexpr index_t numPulses = 128;
+  static constexpr index_t numSamples = 9000;
+  static constexpr index_t waveformLength = 1000;
+  static constexpr index_t numSamplesRnd = 16384;
+  static constexpr index_t numCompressedSamples = numSamples - waveformLength + 1;
+  inline static std::unique_ptr<detail::MatXPybind> pb;
 };
 
 template <typename TensorType>


### PR DESCRIPTION
The CPU sorting, reduction and prefix sum only used a single-threaded version. This adds the parallel versions via thrust algorithms, Speedups are shown below on a 20-core ARM:

<img width="651" height="772" alt="image" src="https://github.com/user-attachments/assets/83090787-3251-4fdf-b8aa-7330212ee416" />
