### PR TITLE
Reset operator PreRun state after PostRun

### DIFF
--- a/include/matx/operators/all.h
+++ b/include/matx/operators/all.h
@@ -125,7 +125,9 @@ namespace detail {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
 
-        matxFree(ptr); 
+        matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }      
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/ambgfun.h
+++ b/include/matx/operators/ambgfun.h
@@ -175,7 +175,9 @@ namespace matx
             y_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
 
-          matxFree(ptr); 
+          matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }
     };
   }

--- a/include/matx/operators/any.h
+++ b/include/matx/operators/any.h
@@ -125,7 +125,9 @@ namespace detail {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
 
-        matxFree(ptr); 
+        matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }          
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/cgsolve.h
+++ b/include/matx/operators/cgsolve.h
@@ -149,7 +149,9 @@ namespace matx
             b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           } 
 
-          matxFree(ptr); 
+          matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }           
     };
   }

--- a/include/matx/operators/channelize_poly.h
+++ b/include/matx/operators/channelize_poly.h
@@ -172,6 +172,8 @@ namespace detail {
         } 
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/conv.h
+++ b/include/matx/operators/conv.h
@@ -227,9 +227,11 @@ namespace matx
 
           if constexpr (is_matx_op<OpB>()) {
             b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          } 
+          }
 
           matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }
     };
   }

--- a/include/matx/operators/corr.h
+++ b/include/matx/operators/corr.h
@@ -207,6 +207,8 @@ namespace matx
           } 
 
           matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }          
     };
   }

--- a/include/matx/operators/cov.h
+++ b/include/matx/operators/cov.h
@@ -138,6 +138,8 @@ namespace matx
           }
 
           matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }          
     };
   }

--- a/include/matx/operators/det.h
+++ b/include/matx/operators/det.h
@@ -110,6 +110,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }        
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/fft.h
+++ b/include/matx/operators/fft.h
@@ -511,7 +511,9 @@ namespace matx
             a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
 
-          matxFree(ptr); 
+          matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }
     };
   }
@@ -1140,7 +1142,9 @@ namespace matx
             a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
 
-          matxFree(ptr);           
+          matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }    
     };    
   }

--- a/include/matx/operators/filter.h
+++ b/include/matx/operators/filter.h
@@ -137,6 +137,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }        
   };
 }

--- a/include/matx/operators/hist.h
+++ b/include/matx/operators/hist.h
@@ -138,6 +138,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }        
   };
 }

--- a/include/matx/operators/matmul.h
+++ b/include/matx/operators/matmul.h
@@ -448,7 +448,9 @@ namespace matx
             b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
           }
 
-          matxFree(ptr);         
+          matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }
     };
   }

--- a/include/matx/operators/matvec.h
+++ b/include/matx/operators/matvec.h
@@ -154,6 +154,8 @@ namespace matx
           } 
 
           matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }           
     };
   }

--- a/include/matx/operators/mean.h
+++ b/include/matx/operators/mean.h
@@ -125,6 +125,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }             
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/median.h
+++ b/include/matx/operators/median.h
@@ -125,6 +125,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }             
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/norm.h
+++ b/include/matx/operators/norm.h
@@ -139,6 +139,8 @@ namespace matx
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/normalize.h
+++ b/include/matx/operators/normalize.h
@@ -151,6 +151,8 @@ namespace matx
           }
 
           matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }
     };
   } // end namespace detail

--- a/include/matx/operators/outer.h
+++ b/include/matx/operators/outer.h
@@ -159,6 +159,8 @@ namespace matx
           } 
 
           matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }      
     };
   }

--- a/include/matx/operators/percentile.h
+++ b/include/matx/operators/percentile.h
@@ -131,6 +131,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }             
   };
 }

--- a/include/matx/operators/pinv.h
+++ b/include/matx/operators/pinv.h
@@ -136,6 +136,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }
   };
 }

--- a/include/matx/operators/pwelch.h
+++ b/include/matx/operators/pwelch.h
@@ -156,6 +156,8 @@ namespace matx
           }
 
           matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }
 
       private:

--- a/include/matx/operators/reduce.h
+++ b/include/matx/operators/reduce.h
@@ -144,6 +144,8 @@ namespace matx
           }
 
           matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }               
     };
   }

--- a/include/matx/operators/resample_poly.h
+++ b/include/matx/operators/resample_poly.h
@@ -162,7 +162,9 @@ namespace detail {
           f_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         } 
 
-        matxFree(ptr);       
+        matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }             
   };
 }

--- a/include/matx/operators/sar_bp.h
+++ b/include/matx/operators/sar_bp.h
@@ -321,6 +321,7 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/softmax.h
+++ b/include/matx/operators/softmax.h
@@ -140,6 +140,8 @@ namespace matx
           }
 
           matxFree(ptr);
+          ptr = nullptr;
+          prerun_done_ = false;
         }   
     };
   }

--- a/include/matx/operators/solve.h
+++ b/include/matx/operators/solve.h
@@ -165,6 +165,8 @@ public:
       b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
     }
     matxFree(ptr);
+    ptr = nullptr;
+    prerun_done_ = false;
   }
 };
 

--- a/include/matx/operators/sparse2dense.h
+++ b/include/matx/operators/sparse2dense.h
@@ -140,6 +140,8 @@ public:
     static_assert(is_sparse_tensor_v<OpA>,
                   "Cannot use sparse2dense on dense input");
     matxFree(ptr);
+    ptr = nullptr;
+    prerun_done_ = false;
   }
 };
 

--- a/include/matx/operators/stdd.h
+++ b/include/matx/operators/stdd.h
@@ -126,6 +126,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/include/matx/operators/trace.h
+++ b/include/matx/operators/trace.h
@@ -126,6 +126,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }
   };
 }

--- a/include/matx/operators/transpose.h
+++ b/include/matx/operators/transpose.h
@@ -148,6 +148,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }
 
       TransposeMatrixOp(const TransposeMatrixOp &rhs) = default;

--- a/include/matx/operators/var.h
+++ b/include/matx/operators/var.h
@@ -126,6 +126,8 @@ namespace detail {
         }
 
         matxFree(ptr);
+        ptr = nullptr;
+        prerun_done_ = false;
       }
 
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const

--- a/test/00_transform/StreamingConv.cu
+++ b/test/00_transform/StreamingConv.cu
@@ -381,11 +381,11 @@ inline float max_rel_err(const matx::tensor_t<float, 1> &a,
   return max_err / (1.0f + max_abs);
 }
 
-// Directly verify the segment operator's PreRun/PostRun lifecycle runs exactly
-// once per feed. The old design ran two independent conv1d(...).run() and
-// (next_retain = ...).run() expressions, materializing a transform segment
-// twice; the probe (no idempotency guard) fails if the lifecycle is run zero or
-// two times. A final flush() reconstructs the full result.
+// Verify the invariant that a segment operator is materialized exactly once per
+// feed -- its PreRun/PostRun lifecycle runs a single time. The probe is a
+// pass-through that counts the PreRun/PostRun calls forwarded to it, so it can
+// distinguish one lifecycle from two where a value check cannot. A final
+// flush() reconstructs the full result.
 TEST(StreamingConv, SegmentLifecycleRunExactlyOnce)
 {
   cudaExecutor exec{};
@@ -415,6 +415,59 @@ TEST(StreamingConv, SegmentLifecycleRunExactlyOnce)
   if (tcnt > 0) { (slice(acc, {off}, {off + tcnt}) = slice(frame, {0}, {tcnt})).run(exec); }
   off += tcnt;
   exec.sync();
+  ASSERT_EQ(off, N);
+  EXPECT_LT(max_rel_err(acc, ref, 1.0f, N), 1e-4f);
+}
+
+// Reusing the same materializing operator requires each completed PostRun to
+// reopen its PreRun guard. Without that reset, the second feed skips
+// materialization, reads the first feed's freed temporary, and unbalances the
+// nested operand lifecycle.
+TEST(StreamingConv, ReusedTransformSegmentRematerializes)
+{
+  cudaExecutor exec{};
+  using T = float;
+  const index_t chunk = 32, N = 2 * chunk, L = 17;
+  auto h = make_tensor<T>({L});
+  for (index_t k = 0; k < L; k++) {
+    h(k) = 1.0f / static_cast<float>(k + 1);
+  }
+  auto sig = make_tensor<T>({chunk});
+  auto full = make_tensor<T>({N});
+  for (index_t i = 0; i < chunk; i++) {
+    sig(i) = std::sin(0.11f * static_cast<float>(i));
+    full(i) = sig(i);
+    full(chunk + i) = sig(i);
+  }
+  auto ref = make_tensor<T>({N});
+  (ref = conv1d(full, h, MATX_C_MODE_SAME)).run(exec);
+
+  PreRunLifecycle segment_operand_life;
+  auto segment = conv1d(make_prerun_tester(sig, segment_operand_life),
+                        ones<T>({1}), MATX_C_MODE_SAME);
+  auto stream_obj = make_conv1d_stream<T>(
+      h, {.mode = MATX_C_MODE_SAME}, exec);
+  auto frame = make_tensor<T>({stream_obj.max_output(chunk)});
+  auto acc = make_tensor<T>({N});
+
+  index_t off = 0;
+  for (int feed = 0; feed < 2; feed++) {
+    const index_t cnt = stream_obj.feed(segment, frame);
+    if (cnt > 0) {
+      (slice(acc, {off}, {off + cnt}) = slice(frame, {0}, {cnt})).run(exec);
+    }
+    off += cnt;
+  }
+  ExpectLifecycleClean(segment_operand_life, "reused conv1d segment",
+                       /*expected_calls=*/2);
+
+  const index_t tcnt = stream_obj.flush(frame);
+  if (tcnt > 0) {
+    (slice(acc, {off}, {off + tcnt}) = slice(frame, {0}, {tcnt})).run(exec);
+  }
+  off += tcnt;
+  exec.sync();
+
   ASSERT_EQ(off, N);
   EXPECT_LT(max_rel_err(acc, ref, 1.0f, N), 1e-4f);
 }


### PR DESCRIPTION
Clear temporary pointers and reset prerun_done_ after PostRun so materializing operators can be reused safely. Some operators already did this, but others freed the underlying memory and left prerun_done_ set. Thus, if the PreRun/PostRun lifecycle were called again, the transform would skip memory allocation since prerun_done_ was set and subsequently an underlying kernel or operator would read from already-freed memory.