### PR TITLE
Fix diag() offset lengths for rectangular matrices

### DIFF
--- a/include/matx/operators/diag.h
+++ b/include/matx/operators/diag.h
@@ -254,17 +254,20 @@ namespace matx
               return op_.Size(dim);
             }
             else {
-              if (k_ == 0) {
-                return cuda::std::min(op_.Size(RANK - 1), op_.Size(RANK-2));
+              const auto rows = op_.Size(RANK - 2);
+              const auto cols = op_.Size(RANK - 1);
+
+              if (k_ >= 0) {
+                if (k_ >= cols) {
+                  return 0;
+                }
+                return cuda::std::min(rows, cols - k_);
               }
               else {
-                // If k is off the main diagonal we need to adjust the sizes
-                if (k_ > 0) {
-                  return cuda::std::min(op_.Size(RANK - 1), op_.Size(RANK-2) - k_);
+                if (k_ <= -rows) {
+                  return 0;
                 }
-                else {
-                  return cuda::std::min(op_.Size(RANK - 1) + k_, op_.Size(RANK-2));
-                }
+                return cuda::std::min(rows + k_, cols);
               }
             }
           }

--- a/test/00_operators/GeneratorTests.cu
+++ b/test/00_operators/GeneratorTests.cu
@@ -205,6 +205,35 @@ TYPED_TEST(BasicGeneratorTestsAll, Diag)
       }
     }    
 
+    {
+      auto wide = make_tensor<TestType>({3, 5});
+      auto tall = make_tensor<TestType>({5, 3});
+
+      auto wide_upper = diag(wide, 1);
+      auto wide_lower = diag(wide, -2);
+      auto tall_upper = diag(tall, 1);
+      auto tall_lower = diag(tall, -1);
+
+      ASSERT_EQ(wide_upper.Size(0), 3);
+      ASSERT_EQ(wide_lower.Size(0), 1);
+      ASSERT_EQ(tall_upper.Size(0), 2);
+      ASSERT_EQ(tall_lower.Size(0), 3);
+
+      ASSERT_EQ(diag(wide, 5).Size(0), 0);
+      ASSERT_EQ(diag(wide, -3).Size(0), 0);
+      ASSERT_EQ(diag(tall, 3).Size(0), 0);
+      ASSERT_EQ(diag(tall, -5).Size(0), 0);
+    }
+
+    {
+      auto batched = make_tensor<TestType>({2, 3, 5});
+      auto op = diag(batched, 1);
+
+      ASSERT_EQ(op.Rank(), 2);
+      ASSERT_EQ(op.Size(0), 2);
+      ASSERT_EQ(op.Size(1), 3);
+    }
+
     // Test with a nested transform. Restrict to floating point types for
     // the convolution
     if constexpr (std::is_same_v<TestType,float> || std::is_same_v<TestType,double>)


### PR DESCRIPTION
Fixes #1213.

## Problem

`diag()` used the row count to limit positive offsets and the column count to limit negative offsets. That works for square matrices, but not for rectangular ones.

For example:

- Shape `{3, 5}`, offset `1`: reported length `2`, expected `3`.
- Shape `{5, 3}`, offset `1`: reported length `3`, expected `2`.

An offset past the final diagonal could also produce a negative length.

## Fix

Use the column extent for positive offsets and the row extent for negative offsets. Return length `0` when the offset is outside the matrix.

## Coverage

Adds tall, wide, batched, and out-of-range regression cases.