### PR TITLE
Forward PreRun/PostRun to all operands in composing operators

### DIFF
--- a/include/matx/operators/interp.h
+++ b/include/matx/operators/interp.h
@@ -433,6 +433,17 @@ namespace matx {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, [[maybe_unused]] Executor &&ex) const {
 
+        // Forward PreRun to the operands to support generic operators/transforms
+        if constexpr (is_matx_op<OpX>()) {
+          x_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+        if constexpr (is_matx_op<OpV>()) {
+          v_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+        if constexpr (is_matx_op<OpXQ>()) {
+          xq_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+
         // Allocate temporary storage for spline coefficients
         if (method_ == InterpMethod::SPLINE) {
           static_assert(is_cuda_executor_v<Executor>, "cubic spline interpolation only supports the CUDA executor currently");
@@ -481,6 +492,16 @@ namespace matx {
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PostRun([[maybe_unused]] ShapeType &&shape,
                                   [[maybe_unused]] Executor &&ex) const noexcept {
+        if constexpr (is_matx_op<OpX>()) {
+          x_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+        if constexpr (is_matx_op<OpV>()) {
+          v_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+        if constexpr (is_matx_op<OpXQ>()) {
+          xq_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+
         if (method_ == InterpMethod::SPLINE) {
           matxFree(ptr_m_);
         }

--- a/include/matx/operators/polyval.h
+++ b/include/matx/operators/polyval.h
@@ -160,6 +160,10 @@ namespace matx
           if constexpr (is_matx_op<Op>()) {
             op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
+
+          if constexpr (is_matx_op<Coeffs>()) {
+            coeffs_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
         }
 
         template <typename ShapeType, typename Executor>
@@ -167,6 +171,10 @@ namespace matx
         {
           if constexpr (is_matx_op<Op>()) {
             op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+
+          if constexpr (is_matx_op<Coeffs>()) {
+            coeffs_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
         }
 
@@ -183,7 +191,8 @@ namespace matx
           }
           else if constexpr (Cap == OperatorCapability::SUPPORTS_JIT) {
 #ifdef MATX_EN_JIT
-            return combine_capabilities<Cap>(true, detail::get_operator_capability<Cap>(op_, in));
+            return combine_capabilities<Cap>(true, detail::get_operator_capability<Cap>(op_, in),
+                                                    detail::get_operator_capability<Cap>(coeffs_, in));
 #else
             return false;
 #endif

--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -231,6 +231,10 @@ namespace matx
           if constexpr (is_matx_op<T>()) {
             op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
+
+          if constexpr (is_matx_op<IdxType>()) {
+            idx_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
         }
 
         template <typename ShapeType, typename Executor>
@@ -238,6 +242,10 @@ namespace matx
         {
           if constexpr (is_matx_op<T>()) {
             op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+
+          if constexpr (is_matx_op<IdxType>()) {
+            idx_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
         }
 
@@ -254,7 +262,8 @@ namespace matx
           }
           else if constexpr (Cap == OperatorCapability::SUPPORTS_JIT) {
 #ifdef MATX_EN_JIT
-            return combine_capabilities<Cap>(true, detail::get_operator_capability<Cap>(op_, in));
+            return combine_capabilities<Cap>(true, detail::get_operator_capability<Cap>(op_, in),
+                                                    detail::get_operator_capability<Cap>(idx_, in));
 #else
             return false;
 #endif

--- a/include/matx/operators/sar_bp.h
+++ b/include/matx/operators/sar_bp.h
@@ -233,10 +233,11 @@ namespace detail {
       template <OperatorCapability Cap>
       __MATX_INLINE__ __MATX_HOST__ auto get_capability() const {
         auto self_has_cap = capability_attributes<Cap>::default_value;
-        return combine_capabilities<Cap>(self_has_cap, 
+        return combine_capabilities<Cap>(self_has_cap,
                                            detail::get_operator_capability<Cap>(initial_image_),
                                            detail::get_operator_capability<Cap>(range_profiles_),
                                            detail::get_operator_capability<Cap>(platform_positions_),
+                                           detail::get_operator_capability<Cap>(voxel_locations_),
                                            detail::get_operator_capability<Cap>(range_to_mcp_));
       }
 
@@ -276,7 +277,15 @@ namespace detail {
         if constexpr (is_matx_op<PlatPosType>()) {
           platform_positions_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
-      }      
+
+        if constexpr (is_matx_op<VoxLocType>()) {
+          voxel_locations_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+
+        if constexpr (is_matx_op<RangeToMcpType>()) {
+          range_to_mcp_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+      }
 
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -303,8 +312,16 @@ namespace detail {
           platform_positions_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
 
+        if constexpr (is_matx_op<VoxLocType>()) {
+          voxel_locations_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+
+        if constexpr (is_matx_op<RangeToMcpType>()) {
+          range_to_mcp_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+        }
+
         matxFree(ptr);
-      }        
+      }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
       {

--- a/include/matx/operators/shift.h
+++ b/include/matx/operators/shift.h
@@ -229,7 +229,8 @@ namespace matx
           }
           else if constexpr (Cap == OperatorCapability::SUPPORTS_JIT) {
 #ifdef MATX_EN_JIT
-            return combine_capabilities<Cap>(true, detail::get_operator_capability<Cap>(op_, in));
+            return combine_capabilities<Cap>(true, detail::get_operator_capability<Cap>(op_, in),
+                                                    detail::get_operator_capability<Cap>(shift_, in));
 #else
             return false;
 #endif
@@ -276,6 +277,10 @@ namespace matx
           if constexpr (is_matx_op<T1>()) {
             op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
+
+          if constexpr (is_matx_op<T2>()) {
+            shift_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
         }
 
         template <typename ShapeType, typename Executor>
@@ -283,6 +288,10 @@ namespace matx
         {
           if constexpr (is_matx_op<T1>()) {
             op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+          }
+
+          if constexpr (is_matx_op<T2>()) {
+            shift_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
         }
 

--- a/test/00_operators/interp_test.cu
+++ b/test/00_operators/interp_test.cu
@@ -2,6 +2,7 @@
 #include "matx.h"
 #include "test_types.h"
 #include "utilities.h"
+#include "prerun_tester.h"
 
 using namespace matx;
 using namespace matx::test;
@@ -254,5 +255,57 @@ TEST(InterpTests, Interp)
     }
   }
 
+  MATX_EXIT_HANDLER();
+}
+
+// Verify that interp1 forwards PreRun/PostRun to ALL of its operands (sample
+// points, sample values, query points) by wrapping each one in a lifecycle
+// probe. A single invocation covers every forwarded operand.
+template <typename ExecType>
+static void InterpForwardingCheck(ExecType exec)
+{
+  using TestType = float;
+
+  auto x = make_tensor<TestType>({5});
+  x.SetVals({0.0, 1.0, 3.0, 3.5, 4.0});
+  auto v = make_tensor<TestType>({5});
+  v.SetVals({0.0, 2.0, 1.0, 3.0, 4.0});
+  auto xq = make_tensor<TestType>({6});
+  xq.SetVals({-1.0, 0.0, 0.25, 1.0, 1.5, 5.0});
+
+  // Reference computed from the raw operands.
+  auto out_ref = make_tensor<TestType>({xq.Size(0)});
+  (out_ref = interp1(x, v, xq, InterpMethod::LINEAR)).run(exec);
+
+  // Wrap every forwarded operand in a lifecycle probe.
+  PreRunLifecycle sx, sv, sxq;
+  auto out_test = make_tensor<TestType>({xq.Size(0)});
+  (out_test = interp1(make_prerun_tester(x, sx), make_prerun_tester(v, sv),
+                      make_prerun_tester(xq, sxq), InterpMethod::LINEAR))
+      .run(exec);
+  exec.sync();
+
+  // The forwarding contract is validated by the lifecycle counters: each
+  // operand's PreRun/PostRun must have been forwarded exactly once.
+  ExpectLifecycleClean(sx, "x");
+  ExpectLifecycleClean(sv, "v");
+  ExpectLifecycleClean(sxq, "xq");
+
+  // The probe forwards to the wrapped operand transparently, so out_test always
+  // equals out_ref regardless of forwarding; this only confirms the probe is
+  // transparent. The lifecycle counters above are what test the forwarding fix.
+  for (index_t i = 0; i < xq.Size(0); i++) {
+    ASSERT_NEAR(out_test(i), out_ref(i), 1e-4) << "mismatch at index " << i;
+  }
+}
+
+TEST(InterpTests, InterpOperatorInput)
+{
+  MATX_ENTER_HANDLER();
+  // Run on the CUDA executor only: interp1 requires CUDA for the SPLINE method,
+  // and the template instantiation for a host executor triggers the SPLINE
+  // static_assert even for LINEAR. The host executor is already exercised by the
+  // pre-existing InterpTests.Interp test.
+  InterpForwardingCheck(cudaExecutor{});
   MATX_EXIT_HANDLER();
 }

--- a/test/00_operators/polyval_test.cu
+++ b/test/00_operators/polyval_test.cu
@@ -2,6 +2,7 @@
 #include "matx.h"
 #include "test_types.h"
 #include "utilities.h"
+#include "prerun_tester.h"
 
 using namespace matx;
 using namespace matx::test;
@@ -29,6 +30,45 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, PolyVal)
   // example-end polyval-test-1
   exec.sync();
   MATX_TEST_ASSERT_COMPARE(pb, out, "out", 0.01);
+
+  MATX_EXIT_HANDLER();
+}
+
+// Verify polyval forwards PreRun/PostRun to both of its operands (input values
+// and coefficients) by wrapping each in a lifecycle probe.
+TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecsWithoutJIT, PolyValOperatorCoeffs)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  constexpr int N = 5;
+  constexpr int NC = 4;
+
+  auto x = make_tensor<TestType>({N});
+  auto c = make_tensor<TestType>({NC});
+  x.SetVals({0.5, 1.0, 1.5, 2.0, 2.5});
+  c.SetVals({1, 2, 3, 4});
+
+  // Reference from the raw operands.
+  auto out_ref = make_tensor<TestType>({N});
+  (out_ref = polyval(x, c)).run(exec);
+
+  // Wrap both operands in lifecycle probes.
+  PreRunLifecycle sx, sc;
+  auto out_test = make_tensor<TestType>({N});
+  (out_test = polyval(make_prerun_tester(x, sx), make_prerun_tester(c, sc))).run(exec);
+  exec.sync();
+
+  ExpectLifecycleClean(sx, "input");
+  ExpectLifecycleClean(sc, "coeffs");
+
+  for (int i = 0; i < N; i++) {
+    ASSERT_NEAR(static_cast<double>(out_test(i)), static_cast<double>(out_ref(i)),
+                1e-4) << "mismatch at index " << i;
+  }
 
   MATX_EXIT_HANDLER();
 }

--- a/test/00_operators/remap_test.cu
+++ b/test/00_operators/remap_test.cu
@@ -2,6 +2,7 @@
 #include "matx.h"
 #include "test_types.h"
 #include "utilities.h"
+#include "prerun_tester.h"
 
 using namespace matx;
 using namespace matx::test;
@@ -350,8 +351,52 @@ TYPED_TEST(OperatorTestsNumericAllExecs, RemapOp)
           }
         }
       }
-    } 
+    }
   }
 
   MATX_EXIT_HANDLER();
-} 
+}
+
+// Verify remap forwards PreRun/PostRun to both the data operand and the index
+// operand by wrapping each in a lifecycle probe.
+TYPED_TEST(OperatorTestsNumericAllExecsWithoutJIT, RemapOperatorIndex)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  using inner_type = typename inner_op_type_t<TestType>::type;
+
+  ExecType exec{};
+
+  constexpr int N = 5;
+  auto tiv = make_tensor<TestType>({N, N});
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      tiv(i, j) = inner_type(i * N + j);
+    }
+  }
+
+  auto idx = make_tensor<int>({3});
+  idx.SetVals({1, 2, 3});  // select source rows 1, 2, 3
+
+  // Reference from the raw operands.
+  auto out_ref = make_tensor<TestType>({3, N});
+  (out_ref = remap<0>(tiv, idx)).run(exec);
+
+  // Wrap both the data operand and the index operand in lifecycle probes.
+  PreRunLifecycle sd, si;
+  auto out_test = make_tensor<TestType>({3, N});
+  (out_test = remap<0>(make_prerun_tester(tiv, sd), make_prerun_tester(idx, si))).run(exec);
+  exec.sync();
+
+  ExpectLifecycleClean(sd, "data");
+  ExpectLifecycleClean(si, "index");
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < N; j++) {
+      ASSERT_EQ(out_test(i, j), out_ref(i, j)) << "mismatch at (" << i << "," << j << ")";
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}

--- a/test/00_operators/shift_test.cu
+++ b/test/00_operators/shift_test.cu
@@ -2,6 +2,7 @@
 #include "matx.h"
 #include "test_types.h"
 #include "utilities.h"
+#include "prerun_tester.h"
 
 using namespace matx;
 using namespace matx::test;
@@ -256,6 +257,51 @@ TYPED_TEST(OperatorTestsNumericAllExecs, ShiftOp)
         ASSERT_TRUE(
             MatXUtils::MatXTypeCompare(t2r1s(i, j), t2r1((i + shift_amount) % rows, j)));
       }
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// Verify shift forwards PreRun/PostRun to both the data operand and the
+// shift-amount operand by wrapping each in a lifecycle probe.
+TYPED_TEST(OperatorTestsNumericAllExecsWithoutJIT, ShiftOperatorAmount)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  constexpr index_t rows = 10;
+  constexpr index_t cols = 5;
+  tensor_t<TestType, 2> t({rows, cols});
+  for (index_t i = 0; i < rows; i++) {
+    for (index_t j = 0; j < cols; j++) {
+      t(i, j) = static_cast<detail::value_promote_t<TestType>>(i * cols + j);
+    }
+  }
+
+  auto shifts = make_tensor<int>({cols});
+  shifts.SetVals({1, 2, 3, 4, 5});  // per-column shift amounts
+
+  // Reference from the raw operands.
+  tensor_t<TestType, 2> out_ref({rows, cols});
+  (out_ref = shift<0>(t, shifts)).run(exec);
+
+  // Wrap both the data operand and the shift-amount operand in lifecycle probes.
+  PreRunLifecycle sd, ss;
+  tensor_t<TestType, 2> out_test({rows, cols});
+  (out_test = shift<0>(make_prerun_tester(t, sd), make_prerun_tester(shifts, ss))).run(exec);
+  exec.sync();
+
+  ExpectLifecycleClean(sd, "data");
+  ExpectLifecycleClean(ss, "shift");
+
+  for (index_t i = 0; i < rows; i++) {
+    for (index_t j = 0; j < cols; j++) {
+      ASSERT_TRUE(MatXUtils::MatXTypeCompare(out_test(i, j), out_ref(i, j)))
+          << "mismatch at (" << i << "," << j << ")";
     }
   }
 

--- a/test/00_transform/SarBp.cu
+++ b/test/00_transform/SarBp.cu
@@ -35,6 +35,7 @@
 #include "test_types.h"
 #include "utilities.h"
 #include "gtest/gtest.h"
+#include "prerun_tester.h"
 #include <cuda/std/complex>
 
 using namespace matx;
@@ -832,6 +833,85 @@ TYPED_TEST(SarBpTestDoubleType, PixelZIsFixedNonZeroHeight)
         .props<matx::PropSarBpPixelZIsFixed>()).run(this->exec);
       this->exec.sync();
       validate(image_f32, re_thresh, im_thresh);
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// Verify sar_bp forwards PreRun/PostRun to ALL of its operands by wrapping each
+// in a lifecycle probe.
+TYPED_TEST(SarBpTestNonComplexNonHalfFloatTypes, RangeToMcpOperatorInput)
+{
+  MATX_ENTER_HANDLER();
+
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using complex_t = cuda::std::complex<TestType>;
+  using apc_t = std::conditional_t<std::is_same_v<TestType, double>, double3, float3>;
+
+  const index_t num_range_bins = 64;
+  const index_t num_pulses = 64;
+  const index_t image_width = 64;
+  const index_t image_height = 64;
+
+  auto zero_image = matx::zeros<complex_t>({image_height, image_width});
+  const TestType min_x = -10.0;
+  const TestType max_x = 10.0;
+  auto pix_coords_x = matx::linspace<TestType>(min_x, max_x, image_width);
+  auto pix_coords_y = matx::linspace<TestType>(min_x, max_x, image_height);
+  auto pix_coords_yclone = matx::clone<2>(pix_coords_y, {matx::matxKeepDim, image_width});
+  auto pix_coords_xclone = matx::clone<2>(pix_coords_x, {image_height, matx::matxKeepDim});
+  auto voxel_locations = matx::zipvec(
+    pix_coords_xclone, pix_coords_yclone, matx::zeros<TestType>({image_height, image_width}));
+
+  auto range_profiles = matx::ones<complex_t>({num_pulses, num_range_bins});
+  auto platform_positions = matx::make_tensor<apc_t>({num_pulses});
+  auto range_to_mcp = matx::make_tensor<TestType>({num_pulses});
+  const TestType plat_dx = (max_x - min_x) / num_pulses;
+  const TestType plat_y = -1000.0;
+  const TestType plat_z = 1000.0;
+  for (index_t i = 0; i < num_pulses; i++) {
+    const TestType plat_x = min_x + static_cast<TestType>(i) * plat_dx;
+    platform_positions(i) = apc_t{plat_x, plat_y, plat_z};
+    range_to_mcp(i) = ::sqrt(plat_x*plat_x + plat_y*plat_y + plat_z*plat_z);
+  }
+
+  SarBpParams params;
+  if constexpr (std::is_same_v<TestType, double>) {
+    params.compute_type = SarBpComputeType::Double;
+  } else {
+    params.compute_type = SarBpComputeType::Float;
+  }
+  params.features = SarBpFeature::PhaseLUTOptimization;
+  params.center_frequency = 10.0e9;
+  params.del_r = (max_x - min_x) / num_range_bins;
+
+  // Reference from the raw operands.
+  auto image_ref = matx::make_tensor<complex_t>({image_height, image_width});
+  (image_ref = matx::experimental::sar_bp(zero_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, params)).run(this->exec);
+
+  // Wrap every operand in a lifecycle probe.
+  test::PreRunLifecycle s_img, s_rp, s_pp, s_vl, s_rtm;
+  auto image_test = matx::make_tensor<complex_t>({image_height, image_width});
+  (image_test = matx::experimental::sar_bp(
+      test::make_prerun_tester(zero_image, s_img),
+      test::make_prerun_tester(range_profiles, s_rp),
+      test::make_prerun_tester(platform_positions, s_pp),
+      test::make_prerun_tester(voxel_locations, s_vl),
+      test::make_prerun_tester(range_to_mcp, s_rtm), params)).run(this->exec);
+
+  this->exec.sync();
+
+  test::ExpectLifecycleClean(s_img, "initial_image");
+  test::ExpectLifecycleClean(s_rp,  "range_profiles");
+  test::ExpectLifecycleClean(s_pp,  "platform_positions");
+  test::ExpectLifecycleClean(s_vl,  "voxel_locations");
+  test::ExpectLifecycleClean(s_rtm, "range_to_mcp");
+
+  for (index_t i = 0; i < image_height; i++) {
+    for (index_t j = 0; j < image_width; j++) {
+      ASSERT_NEAR(image_test(i, j).real(), image_ref(i, j).real(), this->thresh) << "real mismatch at (" << i << "," << j << ")";
+      ASSERT_NEAR(image_test(i, j).imag(), image_ref(i, j).imag(), this->thresh) << "imag mismatch at (" << i << "," << j << ")";
     }
   }
 

--- a/test/include/prerun_tester.h
+++ b/test/include/prerun_tester.h
@@ -1,0 +1,187 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+// Test-only utility: a lifecycle probe operator used to verify that composing
+// operators forward PreRun()/PostRun() to every operand that needs it. Wrap each
+// operand passed to a composing operator in make_prerun_tester() and assert the
+// resulting PreRunLifecycle counters after run(). This is intentionally NOT part
+// of the public MatX headers.
+//
+// The probe is a transparent pass-through: operator() forwards directly to the
+// wrapped operand (so the composed result is unchanged and correct for every
+// element type and executor), while PreRun()/PostRun() record that the composing
+// operator forwarded the lifecycle calls. The counters are the assertion: if a
+// composing operator fails to forward PreRun to an operand, prerun_count stays 0.
+// This directly measures the forwarding contract that the real bug violated
+// (an unforwarded transform operand never allocates/fills its temporary).
+//
+// SUPPORTS_JIT is always false for PreRunTesterOp. Tests using this probe MUST
+// use the *WithoutJIT typed-test suites (e.g. OperatorTestsNumericAllExecsWithoutJIT),
+// NOT the regular *AllExecs suites. When MATX_EN_JIT is enabled, the *AllExecs
+// suites include CUDAJITExecutor; BaseOp::run() calls ex.Exec() directly and
+// CUDAJITExecutor throws for operators with SUPPORTS_JIT=false.
+
+#include "matx.h"
+#include "gtest/gtest.h"
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace matx {
+namespace test {
+
+// Observable PreRun/PostRun lifecycle state. PreRunTesterOp is copied into the
+// expression tree (including by value into __device__ code), so it holds only a
+// raw observer pointer to this state; the state itself is owned by the caller
+// (e.g. a stack local in the test) and outlives the run.
+struct PreRunLifecycle {
+  int prerun_count = 0;
+  int postrun_count = 0;
+  int active = 0;                     // logical ownership: ++ in PreRun, -- in PostRun
+  const void *tracked_ptr = nullptr;  // set in PreRun, cleared in PostRun
+};
+
+// Plain (non-transform) test operator that wraps an operand and records the
+// PreRun/PostRun calls forwarded to it by a composing operator. operator()
+// transparently forwards to the wrapped operand.
+//
+// By design there is no prerun_done_ idempotency guard: every PreRun/PostRun
+// call is counted so a test can detect both missing AND duplicated forwarding.
+// Use one PreRunLifecycle per operand per run() and assert the expected count.
+template <typename Op>
+class PreRunTesterOp : public matx::BaseOp<PreRunTesterOp<Op>> {
+public:
+  using value_type = typename Op::value_type;
+  using matxop = bool;
+
+private:
+  static constexpr int RANK = Op::Rank();
+
+  mutable typename matx::detail::base_type_t<Op> op_;
+  // Raw observer pointer, NOT a shared_ptr: this operator is copied (including
+  // by value into __device__ code, e.g. shift's get_impl), and copying a
+  // std::shared_ptr on the device is invalid. The PreRunLifecycle is a
+  // test-local variable that outlives the run(); this pointer is only
+  // dereferenced host-side in PreRun/PostRun.
+  PreRunLifecycle *state_;
+
+public:
+  PreRunTesterOp(const Op &op, PreRunLifecycle *state) : op_(op), state_(state) {}
+
+  __MATX_INLINE__ std::string str() const { return "prerun_tester(" + op_.str() + ")"; }
+
+  template <typename CapType, typename... Is>
+  __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
+    return matx::detail::get_value<CapType>(op_, indices...);
+  }
+
+  template <typename... Is>
+  __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const {
+    return this->operator()<matx::detail::DefaultCapabilities>(indices...);
+  }
+
+  static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() {
+    return RANK;
+  }
+
+  constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const {
+    return op_.Size(dim);
+  }
+
+  template <matx::detail::OperatorCapability Cap, typename InType>
+  __MATX_INLINE__ __MATX_HOST__ auto get_capability(InType &in) const {
+    if constexpr (Cap == matx::detail::OperatorCapability::SUPPORTS_JIT) {
+      return false;  // test operator does not support JIT; force the normal path
+    } else if constexpr (Cap == matx::detail::OperatorCapability::ELEMENTS_PER_THREAD) {
+      const auto my_cap = cuda::std::array<matx::detail::ElementsPerThread, 2>{
+          matx::detail::ElementsPerThread::ONE, matx::detail::ElementsPerThread::ONE};
+      return matx::detail::combine_capabilities<Cap>(
+          my_cap, matx::detail::get_operator_capability<Cap>(op_, in));
+    } else {
+      auto self_has_cap = matx::detail::capability_attributes<Cap>::default_value;
+      return matx::detail::combine_capabilities<Cap>(
+          self_has_cap, matx::detail::get_operator_capability<Cap>(op_, in));
+    }
+  }
+
+  template <typename ShapeType, typename Executor>
+  __MATX_INLINE__ void PreRun(ShapeType &&shape, Executor &&ex) const noexcept {
+    state_->prerun_count++;
+    state_->active++;
+    state_->tracked_ptr = state_;
+    if constexpr (matx::is_matx_op<Op>()) {
+      op_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+    }
+  }
+
+  template <typename ShapeType, typename Executor>
+  __MATX_INLINE__ void PostRun(ShapeType &&shape, Executor &&ex) const noexcept {
+    state_->postrun_count++;
+    state_->active--;
+    state_->tracked_ptr = nullptr;
+    if constexpr (matx::is_matx_op<Op>()) {
+      op_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
+    }
+  }
+};
+
+// Wrap `op` so its PreRun/PostRun lifecycle is recorded in `state`. Use one
+// PreRunLifecycle per operand and pass the wrapped operands to the composing
+// operator under test. `state` must outlive the run() (e.g. a test-local
+// variable); taking it by reference makes a dangling temporary a compile error.
+template <typename Op>
+__MATX_INLINE__ auto make_prerun_tester(const Op &op, PreRunLifecycle &state) {
+  return PreRunTesterOp<Op>(op, &state);
+}
+
+// Pure predicate (no gtest dependency) for programmatic checks.
+inline bool lifecycle_clean(const PreRunLifecycle &s, int expected_calls = 1) {
+  return s.prerun_count == expected_calls && s.postrun_count == s.prerun_count &&
+         s.active == 0 && s.tracked_ptr == nullptr;
+}
+
+// gtest helper: one call per operand. Each invariant is its own EXPECT, and the
+// SCOPED_TRACE label identifies which operand failed.
+inline void ExpectLifecycleClean(const PreRunLifecycle &s,
+                                 std::string_view operand, int expected_calls = 1) {
+  SCOPED_TRACE(std::string("prerun_tester operand: ") + std::string(operand));
+  EXPECT_EQ(s.prerun_count, expected_calls);      // PreRun forwarded exactly expected_calls times
+  EXPECT_EQ(s.postrun_count, s.prerun_count);     // PostRun balanced PreRun
+  EXPECT_EQ(s.active, 0);                          // lifecycle ownership released
+  EXPECT_EQ(s.tracked_ptr, nullptr);               // tracked pointer cleared
+}
+
+}  // namespace test
+}  // namespace matx


### PR DESCRIPTION
Several operators that accept operator-valued operands forwarded PreRun() and PostRun() to only a subset of their operands. The dropped operands were still read lazily in the operator's kernel.

When a dropped operand is a transform-style operator that allocates and fills temporary storage during PreRun, that temporary was never allocated or computed, so the consuming operator read uninitialized memory.

Operators fixed (each now forwards both PreRun and PostRun to the previously-dropped operand, guarded by is_matx_op<>()):

  - polyval : coefficient operand
  - interp1 : sample points, sample values, and query points (the default LINEAR method's PreRun was otherwise a no-op)
  - remap   : index operand
  - shift   : shift-amount operand
  - sar_bp  : voxel_locations and range_to_mcp

Each fix adds a self-contained regression test that composes the operator with a new prerun_tester operator that validates PreRun forwarding of the parent operator.