### PR TITLE
[FEA] Match Python's einsum syntax

### DIFF
--- a/docs_input/api/linalg/matvec/einsum.rst
+++ b/docs_input/api/linalg/matvec/einsum.rst
@@ -25,12 +25,25 @@ shorter syntax, and is sometimes more optimized than a direct version of the ope
 
 As of now, MatX only supports a limited set of ``einsum`` operations that would be supported in
 the NumPy version. Specifically only tensor contractions, inner products, and GEMMs are supported 
-and tested at this time. MatX also does not support broadcast '...' notation and has no plans to. While
-the broadcast notation is useful for high-rank tensors, it doesn't add any new features and
-isn't compatible in all expressions inside NumPy. We feel listing out the dimensions makes the 
-syntax more clear without giving up any features. Since ``einsum`` requires an output tensor parameter, 
-only *explicit* mode is supported using the ``->`` operator. This allows type and size checking on the 
-output tensor at the cost of extra verbosity.
+and tested at this time. 
+
+``einsum`` supports two subscript styles:
+
+* **Explicit mode**, using ``->`` to name the output subscript directly. This allows type
+  and size checking on the output tensor. Ex: ``ij,jk->ik``.
+* **Implicit mode**, where ``->`` is omitted and the output subscript is inferred using
+  NumPy's rule: any letter that appears exactly once across all inputs goes to the output
+  (in sorted order); any letter that repeats is summed over. Ex: ``ij,jk`` will automatically
+  infer ``ik`` as output.
+
+``einsum`` also supports NumPy-style broadcast ellipsis (``...``) to represent batch dimensions, 
+instead of spelling them out with letters. For instance, without broadcast notation, you would use:
+``bcij,bcjk->bcik``. However, with broadcast notation you can do the following: ``...ij,...jk->...ik``.
+
+For broadcast notation to work correctly, the batch dimensions represented by ``...`` must have matching sizes. 
+For example, if ``...`` represents ``[5, 2]`` in one tensor, it must also represent ``[5, 2]`` in the other tensor. 
+MatX does not currently support NumPy-style size-1 broadcasting for these dimensions because cuTensorNet requires 
+shared dimensions to have matching sizes. Therefore, MatX throws a clear error if the sizes don't match.
 
 For tensor contractions, MatX uses cuTENSOR and cuTensorNet as the optimized backend libraries. Since
 neither of these libraries are included with CUDA, and not all users need ``einsum`` functionality, ``einsum``

--- a/include/matx/transforms/einsum.h
+++ b/include/matx/transforms/einsum.h
@@ -504,7 +504,7 @@ public:
     i = 0;
     ((params.nmodes_[i++] = tensors.Rank()), ...);
 
-    // For tokens with ellipsis, we cannot compare raw string length
+    //For tokens with ellipsis, we cannot compare raw string length
     // to tensor rank. Therefore, ellipsis tokens are validated with EllipsisRank()
 
     i = 0;
@@ -748,9 +748,10 @@ namespace cutensor {
    * MatX uses a syntax very similar to NumPy's einsum syntax:
    * https://numpy.org/doc/stable/reference/generated/numpy.einsum.html
    *
-   * Ellipses are not supported yet, but a variadic list of tensors for contraction is supported. The output
-   * operator '->' is required in MatX currently, and serves to provide error checking on the output tensor size.
-   *
+   * Broadcast ellipses ("...") are supported for aligning batch dimensions across
+   * operands, and a variadic list of tensors for contraction is also supported. The output
+   * operator '->' is optional; if omitted, the output subscript is inferred using NumPy's
+   * implicit-output rule.
    *
    * @tparam OutputType Output tensor type
    * @tparam InT Types of input tensors

--- a/include/matx/transforms/einsum.h
+++ b/include/matx/transforms/einsum.h
@@ -331,7 +331,7 @@ public:
   /**
    * @brief Infers the output subscript for implicit mode einsum without "->"
    * 
-   * If any input token contains a broadcast ellips ("..."), it represents
+   * If any input token contains a broadcast ellipsis ("..."), it represents
    * the other remaining dimensions
    */
   static std::string InferImplicitOutput(const std::vector<std::string> &input_tokens){
@@ -382,9 +382,9 @@ public:
     // Find output separator
     auto iout = str.find("->");
 
-    //If output separator not found, we detect implicit mode ("ij, jk") instead
+    // If output separator not found, we detect implicit mode ("ij, jk") instead
     // of explicit mode ("ij, jk->ik")
-    //Program infers the output for implicit mode
+    // Program infers the output for implicit mode
     if (iout == std::string::npos) {
       SplitOnCommas(str, out);
       out.push_back(InferImplicitOutput(out));
@@ -446,7 +446,7 @@ public:
   /**
    * @brief Expands a subscript token into one mode ID per tensor dimension
    *
-   * "..." is replaced with synthetic mode IDs that align broadcast dimensi
+   * "..." is replaced with synthetic mode IDs that align broadcast dimensions
    * from the right across operands, matching NumPy's broadcasting rule
    * rightmost dimension covered by "..." always gets the same mode ID
    * regardless of how many dimensions "..." covers for this particular
@@ -504,8 +504,8 @@ public:
     i = 0;
     ((params.nmodes_[i++] = tensors.Rank()), ...);
 
-    //For tokens with ellipsis, we cannot compare raw string length
-    // to tnesor rank. Therefore, ellipsis tokens are validated with EllipsisRank()
+    // For tokens with ellipsis, we cannot compare raw string length
+    // to tensor rank. Therefore, ellipsis tokens are validated with EllipsisRank()
 
     i = 0;
     auto check_rank = [&](const std::string &tok, int32_t rank) {

--- a/include/matx/transforms/einsum.h
+++ b/include/matx/transforms/einsum.h
@@ -422,7 +422,9 @@ public:
  * 
  * @param token subscript token for one einsum operand
  * @param rank number of dimensions in that operand's tensor
+ * @return number of dimensions "..." represents for this operand
  */
+
 
   static int32_t EllipsisRank(const std::string &token, int32_t rank){
     auto epos = FindEllipsis(token);
@@ -451,7 +453,7 @@ public:
    * operand.
    *
    * @param token subscript token, possibly containing "..."
-   * @param rank n describes
+   * @param rank total number of dimensions in this operand's tensor
    * @param modes_out vector to append the expanded mode IDs to
    */
   static void ExpandTokenModes(

--- a/include/matx/transforms/einsum.h
+++ b/include/matx/transforms/einsum.h
@@ -307,8 +307,55 @@ public:
   }
 
   /**
+   * @brief Splits a string on "," into a vector of substrings
+   * 
+   * @param str string to split
+   * @param out vector to append each comma-separated substring to
+   */
+  static void SplitOnCommas(const std::string &str, std::vector<std::string> &out){
+    size_t start = 0;
+    while (start < str.size()){
+      auto sep = str.find(",", start);
+
+      if (sep == std::string::npos){
+        out.push_back(str.substr(start));
+        break;
+      }
+      out.push_back(str.substr(start, sep-start));
+      start = sep + 1;
+
+    }
+  }
+
+  /**
+   * @brief Infers the output subscript for implicit mode einsum without "->"
+   * 
+   */
+  static std::string InferImplicitOutput(const std::vector<std::string> &input_tokens){
+    cuda::std::array<int32_t, 256> counts{};
+    for (const auto &tok : input_tokens){
+        for (const char &c: tok){
+          counts[static_cast<unsigned char>(c)]++;
+    }
+    }
+
+    std::string implicit_out;
+    for (int32_t c=0; c< 256; c++){
+      if (counts[c]==1){
+        implicit_out.push_back(static_cast<char>(c));
+      }
+    }
+    return implicit_out;
+ 
+  }
+
+  /**
    * @brief Tokenizes an einsum string into a vector
    *
+   * Supports both explicit mode, where subscripts contain "->", and
+   * implicit mode (no "->"), where the output subscript is inferred using NumPy's
+   * implicit-output rule. See InferImplicitOutput().
+   * 
    * @param str einsum string
    * @param out tokenized vector
    * @return true if tokenized successfully, or false otherwise
@@ -318,23 +365,18 @@ public:
 
     // Find output separator
     auto iout = str.find("->");
+
+    //If output separator not found, we detect implicit mode ("ij, jk") instead
+    // of explicit mode ("ij, jk->ik")
+    //Program infers the output for implicit mode
     if (iout == std::string::npos) {
-      return false;
+      SplitOnCommas(str, out);
+      out.push_back(InferImplicitOutput(out));
+      return true;
     }
 
-    auto istr = str.substr(0, iout);
-    size_t start = 0;
-    while (start < istr.size()) {
-      auto sep = istr.find(",", start);
-      if (sep == std::string::npos) {
-        out.push_back(istr.substr(start));
-        break;
-      }
-
-      out.push_back(istr.substr(start, sep - start));
-      start += sep - start + 1;
-    }
-
+    SplitOnCommas(str.substr(0, iout), out);
+    
     // Nothing after the output separator -> indicates this is a 0D output
     out.push_back(str.substr(iout + 2));
 

--- a/include/matx/transforms/einsum.h
+++ b/include/matx/transforms/einsum.h
@@ -34,6 +34,7 @@
 #pragma once
 
 #ifdef MATX_EN_CUTENSOR
+#include <algorithm>
 #include <cstdio>
 #include <numeric>
 #include "error.h"
@@ -330,16 +331,31 @@ public:
   /**
    * @brief Infers the output subscript for implicit mode einsum without "->"
    * 
+   * If any input token contains a broadcast ellips ("..."), it represents
+   * the other remaining dimensions
    */
   static std::string InferImplicitOutput(const std::vector<std::string> &input_tokens){
     cuda::std::array<int32_t, 256> counts{};
+
+    bool has_ellipsis = false;
+
     for (const auto &tok : input_tokens){
-        for (const char &c: tok){
-          counts[static_cast<unsigned char>(c)]++;
-    }
+      auto epos = tok.find("...");
+
+      has_ellipsis = has_ellipsis || (epos != std::string::npos);
+
+      for (size_t pos = 0; pos < tok.size(); pos++){
+        if (epos != std::string::npos 
+        && pos >= epos
+        && pos < epos +3){
+          continue;
+        }
+        counts[static_cast<unsigned char>(tok[pos])]++;
+      }
     }
 
-    std::string implicit_out;
+    std::string implicit_out = has_ellipsis ? "..." : "";
+    
     for (int32_t c=0; c< 256; c++){
       if (counts[c]==1){
         implicit_out.push_back(static_cast<char>(c));
@@ -383,6 +399,93 @@ public:
     return true;
   }
 
+/**
+ * @brief Locates the broadcast ellipsis ("...") starting position in a subscript token
+ *
+ * @param token subscript token
+ * @return position of the first "." of "...", or std::string::npos if absent
+ */
+
+ static size_t FindEllipsis(const std::string &token){
+  auto pos = token.find("...");
+
+  // If ellipsis is found, do the following:
+  if (pos != std::string::npos){
+        MATX_ASSERT_STR(token.find("...", pos + 3) == std::string::npos, matxInvalidDim,
+        "einsum subscript may contain at most one ellipsis (\"...\") per operand");
+    }
+  return pos;
+}
+ 
+/**
+ * @brief Returns how many tensor dimensions are represented by "..."
+ * 
+ * @param token subscript token for one einsum operand
+ * @param rank number of dimensions in that operand's tensor
+ */
+
+  static int32_t EllipsisRank(const std::string &token, int32_t rank){
+    auto epos = FindEllipsis(token);
+
+    // If no ellipsis, ellipsis represents 0 dimensions.
+    if (epos == std::string::npos){
+      return 0;
+    }
+    
+  
+    auto ellipsis_rank = rank - static_cast<int32_t>(token.length() - 3); 
+    MATX_ASSERT_STR(ellipsis_rank >=0,
+      matxInvalidDim,
+      "einsum operand rank is too small for the explicit subscripts given alongside \"...\""
+    );
+    return ellipsis_rank;
+  }
+
+  /**
+   * @brief Expands a subscript token into one mode ID per tensor dimension
+   *
+   * "..." is replaced with synthetic mode IDs that align broadcast dimensi
+   * from the right across operands, matching NumPy's broadcasting rule
+   * rightmost dimension covered by "..." always gets the same mode ID
+   * regardless of how many dimensions "..." covers for this particular
+   * operand.
+   *
+   * @param token subscript token, possibly containing "..."
+   * @param rank n describes
+   * @param modes_out vector to append the expanded mode IDs to
+   */
+  static void ExpandTokenModes(
+    const std::string &token,
+    int32_t rank,
+    std::vector<int32_t> &modes_out){
+      constexpr int32_t kEllipsisModeBase = 1000;
+
+      auto epos = FindEllipsis(token);
+      if (epos == std::string::npos) {
+        for (const char &c : token){
+          modes_out.push_back(static_cast<int32_t>(c));
+        }
+        return;
+      }
+      auto ellipsis_rank = EllipsisRank(token, rank);
+      auto before = token.substr(0, epos);
+      auto after = token.substr(epos + 3);
+
+      for (const char &c : before) {
+        modes_out.push_back(static_cast<int32_t>(c));
+      }
+
+      // Add a synthetic mode ID for each hidden dimension represented by "..."
+      // Assigns higher IDs to left dimensions so the rightmost broadcast dimension always gets ID 1000
+      for (int32_t m = 0; m < ellipsis_rank; m++) {
+        modes_out.push_back(kEllipsisModeBase + (ellipsis_rank - 1 - m));
+      }
+
+      for (const char &c : after) {
+        modes_out.push_back(static_cast<int32_t>(c));
+      }
+    }
+  
   static EinsumParams_t<InT...> GetEinsumParams(OutputTensor &out, const std::string &subscripts, const InT&... tensors)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
@@ -396,20 +499,79 @@ public:
     MATX_ASSERT_STR(tokens.size() - 1 == sizeof...(InT), matxInvalidDim, "Number of subscript groups in Einstein notation must match the number of operators (input and output)");
 
     // Set all the token characters
-    for (i = 0; i < tokens.size(); i++) {
-      for (const char &c: tokens[i]) {
-        params.modes_[i].push_back(static_cast<int32_t>(c));
-      }
-    }
-
     i = 0;
     ((params.nmodes_[i++] = tensors.Rank()), ...);
 
+    //For tokens with ellipsis, we cannot compare raw string length
+    // to tnesor rank. Therefore, ellipsis tokens are validated with EllipsisRank()
+
     i = 0;
-    MATX_IGNORE_WARNING_PUSH_GCC("-Wunused-value")
-    MATX_ASSERT_STR(((tokens[i++].length() == static_cast<size_t>(tensors.Rank())), ...), matxInvalidDim,
-        "Tensor rank must match number of einsum subscripts");
-    MATX_IGNORE_WARNING_POP_GCC
+    auto check_rank = [&](const std::string &tok, int32_t rank) {
+      bool ok =
+        tok.find("...") != std::string::npos ||
+        tok.length() == static_cast<size_t>(rank);
+        i++;
+        return ok;
+    };
+
+    MATX_ASSERT_STR(
+    (check_rank(tokens[i], tensors.Rank()) && ...),
+    matxInvalidDim,
+    "Tensor rank must match number of einsum subscripts");
+    
+    i = 0;
+    int32_t max_ellipsis_rank = 0;
+
+    // Calculate this operand’s ellipsis rank and update the maximum.
+    auto track_ellipsis_rank =
+      [&](const std::string &tok, int32_t rank) {
+          max_ellipsis_rank = std::max(max_ellipsis_rank, EllipsisRank(tok, rank));
+          i++;
+        };
+    (track_ellipsis_rank(tokens[i], tensors.Rank()), ...);
+
+    // Ellipsis-covered batch dimensions must match exactly across every operand
+    // cuTensorNet requires tensors share the same modeID to have identical dimension
+    // size. Therefore, MatX does not support NumPy-style size-1 broadcasting for
+    // "..." batch dimensions. 
+    
+    if (max_ellipsis_rank > 0) {
+      std::vector<int64_t> ellipsis_sizes(max_ellipsis_rank, -1);
+      
+      i = 0;
+      auto check_ellipsis_sizes = [&](const auto &t, const std::string &tok) {
+        auto epos = FindEllipsis(tok);
+        if (epos != std::string::npos) {
+          auto ellipsis_rank = EllipsisRank(tok, t.Rank());
+          for (int32_t d = 0; d < ellipsis_rank; d++) {
+            auto dim = static_cast<int32_t>(epos) + (ellipsis_rank - 1 - d);
+            auto size = t.Size(dim);
+            MATX_ASSERT_STR(ellipsis_sizes[d] == -1 || ellipsis_sizes[d] == size, matxInvalidDim,
+                "einsum broadcast (\"...\") dimensions must match exactly across operands; "
+                "MatX does not support NumPy-style size-1 broadcasting for batch dimensions");
+            ellipsis_sizes[d] = size;
+          }
+        }
+        i++;
+      };
+      (check_ellipsis_sizes(tensors, tokens[i]), ...);
+    }
+
+    if (FindEllipsis(tokens[sizeof...(InT)]) != std::string::npos) {
+      MATX_ASSERT_STR(EllipsisRank(tokens[sizeof...(InT)], out.Rank()) == max_ellipsis_rank,
+          matxInvalidDim,
+          "Output tensor rank does not match the number of broadcast dimensions implied by \"...\" in the inputs");
+    }
+
+    // Set all the token characters, expanding "..." into synthetic mode IDs
+    i = 0;
+    auto expand_modes = [&](const std::string &tok, int32_t rank, std::vector<int32_t> &modes) {
+      ExpandTokenModes(tok, rank, modes);
+      i++;
+    };
+    (expand_modes(tokens[i], tensors.Rank(), params.modes_[i]), ...);
+    ExpandTokenModes(tokens[sizeof...(InT)], out.Rank(), params.modes_[sizeof...(InT)]); // output tensor
+  
 
     auto set_sizes = [](auto &t, std::vector<int64_t> &sizes) {
       for (int32_t s = 0; s < t.Rank(); s++) {

--- a/test/00_tensor/EinsumTests.cu
+++ b/test/00_tensor/EinsumTests.cu
@@ -413,4 +413,127 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, TraceImplicitOutput)
   MATX_EXIT_HANDLER();
 }
 
+// Checks broadcast notation in einsum
+TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, BroadcastBatchMatmul)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  // Two batch dimensions (5,2) are covered by "..."
+  auto a1 = make_tensor<TestType>({5*2*4*3}); 
+  auto b1 = make_tensor<TestType>({5*2*3*4});
+
+  // Generates 120 evenly spaces numbers from 0 to 119
+  (a1 = linspace((TestType)0, static_cast<TestType>(a1.Size(0) - 1), a1.Size(0))).run(exec);
+  (b1 = linspace((TestType)0, static_cast<TestType>(b1.Size(0) - 1), b1.Size(0))).run(exec);
+  
+  //Converts 1D tensors into 4D tensors
+  auto a = a1.View({5,2,4,3});
+  auto b = b1.View({5,2,3,4});
+
+  // Output tensor that will store the result of einsum with broadcast notation
+  auto c = make_tensor<TestType>({5,2,4,4});
+
+  // Output tensor that will store result from explicitly-letter einsum
+  auto c_ref = make_tensor<TestType>({5,2,4,4});
+
+  // "..." should behave identically to spelling the batch dims out explicitly
+  
+  // Result from einsum using "..."
+  (c = cutensor::einsum("...ij,...jk->...ik", a, b)).run(exec);
+  
+  // Reference result using explicit batch labels
+  (c_ref = cutensor::einsum("bcij,bcjk->bcik", a, b)).run(exec);
+  
+  exec.sync();
+
+  for (auto i = 0; i < c.Size(0); i++) {
+    for (auto j = 0; j < c.Size(1); j++) {
+      for (auto k = 0; k < c.Size(2); k++) {
+        for (auto l = 0; l < c.Size(3); l++) {
+          MATX_ASSERT_EQ(c(i,j,k,l), c_ref(i,j,k,l));
+        }
+      }
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+// Checks implicit output in einsum with broadcast notation
+TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, BroadcastBatchMatmulImplicitOutput)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  // Two batch dimensions (5,2) are covered by "..."
+  auto a1 = make_tensor<TestType>({5*2*4*3}); 
+  auto b1 = make_tensor<TestType>({5*2*3*4});
+
+  // Generates 120 evenly spaced numbers from 0 to 119
+  (a1 = linspace((TestType)0, static_cast<TestType>(a1.Size(0) - 1), a1.Size(0))).run(exec);
+  (b1 = linspace((TestType)0, static_cast<TestType>(b1.Size(0) - 1), b1.Size(0))).run(exec);
+  
+  // View the 1D tensors as 4D tensors 
+  auto a = a1.View({5,2,4,3});
+  auto b = b1.View({5,2,3,4});
+
+  // Output tensor that will store the result of einsum with broadcast notation
+  // and implicit output
+  auto c = make_tensor<TestType>({5,2,4,4});
+
+  // Output tensor that will store result from explicitly-letter einsum
+  auto c_ref = make_tensor<TestType>({5,2,4,4});
+
+
+  // Result from einsum using "..." and implicit output
+  (c = cutensor::einsum("...ij,...jk", a, b)).run(exec);
+  
+  // Reference result using explicit batch labels
+  (c_ref = cutensor::einsum("bcij,bcjk->bcik", a, b)).run(exec);
+  exec.sync();
+
+  for (auto i = 0; i < c.Size(0); i++) {
+    for (auto j = 0; j < c.Size(1); j++) {
+      for (auto k = 0; k < c.Size(2); k++) {
+        for (auto l = 0; l < c.Size(3); l++) {
+          MATX_ASSERT_EQ(c(i,j,k,l), c_ref(i,j,k,l));
+        }
+      }
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+//Checks if MatX rejects invalid batch sizes when ... is used
+TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, BroadcastBatchSizeMismatchThrows)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  // Batch dims (5 vs 3) covered by "..." do not match. MatX does
+  // not support NumPy-style size-1 broadcasting for these dims due to cuTensor 
+  // limitations. Therefore, mismatch dimensions must throw an error.
+  auto a = make_tensor<TestType>({5,2,4,3});
+  auto b = make_tensor<TestType>({3,2,3,4});
+  auto c = make_tensor<TestType>({5,2,4,4});
+
+  ASSERT_THROW({ (c = cutensor::einsum("...ij,...jk->...ik", a, b)).run(exec); },
+      matx::detail::matxException);
+
+  MATX_EXIT_HANDLER();
+}
+
+
 #endif
+

--- a/test/00_tensor/EinsumTests.cu
+++ b/test/00_tensor/EinsumTests.cu
@@ -328,6 +328,89 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Trace)
   MATX_EXIT_HANDLER();
 }
 
+TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, Contraction3DImplicitOutput)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
+  ExecType exec{};
+
+  this->pb->template InitAndRunTVGenerator<TestType>(
+      "00_operators", "contraction", "run", {});
+
+  auto a1 = make_tensor<TestType>({60});
+  auto b1 = make_tensor<TestType>({24});
+  auto c2 = make_tensor<TestType>({5,2});
+
+  (a1 = linspace((TestType)0, static_cast<TestType>(a1.Size(0) - 1), a1.Size(0))).run(exec);
+  (b1 = linspace((TestType)0, static_cast<TestType>(b1.Size(0) - 1), b1.Size(0))).run(exec);
+  auto a = a1.View({3,4,5});
+  auto b = b1.View({4,3,2});
+
+  // "i" and "j" each occur twice across the two operands and are summed;
+  // "k" and "l" each occur once and become the inferred output "kl",
+  // matching the explicit "ijk,jil->kl" used in Contraction3D.
+  (c2 = cutensor::einsum("ijk,jil", a, b)).run(exec);
+  exec.sync();
+  MATX_TEST_ASSERT_COMPARE(this->pb, c2, "c_float3d", 0.01);
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, GEMMImplicitOutput)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a2 = make_tensor<TestType>({10,20});
+  auto b2 = make_tensor<TestType>({20,10});
+  auto c2 = make_tensor<TestType>({10,10});
+  auto c22 = make_tensor<TestType>({10,10});
+  (a2 = ones<TestType>()).run(exec);
+  (b2 = ones<TestType>()).run(exec);
+
+  // "k" is contracted (appears in both operands); "m" and "n" each occur
+  // once and are inferred as the output "mn", matching explicit "mk,kn->mn".
+  (c2 = cutensor::einsum("mk,kn", a2, b2)).run(exec);
+  (c22 = matmul(a2, b2)).run(exec);
+  exec.sync();
+
+  for (auto i = 0; i < c2.Size(0); i++) {
+    for (auto j = 0; j < c2.Size(1); j++) {
+      MATX_ASSERT_EQ(c2(i,j), c22(i,j));
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, TraceImplicitOutput)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  auto a2 = make_tensor<TestType>({10,10});
+  auto c0_0 = make_tensor<TestType>({});
+  auto c0_1 = make_tensor<TestType>({});
+  (a2 = ones<TestType>()).run(exec);
+
+  // "i" occurs twice within the single operand, so it is summed and the
+  // inferred output is empty (0D), matching explicit "ii->".
+  (c0_0 = cutensor::einsum("ii", a2)).run(exec);
+  (c0_1 = trace(a2)).run(exec);
+  exec.sync();
+
+  MATX_ASSERT_EQ(c0_0(), c0_1());
+  MATX_ASSERT_EQ(c0_0(), 10);
+
+  MATX_EXIT_HANDLER();
+}
 
 #endif

--- a/test/00_tensor/EinsumTests.cu
+++ b/test/00_tensor/EinsumTests.cu
@@ -426,18 +426,18 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, BroadcastBatchMatmul)
   auto a1 = make_tensor<TestType>({5*2*4*3}); 
   auto b1 = make_tensor<TestType>({5*2*3*4});
 
-  // Generates 120 evenly spaces numbers from 0 to 119
+  // Generates 120 evenly spaced numbers from 0 to 119
   (a1 = linspace((TestType)0, static_cast<TestType>(a1.Size(0) - 1), a1.Size(0))).run(exec);
   (b1 = linspace((TestType)0, static_cast<TestType>(b1.Size(0) - 1), b1.Size(0))).run(exec);
   
-  //Converts 1D tensors into 4D tensors
+  // Converts 1D tensors into 4D tensors
   auto a = a1.View({5,2,4,3});
   auto b = b1.View({5,2,3,4});
 
   // Output tensor that will store the result of einsum with broadcast notation
   auto c = make_tensor<TestType>({5,2,4,4});
 
-  // Output tensor that will store result from explicitly-letter einsum
+  // Output tensor that will store result from explicit-letter einsum
   auto c_ref = make_tensor<TestType>({5,2,4,4});
 
   // "..." should behave identically to spelling the batch dims out explicitly
@@ -488,7 +488,7 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, BroadcastBatchMatmulImplicitO
   // and implicit output
   auto c = make_tensor<TestType>({5,2,4,4});
 
-  // Output tensor that will store result from explicitly-letter einsum
+  // Output tensor that will store result from explicit-letter einsum
   auto c_ref = make_tensor<TestType>({5,2,4,4});
 
 
@@ -512,7 +512,7 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, BroadcastBatchMatmulImplicitO
   MATX_EXIT_HANDLER();
 }
 
-//Checks if MatX rejects invalid batch sizes when ... is used
+// Checks if MatX rejects invalid batch sizes when ... is used
 TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, BroadcastBatchSizeMismatchThrows)
 {
   MATX_ENTER_HANDLER();
@@ -523,7 +523,7 @@ TYPED_TEST(EinsumTestsFloatNonComplexNonHalfTypes, BroadcastBatchSizeMismatchThr
 
   // Batch dims (5 vs 3) covered by "..." do not match. MatX does
   // not support NumPy-style size-1 broadcasting for these dims due to cuTensor 
-  // limitations. Therefore, mismatch dimensions must throw an error.
+  // limitations. Therefore, mismatched dimensions must throw an error.
   auto a = make_tensor<TestType>({5,2,4,3});
   auto b = make_tensor<TestType>({3,2,3,4});
   auto c = make_tensor<TestType>({5,2,4,4});


### PR DESCRIPTION
## What this does

Adds two features to `einsum` that make it work more like NumPy's `einsum`:

1. **Broadcast notation (`...`)**: you can now use `...` to represent batch dimensions, instead of spelling them out with letters. For instance, without broadcast notation, you would do something like: `bcij,bcjk->bcik`. 

However, with broadcast notation you can do following: `...ij,...jk->...ik`.

One limitation is that the batch dimensions represented by `...` must have matching sizes. For example, if `...` represents `[5, 2]` in one tensor, it must also represent `[5, 2]` in the other tensor. MatX does not currently support NumPy-style size-1 broadcasting for these dimensions because cuTensorNet requires shared dimensions to have matching sizes. It's a cuTensorNet limitation. 

2. **Optional output**: you can now leave out `->` and MatX will figure out the output for you. Example: `einsum("ii", a)` works the same as `einsum("ii->", a)`.

3. **Single Input (no comma)**: from my understanding, single input with no comma has already been implemented. For instance, 
`ijkl->jlki` is single input (no comma) and it works. In `test/00_tensor/EinsumTests.cu`, following tests check single input (no comma implementation): Permute, Sum, and Trace. I have not added anything new to it. 


## Testing

Added tests for broadcast notation and optional output.

Ran following commands: 
```
cmake --build build -j32 --target test_00_tensor_EinsumTests
./test_00_tensor_EinsumTests --gtest_filter="*ImplicitOutput*:*Broadcast*"
```

I ran all the tests on:
- Ubuntu 22.04, 
- NVIDIA RTX 4500 Ada Generation GPU, 
- driver version 570.133.07
- CUDA 12.8.

## Docs

I didn’t update the docs in this PR yet. The docs page still says broadcast notation isn't supported. If I get a greenlight, I can go ahead and update the documents.

## Concern
If we are supposed to follow any formatting tools, please let me know. I will fix it immediately. I didn’t find any formatting tools details in the repo.

# Related Issue
Closes #300 