### PR TITLE
Fix logspace() JIT code generation

### DIFF
--- a/include/matx/generators/logspace.h
+++ b/include/matx/generators/logspace.h
@@ -65,16 +65,20 @@ namespace matx
           
           return cuda::std::make_tuple(
             func_name,
-            std::format("template <typename T> struct {} {{\n"
-                "  using value_type = T;\n"
+            std::format("template <typename RangeOp> struct {} {{\n"
+                "  using value_type = typename RangeOp::value_type;\n"
                 "  using matxop = bool;\n"
-                "  Range<T> range_;\n"
+                "  typename detail::inner_storage_or_self_t<RangeOp> range_;\n"
                 "  template <typename CapType>\n"
                 "  __MATX_INLINE__ __MATX_DEVICE__ auto operator()(index_t idx) const\n"
                 "  {{\n"
                 "    auto range_val = range_.template operator()<CapType>(idx);\n"
                 "    auto log_func = [](const auto &val) {{\n"
-                "      return cuda::std::pow(10, val);\n"
+                "      if constexpr (is_matx_half_v<value_type>) {{\n"
+                "        return static_cast<value_type>(cuda::std::pow(10, static_cast<float>(val)));\n"
+                "      }} else {{\n"
+                "        return cuda::std::pow(10, val);\n"
+                "      }}\n"
                 "    }};\n"
                 "    return detail::ApplyVecFunc<CapType, value_type>(log_func, range_val);\n"
                 "  }}\n"
@@ -147,6 +151,10 @@ namespace matx
           }
           else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
 #ifdef MATX_EN_JIT
+            const auto [key, value] = get_jit_op_str();
+            if (in.find(key) == in.end()) {
+              in[key] = value;
+            }
             detail::get_operator_capability<Cap>(range_, in);
             return true;
 #else

--- a/test/00_operators/GeneratorTests.cu
+++ b/test/00_operators/GeneratorTests.cu
@@ -1167,6 +1167,49 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Logspace)
   MATX_EXIT_HANDLER();
 }
 
+#ifdef MATX_EN_JIT
+template <typename TestType>
+void TestLogspaceJITType(CUDAJITExecutor &exec)
+{
+  constexpr index_t count = 8;
+  auto direct = make_tensor<TestType>({count});
+  auto composed = make_tensor<TestType>({count});
+  auto op = logspace<0>(direct.Shape(), TestType{0.0f}, TestType{2.0f});
+
+  (direct = op).run(exec);
+  (composed = op * TestType{2.0f}).run(exec);
+  exec.sync();
+
+  for (index_t i = 0; i < count; i++) {
+    const auto exponent = 2.0 * static_cast<double>(i) /
+                          static_cast<double>(count - 1);
+    const auto expected = cuda::std::pow(10.0, exponent);
+
+    if constexpr (IsHalfType<TestType>()) {
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(direct(i), expected, 2));
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(composed(i), expected * 2.0, 2));
+    }
+    else {
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(direct(i), expected, 0.01));
+      EXPECT_TRUE(MatXUtils::MatXTypeCompare(composed(i), expected * 2.0, 0.01));
+    }
+  }
+}
+
+TEST(OperatorTests, LogspaceJIT)
+{
+  MATX_ENTER_HANDLER();
+  CUDAJITExecutor exec{};
+
+  TestLogspaceJITType<matxFp16>(exec);
+  TestLogspaceJITType<matxBf16>(exec);
+  TestLogspaceJITType<float>(exec);
+  TestLogspaceJITType<double>(exec);
+
+  MATX_EXIT_HANDLER();
+}
+#endif
+
 
 TYPED_TEST(BasicGeneratorTestsNumeric, Eye)
 {


### PR DESCRIPTION
Fixes #1214.

## Problem

The JIT type query creates `JITLogspace<RangeOp>`, but the emitted class expected a scalar type and stored `Range<T>`. The class query also registered only the inner range class, leaving `JITLogspace` undefined in the generated source.

## Fix

- Define the generated class in terms of `RangeOp`.
- Register both `JITLogspace` and its nested range class.
- Use the same float conversion as the native path for half-precision exponentiation.

## Coverage

Adds direct and composed JIT cases for FP16, BF16, float, and double. The test requires JIT support only, not MathDx.