### PR TITLE
Fix frexp() and frexpc() projection value types

### DIFF
--- a/include/matx/operators/frexp.h
+++ b/include/matx/operators/frexp.h
@@ -47,7 +47,10 @@ namespace detail {
 
     public:
       using matxop = bool;
-      using value_type = typename OpA::value_type;
+      using input_type = typename OpA::value_type;
+      using fraction_type = typename inner_op_type_t<input_type>::type;
+      using value_type = cuda::std::conditional_t<(WHICH % 2) == 0,
+                                                  fraction_type, int>;
       using self_type = FrexpOp<OpA, WHICH>;
 
       // Propagate dynamic tensor marker through expression tree
@@ -78,9 +81,11 @@ namespace detail {
         return cuda::std::make_tuple(
           func_name,
           std::format("template <typename OpA> struct {} {{\n"
-              "  using value_type = typename OpA::value_type;\n"
-              "  using matxop = bool;\n"
               "  constexpr static int WHICH_ = {};\n"
+              "  using input_type = typename OpA::value_type;\n"
+              "  using fraction_type = typename inner_op_type_t<input_type>::type;\n"
+              "  using value_type = cuda::std::conditional_t<(WHICH_ % 2) == 0, fraction_type, int>;\n"
+              "  using matxop = bool;\n"
               "  constexpr static int Rank_ = {};\n"
               "  constexpr static cuda::std::array<index_t, Rank_> out_dims_ = {{ {} }};\n"
               "  typename detail::inner_storage_or_self_t<detail::base_type_t<OpA>> a_;\n"
@@ -89,8 +94,8 @@ namespace detail {
               "    if constexpr (CapType::ept == ElementsPerThread::ONE) {{\n"
               "      const auto val = get_value<CapType>(a_, indices...);\n"
               "      int rexp;\n"
-              "      if constexpr (is_cuda_complex_v<value_type>) {{\n"
-              "        using inner_type = typename value_type::value_type;\n"
+              "      if constexpr (is_cuda_complex_v<input_type>) {{\n"
+              "        using inner_type = typename input_type::value_type;\n"
               "        const inner_type in = (WHICH_ < 2) ? static_cast<inner_type>(val.real()) : static_cast<inner_type>(val.imag());\n"
               "        if constexpr (cuda::std::is_same_v<float, inner_type>) {{\n"
               "          const float frac = cuda::std::frexpf(in, &rexp);\n"
@@ -108,7 +113,7 @@ namespace detail {
               "          }}\n"
               "        }}\n"
               "      }} else {{\n"
-              "        if constexpr (cuda::std::is_same_v<float, value_type>) {{\n"
+              "        if constexpr (cuda::std::is_same_v<float, input_type>) {{\n"
               "          const float frac = cuda::std::frexpf(val, &rexp);\n"
               "          if constexpr (WHICH_ == 0) {{\n"
               "            return frac;\n"
@@ -139,8 +144,8 @@ namespace detail {
       __MATX_INLINE__ std::string str() const { return "frexp()"; }
       __MATX_INLINE__ FrexpOp(const OpA &a) : a_(a) {
         MATX_LOG_TRACE("{} constructor: rank={}", str(), Rank());
-        static_assert(std::is_floating_point_v<value_type> ||
-                      is_cuda_complex_v<value_type>, "frexp() must take a floating point input");
+        static_assert(std::is_floating_point_v<input_type> ||
+                      is_cuda_complex_v<input_type>, "frexp() must take a floating point input");
 
       };
 
@@ -149,8 +154,8 @@ namespace detail {
       {
         auto get_scalar = [](const auto &x){
           [[maybe_unused]] int rexp;        
-          if constexpr (is_cuda_complex_v<value_type>) {
-            if constexpr (std::is_same_v<float, typename value_type::value_type>) {
+          if constexpr (is_cuda_complex_v<input_type>) {
+            if constexpr (std::is_same_v<float, typename input_type::value_type>) {
               if constexpr (WHICH == 0) { // real fractional
                 const auto frac = cuda::std::frexpf(x.real(), &rexp);
                 return frac;
@@ -182,7 +187,7 @@ namespace detail {
             }
           }
           else {
-            if constexpr (std::is_same_v<float, value_type>) {
+            if constexpr (std::is_same_v<float, input_type>) {
               [[maybe_unused]] const float frac = cuda::std::frexpf(x, &rexp);
               if constexpr (WHICH == 0) { // fractional
                 return frac;

--- a/test/00_operators/frexp_test.cu
+++ b/test/00_operators/frexp_test.cu
@@ -21,6 +21,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, Frexp)
   // Output fractional/integer parts
   auto tofrac = make_tensor<TestType>({10});
   auto toint  = make_tensor<int>({10});
+  auto toexp_parity = make_tensor<int>({10});
 
   for (index_t i = 0; i < tiv0.Size(0); i++) {
     const double x = (static_cast<double>(i) - 5.0) * 0.25;
@@ -32,6 +33,11 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, Frexp)
   (tofrac = ofrac, toint = oint).run(exec);
   // example-end frexp-test-1
 
+  static_assert(std::is_same_v<typename decltype(ofrac)::value_type,
+                               TestType>);
+  static_assert(std::is_same_v<typename decltype(oint)::value_type, int>);
+  (toexp_parity = oint & 1).run(exec);
+
   exec.sync();
 
   int texp;  
@@ -40,11 +46,13 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, Frexp)
       float tfrac = cuda::std::frexpf(tiv0(i), &texp);
       ASSERT_EQ(tfrac, tofrac(i)); 
       ASSERT_EQ(texp,  toint(i)); 
+      ASSERT_EQ(texp & 1, toexp_parity(i));
     }
     else {
       double tfrac = cuda::std::frexp(tiv0(i), &texp);
       ASSERT_EQ(tfrac, tofrac(i)); 
       ASSERT_EQ(texp,  toint(i));   
+      ASSERT_EQ(texp & 1, toexp_parity(i));
     }
   }
 

--- a/test/00_operators/frexpc_test.cu
+++ b/test/00_operators/frexpc_test.cu
@@ -11,6 +11,7 @@ TYPED_TEST(OperatorTestsComplexNonHalfTypesAllExecs, Frexpc)
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  using InnerType = typename TestType::value_type;
 
   ExecType exec{}; 
 
@@ -23,10 +24,10 @@ TYPED_TEST(OperatorTestsComplexNonHalfTypesAllExecs, Frexpc)
   auto tofrac_imag = make_tensor<typename TestType::value_type>({10});
   auto toint_real  = make_tensor<int>({10});
   auto toint_imag  = make_tensor<int>({10});
+  auto tofrac_real_scaled = make_tensor<InnerType>({10});
 
   // Create operators representing fractional and integer
   for (index_t i = 0; i < tiv0.Size(0); i++) {
-    using InnerType = typename TestType::value_type;
     const double xr = (static_cast<double>(i) - 5.0) * 0.25;
     const double xi = (static_cast<double>(i) - 3.0) * 0.5;
     tiv0(i) = TestType(static_cast<InnerType>(xr),
@@ -34,12 +35,20 @@ TYPED_TEST(OperatorTestsComplexNonHalfTypesAllExecs, Frexpc)
   }
   exec.sync();
   const auto [ofrac_real, oint_real, ofrac_imag, oint_imag] = frexpc(tiv0);
-  
+
   (tofrac_real = ofrac_real).run(exec);
   (toint_real = oint_real).run(exec);
   (tofrac_imag = ofrac_imag).run(exec);
   (toint_imag = oint_imag).run(exec);
   // example-end frexpc-test-1
+
+  static_assert(std::is_same_v<typename decltype(ofrac_real)::value_type,
+                               InnerType>);
+  static_assert(std::is_same_v<typename decltype(oint_real)::value_type, int>);
+  static_assert(std::is_same_v<typename decltype(ofrac_imag)::value_type,
+                               InnerType>);
+  static_assert(std::is_same_v<typename decltype(oint_imag)::value_type, int>);
+  (tofrac_real_scaled = ofrac_real * InnerType{2}).run(exec);
 
   exec.sync();
   int texp_real, texp_imag;  
@@ -50,7 +59,8 @@ TYPED_TEST(OperatorTestsComplexNonHalfTypesAllExecs, Frexpc)
       ASSERT_EQ(tfrac_real, tofrac_real(i)); 
       ASSERT_EQ(texp_real,  toint_real(i)); 
       ASSERT_EQ(tfrac_imag, tofrac_imag(i)); 
-      ASSERT_EQ(texp_imag,  toint_imag(i));       
+      ASSERT_EQ(texp_imag,  toint_imag(i));
+      ASSERT_EQ(tfrac_real * 2.0f, tofrac_real_scaled(i));
     }
     else {
       double tfrac_real = cuda::std::frexp(tiv0(i).real(), &texp_real);
@@ -58,7 +68,8 @@ TYPED_TEST(OperatorTestsComplexNonHalfTypesAllExecs, Frexpc)
       ASSERT_EQ(tfrac_real, tofrac_real(i)); 
       ASSERT_EQ(texp_real,  toint_real(i)); 
       ASSERT_EQ(tfrac_imag, tofrac_imag(i)); 
-      ASSERT_EQ(texp_imag,  toint_imag(i));      
+      ASSERT_EQ(texp_imag,  toint_imag(i));
+      ASSERT_EQ(tfrac_real * 2.0, tofrac_real_scaled(i));
     }
   }
 


### PR DESCRIPTION
Fixes #1215.

## Problem

The `frexp()` and `frexpc()` projection operators reported the input type for every result. Their actual result types are:

| Projection | Result type |
| --- | --- |
| Fraction from a real input | Input floating-point type |
| Fraction from a complex input | Real component type |
| Exponent | `int` |

Direct assignment can convert these values, hiding the mismatch. Composed expressions instead use the declared `value_type`, so they selected downstream operations using the wrong type.

## Fix

Keep the input type for the `frexp` calculation, while exposing the actual type of each projection. Apply the same distinction to generated JIT code.

## Coverage

Adds compile-time checks for every projection type, integer composition of exponent projections, and arithmetic composition of complex fraction projections.