### PR TITLE
Add sar_bp PixelZIsZero and PixelZIsFixed properties

### DIFF
--- a/docs_input/api/signalimage/radar/sar_bp.rst
+++ b/docs_input/api/signalimage/radar/sar_bp.rst
@@ -11,7 +11,10 @@ namespace as its API is subject to change.
 .. doxygenfunction:: sar_bp(const ImageType &initial_image, const RangeProfilesType &range_profiles, const PlatPosType &platform_positions, const VoxLocType &voxel_locations, const RangeToMcpType &range_to_mcp, const SarBpParams &params)
 .. doxygenenum:: matx::SarBpComputeType
 .. doxygenenum:: matx::SarBpFeature
+.. doxygenenum:: matx::SarBpPixelZMode
 .. doxygenstruct:: matx::PropSarBpTaylorFastAddThirdOrder
+.. doxygenstruct:: matx::PropSarBpPixelZIsZero
+.. doxygenstruct:: matx::PropSarBpPixelZIsFixed
 .. doxygenstruct:: matx::SarBpParams
    :members:
 
@@ -366,6 +369,35 @@ a thread block, the third-order term becomes more important. The third-order
 property uses a separate kernel instantiation, which avoids a run-time order
 dispatch inside the backprojection kernel.
 
+Pixel Height (Z) Assumptions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SAR images are frequently formed on a flat focal plane, so every output pixel
+shares the same height (z) coordinate -- very often ``z = 0`` (a ground plane at
+the reference height). When that holds, the per-pulse, per-pixel range
+computation carries a redundant pixel-z term that can be elided. MatX exposes
+this as two opt-in, compile-time properties:
+
+- ``PropSarBpPixelZIsZero`` asserts that every pixel has ``z = 0``. The kernel
+  drops the pixel-z term from the per-pulse range computation.
+- ``PropSarBpPixelZIsFixed`` asserts that every pixel shares one (arbitrary,
+  possibly non-zero) z value. On the shared-cache compute paths the uniform
+  per-pulse z contribution is hoisted out of the per-pixel inner loop.
+
+Both are *compile-time assumptions that are not validated at run time*; set one
+only when it actually holds for the supplied ``voxel_locations``. With neither
+property set (the default), each pixel may have a distinct z coordinate, which is
+the correct choice for terrain- or DEM-based focusing. If both are set,
+``PropSarBpPixelZIsZero`` (the stronger assumption) takes precedence. Callers who
+set neither are unaffected: the default kernel is unchanged, and only the
+variants you opt into are additionally instantiated.
+
+Whether ``z`` is literally ``0``/constant depends on the coordinate frame of
+``voxel_locations``. A flat focal plane expressed in a scene-local East-North-Up
+frame (height along z) satisfies these assumptions, whereas a grid expressed in
+ECEF generally does not, since even a flat plane then has all three coordinates
+varying per pixel.
+
 Examples
 ~~~~~~~~
 
@@ -387,3 +419,19 @@ third-order term to a ``TaylorFast`` launch:
 
 The property only affects ``SarBpComputeType::TaylorFast``. Other compute types
 continue to use their ordinary kernel instantiations.
+
+When the image is formed on the ``z = 0`` plane, the ``PropSarBpPixelZIsZero``
+property lets the kernel skip the pixel-z term in the per-pulse range
+computation. Like ``PropSarBpTaylorFastAddThirdOrder``, it is a compile-time
+property applied to the operator, independent of the compute type selected
+through ``SarBpParams``:
+
+.. literalinclude:: ../../../../test/00_transform/SarBp.cu
+   :language: cpp
+   :start-after: example-begin sar-bp-3
+   :end-before: example-end sar-bp-3
+   :dedent:
+
+``PropSarBpPixelZIsFixed`` is the analogous property for a constant, non-zero
+focal-plane height. These assumptions are not validated at run time, so set them
+only when the supplied voxel z coordinates actually satisfy them.

--- a/examples/sarbp/sarbp.cu
+++ b/examples/sarbp/sarbp.cu
@@ -227,6 +227,7 @@ struct BpRunCtx {
   bool is_int16_mode;
   bool apply_window;
   bool taylor_fast_add_third_order;
+  SarBpPixelZMode pixel_z_mode;  // compile-time pixel-z assumption to apply
   int sgn;
   bool do_warmup;
   std::string output_file;
@@ -319,10 +320,25 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
         auto cur_voxel_locations = matx::slice(voxel_locations, {y0, x0}, {y1, x1});
         auto bp = matx::experimental::sar_bp(
             cur_image, cur_profiles, cur_positions, cur_voxel_locations, cur_rtm, ctx.params);
+        // Cross product of the optional TaylorFast third-order term and the
+        // compile-time pixel-z assumption (variable / zero / fixed).
+        auto run_with_z = [&](auto bp_props) {
+          switch (ctx.pixel_z_mode) {
+            case SarBpPixelZMode::Zero:
+              (cur_image = bp_props.template props<matx::PropSarBpPixelZIsZero>()).run(ctx.exec);
+              break;
+            case SarBpPixelZMode::Fixed:
+              (cur_image = bp_props.template props<matx::PropSarBpPixelZIsFixed>()).run(ctx.exec);
+              break;
+            case SarBpPixelZMode::Variable:
+              (cur_image = bp_props).run(ctx.exec);
+              break;
+          }
+        };
         if (ctx.taylor_fast_add_third_order) {
-          (cur_image = bp.template props<matx::PropSarBpTaylorFastAddThirdOrder>()).run(ctx.exec);
+          run_with_z(bp.template props<matx::PropSarBpTaylorFastAddThirdOrder>());
         } else {
-          (cur_image = bp).run(ctx.exec);
+          run_with_z(bp);
         }
       }
     }
@@ -684,6 +700,7 @@ int main(int argc, char **argv) {
         << "                          Add the third-order term for --precision taylor_fast\n"
         << "  --warmup               Warmup GPU kernels and FFT plans before timed run\n"
         << "  --precision <type>     Compute precision: double, float, fltflt, mixed, taylor_fast (default: mixed)\n"
+        << "  --pixel-z <mode>       Compile-time pixel-z assumption: variable, zero, fixed (default: variable)\n"
         << "  -h, --help             Print this help message and exit\n";
   };
 
@@ -701,6 +718,8 @@ int main(int argc, char **argv) {
   bool do_warmup = false;
   bool taylor_fast_add_third_order = false;
   std::string precision_type = "mixed";
+  std::string pixel_z_arg = "variable";
+  SarBpPixelZMode pixel_z_mode = SarBpPixelZMode::Variable;
 
   auto needs_value = [&](int i) -> bool {
     if (i + 1 >= argc) {
@@ -742,6 +761,9 @@ int main(int argc, char **argv) {
     } else if (std::strcmp(argv[i], "--precision") == 0) {
       if (!needs_value(i)) return 1;
       precision_type = argv[++i];
+    } else if (std::strcmp(argv[i], "--pixel-z") == 0) {
+      if (!needs_value(i)) return 1;
+      pixel_z_arg = argv[++i];
     } else if (argv[i][0] == '-') {
       std::cerr << "ERROR: unknown option '" << argv[i] << "'" << std::endl;
       print_usage();
@@ -778,6 +800,19 @@ int main(int argc, char **argv) {
 
   if (taylor_fast_add_third_order && precision_type != "taylor_fast") {
     std::cerr << "ERROR: --taylor-fast-third-order requires --precision taylor_fast" << std::endl;
+    print_usage();
+    return 1;
+  }
+
+  if (pixel_z_arg == "variable") {
+    pixel_z_mode = SarBpPixelZMode::Variable;
+  } else if (pixel_z_arg == "zero") {
+    pixel_z_mode = SarBpPixelZMode::Zero;
+  } else if (pixel_z_arg == "fixed") {
+    pixel_z_mode = SarBpPixelZMode::Fixed;
+  } else {
+    std::cerr << "ERROR: invalid --pixel-z '" << pixel_z_arg
+              << "' (use variable, zero, or fixed)" << std::endl;
     print_usage();
     return 1;
   }
@@ -1110,6 +1145,7 @@ int main(int argc, char **argv) {
       .is_int16_mode         = is_int16_mode,
       .apply_window          = apply_window,
       .taylor_fast_add_third_order = taylor_fast_add_third_order,
+      .pixel_z_mode          = pixel_z_mode,
       .sgn                   = sgn,
       .do_warmup             = do_warmup,
       .output_file           = output_file,

--- a/include/matx/kernels/sar_bp.cuh
+++ b/include/matx/kernels/sar_bp.cuh
@@ -767,6 +767,15 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
                         float pz2_lo = dz2hi.lo;
                         pz2_lo = detail::fmaf_rn(detail::fadd_rn(dz.hi, dz.hi), dz.lo, pz2_lo);
                         pz2_lo = detail::fmaf_rn(dz.lo, dz.lo, pz2_lo);
+                        // Renormalize dz^2 into a canonical fltflt. fast_two_sum's
+                        // |a| >= |b| precondition (a = dz.hi^2, b = the
+                        // O(ulp(dz.hi^2)) remainder) holds whenever |dz.hi| is not
+                        // tiny. It can fail only if the platform sits within
+                        // ~ulp(antenna_z) of the pixel-z plane (sub-mm at km
+                        // altitudes, not physical for SAR), where cancellation makes
+                        // dz non-canonical. Even then it is typically benign; the hi word
+                        // is still correctly rounded and dz^2 is negligible versus
+                        // dx^2 + dy^2 for physically meaningful SAR geometries.
                         sh_mem.ant_pos[ip][2] = fltflt_fast_two_sum(dz2hi.hi, pz2_lo);
                     } else {
                         sh_mem.ant_pos[ip][2] = apz;

--- a/include/matx/kernels/sar_bp.cuh
+++ b/include/matx/kernels/sar_bp.cuh
@@ -83,7 +83,7 @@ struct SarBpBinAndWeight {
 };
 
 template <typename PlatPosAccessor, SarBpComputeType ComputeType, typename strict_compute_t, typename loose_compute_t>
-__device__ inline strict_compute_t ComputeRangeToPixel(const PlatPosAccessor &ant_pos, const index_t pulse_idx, const loose_compute_t px, const loose_compute_t py, const loose_compute_t z0) {
+__device__ inline strict_compute_t ComputeRangeToPixel(const PlatPosAccessor &ant_pos, const index_t pulse_idx, const loose_compute_t px, const loose_compute_t py, const loose_compute_t pz) {
     using plat_pos_t = typename PlatPosAccessor::value_type;
     constexpr int Rank = PlatPosAccessor::Rank;
     constexpr bool IsFloat = ComputeType == SarBpComputeType::Float;
@@ -94,15 +94,17 @@ __device__ inline strict_compute_t ComputeRangeToPixel(const PlatPosAccessor &an
         cuda::std::is_same_v<plat_pos_t, float3> || cuda::std::is_same_v<plat_pos_t, float4>)) || Rank == 2,
         "ComputeRangeToPixel: plat_pos_t must be a 1D tensor of 3D or 4D vectorized type or a 2D tensor with size 3 (x,y,z) in the second dimension");
 
+    // In the PixelZIsZero modes the caller passes pz as a compile-time constant
+    // 0, so dz = pz - ant_pos.z folds to -ant_pos.z.
     if constexpr (Rank == 1) {
         const plat_pos_t ant_pos_p = ant_pos(pulse_idx);
         dx = static_cast<strict_compute_t>(px) - static_cast<strict_compute_t>(ant_pos_p.x);
         dy = static_cast<strict_compute_t>(py) - static_cast<strict_compute_t>(ant_pos_p.y);
-        dz = static_cast<strict_compute_t>(z0) - static_cast<strict_compute_t>(ant_pos_p.z);
+        dz = static_cast<strict_compute_t>(pz) - static_cast<strict_compute_t>(ant_pos_p.z);
     } else {
         dx = static_cast<strict_compute_t>(px) - static_cast<strict_compute_t>(ant_pos(pulse_idx, 0));
         dy = static_cast<strict_compute_t>(py) - static_cast<strict_compute_t>(ant_pos(pulse_idx, 1));
-        dz = static_cast<strict_compute_t>(z0) - static_cast<strict_compute_t>(ant_pos(pulse_idx, 2));
+        dz = static_cast<strict_compute_t>(pz) - static_cast<strict_compute_t>(ant_pos(pulse_idx, 2));
     }
 
     if constexpr (IsFloat) {
@@ -255,38 +257,55 @@ struct SarBpThreadState<SarBpComputeType::TaylorFast, true> {
 // Domain: at least one of dx/dy/dz must not fully cancel (sum of squared
 // distances must be strictly positive) -- three-way simultaneous
 // cancellation is not a meaningful SAR geometry and is not supported.
+template <bool UseCachedPz2 = false>
 __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelFloatFloat(
     const SarBpPulseBlockCache<SarBpComputeType::FloatFloat, true> &sh_mem,
     index_t ip,
-    float px, float py, float pz,
+    float px, float py, [[maybe_unused]] float pz,
     fltflt dr_inv)
 {
     const fltflt apx = sh_mem.ant_pos[ip][0];
     const fltflt apy = sh_mem.ant_pos[ip][1];
-    const fltflt apz = sh_mem.ant_pos[ip][2];
     const fltflt mcp_partial = sh_mem.ant_pos[ip][3];
 
-    // Stage 1: loose dx/dy/dz. We use the general fltflt_two_sum (6 fp32 ops)
-    // for all three dimensions. When it is known that one coordinate is
-    // always greater than the other (e.g., |apz.hi| >= |pz|), the faster
-    // fltflt_fast_two_sum as fltflt_fast_two_sum(apz.hi, -pz) could be used
-    // instead.
+    // Stage 1: loose dx/dy. dz is only formed here when the per-pulse dz^2 is
+    // not cached. We use the general fltflt_two_sum (6 fp32 ops) for each
+    // dimension.
     fltflt dx = fltflt_two_sum(px, -apx.hi);
     fltflt dy = fltflt_two_sum(py, -apy.hi);
-    fltflt dz = fltflt_two_sum(pz, -apz.hi);
     dx.lo = detail::fadd_rn(dx.lo, -apx.lo);
     dy.lo = detail::fadd_rn(dy.lo, -apy.lo);
-    dz.lo = detail::fadd_rn(dz.lo, -apz.lo);
+
+    // dz is formed here (unless the per-pulse dz^2 is cached) so that the
+    // non-cached path keeps the original dx/dy/dz -> px2/py2/pz2 ordering and
+    // codegen. The uniform-z modes always cache (UseCachedPz2), so this branch
+    // is the general per-pixel path.
+    [[maybe_unused]] fltflt dz{};
+    if constexpr (!UseCachedPz2) {
+        const fltflt apz = sh_mem.ant_pos[ip][2];
+        dz = fltflt_two_sum(pz, -apz.hi);
+        dz.lo = detail::fadd_rn(dz.lo, -apz.lo);
+    }
 
     // Stage 2: squared-norm accumulation. Same body as the canonical
     // fltflt_norm3d() but with explicit dx.lo*dx.lo / dy.lo*dy.lo /
     // dz.lo*dz.lo contributions retained. The canonical helper drops those
     // as O(eps^2 * sum_hi); for our non-canonical inputs (post-cancellation
     // |lo| can approach |hi|), they carry the cancelled dimension's full
-    // contribution and must be kept. Cost: 3 fmaf_rn ops vs canonical.
+    // contribution and must be kept.
+    //
+    // For the uniform-z modes the entire z contribution -- the dz two-sum, the
+    // z two-prod, and the 2*dz.hi*dz.lo / dz.lo^2 low-order terms -- is hoisted
+    // into a single fully-compensated fltflt dz^2 (pz2) precomputed once per
+    // pulse in FillPulseBlockCache and read from the antenna-z slot here.
     const fltflt px2 = fltflt_two_prod_fma(dx.hi, dx.hi);
     const fltflt py2 = fltflt_two_prod_fma(dy.hi, dy.hi);
-    const fltflt pz2 = fltflt_two_prod_fma(dz.hi, dz.hi);
+    fltflt pz2;
+    if constexpr (UseCachedPz2) {
+        pz2 = sh_mem.ant_pos[ip][2];
+    } else {
+        pz2 = fltflt_two_prod_fma(dz.hi, dz.hi);
+    }
     const fltflt s = fltflt_two_sum(px2.hi, py2.hi);
     const fltflt t = fltflt_two_sum(s.hi, pz2.hi);
 
@@ -296,10 +315,13 @@ __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelFloatFloat(
     sum_lo = detail::fadd_rn(sum_lo, pz2.lo);
     sum_lo = detail::fmaf_rn(detail::fadd_rn(dx.hi, dx.hi), dx.lo, sum_lo);
     sum_lo = detail::fmaf_rn(detail::fadd_rn(dy.hi, dy.hi), dy.lo, sum_lo);
-    sum_lo = detail::fmaf_rn(detail::fadd_rn(dz.hi, dz.hi), dz.lo, sum_lo);
     sum_lo = detail::fmaf_rn(dx.lo, dx.lo, sum_lo);
     sum_lo = detail::fmaf_rn(dy.lo, dy.lo, sum_lo);
-    sum_lo = detail::fmaf_rn(dz.lo, dz.lo, sum_lo);
+    if constexpr (!UseCachedPz2) {
+        // The z low-order terms are already folded into the cached pz2.
+        sum_lo = detail::fmaf_rn(detail::fadd_rn(dz.hi, dz.hi), dz.lo, sum_lo);
+        sum_lo = detail::fmaf_rn(dz.lo, dz.lo, sum_lo);
+    }
     const float sum_hi = t.hi;
 
     // Renormalize the (sum_hi, sum_lo) pair before sqrt. This is required for
@@ -344,7 +366,7 @@ __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelFloatFloat(
     };
 }
 
-template <bool TaylorFastAddThirdOrder = false>
+template <bool TaylorFastAddThirdOrder = false, bool PixelZIsUniform = false>
 __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelTaylorFast(
     const SarBpPulseBlockCache<SarBpComputeType::TaylorFast, true> &sh_mem,
     const SarBpThreadState<SarBpComputeType::TaylorFast, true> &thread_state,
@@ -362,9 +384,14 @@ __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelTaylorFast(
     // identity floor(n + x) = n + floor(x) for integer n while avoiding the
     // lossy fp32 computation of n + x. ref_bin_int and ref_bin_frac
     // are per-pulse values that were populated in FillPulseBlockCache.
-    const float s = sh_mem.ux[ip] * thread_state.ref_dx +
-                    sh_mem.uy[ip] * thread_state.ref_dy +
-                    sh_mem.uz[ip] * thread_state.ref_dz;
+    // With PixelZIsUniform, every pixel shares the per-block reference's z
+    // (z == 0 for Zero, or a common constant for Fixed), so ref_dz == 0 and the
+    // uz term drops out of the dot product.
+    float s = sh_mem.ux[ip] * thread_state.ref_dx +
+              sh_mem.uy[ip] * thread_state.ref_dy;
+    if constexpr (!PixelZIsUniform) {
+        s += sh_mem.uz[ip] * thread_state.ref_dz;
+    }
     const float q = fmaf(-s, s, thread_state.ref_dsq);
     const float half_inv_R = sh_mem.half_inv_R[ip];
     const float dR_2nd = fmaf(q, half_inv_R, s);
@@ -380,13 +407,13 @@ __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelTaylorFast(
     };
 }
 
-template <SarBpComputeType ComputeType, typename strict_compute_t, typename loose_compute_t>
+template <SarBpComputeType ComputeType, bool PixelZIsZero, bool UseCachedDz2, typename strict_compute_t, typename loose_compute_t>
 __device__ inline SarBpBinAndWeight<loose_compute_t> ComputeBinWeightToPixelPulseBlockCache(
     const SarBpPulseBlockCache<ComputeType, true> &sh_mem,
     index_t ip,
     loose_compute_t px,
     loose_compute_t py,
-    loose_compute_t pz,
+    [[maybe_unused]] loose_compute_t pz,
     strict_compute_t dr_inv)
 {
     constexpr bool IsFloat = ComputeType == SarBpComputeType::Float;
@@ -395,19 +422,31 @@ __device__ inline SarBpBinAndWeight<loose_compute_t> ComputeBinWeightToPixelPuls
 
     const strict_compute_t apx = sh_mem.ant_pos[ip][0];
     const strict_compute_t apy = sh_mem.ant_pos[ip][1];
-    const strict_compute_t apz = sh_mem.ant_pos[ip][2];
     const strict_compute_t mcp_partial = sh_mem.ant_pos[ip][3];
     const strict_compute_t dx = static_cast<strict_compute_t>(px) - apx;
     const strict_compute_t dy = static_cast<strict_compute_t>(py) - apy;
-    const strict_compute_t dz = static_cast<strict_compute_t>(pz) - apz;
+    // The z contribution to the squared distance. In Fixed mode with caching,
+    // slot [2] already holds the per-pulse dz^2 (uniform across pixels), so the
+    // per-pixel subtract+square is skipped. Otherwise slot [2] holds the antenna
+    // z and dz = pz - apz (or -apz when PixelZIsZero -- the explicit elision is
+    // kept here because, unlike the other helpers, the FP64 Mixed path does not
+    // fold the pz == 0 constant as tightly, costing a few registers).
+    strict_compute_t dz2;
+    if constexpr (UseCachedDz2) {
+        dz2 = sh_mem.ant_pos[ip][2];
+    } else {
+        const strict_compute_t apz = sh_mem.ant_pos[ip][2];
+        const strict_compute_t dz = PixelZIsZero ? -apz : (static_cast<strict_compute_t>(pz) - apz);
+        dz2 = dz * dz;
+    }
     strict_compute_t dist;
     if constexpr (IsFloat) {
-        dist = ::sqrtf(dx*dx + dy*dy + dz*dz);
+        dist = ::sqrtf(dx*dx + dy*dy + dz2);
     } else {
 #if __CUDA_ARCH__ == 700 || __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 900 || __CUDA_ARCH__ == 1000
-        dist = ::sqrt(dx*dx + dy*dy + dz*dz);
+        dist = ::sqrt(dx*dx + dy*dy + dz2);
 #else
-        dist = NewtonRaphsonSqrt(dx*dx + dy*dy + dz*dz);
+        dist = NewtonRaphsonSqrt(dx*dx + dy*dy + dz2);
 #endif
     }
 
@@ -425,7 +464,20 @@ __device__ inline SarBpBinAndWeight<loose_compute_t> ComputeBinWeightToPixelPuls
     };
 }
 
-template <SarBpComputeType ComputeType, typename OutImageType, typename InitialImageType, typename RangeProfilesType, typename PlatPosType, typename VoxLocType, typename RangeToMcpType, bool PhaseLUT, bool IsUnitStride, bool TaylorFastAddThirdOrder = false>
+// SarBp backprojection kernel. PixelZMode is a compile-time assumption about
+// the pixel z (height) coordinates, selected by the caller via the
+// PropSarBpPixelZIsZero / PropSarBpPixelZIsFixed properties (see
+// operators/sar_bp.h):
+//   - Variable (default): each pixel may have a distinct z; produces the same
+//     code (and identical mangled name / register usage) as before this
+//     parameter existed, so default callers are unaffected.
+//   - Zero: every pixel z == 0, so the per-pulse range computation drops the
+//     pixel-z term (dz collapses to -antenna_z).
+//   - Fixed: every pixel shares one (runtime) z value; on the shared-cache
+//     compute paths the per-pulse z contribution dz^2 is uniform across pixels
+//     and is precomputed once per pulse (see FillPulseBlockCache), removing the
+//     per-pixel-per-pulse subtract+square from the inner loop.
+template <SarBpComputeType ComputeType, typename OutImageType, typename InitialImageType, typename RangeProfilesType, typename PlatPosType, typename VoxLocType, typename RangeToMcpType, bool PhaseLUT, bool IsUnitStride, bool TaylorFastAddThirdOrder = false, SarBpPixelZMode PixelZMode = SarBpPixelZMode::Variable>
 __launch_bounds__(16*16)
 __global__ void SarBp(OutImageType output, const InitialImageType initial_image, const __grid_constant__ RangeProfilesType range_profiles, const __grid_constant__ PlatPosType platform_positions, const __grid_constant__ VoxLocType voxel_locations, const __grid_constant__ RangeToMcpType range_to_mcp,
                       strict_or_ff_compute_param_t<ComputeType> dr_inv,
@@ -456,6 +508,37 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     constexpr bool IsFloat = ComputeType == SarBpComputeType::Float;
     constexpr bool IsTaylorFast = ComputeType == SarBpComputeType::TaylorFast;
 
+    constexpr bool PixelZIsZero  = PixelZMode == SarBpPixelZMode::Zero;
+    constexpr bool PixelZIsFixed = PixelZMode == SarBpPixelZMode::Fixed;
+    // For the per-pulse-cache compute paths, PixelZIsZero treats z as the
+    // compile-time constant 0 (no pz value needed). Both Zero and Fixed share
+    // the property that the pixel z is uniform across the CTA.
+    constexpr bool PixelZIsUniform = PixelZIsZero || PixelZIsFixed;
+    // Per-pulse z^2 caching. When the pixel z is uniform across the CTA the z
+    // contribution to the squared range is the same for every pixel, so it is
+    // computed once per pulse in FillPulseBlockCache and stored in the
+    // (otherwise unused) antenna-z cache slot -- no extra shared memory.
+    //   - UseCachedDz2: Float/Mixed pulse-block-cache path. Scalar dz^2. Fixed
+    //     only; Zero there keeps the bit-exact inline elision (dz = -apz).
+    //   - UseCachedPz2FF: FloatFloat path. Fully-compensated fltflt dz^2,
+    //     applied to both Zero and Fixed since the compensated-arithmetic z
+    //     terms (dz two-sum, z two-prod, 2*dz.hi*dz.lo, dz.lo^2) are the most
+    //     expensive part of the inner loop and collapse to a single fltflt add.
+    // TaylorFast handles uniform z via its reference-relative offsets
+    // (ref_dz == 0, see PixelZIsUniform); the non-cache paths fall back to the
+    // per-pixel dz computation.
+    constexpr bool UseCachedDz2 =
+        PixelZIsFixed && (IsFloat || IsMixed) && PhaseLUT;
+    constexpr bool UseCachedPz2FF =
+        PixelZIsUniform && IsFloatFloat;
+    // The cooperative cache fill needs the (non-zero) uniform pixel z in every
+    // thread, including out-of-image threads whose own voxel_loc is zeroed.
+    // Those threads patch voxel_loc.z from the CTA-origin pixel (see below) so
+    // pz is correct for all. Zero needs nothing here (its uniform z is 0).
+    constexpr bool NeedFixedPz =
+        PixelZIsFixed &&
+        (((IsFloat || IsMixed) && PhaseLUT) || IsFloatFloat);
+
     using initial_image_t = typename InitialImageType::value_type;
     using image_t = typename OutImageType::value_type;
     using range_profiles_t = typename RangeProfilesType::value_type;
@@ -472,6 +555,7 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     const index_t image_width = output.Size(1);
     const index_t ix = static_cast<index_t>(blockIdx.x * blockDim.x + threadIdx.x);
     const index_t iy = static_cast<index_t>(blockIdx.y * blockDim.y + threadIdx.y);
+    const bool is_valid = ix < image_width && iy < image_height;
 
     // IsUnitStride=true implies the hot inputs must be tensor views (they
     // use .Data()). The transform-level dispatch enforces this; the
@@ -495,7 +579,6 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
 
     __shared__ SarBpPulseBlockCache<ComputeType, UsePulseBlockCache> sh_mem;
 
-    const bool is_valid = ix < image_width && iy < image_height;
     if constexpr (!UsePulseBlockCache) {
         // When the cache is enabled, keep all threads active so they can
         // participate in the CTA-wide cooperative loads of antenna positions.
@@ -511,10 +594,24 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     // is deliberately not covered by the IsUnitStride fast-path logic. The
     // one-shot cost of its operator() is negligible and its layout is free to
     // be anything the caller wants without blocking fast-path eligibility.
-    const voxel_loc_t voxel_loc = is_valid ? voxel_locations(iy, ix) : voxel_loc_t{};
+    voxel_loc_t voxel_loc = is_valid ? voxel_locations(iy, ix) : voxel_loc_t{};
+    // Fixed mode needs the uniform pixel z in every thread that fills the cache,
+    // but out-of-image threads have a zeroed voxel_loc. They take z from the
+    // CTA-origin pixel (thread 0's, always in-image since the CTA origin lies
+    // within the image); in-image threads already have the correct z. Taken only
+    // by out-of-image threads on edge CTAs.
+    if constexpr (NeedFixedPz) {
+        if (!is_valid) {
+            const index_t origin_x = static_cast<index_t>(blockIdx.x * blockDim.x);
+            const index_t origin_y = static_cast<index_t>(blockIdx.y * blockDim.y);
+            voxel_loc.z = voxel_locations(origin_y, origin_x).z;
+        }
+    }
     const loose_compute_t py = static_cast<loose_compute_t>(voxel_loc.y);
     const loose_compute_t px = static_cast<loose_compute_t>(voxel_loc.x);
-    const loose_compute_t pz = static_cast<loose_compute_t>(voxel_loc.z);
+    // When PixelZIsZero is known, pz folds to a compile-time 0 so the z terms in
+    // the range/bin helpers are dropped.
+    const loose_compute_t pz = PixelZIsZero ? static_cast<loose_compute_t>(0) : static_cast<loose_compute_t>(voxel_loc.z);
 
     // TensorAccessor wraps each hot tensor and picks the fast pointer path
     // when IsUnitStride && is_tensor_view_v<Op>, otherwise forwards to
@@ -614,10 +711,20 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
 
             thread_state.ref_dx = is_valid ? static_cast<float>(static_cast<strict_compute_t>(voxel_loc.x) - sh_mem.ref_x) : 0.0f;
             thread_state.ref_dy = is_valid ? static_cast<float>(static_cast<strict_compute_t>(voxel_loc.y) - sh_mem.ref_y) : 0.0f;
-            thread_state.ref_dz = is_valid ? static_cast<float>(static_cast<strict_compute_t>(voxel_loc.z) - sh_mem.ref_z) : 0.0f;
-            thread_state.ref_dsq = fmaf(thread_state.ref_dx, thread_state.ref_dx,
-                                        fmaf(thread_state.ref_dy, thread_state.ref_dy,
-                                             thread_state.ref_dz * thread_state.ref_dz));
+            // When the pixel z is uniform across the CTA (Zero: z == 0, or
+            // Fixed: z == const), the per-block reference pixel shares that same
+            // z, so ref_dz is identically 0 and drops out of ref_dsq and the dot
+            // product in ComputeBinWeightToPixelTaylorFast.
+            if constexpr (PixelZIsUniform) {
+                thread_state.ref_dz = 0.0f;
+                thread_state.ref_dsq = fmaf(thread_state.ref_dx, thread_state.ref_dx,
+                                            thread_state.ref_dy * thread_state.ref_dy);
+            } else {
+                thread_state.ref_dz = is_valid ? static_cast<float>(static_cast<strict_compute_t>(voxel_loc.z) - sh_mem.ref_z) : 0.0f;
+                thread_state.ref_dsq = fmaf(thread_state.ref_dx, thread_state.ref_dx,
+                                            fmaf(thread_state.ref_dy, thread_state.ref_dy,
+                                                 thread_state.ref_dz * thread_state.ref_dz));
+            }
         }
     }
 
@@ -646,7 +753,24 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
                 if constexpr (IsFloatFloat) {
                     sh_mem.ant_pos[ip][0] = static_cast<fltflt>(cuda::std::get<0>(xyz));
                     sh_mem.ant_pos[ip][1] = static_cast<fltflt>(cuda::std::get<1>(xyz));
-                    sh_mem.ant_pos[ip][2] = static_cast<fltflt>(cuda::std::get<2>(xyz));
+                    const fltflt apz = static_cast<fltflt>(cuda::std::get<2>(xyz));
+                    if constexpr (UseCachedPz2FF) {
+                        // Cache the fully-compensated per-pulse dz^2 (uniform
+                        // pixel z) in the antenna-z slot. dz is formed with the
+                        // same arithmetic the inner loop would have used, so the
+                        // only difference from Variable is that the z low-order
+                        // terms are summed here once per pulse rather than per
+                        // pixel. In the Zero mode pz is the compile-time 0.
+                        fltflt dz = fltflt_two_sum(pz, -apz.hi);
+                        dz.lo = detail::fadd_rn(dz.lo, -apz.lo);
+                        const fltflt dz2hi = fltflt_two_prod_fma(dz.hi, dz.hi);
+                        float pz2_lo = dz2hi.lo;
+                        pz2_lo = detail::fmaf_rn(detail::fadd_rn(dz.hi, dz.hi), dz.lo, pz2_lo);
+                        pz2_lo = detail::fmaf_rn(dz.lo, dz.lo, pz2_lo);
+                        sh_mem.ant_pos[ip][2] = fltflt_fast_two_sum(dz2hi.hi, pz2_lo);
+                    } else {
+                        sh_mem.ant_pos[ip][2] = apz;
+                    }
                     const fltflt rtm = static_cast<fltflt>(r_to_mcp(p));
                     const fltflt neg_rtm = fltflt{-rtm.hi, -rtm.lo};
                     sh_mem.ant_pos[ip][3] = fltflt_fma_approx(neg_rtm, dr_inv, bin_offset);
@@ -678,7 +802,18 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
                     // once per pulse here, instead of once per pulse per pixel.
                     sh_mem.ant_pos[ip][0] = static_cast<strict_compute_t>(cuda::std::get<0>(xyz));
                     sh_mem.ant_pos[ip][1] = static_cast<strict_compute_t>(cuda::std::get<1>(xyz));
-                    sh_mem.ant_pos[ip][2] = static_cast<strict_compute_t>(cuda::std::get<2>(xyz));
+                    const strict_compute_t apz = static_cast<strict_compute_t>(cuda::std::get<2>(xyz));
+                    if constexpr (UseCachedDz2) {
+                        // Fixed mode: the pixel z is uniform, so dz = pz - apz and
+                        // its square are per-pulse constants. Cache dz^2 in the
+                        // (otherwise unused after this) antenna-z slot so the inner
+                        // loop loads it directly instead of recomputing the
+                        // subtract+square for every pixel.
+                        const strict_compute_t dz = static_cast<strict_compute_t>(pz) - apz;
+                        sh_mem.ant_pos[ip][2] = dz * dz;
+                    } else {
+                        sh_mem.ant_pos[ip][2] = apz;
+                    }
                     const strict_compute_t rtm = static_cast<strict_compute_t>(r_to_mcp(p));
                     if constexpr (cuda::std::is_same_v<strict_compute_t, double>) {
                         sh_mem.ant_pos[ip][3] = ::fma(-rtm, dr_inv, static_cast<double>(bin_offset));
@@ -713,12 +848,13 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
             // thread_state.range_delta member for use in get_reference_phase_direct().
             SarBpBinAndWeight<loose_compute_t> bin_weight;
             if constexpr (IsFloatFloat) {
-                bin_weight = ComputeBinWeightToPixelFloatFloat(sh_mem, ip, px, py, pz, dr_inv);
+                bin_weight = ComputeBinWeightToPixelFloatFloat<UseCachedPz2FF>(sh_mem, ip, px, py, pz, dr_inv);
             } else if constexpr (IsTaylorFast) {
                 static_assert(PhaseLUT == true, "SarBp: TaylorFast compute type requires PhaseLUT optimization");
-                bin_weight = ComputeBinWeightToPixelTaylorFast<TaylorFastAddThirdOrder>(sh_mem, thread_state, ip);
+                // Zero and Fixed both make ref_dz == 0, so PixelZIsUniform drives the elision.
+                bin_weight = ComputeBinWeightToPixelTaylorFast<TaylorFastAddThirdOrder, PixelZIsUniform>(sh_mem, thread_state, ip);
             } else if constexpr (UsePulseBlockCache) {
-                bin_weight = ComputeBinWeightToPixelPulseBlockCache<ComputeType>(sh_mem, ip, px, py, pz, dr_inv);
+                bin_weight = ComputeBinWeightToPixelPulseBlockCache<ComputeType, PixelZIsZero, UseCachedDz2>(sh_mem, ip, px, py, pz, dr_inv);
             } else {
                 // Below is the most direct / standard path for backprojection. We compute the distance
                 // from the antenna phase center to the pixel for this pulse and from that the differential range

--- a/include/matx/operators/sar_bp.h
+++ b/include/matx/operators/sar_bp.h
@@ -78,6 +78,26 @@ enum class SarBpComputeType {
 };
 
 /**
+ * @brief Compile-time assumption about the pixel z (height) coordinates.
+ *
+ * Many SAR imaging geometries place every output pixel on a single horizontal
+ * focal plane, so the pixel z coordinate is either identically 0 or some other
+ * value that is the same for all pixels. When the caller asserts one of these
+ * cases (via PropSarBpPixelZIsZero / PropSarBpPixelZIsFixed), the kernel can
+ * specialize the per-pulse range computation. This is a compile-time
+ * assumption: the kernel does NOT validate it at run time, so the caller is
+ * responsible for only setting it when it actually holds.
+ */
+enum class SarBpPixelZMode {
+  Variable, /**< No assumption: each pixel may have a distinct z coordinate (default). */
+  Zero,     /**< Every pixel z coordinate is 0. The z difference term collapses to
+                 the antenna z, dropping the pixel-z load/subtraction. */
+  Fixed     /**< Every pixel z coordinate is identical (to an arbitrary value). The
+                 per-pulse z contribution is uniform across pixels and can be hoisted
+                 out of the per-pixel inner loop on the shared-cache compute paths. */
+};
+
+/**
  * @brief Features that can be enabled or disabled for the SAR BP kernel.
  */
 enum class SarBpFeature : uint32_t {
@@ -100,6 +120,29 @@ enum class SarBpFeature : uint32_t {
  * ranges where the second-order approximation may not be accurate enough.
  */
 struct PropSarBpTaylorFastAddThirdOrder {};
+
+/**
+ * @brief Asserts that every output pixel has a z (height) coordinate of 0.
+ *
+ * Selects SarBpPixelZMode::Zero, which lets the kernel drop the pixel-z term
+ * from the per-pulse range computation. This is a compile-time assumption that
+ * is NOT validated at run time; it must only be set when it actually holds for
+ * the supplied voxel locations. If PropSarBpPixelZIsFixed is also set, this
+ * property (Zero, the stronger assumption) takes precedence and the Fixed
+ * property has no effect.
+ */
+struct PropSarBpPixelZIsZero {};
+
+/**
+ * @brief Asserts that every output pixel shares one (arbitrary) z coordinate.
+ *
+ * Selects SarBpPixelZMode::Fixed. On the shared-cache compute paths the per-pulse
+ * z contribution is uniform across pixels and can be hoisted out of the
+ * per-pixel inner loop. This is a compile-time assumption that is NOT validated
+ * at run time. PropSarBpPixelZIsZero (z == 0) is a stronger special case and
+ * takes precedence if both are set.
+ */
+struct PropSarBpPixelZIsFixed {};
 
 // Enable bitmask operations for SarBpFeature
 constexpr SarBpFeature operator|(SarBpFeature lhs, SarBpFeature rhs) noexcept {
@@ -203,7 +246,13 @@ namespace detail {
 
         constexpr bool TaylorFastAddThirdOrder =
           has_property_tag<PropSarBpTaylorFastAddThirdOrder, CurrentProps...>;
-        sar_bp_impl<TaylorFastAddThirdOrder>(
+        // Zero (z == 0) is the stronger assumption and takes precedence over
+        // Fixed (z == const) when both props are present.
+        constexpr SarBpPixelZMode PixelZMode =
+          has_property_tag<PropSarBpPixelZIsZero, CurrentProps...> ? SarBpPixelZMode::Zero :
+          (has_property_tag<PropSarBpPixelZIsFixed, CurrentProps...> ? SarBpPixelZMode::Fixed :
+           SarBpPixelZMode::Variable);
+        sar_bp_impl<TaylorFastAddThirdOrder, PixelZMode>(
           cuda::std::get<0>(out), initial_image_, range_profiles_, platform_positions_,
           voxel_locations_, range_to_mcp_, params_, ex.getStream());
       }

--- a/include/matx/transforms/sar_bp.h
+++ b/include/matx/transforms/sar_bp.h
@@ -44,7 +44,7 @@
 
 namespace matx {
 
-template <bool TaylorFastAddThirdOrder = false, typename OutImageType, typename InitialImageType, typename RangeProfilesType, typename PlatPosType, typename VoxLocType, typename RangeToMcpType>
+template <bool TaylorFastAddThirdOrder = false, SarBpPixelZMode PixelZMode = SarBpPixelZMode::Variable, typename OutImageType, typename InitialImageType, typename RangeProfilesType, typename PlatPosType, typename VoxLocType, typename RangeToMcpType>
 inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image, const RangeProfilesType &range_profiles, const PlatPosType &platform_positions,
   const VoxLocType &voxel_locations, const RangeToMcpType &range_to_mcp, const SarBpParams &params, cudaStream_t stream = 0) {
 #ifdef __CUDACC__
@@ -153,6 +153,12 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
 
   auto dispatch = [&](auto is_unit_c) {
     constexpr bool IsUnitStride = decltype(is_unit_c)::value;
+    // The third-order Taylor term is only meaningful for SarBpComputeType::TaylorFast.
+    // Force it off for every other compute type so they instantiate a single
+    // kernel variant regardless of whether the caller set the
+    // PropSarBpTaylorFastAddThirdOrder property (which would otherwise be a
+    // no-op for them but still produce a redundant kernel instantiation).
+    constexpr bool NoTaylorFastThirdOrder = false;
     if (phase_lut_optimization) {
       constexpr bool PhaseLUT = true;
       const double phase_correction_partial = 4.0 * M_PI * params.del_r * (params.center_frequency / SPEED_OF_LIGHT);
@@ -166,27 +172,27 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
       if (params.compute_type == SarBpComputeType::Double) {
         cuda::std::complex<double> *phase_lut = static_cast<cuda::std::complex<double> *>(workspace);
         SarBpFillPhaseLUT<double, double><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
       } else if (params.compute_type == SarBpComputeType::Mixed) {
         cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
         SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
       } else if (params.compute_type == SarBpComputeType::FloatFloat) {
         cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
         SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-        SarBp<SarBpComputeType::FloatFloat, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::FloatFloat, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, static_cast<fltflt>(dr_inv), phase_correction_partial, phase_lut);
       } else if (params.compute_type == SarBpComputeType::TaylorFast) {
         cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
         SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-        SarBp<SarBpComputeType::TaylorFast, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, TaylorFastAddThirdOrder><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::TaylorFast, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, TaylorFastAddThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
       } else {
         cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
         SarBpFillPhaseLUT<float, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, static_cast<float>(params.center_frequency), static_cast<float>(params.del_r), range_profiles.Size(1));
-        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp,
           static_cast<float>(dr_inv), static_cast<float>(phase_correction_partial), phase_lut);
       }
@@ -194,10 +200,10 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
       constexpr bool PhaseLUT = false;
       const double phase_correction_partial = 4.0 * M_PI * (params.center_frequency / SPEED_OF_LIGHT);
       if (params.compute_type == SarBpComputeType::Double) {
-        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, nullptr);
       } else if (params.compute_type == SarBpComputeType::Mixed) {
-        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, nullptr);
       } else if (params.compute_type == SarBpComputeType::FloatFloat ||
                  params.compute_type == SarBpComputeType::TaylorFast) {
@@ -205,7 +211,7 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
         // in run-time check higher in this function.
         MATX_THROW(matxInvalidParameter, "sar_bp: FloatFloat and TaylorFast compute types require phase LUT optimization");
       } else {
-        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp,
           static_cast<float>(dr_inv), static_cast<float>(phase_correction_partial), nullptr);
       }

--- a/test/00_transform/SarBp.cu
+++ b/test/00_transform/SarBp.cu
@@ -226,6 +226,20 @@ TYPED_TEST(SarBpTestDoubleType, MixedPrecision)
     this->exec.sync();
   }
 
+  // The voxel_locations grid in this test places every pixel on the z = 0 plane,
+  // so the PropSarBpPixelZIsZero assumption holds and can be applied to any
+  // compute type.
+  {
+    // example-begin sar-bp-3
+    params.compute_type = SarBpComputeType::Mixed;
+    params.features = SarBpFeature::PhaseLUTOptimization;
+
+    (image = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, params)
+      .props<PropSarBpPixelZIsZero>()).run(this->exec);
+    // example-end sar-bp-3
+    this->exec.sync();
+  }
+
   MATX_EXIT_HANDLER();
 }
 
@@ -412,11 +426,11 @@ TYPED_TEST(SarBpTestDoubleType, PointTarget)
           ASSERT_NEAR(0.0, image(i, j).imag(), im_thresh);
         } else if (i < image_height / 8 || i >= 3 * image_height / 8) {
           // Away from the scatterer in range, we should not have any non-zero values.
-          ASSERT_EQ(abs(image(i, j).real()), 0);
-          ASSERT_EQ(abs(image(i, j).imag()), 0);
+          ASSERT_EQ(cuda::std::abs(image(i, j).real()), 0);
+          ASSERT_EQ(cuda::std::abs(image(i, j).imag()), 0);
         } else {
-          ASSERT_LT(abs(image(i, j).real()), num_pulses);
-          ASSERT_LT(abs(image(i, j).imag()), num_pulses);
+          ASSERT_LT(cuda::std::abs(image(i, j).real()), num_pulses);
+          ASSERT_LT(cuda::std::abs(image(i, j).imag()), num_pulses);
         }
       }
     }
@@ -449,6 +463,24 @@ TYPED_TEST(SarBpTestDoubleType, PointTarget)
     this->exec.sync();
 
     validate(image, 1.05e-10, 1.05e-10);
+
+    // The pixel z coordinate is 0 for this grid, so the PropSarBpPixelZIsZero
+    // and PropSarBpPixelZIsFixed compile-time assumptions both hold and must
+    // reproduce the focused image.
+    {
+      SCOPED_TRACE("Double PropSarBpPixelZIsZero");
+      (image = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, bp_params)
+        .props<matx::PropSarBpPixelZIsZero>()).run(this->exec);
+      this->exec.sync();
+      validate(image, 1.05e-10, 1.05e-10);
+    }
+    {
+      SCOPED_TRACE("Double PropSarBpPixelZIsFixed");
+      (image = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, bp_params)
+        .props<matx::PropSarBpPixelZIsFixed>()).run(this->exec);
+      this->exec.sync();
+      validate(image, 1.05e-10, 1.05e-10);
+    }
   }
 
   // The mixed precision and single precision backprojectors take single-precision values for range profiles,
@@ -494,26 +526,46 @@ TYPED_TEST(SarBpTestDoubleType, PointTarget)
     MATX_CUDA_CHECK(cudaMemcpy(range_to_mcp.Data(), h_range_to_mcp_f32.data(), h_range_to_mcp_f32.size() * sizeof(float), cudaMemcpyHostToDevice));
 
     bp_params.compute_type = matx::SarBpComputeType::Float;
-    (image = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, bp_params)).run(this->exec);
-    this->exec.sync();
 
-    for (matx::index_t i = 0; i < image_height; i++) {
-      for (matx::index_t j = 0; j < image_width; j++) {
-        if (i == image_height / 4 && j == image_width / 4) {
-          const float expected = 0.98f * num_pulses;
-          const float actual = image(i, j).real();
-          ASSERT_GT(actual, expected);
-          ASSERT_LT(std::abs(image(i, j).imag()), 3.0f);
-        } else if (i < image_height / 8 || i >= 3 * image_height / 8) {
-          // Away from the scatterer in range, we should not have any non-zero values.
-          ASSERT_EQ(abs(image(i, j).real()), 0.0f);
-          ASSERT_EQ(abs(image(i, j).imag()), 0.0f);
-        } else {
-          const float expected = 0.9f * num_pulses;
-          ASSERT_LT(abs(image(i, j).real()), expected);
-          ASSERT_LT(abs(image(i, j).imag()), expected);
+    auto validate_float = [&](auto &img) {
+      for (matx::index_t i = 0; i < image_height; i++) {
+        for (matx::index_t j = 0; j < image_width; j++) {
+          if (i == image_height / 4 && j == image_width / 4) {
+            const float expected = 0.98f * num_pulses;
+            const float actual = img(i, j).real();
+            ASSERT_GT(actual, expected);
+            ASSERT_LT(cuda::std::abs(img(i, j).imag()), 3.0f);
+          } else if (i < image_height / 8 || i >= 3 * image_height / 8) {
+            // Away from the scatterer in range, we should not have any non-zero values.
+            ASSERT_EQ(cuda::std::abs(img(i, j).real()), 0.0f);
+            ASSERT_EQ(cuda::std::abs(img(i, j).imag()), 0.0f);
+          } else {
+            const float expected = 0.9f * num_pulses;
+            ASSERT_LT(cuda::std::abs(img(i, j).real()), expected);
+            ASSERT_LT(cuda::std::abs(img(i, j).imag()), expected);
+          }
         }
       }
+    };
+
+    (image = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, bp_params)).run(this->exec);
+    this->exec.sync();
+    validate_float(image);
+
+    // Pixel z is 0, so both pixel-z assumptions hold and must focus identically.
+    {
+      SCOPED_TRACE("Float PropSarBpPixelZIsZero");
+      (image = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, bp_params)
+        .props<matx::PropSarBpPixelZIsZero>()).run(this->exec);
+      this->exec.sync();
+      validate_float(image);
+    }
+    {
+      SCOPED_TRACE("Float PropSarBpPixelZIsFixed");
+      (image = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, bp_params)
+        .props<matx::PropSarBpPixelZIsFixed>()).run(this->exec);
+      this->exec.sync();
+      validate_float(image);
     }
   }
 
@@ -576,6 +628,210 @@ TYPED_TEST(SarBpTestDoubleType, PointTarget)
       this->exec.sync();
 
       validate(image, f32_accum_re_thresh, 1.8e-2);
+    }
+
+    // The pixel z coordinate is 0 for this grid, so PropSarBpPixelZIsZero and
+    // PropSarBpPixelZIsFixed both hold and must reproduce the focused image for
+    // each of these compute types (and combined with the third-order Taylor
+    // property). The variadic prop_tags pack lets a single helper instantiate
+    // any combination of properties.
+    {
+      auto run_props = [&](const char *tag, double im_thresh, [[maybe_unused]] auto... prop_tags) {
+        SCOPED_TRACE(tag);
+        (image = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, bp_params)
+          .template props<decltype(prop_tags)...>()).run(this->exec);
+        this->exec.sync();
+        validate(image, f32_accum_re_thresh, im_thresh);
+      };
+
+      bp_params.compute_type = matx::SarBpComputeType::Mixed;
+      run_props("Mixed PropSarBpPixelZIsZero", 1.0e-2, matx::PropSarBpPixelZIsZero{});
+      run_props("Mixed PropSarBpPixelZIsFixed", 1.0e-2, matx::PropSarBpPixelZIsFixed{});
+
+      bp_params.compute_type = matx::SarBpComputeType::FloatFloat;
+      run_props("FloatFloat PropSarBpPixelZIsZero", 1.0e-2, matx::PropSarBpPixelZIsZero{});
+      run_props("FloatFloat PropSarBpPixelZIsFixed", 1.0e-2, matx::PropSarBpPixelZIsFixed{});
+
+      bp_params.compute_type = matx::SarBpComputeType::TaylorFast;
+      run_props("TaylorFast PropSarBpPixelZIsZero", 1.8e-2, matx::PropSarBpPixelZIsZero{});
+      run_props("TaylorFast PropSarBpPixelZIsFixed", 1.8e-2, matx::PropSarBpPixelZIsFixed{});
+      run_props("TaylorFast third order PropSarBpPixelZIsZero", 1.8e-2,
+        matx::PropSarBpTaylorFastAddThirdOrder{}, matx::PropSarBpPixelZIsZero{});
+      run_props("TaylorFast third order PropSarBpPixelZIsFixed", 1.8e-2,
+        matx::PropSarBpTaylorFastAddThirdOrder{}, matx::PropSarBpPixelZIsFixed{});
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// Exercise PropSarBpPixelZIsFixed with a genuinely non-zero constant pixel
+// height. Unlike the z == 0 grids above, this drives the cached dz^2 path with
+// a non-trivial value. We verify that, with the assumption holding, the property
+// still produces a correctly focused point-target image for every compute type.
+TYPED_TEST(SarBpTestDoubleType, PixelZIsFixedNonZeroHeight)
+{
+  MATX_ENTER_HANDLER();
+
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  constexpr matx::index_t image_width = 132;
+  constexpr matx::index_t image_height = 132;
+  const matx::index_t num_pulses = 128;
+  const matx::index_t num_range_bins = 128;
+
+  const double pix_dx = 0.5;
+  const double pix_x_min = -1.0 * image_width / 2.0 + pix_dx;
+  const double pix_dy = 0.5;
+  const double pix_y_min = -1.0 * image_height / 2.0 + pix_dy;
+  const double plat_x_min = 1.0 * image_width / 2.0 - 10.0;
+  const double plat_dx = (plat_x_min - pix_x_min) / num_pulses;
+  const double plat_y = -7000.0;
+  const double plat_z = 7000.0;
+  const double target_x = pix_x_min + pix_dx * (image_width / 4.0);
+  const double target_y = pix_y_min + pix_dy * (image_height / 4.0);
+  // A single focal-plane height shared by EVERY image pixel (and the target).
+  // This is exactly the condition PropSarBpPixelZIsFixed asserts -- the height
+  // is constant across the whole image, not merely within a thread block. It is
+  // kept small enough that the target's range bins stay within the range window
+  // (each meter of height shifts the differential range by ~0.7 m and the
+  // window spans ~93 m), while being clearly non-zero so the fixed-z value that
+  // flows through the kernel is non-trivial (z == 0 would not exercise it).
+  const double pixel_z = 10.0;
+
+  matx::SarBpParams bp_params{};
+  bp_params.del_r = ::sqrt((image_width * pix_dx) * (image_width * pix_dx) +
+                           (image_height * pix_dy) * (image_height * pix_dy)) / num_range_bins;
+  bp_params.center_frequency = 10.0e9;
+  bp_params.features = matx::SarBpFeature::PhaseLUTOptimization;
+  const double bin_offset = 0.5 * (num_range_bins - 1);
+
+  // Ideal point-target range profiles for the target at (target_x, target_y, pixel_z).
+  std::vector<double3> h_apc(num_pulses);
+  std::vector<double> h_rtm(num_pulses);
+  std::vector<cuda::std::complex<double>> h_rp(num_pulses * num_range_bins, cuda::std::complex<double>{0.0, 0.0});
+  for (matx::index_t i = 0; i < num_pulses; i++) {
+    h_apc[i] = double3{plat_x_min + plat_dx * static_cast<double>(i), plat_y, plat_z};
+    h_rtm[i] = ::sqrt(h_apc[i].x * h_apc[i].x + h_apc[i].y * h_apc[i].y + h_apc[i].z * h_apc[i].z);
+    const double R = ::sqrt(
+      (h_apc[i].x - target_x) * (h_apc[i].x - target_x) +
+      (h_apc[i].y - target_y) * (h_apc[i].y - target_y) +
+      (h_apc[i].z - pixel_z) * (h_apc[i].z - pixel_z));
+    const double dR = R - h_rtm[i];
+    const double ideal_bin = dR / bp_params.del_r + bin_offset;
+    const double ideal_phase = -4.0 * M_PI * dR * (bp_params.center_frequency / SPEED_OF_LIGHT);
+    double sinx, cosx;
+    ::sincos(ideal_phase, &sinx, &cosx);
+    const cuda::std::complex<double> sample{cosx, sinx};
+    const int b = static_cast<int>(floor(ideal_bin));
+    if (b >= 0 && b < num_range_bins) h_rp[i * num_range_bins + b] = sample;
+    if (b + 1 >= 0 && b + 1 < num_range_bins) h_rp[i * num_range_bins + b + 1] = sample;
+  }
+
+  auto platform_positions = matx::make_tensor<double3>({num_pulses});
+  auto range_to_mcp = matx::make_tensor<double>({num_pulses});
+  MATX_CUDA_CHECK(cudaMemcpy(platform_positions.Data(), h_apc.data(), num_pulses * sizeof(double3), cudaMemcpyHostToDevice));
+  MATX_CUDA_CHECK(cudaMemcpy(range_to_mcp.Data(), h_rtm.data(), num_pulses * sizeof(double), cudaMemcpyHostToDevice));
+
+  const double f32_accum_re_thresh = 1.2e-7 * static_cast<double>(num_pulses);
+
+  // Confirm the property-enabled reconstruction focuses the point target and is
+  // free of spurious energy away from it -- the same structure used by the
+  // PointTarget test.
+  auto validate = [num_pulses](auto &image, double re_thresh, double im_thresh) {
+    for (matx::index_t i = 0; i < image_height; i++) {
+      for (matx::index_t j = 0; j < image_width; j++) {
+        if (i == image_height / 4 && j == image_width / 4) {
+          ASSERT_NEAR(static_cast<double>(num_pulses), static_cast<double>(image(i, j).real()), re_thresh);
+          ASSERT_NEAR(0.0, static_cast<double>(image(i, j).imag()), im_thresh);
+        } else if (i < image_height / 8 || i >= 3 * image_height / 8) {
+          ASSERT_EQ(cuda::std::abs(image(i, j).real()), 0);
+          ASSERT_EQ(cuda::std::abs(image(i, j).imag()), 0);
+        } else {
+          ASSERT_LT(cuda::std::abs(image(i, j).real()), num_pulses);
+          ASSERT_LT(cuda::std::abs(image(i, j).imag()), num_pulses);
+        }
+      }
+    }
+  };
+
+  // Double compute type (complex<double> profiles / image).
+  {
+    SCOPED_TRACE("Double");
+    auto range_profiles = matx::make_tensor<cuda::std::complex<double>>({num_pulses, num_range_bins});
+    MATX_CUDA_CHECK(cudaMemcpy(range_profiles.Data(), h_rp.data(), h_rp.size() * sizeof(cuda::std::complex<double>), cudaMemcpyHostToDevice));
+    auto px = matx::linspace<double>(pix_x_min, pix_x_min + (image_width - 1) * pix_dx, image_width);
+    auto py = matx::linspace<double>(pix_y_min, pix_y_min + (image_height - 1) * pix_dy, image_height);
+    auto voxel_locations = matx::zipvec(matx::clone<2>(px, {image_height, matx::matxKeepDim}),
+                                        matx::clone<2>(py, {matx::matxKeepDim, image_width}),
+                                        pixel_z * matx::ones<double>({image_height, image_width}));
+    auto zero_image = matx::zeros<cuda::std::complex<double>>({image_height, image_width});
+    auto image = matx::make_tensor<cuda::std::complex<double>>({image_height, image_width});
+
+    bp_params.compute_type = matx::SarBpComputeType::Double;
+    (image = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, bp_params)
+      .props<matx::PropSarBpPixelZIsFixed>()).run(this->exec);
+    this->exec.sync();
+    validate(image, 1.0e-9, 1.0e-9);
+  }
+
+  // complex<float> profiles / image, used by Float, Mixed, FloatFloat, and TaylorFast.
+  std::vector<cuda::std::complex<float>> h_rp_f32(h_rp.size());
+  for (size_t k = 0; k < h_rp.size(); k++) {
+    h_rp_f32[k] = static_cast<cuda::std::complex<float>>(h_rp[k]);
+  }
+  auto range_profiles_f32 = matx::make_tensor<cuda::std::complex<float>>({num_pulses, num_range_bins});
+  MATX_CUDA_CHECK(cudaMemcpy(range_profiles_f32.Data(), h_rp_f32.data(), h_rp_f32.size() * sizeof(cuda::std::complex<float>), cudaMemcpyHostToDevice));
+  auto px_f = matx::linspace<float>(static_cast<float>(pix_x_min), static_cast<float>(pix_x_min + (image_width - 1) * pix_dx), image_width);
+  auto py_f = matx::linspace<float>(static_cast<float>(pix_y_min), static_cast<float>(pix_y_min + (image_height - 1) * pix_dy), image_height);
+  auto voxel_locations_f32 = matx::zipvec(matx::clone<2>(px_f, {image_height, matx::matxKeepDim}),
+                                          matx::clone<2>(py_f, {matx::matxKeepDim, image_width}),
+                                          static_cast<float>(pixel_z) * matx::ones<float>({image_height, image_width}));
+  auto zero_image_f32 = matx::zeros<cuda::std::complex<float>>({image_height, image_width});
+  auto image_f32 = matx::make_tensor<cuda::std::complex<float>>({image_height, image_width});
+
+  // Float compute type (fp32 platform positions / range-to-mcp).
+  {
+    SCOPED_TRACE("Float");
+    std::vector<float3> h_apc_f32(num_pulses);
+    std::vector<float> h_rtm_f32(num_pulses);
+    for (matx::index_t i = 0; i < num_pulses; i++) {
+      h_apc_f32[i] = float3{static_cast<float>(h_apc[i].x), static_cast<float>(h_apc[i].y), static_cast<float>(h_apc[i].z)};
+      h_rtm_f32[i] = static_cast<float>(h_rtm[i]);
+    }
+    auto platform_positions_f32 = matx::make_tensor<float3>({num_pulses});
+    auto range_to_mcp_f32 = matx::make_tensor<float>({num_pulses});
+    MATX_CUDA_CHECK(cudaMemcpy(platform_positions_f32.Data(), h_apc_f32.data(), num_pulses * sizeof(float3), cudaMemcpyHostToDevice));
+    MATX_CUDA_CHECK(cudaMemcpy(range_to_mcp_f32.Data(), h_rtm_f32.data(), num_pulses * sizeof(float), cudaMemcpyHostToDevice));
+
+    bp_params.compute_type = matx::SarBpComputeType::Float;
+    (image_f32 = matx::experimental::sar_bp(zero_image_f32, range_profiles_f32, platform_positions_f32, voxel_locations_f32, range_to_mcp_f32, bp_params)
+      .props<matx::PropSarBpPixelZIsFixed>()).run(this->exec);
+    this->exec.sync();
+
+    // Float has lower precision; only require the target to be substantially focused.
+    ASSERT_GT(image_f32(image_height / 4, image_width / 4).real(), 0.98f * num_pulses);
+    ASSERT_LT(cuda::std::abs(image_f32(image_height / 4, image_width / 4).imag()), 3.0f);
+  }
+
+  // Mixed, FloatFloat, and TaylorFast (fp64 platform positions / range-to-mcp).
+  // Mixed and FloatFloat compute the range exactly (in fp64 / fltflt), so the
+  // focused real part is limited only by fp32 accumulation. TaylorFast uses a
+  // local Taylor approximation of the range, so it carries a small additional
+  // approximation error and gets a correspondingly looser (but still tight,
+  // ~1e-5 relative) real threshold.
+  {
+    for (auto ct : {matx::SarBpComputeType::Mixed, matx::SarBpComputeType::FloatFloat, matx::SarBpComputeType::TaylorFast}) {
+      const bool is_taylor = (ct == matx::SarBpComputeType::TaylorFast);
+      SCOPED_TRACE(ct == matx::SarBpComputeType::Mixed ? "Mixed" :
+                   (ct == matx::SarBpComputeType::FloatFloat ? "FloatFloat" : "TaylorFast"));
+      bp_params.compute_type = ct;
+      const double re_thresh = is_taylor ? 1.0e-3 : f32_accum_re_thresh;
+      const double im_thresh = is_taylor ? 1.8e-2 : 1.0e-2;
+      (image_f32 = matx::experimental::sar_bp(zero_image_f32, range_profiles_f32, platform_positions, voxel_locations_f32, range_to_mcp, bp_params)
+        .props<matx::PropSarBpPixelZIsFixed>()).run(this->exec);
+      this->exec.sync();
+      validate(image_f32, re_thresh, im_thresh);
     }
   }
 


### PR DESCRIPTION
The PixelZIsZero and PixelZIsFixed sar_bp compile-time properties assert that the image z locations are either identically zero or all uniformly the same value, respectively. These properties are added by the user and are not verified at run-time by the operator. Adding these properties enables additional optimizations in the sar_bp operator by eliding computations involving the z location or hoisting such computations out of the inner loop. See the updated documentation for a full description.

The performance benefits vary by compute type. On RTX PRO 6000, TaylorFast and FloatFloat benefit by 3% and 10%, respectively, with PixelZIsZero.