### PR TITLE
sarbp: Tune launch bounds and reduce indexing costs

### DIFF
--- a/include/matx/kernels/sar_bp.cuh
+++ b/include/matx/kernels/sar_bp.cuh
@@ -464,6 +464,31 @@ __device__ inline SarBpBinAndWeight<loose_compute_t> ComputeBinWeightToPixelPuls
     };
 }
 
+template <SarBpComputeType ComputeType, SarBpPixelZMode PixelZMode, bool TaylorFastAddThirdOrder>
+struct SarBpMinCtaCount { static constexpr int value = 5; };
+
+template <> struct SarBpMinCtaCount<SarBpComputeType::TaylorFast, SarBpPixelZMode::Zero, false> { static constexpr int value = 6; };
+template <> struct SarBpMinCtaCount<SarBpComputeType::TaylorFast, SarBpPixelZMode::Fixed, false> { static constexpr int value = 6; };
+template <> struct SarBpMinCtaCount<SarBpComputeType::Float, SarBpPixelZMode::Zero, false> { static constexpr int value = 6; };
+template <> struct SarBpMinCtaCount<SarBpComputeType::Float, SarBpPixelZMode::Fixed, false> { static constexpr int value = 6; };
+template <> struct SarBpMinCtaCount<SarBpComputeType::Float, SarBpPixelZMode::Variable, false> { static constexpr int value = 6; };
+
+// Cap the maximum CTA count to the architecture's limit. sm_75 caps at 1024 threads/SM
+// and all other supported architectures allow at least 1536 (6 CTAs). Pushing to 8
+// CTAS_PER_SM would greatly limit register allocation, so treat 6 as the common maximum.
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+#define MATX_SARBP_MAX_CTAS_PER_SM 4
+#else
+#define MATX_SARBP_MAX_CTAS_PER_SM 6
+#endif
+
+// The requested CTA count, clamped to what this architecture can honor.
+template <SarBpComputeType ComputeType, SarBpPixelZMode PixelZMode, bool TaylorFastAddThirdOrder>
+inline constexpr int SarBpMinCtas =
+    (SarBpMinCtaCount<ComputeType, PixelZMode, TaylorFastAddThirdOrder>::value < MATX_SARBP_MAX_CTAS_PER_SM)
+        ? SarBpMinCtaCount<ComputeType, PixelZMode, TaylorFastAddThirdOrder>::value
+        : MATX_SARBP_MAX_CTAS_PER_SM;
+
 // SarBp backprojection kernel. PixelZMode is a compile-time assumption about
 // the pixel z (height) coordinates, selected by the caller via the
 // PropSarBpPixelZIsZero / PropSarBpPixelZIsFixed properties (see
@@ -477,8 +502,13 @@ __device__ inline SarBpBinAndWeight<loose_compute_t> ComputeBinWeightToPixelPuls
 //     compute paths the per-pulse z contribution dz^2 is uniform across pixels
 //     and is precomputed once per pulse (see FillPulseBlockCache), removing the
 //     per-pixel-per-pulse subtract+square from the inner loop.
-template <SarBpComputeType ComputeType, typename OutImageType, typename InitialImageType, typename RangeProfilesType, typename PlatPosType, typename VoxLocType, typename RangeToMcpType, bool PhaseLUT, bool IsUnitStride, bool TaylorFastAddThirdOrder = false, SarBpPixelZMode PixelZMode = SarBpPixelZMode::Variable>
-__launch_bounds__(16*16)
+template <SarBpComputeType ComputeType, typename OutImageType, typename InitialImageType, typename RangeProfilesType, typename PlatPosType, typename VoxLocType, typename RangeToMcpType, bool PhaseLUT, bool IsUnitStride, bool TaylorFastAddThirdOrder = false, SarBpPixelZMode PixelZMode = SarBpPixelZMode::Variable, typename IdxT = index_t>
+// Set the minimum CTA count as a function of the compute type and pixel z mode. This
+// is most important for Double/Mixed where increasing occupancy even at the cost of
+// register spills is beneficial. For modes with reduced register pressure, we set
+// higher minimum CTA counts to avoid the occupancy loss associated with a fixed value
+// for all instantiations.
+__launch_bounds__(16*16, (SarBpMinCtas<ComputeType, PixelZMode, TaylorFastAddThirdOrder>))
 __global__ void SarBp(OutImageType output, const InitialImageType initial_image, const __grid_constant__ RangeProfilesType range_profiles, const __grid_constant__ PlatPosType platform_positions, const __grid_constant__ VoxLocType voxel_locations, const __grid_constant__ RangeToMcpType range_to_mcp,
                       strict_or_ff_compute_param_t<ComputeType> dr_inv,
                       strict_compute_param_t<ComputeType> phase_correction_partial,
@@ -618,7 +648,7 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     // operator(). Binding the tensor's Data() and Stride(0) into the
     // accessor's members forces the compiler to materialize the grid-constant
     // LDCs once at kernel entry rather than reloading inside the pulse loop.
-    detail::TensorAccessor<RangeProfilesType, IsUnitStride> rp(range_profiles);
+    detail::TensorAccessor<RangeProfilesType, IsUnitStride, IdxT> rp(range_profiles);
     detail::TensorAccessor<PlatPosType, IsUnitStride> pp(platform_positions);
 
     // range_to_mcp is required to be a rank-0 or rank-1 MatX operator; the

--- a/include/matx/kernels/sar_bp.cuh
+++ b/include/matx/kernels/sar_bp.cuh
@@ -82,8 +82,8 @@ struct SarBpBinAndWeight {
     int32_t bin_floor_int;
 };
 
-template <typename PlatPosAccessor, SarBpComputeType ComputeType, typename strict_compute_t, typename loose_compute_t>
-__device__ inline strict_compute_t ComputeRangeToPixel(const PlatPosAccessor &ant_pos, const index_t pulse_idx, const loose_compute_t px, const loose_compute_t py, const loose_compute_t pz) {
+template <typename PlatPosAccessor, SarBpComputeType ComputeType, typename strict_compute_t, typename loose_compute_t, typename IdxT>
+__device__ inline strict_compute_t ComputeRangeToPixel(const PlatPosAccessor &ant_pos, const IdxT pulse_idx, const loose_compute_t px, const loose_compute_t py, const loose_compute_t pz) {
     using plat_pos_t = typename PlatPosAccessor::value_type;
     constexpr int Rank = PlatPosAccessor::Rank;
     constexpr bool IsFloat = ComputeType == SarBpComputeType::Float;
@@ -257,10 +257,10 @@ struct SarBpThreadState<SarBpComputeType::TaylorFast, true> {
 // Domain: at least one of dx/dy/dz must not fully cancel (sum of squared
 // distances must be strictly positive) -- three-way simultaneous
 // cancellation is not a meaningful SAR geometry and is not supported.
-template <bool UseCachedPz2 = false>
+template <bool UseCachedPz2 = false, typename IdxT = index_t>
 __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelFloatFloat(
     const SarBpPulseBlockCache<SarBpComputeType::FloatFloat, true> &sh_mem,
-    index_t ip,
+    IdxT ip,
     float px, float py, [[maybe_unused]] float pz,
     fltflt dr_inv)
 {
@@ -366,11 +366,11 @@ __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelFloatFloat(
     };
 }
 
-template <bool TaylorFastAddThirdOrder = false, bool PixelZIsUniform = false>
+template <bool TaylorFastAddThirdOrder = false, bool PixelZIsUniform = false, typename IdxT = index_t>
 __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelTaylorFast(
     const SarBpPulseBlockCache<SarBpComputeType::TaylorFast, true> &sh_mem,
     const SarBpThreadState<SarBpComputeType::TaylorFast, true> &thread_state,
-    index_t ip)
+    IdxT ip)
 {
     // In the mathematical derivation in the documentation, we defined s = dot(u, d) as
     // the dot product of the along-range unit vector u=(ux, uy, uz) with the local offset d,
@@ -407,10 +407,10 @@ __device__ inline SarBpBinAndWeight<float> ComputeBinWeightToPixelTaylorFast(
     };
 }
 
-template <SarBpComputeType ComputeType, bool PixelZIsZero, bool UseCachedDz2, typename strict_compute_t, typename loose_compute_t>
+template <SarBpComputeType ComputeType, bool PixelZIsZero, bool UseCachedDz2, typename strict_compute_t, typename loose_compute_t, typename IdxT>
 __device__ inline SarBpBinAndWeight<loose_compute_t> ComputeBinWeightToPixelPulseBlockCache(
     const SarBpPulseBlockCache<ComputeType, true> &sh_mem,
-    index_t ip,
+    IdxT ip,
     loose_compute_t px,
     loose_compute_t py,
     [[maybe_unused]] loose_compute_t pz,
@@ -615,7 +615,7 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
         if (! is_valid) return;
     }
 
-    const index_t num_pulses = range_profiles.Size(0);
+    const IdxT num_pulses = static_cast<IdxT>(range_profiles.Size(0));
     const int32_t num_range_bins = static_cast<int32_t>(range_profiles.Size(1));
 
     static_assert(cuda::std::is_same_v<voxel_loc_t, double3> || cuda::std::is_same_v<voxel_loc_t, double4> ||
@@ -656,7 +656,7 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     // views or forwards to operator() for computed ops (e.g. ConstVal).
     const detail::TensorAccessor<RangeToMcpType, IsUnitStride> rtm_acc(range_to_mcp);
 
-    const auto r_to_mcp = [rtm_acc](index_t p) -> auto {
+    const auto r_to_mcp = [rtm_acc](IdxT p) -> auto {
         if constexpr (RangeToMcpType::Rank() == 0) {
             return rtm_acc();
         } else {
@@ -764,11 +764,12 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
 
     // Most ComputeTypes amortize some redundant computations or data conversions by leveraging
     // per-pulse-block shared memory.
-    const auto FillPulseBlockCache = [&](index_t pulse_base, index_t num_pulses_in_block) {
+    const auto FillPulseBlockCache = [&](IdxT pulse_base, IdxT num_pulses_in_block) {
         if constexpr (UsePulseBlockCache) {
             __syncthreads();
-            for (index_t ip = tid; ip < num_pulses_in_block; ip += blockDim.x * blockDim.y) {
-                const index_t p = pulse_base + ip;
+            for (IdxT ip = static_cast<IdxT>(tid); ip < num_pulses_in_block;
+                 ip += static_cast<IdxT>(blockDim.x * blockDim.y)) {
+                const IdxT p = pulse_base + ip;
                 // Accessor does the IsUnitStride / rank dispatch internally,
                 // so we just ask for (apx, apy, apz) uniformly.
                 auto load_xyz = [&]() {
@@ -867,12 +868,14 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
     };
 
     const int num_pulse_blocks = static_cast<int>(
-        (num_pulses + static_cast<index_t>(PULSE_BLOCK_SIZE) - 1) / static_cast<index_t>(PULSE_BLOCK_SIZE));
+        (num_pulses + static_cast<IdxT>(PULSE_BLOCK_SIZE) - static_cast<IdxT>(1)) /
+        static_cast<IdxT>(PULSE_BLOCK_SIZE));
     for (int block = 0; block < num_pulse_blocks; ++block) {
-        const index_t pulse_base = static_cast<index_t>(block) * static_cast<index_t>(PULSE_BLOCK_SIZE);
-        const index_t pulses_remaining = num_pulses - pulse_base;
-        const index_t num_pulses_in_block =
-            (pulses_remaining < static_cast<index_t>(PULSE_BLOCK_SIZE)) ? pulses_remaining : static_cast<index_t>(PULSE_BLOCK_SIZE);
+        const IdxT pulse_base = static_cast<IdxT>(block) * static_cast<IdxT>(PULSE_BLOCK_SIZE);
+        const IdxT pulses_remaining = num_pulses - pulse_base;
+        const IdxT num_pulses_in_block =
+            (pulses_remaining < static_cast<IdxT>(PULSE_BLOCK_SIZE)) ?
+                pulses_remaining : static_cast<IdxT>(PULSE_BLOCK_SIZE);
 
         FillPulseBlockCache(pulse_base, num_pulses_in_block);
         if (! is_valid) {
@@ -880,8 +883,8 @@ __global__ void SarBp(OutImageType output, const InitialImageType initial_image,
         }
 
         #pragma unroll 4
-        for (index_t ip = 0; ip < num_pulses_in_block; ++ip) {
-            const index_t p = pulse_base + ip;
+        for (IdxT ip = 0; ip < num_pulses_in_block; ++ip) {
+            const IdxT p = pulse_base + ip;
 
             // The following branches all compute at least the base range bin index and interpolation weight
             // for the current pulse. Paths not using the PhaseLUT optimization will also populate the

--- a/include/matx/kernels/tensor_accessor.h
+++ b/include/matx/kernels/tensor_accessor.h
@@ -59,7 +59,7 @@ template <typename Op>
 using data_ptr_of_op_t = typename data_ptr_of_op<Op, is_tensor_view_v<Op>>::type;
 
 // Forward declaration — defined below.
-template <typename Op, bool IsUnitStride, int NumBound>
+template <typename Op, bool IsUnitStride, int NumBound, typename IdxT = index_t>
 struct BoundAccessor;
 
 // ----------------------------------------------------------------------------
@@ -86,7 +86,10 @@ struct BoundAccessor;
 // access time; on the slow path it captures the bound indices and forwards
 // them to op(leading..., is...).
 // ----------------------------------------------------------------------------
-template <typename Op, bool IsUnitStride, int RankParam = Op::Rank()>
+// IdxT selects the width of the offset arithmetic. It defaults to index_t.
+// Callers that have already proven every index the kernel forms fits in 32 bits
+// can pass int32_t to collapse the 64-bit integer arithmetic into 32-bit arithmetic.
+template <typename Op, bool IsUnitStride, typename IdxT = index_t, int RankParam = Op::Rank()>
 struct TensorAccessor {
     static_assert(is_matx_op<Op>(), "TensorAccessor requires a MatX operator");
     static constexpr bool FastPath = IsUnitStride && is_tensor_view_v<Op>;
@@ -100,7 +103,7 @@ struct TensorAccessor {
 
     const Op& op_;
     data_ptr_of_op_t<Op> data_;
-    index_t outer_strides_[NumOuterStored];
+    IdxT outer_strides_[NumOuterStored];
 
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
     explicit TensorAccessor(const Op& op) : op_(op), data_(nullptr) {
@@ -109,7 +112,7 @@ struct TensorAccessor {
             if constexpr (NumOuter > 0) {
                 MATX_LOOP_UNROLL
                 for (int d = 0; d < NumOuter; ++d) {
-                    outer_strides_[d] = op.Stride(d);
+                    outer_strides_[d] = static_cast<IdxT>(op.Stride(d));
                 }
             }
         }
@@ -126,9 +129,9 @@ struct TensorAccessor {
         requires (Rank >= 1 && sizeof...(Is) == Rank)
     {
         if constexpr (FastPath) {
-            const index_t idx_arr[] = { static_cast<index_t>(is)... };
+            const IdxT idx_arr[] = { static_cast<IdxT>(is)... };
             // Last-dim stride is 1 under IsUnitStride.
-            index_t offset = idx_arr[Rank - 1];
+            IdxT offset = idx_arr[Rank - 1];
             if constexpr (NumOuter > 0) {
                 MATX_LOOP_UNROLL
                 for (int d = 0; d < NumOuter; ++d) {
@@ -148,7 +151,7 @@ struct TensorAccessor {
     auto bind(Leading... leading) const
         requires (sizeof...(Leading) > 0 && sizeof...(Leading) <= Rank)
     {
-        return BoundAccessor<Op, IsUnitStride, sizeof...(Leading)>(
+        return BoundAccessor<Op, IsUnitStride, sizeof...(Leading), IdxT>(
             *this, static_cast<index_t>(leading)...);
     }
 };
@@ -167,7 +170,7 @@ struct TensorAccessor {
 // Slow path: stores the bound indices and forwards them, together with the
 // per-access indices, to op(leading..., is...).
 // ----------------------------------------------------------------------------
-template <typename Op, bool IsUnitStride, int NumBound>
+template <typename Op, bool IsUnitStride, int NumBound, typename IdxT>
 struct BoundAccessor {
     static_assert(NumBound > 0, "BoundAccessor requires at least one bound dim");
     static_assert(is_matx_op<Op>(), "BoundAccessor requires a MatX operator");
@@ -182,13 +185,13 @@ struct BoundAccessor {
 
     const Op& op_;
     data_ptr_of_op_t<Op> base_;              // fast path: already advanced past bound coords
-    index_t rem_outer_strides_[NumRemOuterStored];
+    IdxT rem_outer_strides_[NumRemOuterStored];
     index_t bound_idxs_[NumBound];           // slow path: forward to op(bound..., is...)
 
     // Construct from a parent TensorAccessor + leading index pack.
     template <typename... Leading>
     __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__
-    BoundAccessor(const TensorAccessor<Op, IsUnitStride>& parent, Leading... leading)
+    BoundAccessor(const TensorAccessor<Op, IsUnitStride, IdxT>& parent, Leading... leading)
         : op_(parent.op_), base_(nullptr)
     {
         static_assert(sizeof...(Leading) == NumBound, "Mismatched bind arity");
@@ -201,17 +204,17 @@ struct BoundAccessor {
 
         if constexpr (FastPath) {
             base_ = parent.data_;
-            index_t off = 0;
+            IdxT off = 0;
             MATX_LOOP_UNROLL
             for (int d = 0; d < NumBound; ++d) {
                 // parent.outer_strides_ only covers dims 0..OriginalRank-2.
                 // The last dim's stride is implicitly 1 under IsUnitStride
                 // and is not stored, so bind of that dim must use 1 directly
                 // rather than read past the populated slots.
-                const index_t stride_d = (d < OriginalRank - 1)
+                const IdxT stride_d = (d < OriginalRank - 1)
                     ? parent.outer_strides_[d]
-                    : static_cast<index_t>(1);
-                off += leading_arr[d] * stride_d;
+                    : static_cast<IdxT>(1);
+                off += static_cast<IdxT>(leading_arr[d]) * stride_d;
             }
             base_ += off;
             if constexpr (NumRemOuter > 0) {
@@ -240,8 +243,8 @@ struct BoundAccessor {
         requires (Rank >= 1 && sizeof...(Is) == Rank)
     {
         if constexpr (FastPath) {
-            const index_t idx_arr[] = { static_cast<index_t>(is)... };
-            index_t offset = idx_arr[Rank - 1];
+            const IdxT idx_arr[] = { static_cast<IdxT>(is)... };
+            IdxT offset = idx_arr[Rank - 1];
             if constexpr (NumRemOuter > 0) {
                 MATX_LOOP_UNROLL
                 for (int d = 0; d < NumRemOuter; ++d) {

--- a/include/matx/transforms/sar_bp.h
+++ b/include/matx/transforms/sar_bp.h
@@ -106,6 +106,19 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
                "compute type for larger range-bin counts.");
   }
 
+  // 32-bit tensor indexing requires tensor views as otherwise the operator may
+  // have no defined Stride().
+  bool use_32bit = false;
+  if constexpr (is_tensor_view_v<RangeProfilesType>) {
+    const index_t rp_stride = range_profiles.Stride(0);
+    constexpr int64_t kMax = static_cast<int64_t>(cuda::std::numeric_limits<int32_t>::max());
+    use_32bit = rp_stride > 0 &&
+                range_profiles.Size(1) <= kMax &&
+                static_cast<int64_t>(num_pulses) <=
+                    (kMax - static_cast<int64_t>(range_profiles.Size(1))) /
+                        static_cast<int64_t>(rp_stride);
+  }
+
   const double dr_inv = 1.0 / params.del_r;
 
   const dim3 block(16, 16);
@@ -151,7 +164,8 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
     }
   }
 
-  auto dispatch = [&](auto is_unit_c) {
+  auto dispatch = [&](auto idx_tag, auto is_unit_c) {
+    using IdxT = decltype(idx_tag);
     constexpr bool IsUnitStride = decltype(is_unit_c)::value;
     // The third-order Taylor term is only meaningful for SarBpComputeType::TaylorFast.
     // Force it off for every other compute type so they instantiate a single
@@ -172,27 +186,27 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
       if (params.compute_type == SarBpComputeType::Double) {
         cuda::std::complex<double> *phase_lut = static_cast<cuda::std::complex<double> *>(workspace);
         SarBpFillPhaseLUT<double, double><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode, IdxT><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
       } else if (params.compute_type == SarBpComputeType::Mixed) {
         cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
         SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode, IdxT><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
       } else if (params.compute_type == SarBpComputeType::FloatFloat) {
         cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
         SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-        SarBp<SarBpComputeType::FloatFloat, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::FloatFloat, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode, IdxT><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, static_cast<fltflt>(dr_inv), phase_correction_partial, phase_lut);
       } else if (params.compute_type == SarBpComputeType::TaylorFast) {
         cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
         SarBpFillPhaseLUT<double, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, params.center_frequency, params.del_r, range_profiles.Size(1));
-        SarBp<SarBpComputeType::TaylorFast, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, TaylorFastAddThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::TaylorFast, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, TaylorFastAddThirdOrder, PixelZMode, IdxT><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, phase_lut);
       } else {
         cuda::std::complex<float> *phase_lut = static_cast<cuda::std::complex<float> *>(workspace);
         SarBpFillPhaseLUT<float, float><<<lut_grid, lut_block, 0, stream>>>(phase_lut, static_cast<float>(params.center_frequency), static_cast<float>(params.del_r), range_profiles.Size(1));
-        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode, IdxT><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp,
           static_cast<float>(dr_inv), static_cast<float>(phase_correction_partial), phase_lut);
       }
@@ -200,10 +214,10 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
       constexpr bool PhaseLUT = false;
       const double phase_correction_partial = 4.0 * M_PI * (params.center_frequency / SPEED_OF_LIGHT);
       if (params.compute_type == SarBpComputeType::Double) {
-        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode, IdxT><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, nullptr);
       } else if (params.compute_type == SarBpComputeType::Mixed) {
-        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Mixed, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode, IdxT><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, nullptr);
       } else if (params.compute_type == SarBpComputeType::FloatFloat ||
                  params.compute_type == SarBpComputeType::TaylorFast) {
@@ -211,7 +225,7 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
         // in run-time check higher in this function.
         MATX_THROW(matxInvalidParameter, "sar_bp: FloatFloat and TaylorFast compute types require phase LUT optimization");
       } else {
-        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode><<<grid, block, 0, stream>>>(
+        SarBp<SarBpComputeType::Float, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode, IdxT><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp,
           static_cast<float>(dr_inv), static_cast<float>(phase_correction_partial), nullptr);
       }
@@ -221,14 +235,24 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
   // Only instantiate the IsUnitStride=true kernel when the types support it;
   // otherwise forcing that template instantiation would reach .Data() on a
   // non-tensor-view and fail at compile time.
-  if constexpr (fast_path_eligible) {
-    if (is_unit_stride) {
-      dispatch(cuda::std::bool_constant<true>{});
+  auto dispatch_stride = [&](auto idx_tag) {
+    if constexpr (fast_path_eligible) {
+      if (is_unit_stride) {
+        dispatch(idx_tag, cuda::std::bool_constant<true>{});
+      } else {
+        dispatch(idx_tag, cuda::std::bool_constant<false>{});
+      }
     } else {
-      dispatch(cuda::std::bool_constant<false>{});
+      dispatch(idx_tag, cuda::std::bool_constant<false>{});
     }
+  };
+
+  if constexpr (sizeof(index_t) <= sizeof(int32_t)) {
+    dispatch_stride(index_t{});
+  } else if (use_32bit) {
+    dispatch_stride(int32_t{});
   } else {
-    dispatch(cuda::std::bool_constant<false>{});
+    dispatch_stride(index_t{});
   }
 #endif // __CUDACC__
 }

--- a/include/matx/transforms/sar_bp.h
+++ b/include/matx/transforms/sar_bp.h
@@ -107,7 +107,9 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
   }
 
   // 32-bit tensor indexing requires tensor views as otherwise the operator may
-  // have no defined Stride().
+  // have no defined Stride(). In addition to proving the largest range-profile
+  // offset fits, this inequality proves num_pulses itself fits in int32_t, so
+  // the selected kernel may also use IdxT for its pulse counters and indices.
   bool use_32bit = false;
   if constexpr (is_tensor_view_v<RangeProfilesType>) {
     const index_t rp_stride = range_profiles.Stride(0);


### PR DESCRIPTION
The TensorAccessor class used by SarBp already reduces indexing costs by hoisting strides into registers and often avoiding inner loop LDC instructions. However, with 64-bit indexing (index_t = int64_t), which is the default, there are still 64-bit integer arithmetic instructions associated with tensor access.

Add an explicit index type, defaulted to index_t, to TensorAccessor so that we can opt-in to 32-bit arithmetic when the tensors/operators are small enough that they will not exceed int32_t bounds. This changes both instruction count and register count in cases where the 32-bit indices apply. Leverage this in sar_bp to reduce instruction count when building with 64-bit indices (and when the optimization can apply).

Also add a minimum CTAs value to the launch bounds. This is a trait of ComputeType, PixelZType, and TaylorFastAddThirdOrder because those all impact register utilization.

On average, across B200 / RTX PRO 6000 / B300, we see improvements of 2-4% for TaylorFast modes and 1-2% for FloatFloat. On B200, we see 3-4% improvements for Mixed.