### PR TITLE
sarbp example: derive del_r from sample spacing, not bandwidth

### DIFF
--- a/examples/sarbp/README.md
+++ b/examples/sarbp/README.md
@@ -56,6 +56,9 @@ python cphd_to_sarbp_input.py /path/to/file.cphd -o sarbp_input.sarbp
 
 This writes a `.sarbp` file (`sarbp_input.sarbp` in the example) that packages the phase history,
 platform positions, and image grid parameters into a single binary.
+For FX-domain input, the converter derives the compressed range-bin spacing from the complete
+sampled-frequency grid (`num_samples * SCSS`). The CPHD `Global.FxBand` support is used for
+physical range-resolution estimates, not FFT bin spacing.
 
 ### Common options
 
@@ -151,10 +154,11 @@ The script determines image dimensions in this order:
 | `--size HxW` | Image dimensions (overrides `.sarbp` header) |
 | `--percentile LO,HI` | Percentile-based contrast stretch on the dB image (default: `5,95`) |
 | `--dynamic-range DB` | Use a fixed dB-below-peak floor instead of the percentile stretch |
+| `--flip-ud` | Flip the image and vertical coordinate axis without modifying the raw file |
 | `--save FILE` | Save to file instead of displaying |
 | `--cmap NAME` | Matplotlib colormap (default: gray) |
 
-By default the viewer applies a percentile-based contrast stretch: it computes the 5th and 95th percentiles of the dB-scaled image and uses those as the colormap's vmin/vmax. This prevents a small number of bright scatterers (specular returns from buildings, corner reflectors, etc.) from dominating the dynamic range and washing the rest of the scene to black. A fixed dB-below-peak floor (`--dynamic-range`) is available as an override, but the percentile stretch is generally the more useful default for inspecting these images.
+By default the viewer applies a percentile-based contrast stretch: it computes the 5th and 95th percentiles of the nonzero dB-scaled pixels and uses those as the colormap's vmin/vmax. Exact-zero pixels receive no backprojection contribution (for example, outside the range swath) and are excluded so they do not pin the lower percentile to the logarithmic floor and wash out the valid image. A fixed dB-below-peak floor (`--dynamic-range`) is available as an override, but the percentile stretch is generally the more useful default for inspecting these images.
 
 Below is the image generated for the 8192 x 8192 reconstruction using `python view_sarbp_image.py /path/to/file.raw --save image.png`.
 The scene is Hartsfield-Jackson Atlanta International Airport. The terminals are the vertical structures and the runways around the

--- a/examples/sarbp/cphd_to_sarbp_input.py
+++ b/examples/sarbp/cphd_to_sarbp_input.py
@@ -68,6 +68,30 @@ SARBP_VERSION = 2
 SARBP_HEADER_SIZE = 256               # fixed header size in bytes (padded for alignment)
 
 
+def _range_bin_spacing_from_scss(num_samples: int, scss: np.ndarray,
+                                 speed_of_light: float = 299792458.0):
+    """Return FX-to-range FFT bin spacing from the CPHD sample grid.
+
+    ``Global.FxBand`` describes the valid signal support, which can exclude
+    guard samples. FFT delay-bin spacing is instead set by the complete
+    sampled-frequency grid: ``num_samples * SCSS``.
+
+    The .sarbp format currently stores one range spacing for every pulse. Use
+    the median SCSS and report its relative span so callers can warn when a
+    CPHD has materially pulse-varying sample spacing.
+    """
+    scss_values = np.asarray(scss, dtype=np.float64)
+    if scss_values.size == 0:
+        raise ValueError("CPHD contains no SCSS values")
+    if not np.all(np.isfinite(scss_values)) or np.any(scss_values <= 0.0):
+        raise ValueError("CPHD SCSS values must be finite and positive")
+
+    scss_ref = float(np.median(scss_values))
+    relative_span = float(np.ptp(scss_values) / scss_ref)
+    del_r = speed_of_light / (2.0 * num_samples * scss_ref)
+    return del_r, scss_ref, relative_span
+
+
 def ecef_to_enu(ecef_points: np.ndarray, ref_ecef: np.ndarray,
                 ref_lat_rad: float, ref_lon_rad: float) -> np.ndarray:
     """Convert ECEF coordinates to local East-North-Up (ENU) frame.
@@ -784,7 +808,18 @@ def process_cphd(cphd_path: str, output_path: str,
     bandwidth = data['bandwidth_hz']
     center_freq = data['center_freq_hz']
     lam = c / center_freq
-    del_r = c / (2.0 * bandwidth)  # range bin spacing = slant-range resolution
+    slant_range_res = c / (2.0 * bandwidth)
+    # Range-bin spacing after the FX-to-range FFT is determined by the full
+    # sampled-frequency grid, not by Global.FxBand signal support. FxBand may
+    # exclude guard samples and therefore cannot be used as the FFT bandwidth.
+    del_r, scss_ref, scss_relative_span = _range_bin_spacing_from_scss(
+        num_range_bins, data['scss'], c)
+    print(f"FX sample spacing: {scss_ref:.6f} Hz "
+          f"(relative pulse span: {scss_relative_span:.3e})")
+    print(f"Range-bin spacing: {del_r:.6f} m (SCSS sample-grid definition)")
+    if scss_relative_span > 1.0e-6:
+        print("WARNING: SCSS varies materially across pulses; the .sarbp format "
+              "stores a single del_r, so the median SCSS will be used")
 
     # Mid-aperture geometry for resolution/extent computation
     mid = num_pulses // 2
@@ -795,7 +830,7 @@ def process_cphd(cphd_path: str, output_path: str,
     incidence = np.pi / 2.0 - grazing
 
     # Ground-range resolution (slant-range projected onto ground plane)
-    ground_range_res = del_r / np.sin(incidence)
+    ground_range_res = slant_range_res / np.sin(incidence)
 
     # Cross-range resolution: lambda * R / (2 * v_cross * T_aperture)
     vel_ecef = (data['tx_vel'] + data['rx_vel']) / 2.0
@@ -812,7 +847,7 @@ def process_cphd(cphd_path: str, output_path: str,
     T_aperture = (num_pulses - 1) * pulse_stride / data['prf']
     cross_range_res = lam * R0 / (2.0 * v_cross * T_aperture)
 
-    print(f"Native resolution: slant-range={del_r:.3f} m, "
+    print(f"Native resolution: slant-range={slant_range_res:.3f} m, "
           f"ground-range={ground_range_res:.3f} m, "
           f"cross-range={cross_range_res:.3f} m")
     print(f"  Grazing angle: {np.degrees(grazing):.1f} deg, "

--- a/examples/sarbp/view_sarbp_image.py
+++ b/examples/sarbp/view_sarbp_image.py
@@ -41,6 +41,7 @@ Usage:
     python view_sarbp_image.py output.raw --size 2048x2048
     python view_sarbp_image.py output.raw --percentile 2,98
     python view_sarbp_image.py output.raw --dynamic-range 50
+    python view_sarbp_image.py output.raw --flip-ud
     python view_sarbp_image.py output.raw --save output.png
 """
 
@@ -111,6 +112,9 @@ def main():
                         help="Save image to file (e.g. output.png) instead of displaying")
     parser.add_argument("--cmap", default="gray",
                         help="Matplotlib colormap (default: gray)")
+    parser.add_argument("--flip-ud", action="store_true",
+                        help="Flip the image and vertical coordinate axis up-down; "
+                             "does not modify the raw image file")
     args = parser.parse_args()
 
     # Determine image dimensions (priority: --size > --sarbp / auto-discover > square guess)
@@ -183,8 +187,22 @@ def main():
             print(f"ERROR: --percentile LO,HI must satisfy 0 <= LO < HI <= 100, "
                   f"got {lo_p},{hi_p}", file=sys.stderr)
             sys.exit(1)
-        vmin, vmax = np.percentile(mag_db, [lo_p, hi_p])
-        print(f"Percentile stretch: {lo_p}th={vmin:.2f} dB, {hi_p}th={vmax:.2f} dB")
+        # Pixels with exactly zero magnitude received no backprojection
+        # contribution (for example, outside the range swath). Including them
+        # can pin the lower percentile to the log floor and wash out the valid
+        # image. Fall back to all pixels for an all-zero image.
+        stretch_values = mag_db[mag > 0.0]
+        if stretch_values.size == 0:
+            stretch_values = mag_db.ravel()
+        # Boolean indexing above already produced a disposable dense array.
+        # Let percentile partition it in place instead of making another
+        # image-sized copy, which is significant for the large SAR images this
+        # viewer is intended to handle. In the all-zero fallback, modifying the
+        # flattened mag_db view is harmless because every value is identical.
+        vmin, vmax = np.percentile(stretch_values, [lo_p, hi_p],
+                                   overwrite_input=True)
+        print(f"Percentile stretch (nonzero pixels): "
+              f"{lo_p}th={vmin:.2f} dB, {hi_p}th={vmax:.2f} dB")
 
     # Import matplotlib only when needed so the script can be used without
     # a display if only --save is used.
@@ -235,6 +253,9 @@ def main():
     im = ax.imshow(mag_db, cmap=args.cmap, vmin=vmin, vmax=vmax,
                    origin="lower", aspect="equal", extent=extent)
     fig.colorbar(im, ax=ax, label="dB", shrink=0.8)
+    if args.flip_ud:
+        ax.invert_yaxis()
+        print("Display orientation: flipped up-down (vertical axis reversed)")
     ax.set_title("SAR Backprojection Image")
     if has_coords:
         ax.set_xlabel("East (m)")


### PR DESCRIPTION
The sarbp example previously computed the range bin spacing (del_r) based on the signal bandwidth in the CPHD file. Ths can differ from the actual sample frequency spacing, e.g., when there are guard bins. Since we want del_r to match FFT bin spacing, we now derive del_r from the sample spacing rather than the nominal bandwidth.

The sarbp operator supports a constant del_r, but it is possible for FFT bin spacing to vary pulse-to-pulse. Thus, we use the median del_r and warn if it varies significantly pusle-to-pulse.

Also add a --flip-ud option to the viewer to flip the vertical axis and adjust the stretch logic to avoid including zeros in the stretch calculation.