### PR TITLE
Add corrmap operator for windowed correlation maps

### DIFF
--- a/docs_input/api/stats/corr/corrmap.rst
+++ b/docs_input/api/stats/corr/corrmap.rst
@@ -1,0 +1,101 @@
+.. _corrmap_func:
+
+corrmap
+#######
+
+Per-element windowed correlation map between two operators of identical
+shape. Unlike :ref:`corr_func`, which produces a single function-of-lag
+output, ``corrmap`` produces an output of the **same shape as the input**,
+where each output element is a normalized correlation computed over a small
+window of samples around the corresponding input element.
+
+Supports a 1-D window over the last input dimension (signal-processing form)
+and a 2-D window over the last two input dimensions (image-processing form).
+All other dimensions are treated as independent batches. The window is
+cropped at the input boundary: out-of-bounds offsets are skipped and the
+normalization uses only the in-bounds samples (means and energies are
+computed over the cropped window, not over a zero-padded one).
+
+Typical applications:
+
+- SAR / InSAR coherence and interferogram phase (complex inputs, MAGNITUDE normalization)
+- Stereo matching disparity cost (real inputs, ZNCC normalization)
+- Template matching, optical flow, change detection (ZNCC normalization)
+
+.. versionadded:: 1.0.0
+
+.. doxygenfunction:: corrmap(const OpA &A, const OpB &B, index_t window)
+.. doxygenfunction:: corrmap(const OpA &A, const OpB &B, const cuda::std::array<index_t, 2> &window)
+
+Normalization modes
+~~~~~~~~~~~~~~~~~~~
+
+The compile-time template parameter ``Mode`` selects how each window's
+samples are combined. The full mathematical definition of each mode is
+given in its ``CorrMapNormalize`` enum value.
+
+.. doxygenenum:: matx::CorrMapNormalize
+
+Input type requirements
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Inputs must be floating-point or complex floating-point. Supported inner
+scalar types are ``float``, ``double``, ``matx::matxFp16`` /
+``matx::matxBf16`` (and the underlying ``__half`` / ``__nv_bfloat16``),
+and their complex counterparts.
+
+Integer and complex-integer inputs are rejected at compile time by a
+``static_assert``. This applies to every mode, including
+:cpp:enumerator:`matx::CorrMapNormalize::NONE`: although the NONE-mode
+product :math:`A \cdot \bar B` is mathematically well-defined for
+integer operands, the normalized modes (MAGNITUDE / ZNCC) require a
+final division that would silently truncate to zero for integer
+arithmetic, so all integer inputs are rejected uniformly to avoid a
+surprising mode-dependent failure mode. Cast integer inputs explicitly
+before calling, e.g. ``corrmap(as_float(A), as_float(B), w)``.
+
+Output element type
+~~~~~~~~~~~~~~~~~~~
+
+- Complex if either input is complex.
+- Real otherwise.
+- Precision is the greater of the inputs: e.g. ``float + double`` produces
+  ``double``, ``complex<float> + complex<double>`` produces
+  ``complex<double>``, and ``complex<float> + double`` also produces
+  ``complex<double>``.
+
+Window indexing
+~~~~~~~~~~~~~~~
+
+The window uses the floor-center convention: for a
+window of length :math:`w` centered at index :math:`n`, the offsets span
+:math:`[-\lfloor w/2 \rfloor,\ w - 1 - \lfloor w/2 \rfloor]`. Odd window
+sizes are exactly centered; even window sizes introduce a half-element
+registration offset.
+
+Examples
+~~~~~~~~
+
+2-D MAGNITUDE on complex inputs (SAR/InSAR coherence):
+
+.. literalinclude:: ../../../../test/00_operators/corrmap_test.cu
+   :language: cpp
+   :start-after: example-begin corrmap-2d-magnitude
+   :end-before: example-end corrmap-2d-magnitude
+   :dedent:
+
+2-D ZNCC on real inputs (classic normalized cross-correlation):
+
+.. literalinclude:: ../../../../test/00_operators/corrmap_test.cu
+   :language: cpp
+   :start-after: example-begin corrmap-2d-zncc
+   :end-before: example-end corrmap-2d-zncc
+   :dedent:
+
+1-D MAGNITUDE on a batched real signal:
+
+.. literalinclude:: ../../../../test/00_operators/corrmap_test.cu
+   :language: cpp
+   :start-after: example-begin corrmap-1d-magnitude
+   :end-before: example-end corrmap-1d-magnitude
+   :dedent:

--- a/docs_input/executor_compatibility.rst
+++ b/docs_input/executor_compatibility.rst
@@ -80,6 +80,7 @@ fused JIT expression; non-JIT CUDA execution through cudaExecutor remains availa
    "conv2d", "|yes|", "|yes|", "|no|", "Direct convolution supports host and CUDA executors."
    "copy", "|yes|", "|yes|", "|no|", "Executor-dispatched assignment/copy transform; CUDAJITExecutor fuses expression evaluation instead of using this transform directly."
    "corr", "|yes|", "|yes|", "|no|", "Direct correlation supports host and CUDA executors. FFT correlation can use the CPU FFT backend when enabled."
+   "corrmap", "|yes|", "|yes|", "|yes|", "Per-element windowed correlation map (1-D or 2-D window). Inputs must be floating-point or complex floating-point; integer inputs are rejected by static_assert."
    "cos", "|yes|", "|yes|", "|yes|", "Element-wise expression."
    "cosh", "|yes|", "|yes|", "|yes|", "Element-wise expression."
    "cov", "|no|", "|yes|", "|no|", "CUDA-only covariance transform."

--- a/include/matx/operators/corrmap.h
+++ b/include/matx/operators/corrmap.h
@@ -205,27 +205,33 @@ namespace matx
           is_dynamic_tensor_v<OpB> || is_dynamic_rank_op_v<OpB>>;
 
 #ifdef MATX_EN_JIT
-        // JIT storage: same operands the host operator() reads, plus the
-        // runtime window-size array.
+        // JIT storage: same operands the host operator() reads. The window
+        // sizes are baked into the generated type as a constexpr array (see
+        // get_jit_class_name / get_jit_op_str), so they are not stored here.
         struct JIT_Storage {
           typename detail::inner_storage_or_self_t<detail::base_type_t<OpA>> a_;
           typename detail::inner_storage_or_self_t<detail::base_type_t<OpB>> b_;
-          cuda::std::array<index_t, WindowRank> window_;
           cuda::std::array<index_t, out_rank> out_dims_;
         };
 
         JIT_Storage ToJITStorage() const {
           return JIT_Storage{detail::to_jit_storage(a_),
                              detail::to_jit_storage(b_),
-                             window_,
                              out_dims_};
         }
 
-        // The class name encodes WindowRank and Mode so each (rank, mode)
-        // combination gets its own NVRTC-cached class.
+        // The class name encodes WindowRank, Mode, and the window dimensions so
+        // each (rank, mode, window) combination gets its own NVRTC-cached class.
+        // Baking the window sizes into the type (rather than passing them as
+        // runtime storage) lets the generated window loops use compile-time
+        // bounds and unroll, matching how slice() bakes its sizes/dims/starts.
         __MATX_INLINE__ std::string get_jit_class_name() const {
-          return std::format("JITCorrMap_w{}_m{}", WindowRank,
-                             static_cast<int>(Mode));
+          std::string win_str;
+          for (int d = 0; d < WindowRank; d++) {
+            win_str += std::format("_{}", window_[d]);
+          }
+          return std::format("JITCorrMap_w{}_m{}{}", WindowRank,
+                             static_cast<int>(Mode), win_str);
         }
 
         // Emit the operator's struct definition for NVRTC compilation. The
@@ -255,7 +261,7 @@ namespace matx
               "\n"
               "  typename detail::inner_storage_or_self_t<detail::base_type_t<OpA>> a_;\n"
               "  typename detail::inner_storage_or_self_t<detail::base_type_t<OpB>> b_;\n"
-              "  cuda::std::array<index_t, WindowRank> window_;\n"
+              "  static constexpr cuda::std::array<index_t, WindowRank> window_ = {{ {6} }};\n"
               "  cuda::std::array<index_t, out_rank> out_dims_;\n"
               "\n"
               "  // Scalar sqrt: dispatches half precision through float to avoid\n"
@@ -270,7 +276,7 @@ namespace matx
               "  }}\n"
               "\n"
               "  template <typename CapType, typename... Is>\n"
-              "  __MATX_INLINE__ __MATX_DEVICE__ decltype(auto) operator()(Is... indices) const {{\n"
+              "  __MATX_INLINE__ __MATX_DEVICE__ auto operator()(Is... indices) const {{\n"
               "    if constexpr (CapType::ept != ElementsPerThread::ONE) {{\n"
               "      return Vector<value_type, static_cast<size_t>(CapType::ept)>();\n"
               "    }} else {{\n"
@@ -403,7 +409,8 @@ namespace matx
               static_cast<int>(Mode),
               static_cast<int>(CorrMapNormalize::NONE),
               static_cast<int>(CorrMapNormalize::MAGNITUDE),
-              static_cast<int>(CorrMapNormalize::ZNCC))
+              static_cast<int>(CorrMapNormalize::ZNCC),
+              detail::array_to_string(window_))
           );
         }
 #endif
@@ -434,7 +441,7 @@ namespace matx
         }
 
         template <typename CapType, typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
         {
           // corrmap only supports one element per thread. The ELEMENTS_PER_THREAD
           // capability below advertises this, and combine_capabilities() forces

--- a/include/matx/operators/corrmap.h
+++ b/include/matx/operators/corrmap.h
@@ -237,11 +237,11 @@ namespace matx
           return cuda::std::make_tuple(
             func_name,
             std::format(
-              "template <typename OpA, typename OpB> struct {} {{\n"
+              "template <typename OpA, typename OpB> struct {0} {{\n"
               "  using matxop = bool;\n"
               "  static constexpr int32_t out_rank = OpA::Rank();\n"
-              "  static constexpr int WindowRank = {};\n"
-              "  static constexpr int Mode = {};  // 0=NONE, 1=MAGNITUDE, 2=ZNCC\n"
+              "  static constexpr int WindowRank = {1};\n"
+              "  static constexpr int Mode = {2};  // NONE={3}, MAGNITUDE={4}, ZNCC={5}\n"
               "  using inner_a_ = typename inner_op_type_t<typename OpA::value_type>::type;\n"
               "  using inner_b_ = typename inner_op_type_t<typename OpB::value_type>::type;\n"
               "  static constexpr bool any_complex_ =\n"
@@ -286,8 +286,8 @@ namespace matx
               "      }}\n"
               "\n"
               "      constexpr bool is_cplx = is_complex_v<value_type>;\n"
-              "      constexpr bool need_energies = (Mode == 1);  // MAGNITUDE\n"
-              "      constexpr bool use_welford   = (Mode == 2);  // ZNCC\n"
+              "      constexpr bool need_energies = (Mode == {4});  // MAGNITUDE\n"
+              "      constexpr bool use_welford   = (Mode == {5});  // ZNCC\n"
               "\n"
               "      [[maybe_unused]] value_type sum_ab{{}};\n"
               "      [[maybe_unused]] inner_type sum_aa{{0}};\n"
@@ -371,9 +371,9 @@ namespace matx
               "\n"
               "      if (n_valid == 0) return value_type{{}};\n"
               "\n"
-              "      if constexpr (Mode == 0) {{  // NONE\n"
+              "      if constexpr (Mode == {3}) {{  // NONE\n"
               "        return sum_ab;\n"
-              "      }} else if constexpr (Mode == 1) {{  // MAGNITUDE\n"
+              "      }} else if constexpr (Mode == {4}) {{  // MAGNITUDE\n"
               "        const inner_type denom = scalar_sqrt(sum_aa * sum_bb);\n"
               "        if (denom == inner_type{{0}}) return value_type{{}};\n"
               "        if constexpr (is_cplx) {{\n"
@@ -398,7 +398,12 @@ namespace matx
               "  static __MATX_INLINE__ constexpr __MATX_DEVICE__ int32_t Rank() {{ return out_rank; }}\n"
               "  constexpr __MATX_INLINE__ __MATX_DEVICE__ index_t Size(int dim) const {{ return out_dims_[dim]; }}\n"
               "}};\n",
-              func_name, WindowRank, static_cast<int>(Mode))
+              func_name,
+              WindowRank,
+              static_cast<int>(Mode),
+              static_cast<int>(CorrMapNormalize::NONE),
+              static_cast<int>(CorrMapNormalize::MAGNITUDE),
+              static_cast<int>(CorrMapNormalize::ZNCC))
           );
         }
 #endif

--- a/include/matx/operators/corrmap.h
+++ b/include/matx/operators/corrmap.h
@@ -1,0 +1,832 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "matx/core/type_utils.h"
+#include "matx/operators/base_operator.h"
+#include <cuda/std/cmath>
+#include <cuda/std/array>
+
+namespace matx
+{
+
+  /**
+   * @brief Normalization mode for the windowed correlation map.
+   *
+   * Given two inputs \f$ A, B \f$ of identical shape, for each output element
+   * the operator iterates over a small window \f$ W \f$ around that element
+   * and combines the samples according to the selected mode.
+   *
+   * In the per-value equations below, \f$ a_k, b_k \f$ are the input samples
+   * at the window offsets \f$ k \in W \f$, the conjugate is
+   * \f$ \overline{\cdot} \f$ (the identity for real inputs), and \f$ N = |W|
+   * \f$ is the number of in-bounds samples in the window.
+   *
+   * For the MAGNITUDE and ZNCC modes the listed result ranges are the
+   * mathematical bounds. The operator does not clamp, so floating-point
+   * arithmetic may produce values slightly outside the bounds in degenerate
+   * windows.
+   */
+  enum class CorrMapNormalize {
+    /**
+     * @brief Raw windowed inner product. Result is unbounded, other than
+     * the data type limits.
+     *
+     * \f[
+     *   y = \sum_{k \in W} a_k \, \overline{b_k}
+     * \f]
+     */
+    NONE,
+
+    /**
+     * @brief Energy-normalized cross-correlation: divide by the geometric
+     * mean of the two windowed energies.
+     *
+     * For complex inputs the result is complex with magnitude in
+     * \f$ [0, 1] \f$: \f$ |y| \f$ is the SAR/InSAR coherence magnitude and
+     * \f$ \angle y \f$ is the interferogram phase. For real inputs the
+     * result lies in \f$ [-1, 1] \f$.
+     *
+     * \f[
+     *   y = \frac{\displaystyle \sum_{k \in W} a_k \, \overline{b_k}}
+     *            {\sqrt{\displaystyle \sum_{k \in W} |a_k|^2 \;
+     *                   \sum_{k \in W} |b_k|^2}}
+     * \f]
+     */
+    MAGNITUDE,
+
+    /**
+     * @brief Zero-mean normalized cross-correlation: subtract the
+     * window-local means before normalizing.
+     *
+     * This is the classic NCC used in image processing, pattern matching,
+     * and is equivalent to the Pearson correlation coefficient. Let
+     * \f$ \mu_a = \tfrac{1}{N}\sum_{k \in W} a_k \f$ and
+     * \f$ \mu_b = \tfrac{1}{N}\sum_{k \in W} b_k \f$ be the window-local
+     * means. Result is in \f$ [-1, 1] \f$ for real inputs; complex with
+     * magnitude \f$ \le 1 \f$ for complex inputs.
+     *
+     * \f[
+     *   y = \frac{\displaystyle \sum_{k \in W} (a_k - \mu_a)\,
+     *                                  \overline{(b_k - \mu_b)}}
+     *            {\sqrt{\displaystyle \sum_{k \in W} |a_k - \mu_a|^2 \;
+     *                   \sum_{k \in W} |b_k - \mu_b|^2}}
+     * \f]
+     */
+    ZNCC
+  };
+
+  namespace detail {
+
+    // Scalar sqrt that dispatches half precision to matx::sqrt's half overload
+    // (in matx/core/half.h). cuda::std::sqrt is ambiguous for matxFp16 /
+    // matxBf16 (and the raw __half / __nv_bfloat16) because their implicit
+    // conversions match multiple of its built-in overloads.
+    template <typename T>
+    __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ T corrmap_scalar_sqrt(T x)
+    {
+      if constexpr (is_matx_half_v<T> || is_half_v<T>) {
+        return matx::sqrt(x);
+      } else {
+        return cuda::std::sqrt(x);
+      }
+    }
+
+    // Per-pixel windowed correlation map.
+    //
+    // WindowRank == 1: the window slides along the last input dimension.
+    //                  All other input dims are batch.
+    // WindowRank == 2: the window slides along the last two input dimensions.
+    //                  All other input dims are batch.
+    //
+    // Mode is a compile-time template parameter so the normalization formula
+    // collapses to a single branch and the mean accumulators are elided when
+    // they're not needed.
+    //
+    // The output shape is always identical to the input shape.
+    template <typename OpA, typename OpB, int WindowRank, CorrMapNormalize Mode>
+    class CorrMapOp : public BaseOp<CorrMapOp<OpA, OpB, WindowRank, Mode>>
+    {
+      private:
+        static_assert(WindowRank == 1 || WindowRank == 2,
+                      "corrmap supports 1-D or 2-D windows only");
+
+        mutable typename detail::base_type_t<OpA> a_;
+        mutable typename detail::base_type_t<OpB> b_;
+        cuda::std::array<index_t, WindowRank> window_;
+
+        static constexpr int32_t out_rank = OpA::Rank();
+        cuda::std::array<index_t, out_rank> out_dims_;
+
+      public:
+        using matxop = bool;
+
+      private:
+        // Decide the output precision and whether the output is complex by
+        // separating the two questions:
+        //   * inner_type = common_type of the two real precisions (so e.g.
+        //     float + double -> double).
+        //   * any_complex = true if either input is complex.
+        using inner_a_ = typename inner_op_type_t<typename OpA::value_type>::type;
+        using inner_b_ = typename inner_op_type_t<typename OpB::value_type>::type;
+        static constexpr bool any_complex_ =
+          is_complex_v<typename OpA::value_type> ||
+          is_complex_v<typename OpB::value_type>;
+
+        // Reject integer inputs. Normalized modes (MAGNITUDE / ZNCC) would
+        // silently truncate the final division to 0 for integer inner types,
+        // producing meaningless results. Users wanting integer inputs must
+        // cast explicitly (e.g. corrmap(as_float(A), as_float(B), w)).
+        template <typename T>
+        static constexpr bool is_supported_inner_v =
+          cuda::std::is_same_v<T, float> ||
+          cuda::std::is_same_v<T, double> ||
+          is_matx_half_v<T> ||
+          is_half_v<T>;
+        static_assert(is_supported_inner_v<inner_a_>,
+                      "corrmap() requires floating-point (or complex floating-point) input types");
+        static_assert(is_supported_inner_v<inner_b_>,
+                      "corrmap() requires floating-point (or complex floating-point) input types");
+
+      public:
+        // Real scalar type for energy accumulators and normalization.
+        using inner_type = cuda::std::common_type_t<inner_a_, inner_b_>;
+
+        // Output type:
+        //   complex<float>  + complex<double> -> complex<double>
+        //   float           + double          -> double
+        //   float           + complex<double> -> complex<double>
+        //   matxFp16Complex + matxFp16        -> matxFp16Complex
+        //
+        // complex_from_scalar_t maps the inner scalar to the right complex
+        // wrapper (cuda::std::complex<T> for float/double, matxHalfComplex<T>
+        // for half types). This is what keeps matxFp16Complex outputs from
+        // becoming the ill-formed cuda::std::complex<matxFp16>.
+        using value_type = cuda::std::conditional_t<
+          any_complex_,
+          complex_from_scalar_t<inner_type>,
+          inner_type>;
+
+        using self_type = CorrMapOp<OpA, OpB, WindowRank, Mode>;
+
+        // Propagate dynamic tensor marker through expression tree
+        using dynamic_tensor_expr = cuda::std::bool_constant<
+          is_dynamic_tensor_v<OpA> || is_dynamic_rank_op_v<OpA> ||
+          is_dynamic_tensor_v<OpB> || is_dynamic_rank_op_v<OpB>>;
+
+#ifdef MATX_EN_JIT
+        // JIT storage: same operands the host operator() reads, plus the
+        // runtime window-size array.
+        struct JIT_Storage {
+          typename detail::inner_storage_or_self_t<detail::base_type_t<OpA>> a_;
+          typename detail::inner_storage_or_self_t<detail::base_type_t<OpB>> b_;
+          cuda::std::array<index_t, WindowRank> window_;
+          cuda::std::array<index_t, out_rank> out_dims_;
+        };
+
+        JIT_Storage ToJITStorage() const {
+          return JIT_Storage{detail::to_jit_storage(a_),
+                             detail::to_jit_storage(b_),
+                             window_,
+                             out_dims_};
+        }
+
+        // The class name encodes WindowRank and Mode so each (rank, mode)
+        // combination gets its own NVRTC-cached class.
+        __MATX_INLINE__ std::string get_jit_class_name() const {
+          return std::format("JITCorrMap_w{}_m{}", WindowRank,
+                             static_cast<int>(Mode));
+        }
+
+        // Emit the operator's struct definition for NVRTC compilation. The
+        // body mirrors the host operator() exactly -- the `if constexpr`
+        // branches on Mode, WindowRank, and is_cplx collapse at JIT
+        // compile time the same way they do on the host side.
+        __MATX_INLINE__ auto get_jit_op_str() const {
+          std::string func_name = get_jit_class_name();
+          return cuda::std::make_tuple(
+            func_name,
+            std::format(
+              "template <typename OpA, typename OpB> struct {} {{\n"
+              "  using matxop = bool;\n"
+              "  static constexpr int32_t out_rank = OpA::Rank();\n"
+              "  static constexpr int WindowRank = {};\n"
+              "  static constexpr int Mode = {};  // 0=NONE, 1=MAGNITUDE, 2=ZNCC\n"
+              "  using inner_a_ = typename inner_op_type_t<typename OpA::value_type>::type;\n"
+              "  using inner_b_ = typename inner_op_type_t<typename OpB::value_type>::type;\n"
+              "  static constexpr bool any_complex_ =\n"
+              "    is_complex_v<typename OpA::value_type> ||\n"
+              "    is_complex_v<typename OpB::value_type>;\n"
+              "  using inner_type = cuda::std::common_type_t<inner_a_, inner_b_>;\n"
+              "  using value_type = cuda::std::conditional_t<\n"
+              "    any_complex_,\n"
+              "    complex_from_scalar_t<inner_type>,\n"
+              "    inner_type>;\n"
+              "\n"
+              "  typename detail::inner_storage_or_self_t<detail::base_type_t<OpA>> a_;\n"
+              "  typename detail::inner_storage_or_self_t<detail::base_type_t<OpB>> b_;\n"
+              "  cuda::std::array<index_t, WindowRank> window_;\n"
+              "  cuda::std::array<index_t, out_rank> out_dims_;\n"
+              "\n"
+              "  // Scalar sqrt: dispatches half precision through float to avoid\n"
+              "  // cuda::std::sqrt overload ambiguity for the half types.\n"
+              "  template <typename T>\n"
+              "  static __MATX_INLINE__ __MATX_DEVICE__ T scalar_sqrt(T x) {{\n"
+              "    if constexpr (is_matx_half_v<T> || is_half_v<T>) {{\n"
+              "      return static_cast<T>(cuda::std::sqrt(static_cast<float>(x)));\n"
+              "    }} else {{\n"
+              "      return cuda::std::sqrt(x);\n"
+              "    }}\n"
+              "  }}\n"
+              "\n"
+              "  template <typename CapType, typename... Is>\n"
+              "  __MATX_INLINE__ __MATX_DEVICE__ decltype(auto) operator()(Is... indices) const {{\n"
+              "    if constexpr (CapType::ept != ElementsPerThread::ONE) {{\n"
+              "      return Vector<value_type, static_cast<size_t>(CapType::ept)>();\n"
+              "    }} else {{\n"
+              "      constexpr int rank = static_cast<int>(sizeof...(Is));\n"
+              "      cuda::std::array<index_t, rank> out_idx{{static_cast<index_t>(indices)...}};\n"
+              "\n"
+              "      cuda::std::array<index_t, WindowRank> win_dim_size;\n"
+              "      cuda::std::array<index_t, WindowRank> win_start;\n"
+              "      for (int d = 0; d < WindowRank; d++) {{\n"
+              "        win_dim_size[d] = a_.Size(rank - WindowRank + d);\n"
+              "        const index_t center = out_idx[rank - WindowRank + d];\n"
+              "        win_start[d] = center - (window_[d] / 2);\n"
+              "      }}\n"
+              "\n"
+              "      constexpr bool is_cplx = is_complex_v<value_type>;\n"
+              "      constexpr bool need_energies = (Mode == 1);  // MAGNITUDE\n"
+              "      constexpr bool use_welford   = (Mode == 2);  // ZNCC\n"
+              "\n"
+              "      [[maybe_unused]] value_type sum_ab{{}};\n"
+              "      [[maybe_unused]] inner_type sum_aa{{0}};\n"
+              "      [[maybe_unused]] inner_type sum_bb{{0}};\n"
+              "      [[maybe_unused]] value_type mean_a{{}}, mean_b{{}}, C{{}};\n"
+              "      [[maybe_unused]] inner_type M2_a{{0}}, M2_b{{0}};\n"
+              "      index_t n_valid = 0;\n"
+              "      cuda::std::array<index_t, rank> idx = out_idx;\n"
+              "\n"
+              "      auto accumulate = [&](const cuda::std::array<index_t, rank> &read_idx) {{\n"
+              "        const value_type a_val = static_cast<value_type>(detail::get_value<CapType>(a_, read_idx));\n"
+              "        const value_type b_val = static_cast<value_type>(detail::get_value<CapType>(b_, read_idx));\n"
+              "        n_valid++;\n"
+              "        if constexpr (use_welford) {{\n"
+              "          const inner_type n = static_cast<inner_type>(n_valid);\n"
+              "          if constexpr (is_cplx) {{\n"
+              "            const inner_type da_r = a_val.real() - mean_a.real();\n"
+              "            const inner_type da_i = a_val.imag() - mean_a.imag();\n"
+              "            const inner_type db_r = b_val.real() - mean_b.real();\n"
+              "            const inner_type db_i = b_val.imag() - mean_b.imag();\n"
+              "            mean_a = value_type{{mean_a.real() + da_r / n, mean_a.imag() + da_i / n}};\n"
+              "            mean_b = value_type{{mean_b.real() + db_r / n, mean_b.imag() + db_i / n}};\n"
+              "            const inner_type an_r = a_val.real() - mean_a.real();\n"
+              "            const inner_type an_i = a_val.imag() - mean_a.imag();\n"
+              "            const inner_type bn_r = b_val.real() - mean_b.real();\n"
+              "            const inner_type bn_i = b_val.imag() - mean_b.imag();\n"
+              "            C = value_type{{C.real() + da_r * bn_r + da_i * bn_i,\n"
+              "                            C.imag() + da_i * bn_r - da_r * bn_i}};\n"
+              "            M2_a += da_r * an_r + da_i * an_i;\n"
+              "            M2_b += db_r * bn_r + db_i * bn_i;\n"
+              "          }} else {{\n"
+              "            const inner_type da = a_val - mean_a;\n"
+              "            const inner_type db = b_val - mean_b;\n"
+              "            mean_a += da / n;\n"
+              "            mean_b += db / n;\n"
+              "            C    += da * (b_val - mean_b);\n"
+              "            M2_a += da * (a_val - mean_a);\n"
+              "            M2_b += db * (b_val - mean_b);\n"
+              "          }}\n"
+              "        }} else {{\n"
+              "          if constexpr (is_cplx) {{\n"
+              "            const inner_type ar = a_val.real();\n"
+              "            const inner_type ai = a_val.imag();\n"
+              "            const inner_type br = b_val.real();\n"
+              "            const inner_type bi = b_val.imag();\n"
+              "            sum_ab += value_type{{ar * br + ai * bi, ai * br - ar * bi}};\n"
+              "            if constexpr (need_energies) {{\n"
+              "              sum_aa += ar * ar + ai * ai;\n"
+              "              sum_bb += br * br + bi * bi;\n"
+              "            }}\n"
+              "          }} else {{\n"
+              "            sum_ab += a_val * b_val;\n"
+              "            if constexpr (need_energies) {{\n"
+              "              sum_aa += a_val * a_val;\n"
+              "              sum_bb += b_val * b_val;\n"
+              "            }}\n"
+              "          }}\n"
+              "        }}\n"
+              "      }};\n"
+              "\n"
+              "      if constexpr (WindowRank == 1) {{\n"
+              "        for (index_t dr = 0; dr < window_[0]; dr++) {{\n"
+              "          const index_t r = win_start[0] + dr;\n"
+              "          if (r < 0 || r >= win_dim_size[0]) continue;\n"
+              "          idx[rank - 1] = r;\n"
+              "          accumulate(idx);\n"
+              "        }}\n"
+              "      }} else {{\n"
+              "        for (index_t dr = 0; dr < window_[0]; dr++) {{\n"
+              "          const index_t r = win_start[0] + dr;\n"
+              "          if (r < 0 || r >= win_dim_size[0]) continue;\n"
+              "          idx[rank - 2] = r;\n"
+              "          for (index_t dc = 0; dc < window_[1]; dc++) {{\n"
+              "            const index_t c = win_start[1] + dc;\n"
+              "            if (c < 0 || c >= win_dim_size[1]) continue;\n"
+              "            idx[rank - 1] = c;\n"
+              "            accumulate(idx);\n"
+              "          }}\n"
+              "        }}\n"
+              "      }}\n"
+              "\n"
+              "      if (n_valid == 0) return value_type{{}};\n"
+              "\n"
+              "      if constexpr (Mode == 0) {{  // NONE\n"
+              "        return sum_ab;\n"
+              "      }} else if constexpr (Mode == 1) {{  // MAGNITUDE\n"
+              "        const inner_type denom = scalar_sqrt(sum_aa * sum_bb);\n"
+              "        if (denom == inner_type{{0}}) return value_type{{}};\n"
+              "        if constexpr (is_cplx) {{\n"
+              "          return value_type{{sum_ab.real() / denom, sum_ab.imag() / denom}};\n"
+              "        }} else {{\n"
+              "          return sum_ab / denom;\n"
+              "        }}\n"
+              "      }} else {{\n"
+              "        const inner_type denom = scalar_sqrt(\n"
+              "          cuda::std::max(M2_a, inner_type{{0}}) *\n"
+              "          cuda::std::max(M2_b, inner_type{{0}}));\n"
+              "        if (denom == inner_type{{0}}) return value_type{{}};\n"
+              "        if constexpr (is_cplx) {{\n"
+              "          return value_type{{C.real() / denom, C.imag() / denom}};\n"
+              "        }} else {{\n"
+              "          return C / denom;\n"
+              "        }}\n"
+              "      }}\n"
+              "    }}\n"
+              "  }}\n"
+              "\n"
+              "  static __MATX_INLINE__ constexpr __MATX_DEVICE__ int32_t Rank() {{ return out_rank; }}\n"
+              "  constexpr __MATX_INLINE__ __MATX_DEVICE__ index_t Size(int dim) const {{ return out_dims_[dim]; }}\n"
+              "}};\n",
+              func_name, WindowRank, static_cast<int>(Mode))
+          );
+        }
+#endif
+
+        __MATX_INLINE__ std::string str() const { return "corrmap()"; }
+
+        __MATX_INLINE__ CorrMapOp(const OpA &A, const OpB &B,
+                                  const cuda::std::array<index_t, WindowRank> &window)
+          : a_(A), b_(B), window_(window)
+        {
+          MATX_STATIC_ASSERT_STR(OpA::Rank() >= WindowRank,
+            matxInvalidDim,
+            "corrmap() input rank must be >= window rank.");
+          MATX_STATIC_ASSERT_STR(OpA::Rank() == OpB::Rank(),
+            matxInvalidDim,
+            "corrmap() requires both inputs to have the same rank.");
+
+          for (int d = 0; d < WindowRank; d++) {
+            MATX_ASSERT_STR(window[d] >= 1, matxInvalidParameter,
+              "corrmap() window dimensions must be >= 1.");
+          }
+
+          for (int32_t i = 0; i < OpA::Rank(); i++) {
+            MATX_ASSERT_STR(a_.Size(i) == b_.Size(i), matxInvalidSize,
+              "corrmap() inputs must have matching shapes in every dimension.");
+            out_dims_[i] = a_.Size(i);
+          }
+        }
+
+        template <typename CapType, typename... Is>
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
+        {
+          // corrmap only supports one element per thread. The ELEMENTS_PER_THREAD
+          // capability below advertises this, and combine_capabilities() forces
+          // the framework to pick EPT==ONE for any expression containing this
+          // operator. The EPT > 1 branch here is an unreachable placeholder
+          // that satisfies template instantiation during capability probing.
+          if constexpr (CapType::ept != ElementsPerThread::ONE) {
+            return Vector<value_type, static_cast<size_t>(CapType::ept)>();
+          } else {
+            constexpr int rank = static_cast<int>(sizeof...(Is));
+            cuda::std::array<index_t, rank> out_idx{static_cast<index_t>(indices)...};
+
+            // Sizes of the input dims that the window slides over (the last
+            // WindowRank dims).
+            cuda::std::array<index_t, WindowRank> win_dim_size;
+            cuda::std::array<index_t, WindowRank> win_start;
+            for (int d = 0; d < WindowRank; d++) {
+              win_dim_size[d] = a_.Size(rank - WindowRank + d);
+              const index_t center = out_idx[rank - WindowRank + d];
+              // Floor-center convention: offsets span [-(w/2), w-1-(w/2)].
+              win_start[d] = center - (window_[d] / 2);
+            }
+
+            constexpr bool is_cplx = is_complex_v<value_type>;
+            // NONE: just sum_ab.
+            // MAGNITUDE: sum_ab + energies. No mean subtraction, so no
+            //   cancellation risk -- a simple accumulator is fine.
+            // ZNCC: Welford's online algorithm for the centered cross-
+            //   product and centered energies. Avoids the
+            //   single-pass centered-identity cancellation that would
+            //   otherwise turn near-equal sum_ab and n*ma*mb into noise.
+            constexpr bool need_energies = (Mode == CorrMapNormalize::MAGNITUDE);
+            constexpr bool use_welford   = (Mode == CorrMapNormalize::ZNCC);
+
+            // Simple-sum accumulators for NONE and MAGNITUDE.
+            [[maybe_unused]] value_type sum_ab{};
+            [[maybe_unused]] inner_type sum_aa{0};
+            [[maybe_unused]] inner_type sum_bb{0};
+
+            // Welford state for ZNCC: running means, centered cross-product
+            // C = sum (a-mu_a) conj(b-mu_b), and centered energies
+            // M2_a = sum |a-mu_a|^2, M2_b = sum |b-mu_b|^2.
+            [[maybe_unused]] value_type mean_a{}, mean_b{}, C{};
+            [[maybe_unused]] inner_type M2_a{0}, M2_b{0};
+
+            index_t n_valid = 0;
+            cuda::std::array<index_t, rank> idx = out_idx;
+
+            // Inline lambda: read one sample, update accumulators.
+            auto accumulate = [&](const cuda::std::array<index_t, rank> &read_idx) {
+              const value_type a_val = static_cast<value_type>(get_value<CapType>(a_, read_idx));
+              const value_type b_val = static_cast<value_type>(get_value<CapType>(b_, read_idx));
+              n_valid++;
+
+              if constexpr (use_welford) {
+                // Welford recurrence: deltas computed against the OLD running
+                // mean, then mean is updated, then M2 / C use the NEW mean.
+                // This keeps every accumulated quantity well-conditioned and
+                // dodges the catastrophic cancellation of the closed-form
+                // centered identity on highly correlated inputs.
+                const inner_type n = static_cast<inner_type>(n_valid);
+                if constexpr (is_cplx) {
+                  const inner_type da_r = a_val.real() - mean_a.real();
+                  const inner_type da_i = a_val.imag() - mean_a.imag();
+                  const inner_type db_r = b_val.real() - mean_b.real();
+                  const inner_type db_i = b_val.imag() - mean_b.imag();
+                  // Update means: mean += delta / n.
+                  mean_a = value_type{mean_a.real() + da_r / n,
+                                      mean_a.imag() + da_i / n};
+                  mean_b = value_type{mean_b.real() + db_r / n,
+                                      mean_b.imag() + db_i / n};
+                  // Centered values against the NEW means.
+                  const inner_type an_r = a_val.real() - mean_a.real();
+                  const inner_type an_i = a_val.imag() - mean_a.imag();
+                  const inner_type bn_r = b_val.real() - mean_b.real();
+                  const inner_type bn_i = b_val.imag() - mean_b.imag();
+                  // C += delta_a_old * conj(b - mean_b_new).
+                  C = value_type{C.real() + da_r * bn_r + da_i * bn_i,
+                                 C.imag() + da_i * bn_r - da_r * bn_i};
+                  // M2_a += Re(delta_a_old * conj(a - mean_a_new))
+                  //       = da_r * an_r + da_i * an_i  (the imaginary part
+                  //       cancels for the variance update).
+                  M2_a += da_r * an_r + da_i * an_i;
+                  M2_b += db_r * bn_r + db_i * bn_i;
+                } else {
+                  const inner_type da = a_val - mean_a;
+                  const inner_type db = b_val - mean_b;
+                  mean_a += da / n;
+                  mean_b += db / n;
+                  C    += da * (b_val - mean_b);
+                  M2_a += da * (a_val - mean_a);
+                  M2_b += db * (b_val - mean_b);
+                }
+              } else {
+                // NONE / MAGNITUDE: straight accumulators.
+                if constexpr (is_cplx) {
+                  const inner_type ar = a_val.real();
+                  const inner_type ai = a_val.imag();
+                  const inner_type br = b_val.real();
+                  const inner_type bi = b_val.imag();
+                  // a * conj(b)
+                  sum_ab += value_type{ar * br + ai * bi, ai * br - ar * bi};
+                  if constexpr (need_energies) {
+                    sum_aa += ar * ar + ai * ai;
+                    sum_bb += br * br + bi * bi;
+                  }
+                } else {
+                  sum_ab += a_val * b_val;
+                  if constexpr (need_energies) {
+                    sum_aa += a_val * a_val;
+                    sum_bb += b_val * b_val;
+                  }
+                }
+              }
+            };
+
+            if constexpr (WindowRank == 1) {
+              for (index_t dr = 0; dr < window_[0]; dr++) {
+                const index_t r = win_start[0] + dr;
+                if (r < 0 || r >= win_dim_size[0]) continue;
+                idx[rank - 1] = r;
+                accumulate(idx);
+              }
+            } else { // WindowRank == 2
+              for (index_t dr = 0; dr < window_[0]; dr++) {
+                const index_t r = win_start[0] + dr;
+                if (r < 0 || r >= win_dim_size[0]) continue;
+                idx[rank - 2] = r;
+                for (index_t dc = 0; dc < window_[1]; dc++) {
+                  const index_t c = win_start[1] + dc;
+                  if (c < 0 || c >= win_dim_size[1]) continue;
+                  idx[rank - 1] = c;
+                  accumulate(idx);
+                }
+              }
+            }
+
+            if (n_valid == 0) {
+              return value_type{};
+            }
+
+            if constexpr (Mode == CorrMapNormalize::NONE) {
+              return sum_ab;
+            }
+            else if constexpr (Mode == CorrMapNormalize::MAGNITUDE) {
+              const inner_type denom = corrmap_scalar_sqrt(sum_aa * sum_bb);
+              if (denom == inner_type{0}) {
+                return value_type{};
+              }
+              if constexpr (is_cplx) {
+                return value_type{sum_ab.real() / denom, sum_ab.imag() / denom};
+              } else {
+                return sum_ab / denom;
+              }
+            }
+            else { // Mode == CorrMapNormalize::ZNCC
+              // Welford state already holds the centered cross-product (C)
+              // and the centered energies (M2_a, M2_b). Both M2 terms are
+              // non-negative by construction; the cuda::std::max guard is
+              // defensive against accumulated rounding pushing them slightly
+              // below zero in lower precisions.
+              const inner_type denom = corrmap_scalar_sqrt(
+                cuda::std::max(M2_a, inner_type{0}) *
+                cuda::std::max(M2_b, inner_type{0}));
+              if (denom == inner_type{0}) {
+                return value_type{};
+              }
+              if constexpr (is_cplx) {
+                return value_type{C.real() / denom, C.imag() / denom};
+              } else {
+                return C / denom;
+              }
+            }
+          }
+        }
+
+        template <typename... Is>
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
+        {
+          return this->operator()<DefaultCapabilities>(indices...);
+        }
+
+        template <OperatorCapability Cap, typename InType>
+        __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
+          if constexpr (Cap == OperatorCapability::JIT_TYPE_QUERY) {
+#ifdef MATX_EN_JIT
+            const auto a_jit_name = detail::get_operator_capability<Cap>(a_, in);
+            const auto b_jit_name = detail::get_operator_capability<Cap>(b_, in);
+            return std::format("{}<{},{}>", get_jit_class_name(), a_jit_name, b_jit_name);
+#else
+            return "";
+#endif
+          }
+          else if constexpr (Cap == OperatorCapability::SUPPORTS_JIT) {
+#ifdef MATX_EN_JIT
+            return combine_capabilities<Cap>(true,
+              detail::get_operator_capability<Cap>(a_, in),
+              detail::get_operator_capability<Cap>(b_, in));
+#else
+            return false;
+#endif
+          }
+          else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
+#ifdef MATX_EN_JIT
+            const auto [key, value] = get_jit_op_str();
+            if (in.find(key) == in.end()) {
+              in[key] = value;
+            }
+            detail::get_operator_capability<Cap>(a_, in);
+            detail::get_operator_capability<Cap>(b_, in);
+            return true;
+#else
+            return false;
+#endif
+          }
+          else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
+            const auto my_cap = cuda::std::array<ElementsPerThread, 2>{
+              ElementsPerThread::ONE, ElementsPerThread::ONE};
+            return combine_capabilities<Cap>(
+              my_cap,
+              detail::get_operator_capability<Cap>(a_, in),
+              detail::get_operator_capability<Cap>(b_, in));
+          }
+          else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
+            // Each output element reads a neighborhood of input samples
+            // (the window). An in-place expression like
+            // (A = corrmap(A, B, ...)).run(...) would have a thread writing
+            // to A(r, c) race with neighbor threads still reading A(r+/-k,
+            // c+/-k), corrupting the output. Mark this as input/output
+            // non-pointwise so the alias detector flags such expressions.
+            auto in_copy = in;
+            in_copy.permutes_input_output = true;
+            return combine_capabilities<Cap>(
+              detail::get_operator_capability<Cap>(a_, in_copy),
+              detail::get_operator_capability<Cap>(b_, in_copy));
+          }
+          else {
+            auto self_has_cap = capability_attributes<Cap>::default_value;
+            return combine_capabilities<Cap>(
+              self_has_cap,
+              detail::get_operator_capability<Cap>(a_, in),
+              detail::get_operator_capability<Cap>(b_, in));
+          }
+        }
+
+        static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
+        {
+          return out_rank;
+        }
+
+        constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
+        {
+          return out_dims_[dim];
+        }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PreRun(ShapeType &&shape, Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<OpA>()) {
+            a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+          if constexpr (is_matx_op<OpB>()) {
+            b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
+
+        template <typename ShapeType, typename Executor>
+        __MATX_INLINE__ void PostRun(ShapeType &&shape, Executor &&ex) const noexcept
+        {
+          if constexpr (is_matx_op<OpA>()) {
+            a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+          if constexpr (is_matx_op<OpB>()) {
+            b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+        }
+    };
+  } // namespace detail
+
+  /**
+   * @brief Per-sample 1-D windowed correlation map.
+   *
+   * Slides a 1-D window of length \f$ w \f$ along the last input dimension;
+   * all other dimensions are treated as independent batches. Input and
+   * output have the same shape.
+   *
+   * For an output sample at index \f$ n \f$ along the windowed dimension,
+   * let \f$ W \f$ denote the set of in-bounds window offsets
+   * \f[
+   *   W = \bigl\{\, k \in \mathbb{Z} \;:\;
+   *               -\lfloor w/2 \rfloor \le k \le w - 1 - \lfloor w/2 \rfloor,
+   *               \ \text{and } n + k \text{ is in-bounds}\bigr\}.
+   * \f]
+   * This is the floor-center indexing convention. For odd \f$ w \f$ the
+   * window is exactly centered on \f$ n \f$; for even \f$ w \f$ it is
+   * asymmetric by half a sample. The window is cropped at the input
+   * boundary: out-of-bounds offsets are skipped and the normalization
+   * uses only the in-bounds samples (means and energies are computed
+   * over the cropped window, not over a zero-padded one).
+   *
+   * For the selected normalization mode the operator computes
+   *
+   * \f[
+   *   y_n = f_{\text{Mode}}\!\left(
+   *           \{a_k : k \in W\},\ \{b_k : k \in W\}\right),
+   *   \qquad a_k = A(\ldots, n + k),\ b_k = B(\ldots, n + k),
+   * \f]
+   *
+   * where the function \f$ f_{\text{Mode}} \f$ is given in
+   * \ref CorrMapNormalize.
+   *
+   * Output element type:
+   *   - complex if either input is complex
+   *   - real otherwise
+   *   - precision is the greater of the inputs (e.g. `float + double ->
+   *     double`, `complex<float> + complex<double> -> complex<double>`,
+   *     `complex<float> + double -> complex<double>`)
+   *
+   * @tparam Mode Normalization mode (compile-time). Defaults to
+   *              CorrMapNormalize::MAGNITUDE.
+   * @tparam OpA Type of input operator A
+   * @tparam OpB Type of input operator B
+   * @param A Input operator A
+   * @param B Input operator B (same shape as A)
+   * @param window Window length \f$ w \ge 1 \f$
+   * @return corrmap operator producing a tensor with the same shape as A
+   */
+  template <CorrMapNormalize Mode = CorrMapNormalize::MAGNITUDE,
+            typename OpA, typename OpB>
+  __MATX_INLINE__ auto corrmap(const OpA &A, const OpB &B,
+                               index_t window)
+  {
+    return detail::CorrMapOp<OpA, OpB, 1, Mode>(
+        A, B, cuda::std::array<index_t, 1>{window});
+  }
+
+  /**
+   * @brief Per-pixel 2-D windowed correlation map.
+   *
+   * Slides a 2-D window of shape \f$ w_r \times w_c \f$ over the last two
+   * input dimensions; all other dimensions are treated as independent
+   * batches. Input and output have the same shape.
+   *
+   * For an output pixel at row \f$ r \f$, column \f$ c \f$, let \f$ W \f$
+   * denote the set of in-bounds window offsets
+   * \f[
+   *   W = \bigl\{\, (i, j) \in \mathbb{Z}^2 \;:\;
+   *               -\lfloor w_r/2 \rfloor \le i \le w_r - 1 - \lfloor w_r/2 \rfloor,\
+   *               -\lfloor w_c/2 \rfloor \le j \le w_c - 1 - \lfloor w_c/2 \rfloor,\
+   *               \ \text{and } (r + i, c + j) \text{ is in-bounds}\bigr\}.
+   * \f]
+   * This is the floor-center indexing convention. For odd window sizes the
+   * window is exactly centered on \f$ (r, c) \f$; for even sizes it is
+   * asymmetric by half a pixel, which introduces a half-pixel registration
+   * offset relative to the output grid. The window is cropped at the input
+   * boundary: out-of-bounds offsets are skipped and the normalization uses
+   * only the in-bounds samples (means and energies are computed over the
+   * cropped window, not over a zero-padded one).
+   *
+   * For the selected normalization mode the operator computes
+   *
+   * \f[
+   *   y_{r,c} = f_{\text{Mode}}\!\left(
+   *               \{a_{i,j} : (i,j) \in W\},\
+   *               \{b_{i,j} : (i,j) \in W\}\right),
+   *   \quad a_{i,j} = A(\ldots, r + i,\ c + j),\
+   *         b_{i,j} = B(\ldots, r + i,\ c + j),
+   * \f]
+   *
+   * where the function \f$ f_{\text{Mode}} \f$ is given in
+   * \ref CorrMapNormalize. With complex inputs and the MAGNITUDE mode the
+   * result is the complex interferometric coherence: take `abs(...)` for
+   * the coherence magnitude or `angle(...)` for the interferogram phase.
+   *
+   * Output element type:
+   *   - complex if either input is complex
+   *   - real otherwise
+   *   - precision is the greater of the inputs (e.g. `float + double ->
+   *     double`, `complex<float> + complex<double> -> complex<double>`,
+   *     `complex<float> + double -> complex<double>`)
+   *
+   * @tparam Mode Normalization mode (compile-time). Defaults to
+   *              CorrMapNormalize::MAGNITUDE (interferometric coherence for
+   *              complex inputs).
+   * @tparam OpA Type of input operator A
+   * @tparam OpB Type of input operator B
+   * @param A Input operator A
+   * @param B Input operator B (same shape as A)
+   * @param window Window dimensions `{rows, cols}`, each \f$ \ge 1 \f$
+   * @return corrmap operator producing a tensor with the same shape as A
+   */
+  template <CorrMapNormalize Mode = CorrMapNormalize::MAGNITUDE,
+            typename OpA, typename OpB>
+  __MATX_INLINE__ auto corrmap(const OpA &A, const OpB &B,
+                               const cuda::std::array<index_t, 2> &window)
+  {
+    return detail::CorrMapOp<OpA, OpB, 2, Mode>(A, B, window);
+  }
+
+} // end namespace matx

--- a/include/matx/operators/operators.h
+++ b/include/matx/operators/operators.h
@@ -49,6 +49,7 @@
 #include "matx/operators/cgsolve.h"
 #include "matx/operators/comma.h"
 #include "matx/operators/corr.h"
+#include "matx/operators/corrmap.h"
 #include "matx/operators/cov.h"
 #include "matx/operators/cross.h"
 #include "matx/operators/cumsum.h"

--- a/test/00_operators/CMakeLists.txt
+++ b/test/00_operators/CMakeLists.txt
@@ -18,6 +18,7 @@ set(OPERATOR_TEST_FILES
   complex_type_compatibility_test.cu
   concat_test.cu
   cross_test.cu
+  corrmap_test.cu
   fftshift_test.cu
   filter_test.cu
   find_peaks.cu

--- a/test/00_operators/aliased_memory_test.cu
+++ b/test/00_operators/aliased_memory_test.cu
@@ -335,5 +335,28 @@ TYPED_TEST(OperatorTestsFloatAllExecs, MatmulAliasing)
   MATX_EXIT_HANDLER();
 }
 
+// Test that corrmap() with aliasing DOES throw. Each output element reads a
+// window of neighboring input samples, so writing to A while still reading
+// from A would corrupt the result.
+TYPED_TEST(OperatorTestsFloatAllExecs, CorrMapAliasing)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a = make_tensor<TestType>({10, 10});
+  auto b = make_tensor<TestType>({10, 10});
+
+  // a appears on the LHS and as an input to corrmap on the RHS.
+  EXPECT_THROW({
+    (a = corrmap(a, b, cuda::std::array<index_t, 2>{3, 3})).run(exec);
+    exec.sync();
+  }, matx::detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}
 
 #endif

--- a/test/00_operators/corrmap_test.cu
+++ b/test/00_operators/corrmap_test.cu
@@ -1,0 +1,649 @@
+#include "operator_test_types.hpp"
+#include "matx.h"
+#include "test_types.h"
+#include "utilities.h"
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+using namespace matx;
+using namespace matx::test;
+
+namespace {
+
+// CPU reference for 2-D corrmap on a single (H, W) image.
+//
+// Two-pass implementation in all modes: pass 1 collects the in-bounds
+// samples (and the means for ZNCC); pass 2 accumulates the products on the
+// (already-centered, for ZNCC) sample values. The MAGNITUDE and ZNCC cases
+// share the same final normalization step. This avoids the single-pass
+// centered identity's cancellation, so the operator's single-pass form is
+// being validated against an independent algorithm rather than against
+// itself.
+template <typename T>
+T corrmap_ref_2d(const T *A, const T *B,
+                 int H, int W,
+                 int row, int col,
+                 int win_r, int win_c,
+                 CorrMapNormalize mode)
+{
+  using inner_t = typename inner_op_type_t<T>::type;
+  constexpr bool is_cplx = is_complex_v<T>;
+
+  // Pass 1: gather in-bounds samples.
+  const int row_start = row - (win_r / 2);
+  const int col_start = col - (win_c / 2);
+  std::vector<T> a_samples;
+  std::vector<T> b_samples;
+  a_samples.reserve(static_cast<size_t>(win_r * win_c));
+  b_samples.reserve(static_cast<size_t>(win_r * win_c));
+  for (int dr = 0; dr < win_r; dr++) {
+    const int r = row_start + dr;
+    if (r < 0 || r >= H) continue;
+    for (int dc = 0; dc < win_c; dc++) {
+      const int c = col_start + dc;
+      if (c < 0 || c >= W) continue;
+      a_samples.push_back(A[r * W + c]);
+      b_samples.push_back(B[r * W + c]);
+    }
+  }
+
+  const int n_valid = static_cast<int>(a_samples.size());
+  if (n_valid == 0) return T{};
+
+  // For ZNCC, also compute the window-local means in pass 1.
+  T ma{}, mb{};
+  if (mode == CorrMapNormalize::ZNCC) {
+    for (int i = 0; i < n_valid; i++) {
+      ma += a_samples[i];
+      mb += b_samples[i];
+    }
+    const inner_t n = static_cast<inner_t>(n_valid);
+    if constexpr (is_cplx) {
+      ma = T{ma.real() / n, ma.imag() / n};
+      mb = T{mb.real() / n, mb.imag() / n};
+    } else {
+      ma /= n;
+      mb /= n;
+    }
+  }
+
+  // Pass 2: accumulate on (possibly centered) values.
+  T sum_ab{};
+  inner_t sum_aa{0};
+  inner_t sum_bb{0};
+  for (int i = 0; i < n_valid; i++) {
+    T a = a_samples[i];
+    T b = b_samples[i];
+    if (mode == CorrMapNormalize::ZNCC) {
+      if constexpr (is_cplx) {
+        a = T{a.real() - ma.real(), a.imag() - ma.imag()};
+        b = T{b.real() - mb.real(), b.imag() - mb.imag()};
+      } else {
+        a -= ma;
+        b -= mb;
+      }
+    }
+    if constexpr (is_cplx) {
+      const inner_t ar = a.real();
+      const inner_t ai = a.imag();
+      const inner_t br = b.real();
+      const inner_t bi = b.imag();
+      // a * conj(b)
+      sum_ab += T{ar * br + ai * bi, ai * br - ar * bi};
+      sum_aa += ar * ar + ai * ai;
+      sum_bb += br * br + bi * bi;
+    } else {
+      sum_ab += a * b;
+      sum_aa += a * a;
+      sum_bb += b * b;
+    }
+  }
+
+  if (mode == CorrMapNormalize::NONE) {
+    return sum_ab;
+  }
+
+  // MAGNITUDE and ZNCC share the final normalize step (ZNCC's centering
+  // happened in pass 2; from here their math is identical).
+  const inner_t denom = std::sqrt(sum_aa * sum_bb);
+  if (denom == inner_t{0}) return T{};
+  if constexpr (is_cplx) {
+    return T{sum_ab.real() / denom, sum_ab.imag() / denom};
+  } else {
+    return sum_ab / denom;
+  }
+}
+
+// CPU reference for 1-D corrmap on a single length-N signal.
+template <typename T>
+T corrmap_ref_1d(const T *A, const T *B,
+                 int N,
+                 int idx,
+                 int win,
+                 CorrMapNormalize mode)
+{
+  // Treat as 2-D with H=1, W=N, win_r=1.
+  return corrmap_ref_2d<T>(A, B, /*H=*/1, /*W=*/N, /*row=*/0, /*col=*/idx,
+                            /*win_r=*/1, /*win_c=*/win, mode);
+}
+
+// Fill a tensor of any rank with deterministic uniform random samples in
+// [-1, 1) using std::mt19937 on the host. We use mt19937 rather than MatX's
+// random() operator because the current MatX host executor generates one
+// element at a time via curandGenerateUniform host calls, which makes
+// the tests take longer to run.
+//
+// The tensor is treated as a contiguous row-major linear buffer (the
+// default layout produced by make_tensor) — we populate flat once and
+// std::copy it into tensor.Data().
+template <typename T, typename Tensor>
+void fill_random(Tensor &tensor, std::vector<T> &flat, uint64_t seed)
+{
+  using inner_t = typename inner_op_type_t<T>::type;
+  std::mt19937 rng(static_cast<unsigned>(seed));
+  std::uniform_real_distribution<double> dist(-1.0, 1.0);
+
+  const index_t total = tensor.TotalSize();
+  flat.resize(static_cast<size_t>(total));
+
+  for (index_t i = 0; i < total; i++) {
+    if constexpr (is_complex_v<T>) {
+      flat[static_cast<size_t>(i)] =
+        T{static_cast<inner_t>(dist(rng)), static_cast<inner_t>(dist(rng))};
+    } else {
+      flat[static_cast<size_t>(i)] = static_cast<T>(dist(rng));
+    }
+  }
+
+  std::copy(flat.begin(), flat.end(), tensor.Data());
+}
+
+// Magnitude of a scalar difference. We compute through double to avoid
+// cuda::std::abs ambiguity for half complex (matxFp16Complex / matxBf16Complex
+// where multiple abs overloads are visible).
+template <typename T>
+double abs_diff(T x, T y)
+{
+  const T d = x - y;
+  if constexpr (is_complex_v<T>) {
+    const double r = static_cast<double>(d.real());
+    const double i = static_cast<double>(d.imag());
+    return std::sqrt(r * r + i * i);
+  } else {
+    return std::abs(static_cast<double>(d));
+  }
+}
+
+// Helper: invoke a generic lambda once per normalization mode (compile-time).
+template <typename F>
+void for_each_mode(F &&fn) {
+  fn.template operator()<CorrMapNormalize::NONE>();
+  fn.template operator()<CorrMapNormalize::MAGNITUDE>();
+  fn.template operator()<CorrMapNormalize::ZNCC>();
+}
+
+// Per-precision tolerances. The operator uses Welford's online algorithm
+// for ZNCC (stable single-pass) and simple accumulators for NONE/MAGNITUDE
+// (no cancellation risk). The constants returned by the helpers below are
+// empirical upper bounds: each one is set just above the worst observed
+// error across all tests at that precision. As a hard floor, every
+// constant stays above 2*ulp(1.0) so we never assert below representable
+// resolution:
+//
+//   precision  ulp(1.0)     2*ulp(1.0)   (lower bound only)
+//   bf16       2^-7  ~ 7.8e-3  ~ 1.56e-2
+//   fp16       2^-10 ~ 9.8e-4  ~ 1.95e-3
+//   float      2^-23 ~ 1.2e-7  ~ 2.38e-7
+//   double     2^-52 ~ 2.2e-16 ~ 4.44e-16
+//
+// For NONE mode the expected value can grow with window size (sum of N
+// products) so ulp(expected) >= ulp(N). The matches-reference tolerances
+// include enough headroom to cover this, which is why the bf16/fp16 NONE
+// constants sit well above the 2*ulp(1.0) floor.
+
+// Tolerance for matches-reference style tests (NONE/MAGNITUDE/ZNCC against
+// an independent two-pass reference).
+template <typename InnerT>
+constexpr double tolerance_for()
+{
+  if constexpr (std::is_same_v<InnerT, matxBf16>) {
+    return 3.0e-2;
+  } else if constexpr (std::is_same_v<InnerT, matxFp16>) {
+    return 5.0e-3;
+  } else if constexpr (std::is_same_v<InnerT, float>) {
+    return 5.0e-5;
+  } else {
+    return 1.0e-12; // double
+  }
+}
+
+// Tolerance for MAGNITUDE-only tests (self-coherence, batched 1-D
+// MAGNITUDE). Closer to the floor because there's no centering step.
+template <typename InnerT>
+constexpr double tolerance_magnitude_for()
+{
+  if constexpr (std::is_same_v<InnerT, matxBf16>) {
+    return 2.0e-2;
+  } else if constexpr (std::is_same_v<InnerT, matxFp16>) {
+    return 2.0e-3;
+  } else if constexpr (std::is_same_v<InnerT, float>) {
+    return 1.0e-6;
+  } else {
+    return 1.0e-14; // double
+  }
+}
+
+// Tolerance for the ZNCC affine-invariance test (B = alpha*A + beta).
+template <typename InnerT>
+constexpr double tolerance_zncc_affine_for()
+{
+  if constexpr (std::is_same_v<InnerT, matxBf16>) {
+    return 5.0e-2;
+  } else if constexpr (std::is_same_v<InnerT, matxFp16>) {
+    return 5.0e-3;
+  } else if constexpr (std::is_same_v<InnerT, float>) {
+    return 5.0e-6;
+  } else {
+    return 1.0e-12; // double
+  }
+}
+
+} // namespace
+
+// 2-D corrmap matches CPU reference across odd/even windows and all modes,
+// on float, double, complex<float>, complex<double>.
+TYPED_TEST(OperatorTestsFloatAllExecs, CorrMap2DMatchesReference)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
+
+  constexpr int H = 12;
+  constexpr int W = 14;
+  // {1,1} is a degenerate case: NONE is pointwise A*conj(B); MAGNITUDE
+  // produces unit-magnitude (phase-only) values; ZNCC is identically 0
+  // (centered-value sums vanish for a single sample).
+  const std::vector<std::pair<int,int>> windows = {{1,1}, {3,3}, {5,5}, {4,6}, {7,3}};
+
+  auto A = make_tensor<TestType>({H, W});
+  auto B = make_tensor<TestType>({H, W});
+  auto Y = make_tensor<TestType>({H, W});
+
+  std::vector<TestType> flat_a, flat_b;
+  fill_random(A, flat_a, /*seed=*/0x5eed);
+  fill_random(B, flat_b, /*seed=*/0x5eed + 1);
+
+  const double tol = tolerance_for<typename inner_op_type_t<TestType>::type>();
+
+  for (auto [wr, wc] : windows) {
+    for_each_mode([&]<CorrMapNormalize Mode>() {
+      (Y = corrmap<Mode>(A, B, cuda::std::array<index_t, 2>{wr, wc})).run(exec);
+      exec.sync();
+
+      for (int r = 0; r < H; r++) {
+        for (int c = 0; c < W; c++) {
+          TestType expected = corrmap_ref_2d<TestType>(
+              flat_a.data(), flat_b.data(), H, W, r, c, wr, wc, Mode);
+          ASSERT_LT(abs_diff(Y(r, c), expected), tol)
+              << "mismatch at (" << r << "," << c << ") win=" << wr << "x" << wc
+              << " mode=" << static_cast<int>(Mode);
+        }
+      }
+    });
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// 1-D corrmap matches CPU reference. Exercises the scalar-window overload.
+TYPED_TEST(OperatorTestsFloatAllExecs, CorrMap1DMatchesReference)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  using inner_t = typename inner_op_type_t<TestType>::type;
+  ExecType exec{};
+
+  constexpr int N = 32;
+  // w=1 is a degenerate case: NONE is pointwise A*conj(B); MAGNITUDE
+  // produces unit-magnitude (phase-only) values; ZNCC is identically 0
+  // (centered-value sums vanish for a single sample).
+  const std::vector<int> windows = {1, 3, 5, 4, 8};
+
+  auto A = make_tensor<TestType>({N});
+  auto B = make_tensor<TestType>({N});
+  auto Y = make_tensor<TestType>({N});
+
+  std::vector<TestType> flat_a, flat_b;
+  fill_random(A, flat_a, /*seed=*/0xFEEDFACE);
+  fill_random(B, flat_b, /*seed=*/0xFEEDFACE + 1);
+
+  const double tol = tolerance_for<inner_t>();
+  for (auto w : windows) {
+    for_each_mode([&]<CorrMapNormalize Mode>() {
+      (Y = corrmap<Mode>(A, B, static_cast<index_t>(w))).run(exec);
+      exec.sync();
+      for (int i = 0; i < N; i++) {
+        TestType expected = corrmap_ref_1d<TestType>(
+            flat_a.data(), flat_b.data(), N, i, w, Mode);
+        ASSERT_LT(abs_diff(Y(i), expected), tol)
+            << "1d mismatch at " << i << " w=" << w
+            << " mode=" << static_cast<int>(Mode);
+      }
+    });
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// Self-coherence: A == B with MAGNITUDE mode → |result| == 1 everywhere the
+// window has any in-bounds samples. Complex self-coherence has zero phase.
+TYPED_TEST(OperatorTestsFloatAllExecs, CorrMapSelfCoherenceIsOne)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  using inner_t = typename inner_op_type_t<TestType>::type;
+  ExecType exec{};
+
+  constexpr int H = 8;
+  constexpr int W = 8;
+  constexpr int win = 3;
+
+  auto A    = make_tensor<TestType>({H, W});
+  auto Y    = make_tensor<TestType>({H, W});
+  auto Ymag = make_tensor<inner_t>({H, W});
+
+  std::vector<TestType> flat_a;
+  fill_random(A, flat_a, /*seed=*/0xC0FFEE);
+
+  // example-begin corrmap-2d-magnitude
+  // 2-D windowed coherence between two complex images (here A==A for the
+  // self-coherence sanity check). |Y(r,c)| is the SAR/InSAR coherence map.
+  (Y = corrmap<CorrMapNormalize::MAGNITUDE>(
+        A, A, cuda::std::array<index_t, 2>{win, win})).run(exec);
+  // example-end corrmap-2d-magnitude
+  // Use MatX's abs() to extract the coherence magnitude as a real tensor.
+  (Ymag = abs(Y)).run(exec);
+  exec.sync();
+
+  const double tol = tolerance_magnitude_for<inner_t>();
+  for (int r = 0; r < H; r++) {
+    for (int c = 0; c < W; c++) {
+      ASSERT_NEAR(static_cast<double>(Ymag(r, c)), 1.0, tol)
+          << "self-coherence != 1 at (" << r << "," << c << ")";
+      if constexpr (is_complex_v<TestType>) {
+        ASSERT_NEAR(static_cast<double>(Y(r, c).imag()), 0.0, tol)
+            << "self-coherence phase != 0 at (" << r << "," << c << ")";
+      }
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// ZNCC is invariant to positive affine transforms of either input.
+TYPED_TEST(OperatorTestsFloatAllExecs, CorrMapZnccAffineInvariant)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  using inner_t  = typename inner_op_type_t<TestType>::type;
+  ExecType exec{};
+
+  constexpr int H = 10;
+  constexpr int W = 10;
+  constexpr int win = 5;
+  // Real-valued alpha > 0 keeps the expected ZNCC at exactly 1 (+0i for
+  // complex inputs).
+  constexpr TestType alpha = static_cast<TestType>(3);
+  constexpr TestType beta  = static_cast<TestType>(7);
+  const TestType expected  = static_cast<TestType>(1);
+
+  auto A = make_tensor<TestType>({H, W});
+  auto B = make_tensor<TestType>({H, W});
+  auto Y = make_tensor<TestType>({H, W});
+
+  std::vector<TestType> flat_a;
+  fill_random(A, flat_a, /*seed=*/0x1234);
+  // Compute B = alpha*A + beta elementwise on host. We avoid the tensor
+  // expression form because we currently hit a template deduction issue
+  // with matxHalfComplex's unconstrained scalar operator* templates.
+  for (int r = 0; r < H; r++) {
+    for (int c = 0; c < W; c++) {
+      B(r, c) = A(r, c) * alpha + beta;
+    }
+  }
+
+  // example-begin corrmap-2d-zncc
+  // Per-pixel ZNCC (mean-subtracted normalized cross-correlation): classic
+  // NCC for image processing, pattern matching, etc. Real result in [-1, 1].
+  (Y = corrmap<CorrMapNormalize::ZNCC>(
+        A, B, cuda::std::array<index_t, 2>{win, win})).run(exec);
+  // example-end corrmap-2d-zncc
+  exec.sync();
+
+  const double tol = tolerance_zncc_affine_for<inner_t>();
+  // Interior pixels see the full window — ZNCC must be 1 within tol.
+  const int border = win / 2;
+  for (int r = border; r < H - border; r++) {
+    for (int c = border; c < W - border; c++) {
+      ASSERT_LT(abs_diff(Y(r, c), expected), tol)
+          << "zncc != 1 at (" << r << "," << c << ")";
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// Batched rank-3 inputs with 2-D window: leading dim is batched independently.
+TYPED_TEST(OperatorTestsFloatAllExecs, CorrMapBatched2D)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  using inner_t  = typename inner_op_type_t<TestType>::type;
+  ExecType exec{};
+
+  constexpr int B_ = 3;
+  constexpr int H = 7;
+  constexpr int W = 9;
+  constexpr int win = 3;
+
+  auto A = make_tensor<TestType>({B_, H, W});
+  auto B = make_tensor<TestType>({B_, H, W});
+  auto Y = make_tensor<TestType>({B_, H, W});
+
+  std::vector<TestType> flat_a, flat_b;
+  fill_random(A, flat_a, /*seed=*/0xABCD);
+  fill_random(B, flat_b, /*seed=*/0xABCD + 1);
+
+  (Y = corrmap<CorrMapNormalize::ZNCC>(
+        A, B, cuda::std::array<index_t, 2>{win, win})).run(exec);
+  exec.sync();
+
+  const double tol = tolerance_for<inner_t>();
+  for (int b = 0; b < B_; b++) {
+    for (int r = 0; r < H; r++) {
+      for (int c = 0; c < W; c++) {
+        const size_t batch_offset = static_cast<size_t>(b) * H * W;
+        TestType expected = corrmap_ref_2d<TestType>(
+            flat_a.data() + batch_offset, flat_b.data() + batch_offset,
+            H, W, r, c, win, win, CorrMapNormalize::ZNCC);
+        ASSERT_LT(abs_diff(Y(b, r, c), expected), tol)
+            << "batched mismatch at b=" << b << " (" << r << "," << c << ")";
+      }
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// Executor-only fixture: TypeParam is just the executor type. The test
+// below hard-codes its own input type pairs, so there is no data-type
+// axis to parameterize over.
+template <typename ExecType>
+class CorrMapExecutorOnly : public ::testing::Test {};
+
+using CorrMapExecutorTypes = TupleToTypes<ExecutorTypesAll>::type;
+TYPED_TEST_SUITE(CorrMapExecutorOnly, CorrMapExecutorTypes);
+
+// Mixed input types: output type and value follow common_type semantics.
+//   float    + double           -> double
+//   complex<float> + complex<double> -> complex<double>
+//   float    + complex<double>  -> complex<double>
+//   complex<float> + double     -> complex<double>
+TYPED_TEST(CorrMapExecutorOnly, MixedTypes)
+{
+  MATX_ENTER_HANDLER();
+  using ExecType = TypeParam;
+  ExecType exec{};
+
+  constexpr int N = 8;
+
+  // Case 1: float + double -> double
+  {
+    auto A = make_tensor<float>({N});
+    auto B = make_tensor<double>({N});
+    for (int i = 0; i < N; i++) {
+      A(i) = static_cast<float>(0.5 * i);
+      B(i) = static_cast<double>(0.25 * i + 0.1);
+    }
+    auto expr = corrmap<CorrMapNormalize::ZNCC>(A, B, static_cast<index_t>(3));
+    using ExprT = decltype(expr);
+    using OutT = typename ExprT::value_type;
+    static_assert(cuda::std::is_same_v<OutT, double>,
+                  "float + double should yield double");
+
+    auto Y = make_tensor<OutT>({N});
+    (Y = expr).run(exec);
+    exec.sync();
+    // Sanity: result is finite and in [-1, 1] for ZNCC.
+    for (int i = 0; i < N; i++) {
+      ASSERT_GE(Y(i), -1.0 - 1e-10);
+      ASSERT_LE(Y(i),  1.0 + 1e-10);
+    }
+  }
+
+  // Case 2: complex<float> + complex<double> -> complex<double>
+  {
+    auto A = make_tensor<cuda::std::complex<float>>({N});
+    auto B = make_tensor<cuda::std::complex<double>>({N});
+    for (int i = 0; i < N; i++) {
+      A(i) = {static_cast<float>(0.5 * i), static_cast<float>(0.3)};
+      B(i) = {0.25 * i + 0.1, -0.2};
+    }
+    auto expr = corrmap<CorrMapNormalize::MAGNITUDE>(A, B, static_cast<index_t>(3));
+    using ExprT = decltype(expr);
+    using OutT = typename ExprT::value_type;
+    static_assert(cuda::std::is_same_v<OutT, cuda::std::complex<double>>,
+                  "complex<float> + complex<double> should yield complex<double>");
+
+    auto Y = make_tensor<OutT>({N});
+    (Y = expr).run(exec);
+    exec.sync();
+    for (int i = 0; i < N; i++) {
+      const double mag = std::sqrt(Y(i).real() * Y(i).real() +
+                                   Y(i).imag() * Y(i).imag());
+      ASSERT_LE(mag, 1.0 + 1e-12);
+    }
+  }
+
+  // Case 3: float + complex<double> -> complex<double>
+  {
+    auto A = make_tensor<float>({N});
+    auto B = make_tensor<cuda::std::complex<double>>({N});
+    for (int i = 0; i < N; i++) {
+      A(i) = static_cast<float>(0.5 * i);
+      B(i) = {0.25 * i + 0.1, -0.2};
+    }
+    auto expr = corrmap<CorrMapNormalize::MAGNITUDE>(A, B, static_cast<index_t>(3));
+    using ExprT = decltype(expr);
+    using OutT = typename ExprT::value_type;
+    static_assert(cuda::std::is_same_v<OutT, cuda::std::complex<double>>,
+                  "float + complex<double> should yield complex<double>");
+
+    auto Y = make_tensor<OutT>({N});
+    (Y = expr).run(exec);
+    exec.sync();
+    for (int i = 0; i < N; i++) {
+      const double mag = std::sqrt(Y(i).real() * Y(i).real() +
+                                   Y(i).imag() * Y(i).imag());
+      ASSERT_LE(mag, 1.0 + 1e-12);
+    }
+  }
+
+  // Case 4: complex<float> + double -> complex<double>
+  // (the complex-ness and the precision are decided independently)
+  {
+    auto A = make_tensor<cuda::std::complex<float>>({N});
+    auto B = make_tensor<double>({N});
+    for (int i = 0; i < N; i++) {
+      A(i) = {static_cast<float>(0.5 * i), static_cast<float>(0.3)};
+      B(i) = 0.25 * i + 0.1;
+    }
+    auto expr = corrmap<CorrMapNormalize::MAGNITUDE>(A, B, static_cast<index_t>(3));
+    using ExprT = decltype(expr);
+    using OutT = typename ExprT::value_type;
+    static_assert(cuda::std::is_same_v<OutT, cuda::std::complex<double>>,
+                  "complex<float> + double should yield complex<double>");
+
+    auto Y = make_tensor<OutT>({N});
+    (Y = expr).run(exec);
+    exec.sync();
+    for (int i = 0; i < N; i++) {
+      const double mag = std::sqrt(Y(i).real() * Y(i).real() +
+                                   Y(i).imag() * Y(i).imag());
+      ASSERT_LE(mag, 1.0 + 1e-12);
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// Batched rank-2 inputs with 1-D window: each row is an independent signal.
+TYPED_TEST(OperatorTestsFloatAllExecs, CorrMapBatched1D)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  using inner_t  = typename inner_op_type_t<TestType>::type;
+  ExecType exec{};
+
+  constexpr int B_ = 4;
+  constexpr int N = 24;
+  constexpr int win = 5;
+
+  auto A = make_tensor<TestType>({B_, N});
+  auto B = make_tensor<TestType>({B_, N});
+  auto Y = make_tensor<TestType>({B_, N});
+
+  std::vector<TestType> flat_a, flat_b;
+  fill_random(A, flat_a, /*seed=*/0x9999);
+  fill_random(B, flat_b, /*seed=*/0x9999 + 1);
+
+  // example-begin corrmap-1d-magnitude
+  // 1-D sliding-window correlation on a batch of length-N signals. The
+  // scalar window argument selects the 1-D overload; the leading dim is
+  // batched independently.
+  (Y = corrmap<CorrMapNormalize::MAGNITUDE>(A, B, win)).run(exec);
+  // example-end corrmap-1d-magnitude
+  exec.sync();
+
+  const double tol = tolerance_magnitude_for<inner_t>();
+  for (int b = 0; b < B_; b++) {
+    for (int i = 0; i < N; i++) {
+      const size_t batch_offset = static_cast<size_t>(b) * N;
+      TestType expected = corrmap_ref_1d<TestType>(
+          flat_a.data() + batch_offset, flat_b.data() + batch_offset,
+          N, i, win, CorrMapNormalize::MAGNITUDE);
+      ASSERT_LT(abs_diff(Y(b, i), expected), tol)
+          << "batched 1d mismatch at b=" << b << " i=" << i;
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}


### PR DESCRIPTION
Add the corrmap() operator, which computes 1D or 2D correlation maps. corrmap produces a per-sample or per-pixel measure of correlation between two signals or images (or, generically, tensors) over a small window local to each output sample. The output is the same size as the input. The 1D and 2D corrmap operators are differentiated by the rank of the window lengths provided to the operator. 2D correlation maps are common in SAR. For that use case, use the MAGNITUDE normalization type and take the abs() of the output to get the real-valued correlation values in the range [0, 1].

See the MatX documentation for full details of the corrmap() operator and normalization modes.