### PR TITLE
[FEA] Add support for mdspan

### DIFF
--- a/docs_input/api/creation/tensors/make.rst
+++ b/docs_input/api/creation/tensors/make.rst
@@ -38,6 +38,26 @@ Custom Allocator Support
 .. doxygenfunction:: make_tensor( TensorType &tensor, const index_t (&shape)[TensorType::Rank()], Allocator&& alloc)
 .. doxygenfunction:: make_tensor( TensorType &tensor, ShapeType &&shape, Allocator&& alloc)
 
+cuda::std::mdspan Support
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``cuda::std::mdspan`` creates a non-owning tensor using mdspan's existing memory.
+
+.. code-block:: cpp
+
+    #include <cuda/std/mdspan>
+    int data[6]{};
+    using extents_type = cuda::std::extents<matx::index_t, 2, 3>;
+    cuda::std::mdspan<int, extents_type> span{data};
+    auto tensor = matx::make_tensor(span);
+
+The tensor uses the mdspan's original data, dimensions, and strides without
+copying the data. The original data must be valid while the tensor is being used.
+Static and dynamic extents are supported with ``layout_right``,
+``layout_left``, and ``layout_stride``.
+
+.. doxygenfunction:: make_tensor(const cuda::std::mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy> &span)
+
 DLPack Support
 ~~~~~~~~~~~~~~
 .. versionadded:: 1.1.0

--- a/docs_input/api/creation/tensors/make.rst
+++ b/docs_input/api/creation/tensors/make.rst
@@ -38,25 +38,43 @@ Custom Allocator Support
 .. doxygenfunction:: make_tensor( TensorType &tensor, const index_t (&shape)[TensorType::Rank()], Allocator&& alloc)
 .. doxygenfunction:: make_tensor( TensorType &tensor, ShapeType &&shape, Allocator&& alloc)
 
-cuda::std::mdspan Support
-~~~~~~~~~~~~~~~~~~~~~~~~~
+mdspan Support
+~~~~~~~~~~~~~~
 
-``cuda::std::mdspan`` creates a non-owning tensor using mdspan's existing memory.
+MatX can create non-owning tensors from ``cuda::std::mdspan`` and, when
+available, ``std::mdspan``.
+
+For C++20 and CUDA mdspan:
 
 .. code-block:: cpp
 
     #include <cuda/std/mdspan>
+
     int data[6]{};
     using extents_type = cuda::std::extents<matx::index_t, 2, 3>;
     cuda::std::mdspan<int, extents_type> span{data};
+
+    auto tensor = matx::make_tensor(span);
+
+When C++23 ``std::mdspan`` is available,
+it can be used in the same way:
+
+.. code-block:: cpp
+
+    #include <mdspan>
+
+    int data[6]{};
+    using extents_type = std::extents<matx::index_t, 2, 3>;
+    std::mdspan<int, extents_type> span{data};
+
     auto tensor = matx::make_tensor(span);
 
 The tensor uses the mdspan's original data, dimensions, and strides without
-copying the data. The original data must be valid while the tensor is being used.
-Static and dynamic extents are supported with ``layout_right``,
+copying the data. The original data must remain valid while the tensor is being
+used. Static and dynamic extents are supported with ``layout_right``,
 ``layout_left``, and ``layout_stride``.
 
-.. doxygenfunction:: make_tensor(const cuda::std::mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy> &span)
+.. doxygenfunction:: make_tensor(const Mdspan &span)
 
 DLPack Support
 ~~~~~~~~~~~~~~

--- a/docs_input/quickstart.rst
+++ b/docs_input/quickstart.rst
@@ -71,6 +71,17 @@ The same operator can be used to get values:
     auto f0 = t0();  // t0 is a rank-0 tensor (scalar)
     auto f1 = t1(5); // t1 is a rank-1 tensor (scalar)
 
+When compiling in C++23 mode with multidimensional subscript support, tensors
+can also be indexed using ``operator[]``:
+
+.. code-block:: cpp
+
+    t[2, 2] = 5.5;
+    float value = t[2, 2];
+
+This has the same indexing behavior as ``operator()``. The ``operator()``
+syntax is still available in C++23 and can be used with C++20.
+
 Tensors can also be initialized using initializer list syntax using the ``SetVals`` function:
 
 .. code-block:: cpp

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -44,7 +44,74 @@
 #include "matx/core/tensor_desc.h"
 #include "matx/core/dlpack.h"
 #include "matx/core/log.h"
+
+#if __has_include(<mdspan>)
+  #include <mdspan>
+#endif
 namespace matx {
+
+namespace detail {
+
+template <typename T>
+struct mdspan_traits {
+  static constexpr bool is_mdspan = false;
+};
+
+// If the type is a CUDA mdspan, check whether its layout and accessor
+// can be used with MatX
+template <typename ElementType,
+          typename Extents,
+          typename LayoutPolicy,
+          typename AccessorPolicy>
+struct mdspan_traits<
+    cuda::std::mdspan<
+        ElementType,
+        Extents,
+        LayoutPolicy,
+        AccessorPolicy>> {
+  static constexpr bool is_mdspan = true;
+
+  // Checks whether the mdspan layout is supported by MatX
+  static constexpr bool has_supported_layout =
+      std::is_same_v<LayoutPolicy, cuda::std::layout_right> ||
+      std::is_same_v<LayoutPolicy, cuda::std::layout_left> ||
+      std::is_same_v<LayoutPolicy, cuda::std::layout_stride>;
+
+  // Rejects custom accessor functions
+  static constexpr bool has_default_accessor =
+      std::is_same_v<
+          AccessorPolicy,
+          cuda::std::default_accessor<ElementType>>;
+};
+
+// Type checker for the official C++23 std::mdspan
+#if defined(__cpp_lib_mdspan) && (__cpp_lib_mdspan >= 202207L)
+template <typename ElementType,
+          typename Extents,
+          typename LayoutPolicy,
+          typename AccessorPolicy>
+struct mdspan_traits<
+    std::mdspan<
+        ElementType,
+        Extents,
+        LayoutPolicy,
+        AccessorPolicy>> {
+  static constexpr bool is_mdspan = true;
+
+  static constexpr bool has_supported_layout =
+      std::is_same_v<LayoutPolicy, std::layout_right> ||
+      std::is_same_v<LayoutPolicy, std::layout_left> ||
+      std::is_same_v<LayoutPolicy, std::layout_stride>;
+
+  static constexpr bool has_default_accessor =
+      std::is_same_v<
+          AccessorPolicy,
+          std::default_accessor<ElementType>>;
+};
+#endif
+
+} 
+
 
 /**
  * Create a tensor with a C array for the shape using implicitly-allocated memory
@@ -632,43 +699,38 @@ auto make_tensor( T* const data,
  * using strides
  * @return A MatX tensor that uses the existing data
  */
-template <typename ElementType,
-          typename Extents,
-          typename LayoutPolicy,
-          typename AccessorPolicy>
-  // Ensures users can only use layout_right, layout_left, and layout_stride
-  requires(
-    std::is_same_v<LayoutPolicy, cuda::std::layout_right> ||
-    std::is_same_v<LayoutPolicy, cuda::std::layout_left> ||
-    std::is_same_v<LayoutPolicy, cuda::std::layout_stride>)
-auto make_tensor(
-  const cuda::std::mdspan<
-    ElementType,
-    Extents,
-    LayoutPolicy,
-    AccessorPolicy>&span
-    ){
-    MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-    using mdspan_type = cuda::std::mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>;
-    
-    static_assert(
-    !std::is_const_v<ElementType>,
-    "make_tensor does not support mdspan with const elements");
-    
-  // Do not allow custom accessors that might have special behavior
-  // that MatX does not understand
-    static_assert(
-    std::is_same_v<
-        AccessorPolicy,
-        cuda::std::default_accessor<ElementType>>,
-    "make_tensor only supports mdspan with cuda::std::default_accessor");
+template <typename Mdspan>
   
-    static_assert(
-    std::is_same_v<
-        typename mdspan_type::data_handle_type,
-        ElementType *>,
-    "make_tensor requires an mdspan with an ElementType* data handle");
+  // Only allow either CUDA mdspan or C++23 mdspan
+  requires detail::mdspan_traits<remove_cvref_t<Mdspan>>::is_mdspan
+  auto make_tensor(const Mdspan &span)
+  {
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
+    using mdspan_type = remove_cvref_t<Mdspan>;
+    using mdspan_traits = detail::mdspan_traits<mdspan_type>;
+    using ElementType = typename mdspan_type::element_type;
+    using Extents = typename mdspan_type::extents_type;
+
+    static_assert(
+        mdspan_traits::has_supported_layout,
+        "make_tensor only supports layout_right, layout_left, and layout_stride");
+
+    static_assert(
+        !std::is_const_v<ElementType>,
+        "make_tensor does not support mdspan with const elements");
+
+    static_assert(
+        mdspan_traits::has_default_accessor,
+        "make_tensor only supports mdspan with its default_accessor");
+
+    // Checks whether the mdspan uses a normal pointer for its data
+    static_assert(
+        std::is_same_v<
+            typename mdspan_type::data_handle_type,
+            ElementType *>,
+        "make_tensor requires mdspan to use a regular pointer for its data");
+        
     constexpr int RANK = static_cast<int>(Extents::rank());
 
     cuda::std::array<index_t, RANK> shape{};

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -35,6 +35,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cuda/std/mdspan>
 #include <limits>
 #include <type_traits>
 
@@ -620,6 +621,88 @@ auto make_tensor( T* const data,
   return tensor_t<T, Dstrip::Rank(), Dstrip>{std::move(storage), std::forward<D>(desc)};
 }
 
+
+/**
+ * Takes an mdspan and creates a MatX tensor that looks at the same data.
+ * The returned tensor does not copy the underlying data but uses the same
+ * dimensions, strides, and data pointer as the mdspan.
+ * MatX will not delete the underlying data.
+ *
+ * @param span Tells us the data location, dimensions, and how it is arranged
+ * using strides
+ * @return A MatX tensor that uses the existing data
+ */
+template <typename ElementType,
+          typename Extents,
+          typename LayoutPolicy,
+          typename AccessorPolicy>
+
+auto make_tensor(
+  const cuda::std::mdspan<
+    ElementType,
+    Extents,
+    LayoutPolicy,
+    AccessorPolicy> &span
+  ){
+    MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+    using mdspan_type = cuda::std::mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>;
+    using mapping_type = typename mdspan_type::mapping_type;
+    
+    static_assert(
+    !std::is_const_v<ElementType>,
+    "make_tensor does not support mdspan with const elements");
+    
+  // Do not allow custom accessors that might have special behavior
+  // that MatX does not understand
+    static_assert(
+    std::is_same_v<
+        AccessorPolicy,
+        cuda::std::default_accessor<ElementType>>,
+    "make_tensor only supports mdspan with cuda::std::default_accessor");
+  
+    static_assert(
+    std::is_same_v<
+        typename mdspan_type::data_handle_type,
+        ElementType *>,
+    "make_tensor requires an mdspan with an ElementType* data handle");
+
+    static_assert(
+    mapping_type::is_always_strided(),
+    "make_tensor requires an mdspan with a strided layout mapping");
+
+    constexpr int RANK = static_cast<int>(Extents::rank());
+
+    cuda::std::array<index_t, RANK> shape{};
+    cuda::std::array<index_t, RANK> strides{};
+
+    // Finds largest number MatX's index_t can store
+    constexpr auto max_index = static_cast<uint64_t>(std::numeric_limits<index_t>::max());
+    for (int r = 0; r < RANK; r++) {
+      const auto extent = span.extent(r);
+      const auto stride = span.mapping().stride(r);      
+
+      // Checks is the mdspan dimensions larger than the biggest
+      // number MatX can store
+      if (static_cast<uint64_t>(extent) > max_index) {
+        MATX_THROW(
+            matxInvalidSize,
+            "mdspan extent is too large for MatX index_t");
+      }
+      // Same check for stride
+      if (static_cast<uint64_t>(stride) > max_index) {
+        MATX_THROW(
+            matxInvalidSize,
+            "mdspan stride is too large for MatX index_t");
+      }
+      //Converts mdspan's dimension size and 
+      //stride into MatX's index_t
+      shape[r] = static_cast<index_t>(extent);
+      strides[r] = static_cast<index_t>(stride);
+    }
+
+    DefaultDescriptor<RANK> desc{std::move(shape), std::move(strides)};
+    return make_tensor(span.data_handle(), std::move(desc), false);
+ }
 /**
  * Create a tensor with user-defined memory and an existing descriptor
  *

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -636,17 +636,20 @@ template <typename ElementType,
           typename Extents,
           typename LayoutPolicy,
           typename AccessorPolicy>
-
+  // Ensures users can only use layout_right, layout_left, and layout_stride
+  requires(
+    std::is_same_v<LayoutPolicy, cuda::std::layout_right> ||
+    std::is_same_v<LayoutPolicy, cuda::std::layout_left> ||
+    std::is_same_v<LayoutPolicy, cuda::std::layout_stride>)
 auto make_tensor(
   const cuda::std::mdspan<
     ElementType,
     Extents,
     LayoutPolicy,
-    AccessorPolicy> &span
-  ){
+    AccessorPolicy>&span
+    ){
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
     using mdspan_type = cuda::std::mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>;
-    using mapping_type = typename mdspan_type::mapping_type;
     
     static_assert(
     !std::is_const_v<ElementType>,
@@ -665,10 +668,6 @@ auto make_tensor(
         typename mdspan_type::data_handle_type,
         ElementType *>,
     "make_tensor requires an mdspan with an ElementType* data handle");
-
-    static_assert(
-    mapping_type::is_always_strided(),
-    "make_tensor requires an mdspan with a strided layout mapping");
 
     constexpr int RANK = static_cast<int>(Extents::rank());
 

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -43,7 +43,6 @@
 #include "matx/core/tensor_desc.h"
 #include "matx/core/dlpack.h"
 #include "matx/core/log.h"
-#include "matx/core/type_utils.h"
 
 
 namespace matx {

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -35,7 +35,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <cuda/std/mdspan>
 #include <limits>
 #include <type_traits>
 
@@ -44,74 +43,10 @@
 #include "matx/core/tensor_desc.h"
 #include "matx/core/dlpack.h"
 #include "matx/core/log.h"
+#include "matx/core/type_utils.h"
 
-#if __has_include(<mdspan>)
-  #include <mdspan>
-#endif
+
 namespace matx {
-
-namespace detail {
-
-template <typename T>
-struct mdspan_traits {
-  static constexpr bool is_mdspan = false;
-};
-
-// If the type is a CUDA mdspan, check whether its layout and accessor
-// can be used with MatX
-template <typename ElementType,
-          typename Extents,
-          typename LayoutPolicy,
-          typename AccessorPolicy>
-struct mdspan_traits<
-    cuda::std::mdspan<
-        ElementType,
-        Extents,
-        LayoutPolicy,
-        AccessorPolicy>> {
-  static constexpr bool is_mdspan = true;
-
-  // Checks whether the mdspan layout is supported by MatX
-  static constexpr bool has_supported_layout =
-      std::is_same_v<LayoutPolicy, cuda::std::layout_right> ||
-      std::is_same_v<LayoutPolicy, cuda::std::layout_left> ||
-      std::is_same_v<LayoutPolicy, cuda::std::layout_stride>;
-
-  // Rejects custom accessor functions
-  static constexpr bool has_default_accessor =
-      std::is_same_v<
-          AccessorPolicy,
-          cuda::std::default_accessor<ElementType>>;
-};
-
-// Type checker for the official C++23 std::mdspan
-#if defined(__cpp_lib_mdspan) && (__cpp_lib_mdspan >= 202207L)
-template <typename ElementType,
-          typename Extents,
-          typename LayoutPolicy,
-          typename AccessorPolicy>
-struct mdspan_traits<
-    std::mdspan<
-        ElementType,
-        Extents,
-        LayoutPolicy,
-        AccessorPolicy>> {
-  static constexpr bool is_mdspan = true;
-
-  static constexpr bool has_supported_layout =
-      std::is_same_v<LayoutPolicy, std::layout_right> ||
-      std::is_same_v<LayoutPolicy, std::layout_left> ||
-      std::is_same_v<LayoutPolicy, std::layout_stride>;
-
-  static constexpr bool has_default_accessor =
-      std::is_same_v<
-          AccessorPolicy,
-          std::default_accessor<ElementType>>;
-};
-#endif
-
-} 
-
 
 /**
  * Create a tensor with a C array for the shape using implicitly-allocated memory

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -1269,6 +1269,41 @@ MATX_IGNORE_WARNING_POP_GCC
       return this->template operator()<DefaultCapabilities>(indices...);
     }
 
+    /*
+      * Checks whether the compiler supports C++23 multidimensional operator[]    
+      */
+    #if defined(__cpp_multidimensional_subscript) && (__cpp_multidimensional_subscript >= 202211L)
+
+      /**
+        * Gets a tensor value using C++23 multidimensional indexing
+        *
+        * @returns Value at the specified indices
+        */
+      template <typename... Is> requires (RANK > 0 &&
+          sizeof...(Is) == RANK &&
+          cuda::std::conjunction_v<cuda::std::is_integral<Is>...>)
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator[](Is... indices) const noexcept
+      {
+        return this->template operator()<DefaultCapabilities>(indices...);
+      }
+
+      /**
+      * Accesses a tensor value using C++23 multidimensional indexing
+      *
+      * The returned value can be modified
+      *
+      * @returns Value at the specified indices      
+      */
+      template <typename... Is>
+        requires (RANK > 0 &&
+                  sizeof...(Is) == RANK &&
+                  cuda::std::conjunction_v<cuda::std::is_integral<Is>...>)
+      __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator[](Is... indices) noexcept
+      {
+        return this->template operator()<DefaultCapabilities>(indices...);
+      }
+    #endif
+
     template <typename CapType>
     __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator()(const cuda::std::array<index_t, RANK> &idx) const noexcept
     {

--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -35,6 +35,13 @@
 #include "matx/core/operator_options.h"
 #include "matx/core/type_utils_both.h"
 
+#include <cuda/std/mdspan>
+
+#if __has_include(<mdspan>)
+  #include <mdspan>
+#endif
+
+
 #include <memory>
 #include <cublas_v2.h>
 #include <cusparse.h>
@@ -201,6 +208,66 @@ inline constexpr bool has_index_cmp_op_v = requires {
 
 
 namespace detail {
+
+// Checks for cuda::std::mdspan and std::mdspan types
+template <typename T>
+struct mdspan_traits {
+  static constexpr bool is_mdspan = false;
+};
+
+// If the type is a CUDA mdspan, check whether its layout and accessor
+// can be used with MatX
+template <typename ElementType,
+          typename Extents,
+          typename LayoutPolicy,
+          typename AccessorPolicy>
+struct mdspan_traits<
+    cuda::std::mdspan<
+        ElementType,
+        Extents,
+        LayoutPolicy,
+        AccessorPolicy>> {
+  static constexpr bool is_mdspan = true;
+
+  // Checks whether the mdspan layout is supported by MatX
+  static constexpr bool has_supported_layout =
+      std::is_same_v<LayoutPolicy, cuda::std::layout_right> ||
+      std::is_same_v<LayoutPolicy, cuda::std::layout_left> ||
+      std::is_same_v<LayoutPolicy, cuda::std::layout_stride>;
+
+  // Checks whether the mdspan uses the default accessor
+  static constexpr bool has_default_accessor =
+      std::is_same_v<
+          AccessorPolicy,
+          cuda::std::default_accessor<ElementType>>;
+};
+
+// Type checker for the official C++23 std::mdspan
+#if defined(__cpp_lib_mdspan) && (__cpp_lib_mdspan >= 202207L)
+template <typename ElementType,
+          typename Extents,
+          typename LayoutPolicy,
+          typename AccessorPolicy>
+struct mdspan_traits<
+    std::mdspan<
+        ElementType,
+        Extents,
+        LayoutPolicy,
+        AccessorPolicy>> {
+  static constexpr bool is_mdspan = true;
+
+  static constexpr bool has_supported_layout =
+      std::is_same_v<LayoutPolicy, std::layout_right> ||
+      std::is_same_v<LayoutPolicy, std::layout_left> ||
+      std::is_same_v<LayoutPolicy, std::layout_stride>;
+
+  static constexpr bool has_default_accessor =
+      std::is_same_v<
+          AccessorPolicy,
+          std::default_accessor<ElementType>>;
+};
+#endif
+
 
 // Supported MatX data types. This enum helps translate types into integers for
 // hashing purposes

--- a/test/00_tensor/MakeTensorTests.cu
+++ b/test/00_tensor/MakeTensorTests.cu
@@ -34,8 +34,13 @@
 #include "gtest/gtest.h"
 
 #include <cuda/std/array>
+#include <cuda/std/mdspan>
 #include <cstdlib>
+#include <cstdint>
 #include <memory>
+#include <type_traits>
+#include <limits>
+
 
 using namespace matx;
 
@@ -219,6 +224,266 @@ TEST(MakeTensorTests, CreatesPointerBackedViews)
   ExpectShape2(placed_strided_view, 2, 3);
   placed_strided_view(1, 2) = 42;
   EXPECT_EQ(data[5], 42);
+
+  MATX_EXIT_HANDLER();
+}
+
+// Checks whether make_tensor(span) creates a correct MatX
+// view of the same memory described by the mdspan
+// 1. Checks tensor type
+// 2. Same memory for the MatX tensor and mdspan
+// 3. Same dimensions 
+// 4. Changes through either view are visible through the other
+TEST(MakeTensorTests, CreatesLayoutRightStaticMdspanView)
+{
+  MATX_ENTER_HANDLER();
+
+  using extents_type = cuda::std::extents<index_t, 2, 3>;
+
+  int data[6] = {};
+  cuda::std::mdspan<int, extents_type, cuda::std::layout_right> span{data};
+
+  auto tensor = make_tensor(span);
+
+  // Verify the mdspan overload returns the expected tensor type
+  static_assert(decltype(tensor)::Rank() == 2);
+  static_assert(
+      std::is_same_v<typename decltype(tensor)::value_type, int>);
+
+  // MatX must use the original pointer without copying the data
+  EXPECT_EQ(tensor.Data(), span.data_handle());
+
+  // Checks the dimensions
+  ExpectShape2(tensor, 2, 3);
+
+  // Checks if MatX can access different elements
+  // Check that MatX row stride matches the mdspan’s row stride
+  EXPECT_EQ(tensor.Stride(0), span.mapping().stride(0)); 
+ 
+  // Check that MatX column stride matches the mdspan’s column stride
+  EXPECT_EQ(tensor.Stride(1), span.mapping().stride(1)); 
+
+  // If you write through MatX tensor, it will change the original memory
+  tensor(1, 2) = 71;
+  EXPECT_EQ(data[5], 71);
+
+  // Writing to the original memory must be visible through MatX.
+  data[1] = 72;
+  EXPECT_EQ(tensor(0, 1), 72);
+
+  MATX_EXIT_HANDLER();
+}
+
+// Test for row-major dynamic tensors
+TEST(MakeTensorTests, CreatesLayoutRightDynamicMdspanView)
+{
+  MATX_ENTER_HANDLER();
+
+  // This says the mdspan has 2 dimensions, but their sizes are given later.
+  using extents_type = cuda::std::dextents<index_t, 2>;
+
+  int data[6] = {};
+
+  // Passing 2 and 3 provides the dimension sizes at runtime
+  cuda::std::mdspan<int, extents_type, cuda::std::layout_right> span{
+      data, 2, 3};
+
+  auto tensor = make_tensor(span);
+
+  // Verify the mdspan overload returns the expected tensor type
+  static_assert(decltype(tensor)::Rank() == 2);
+  static_assert(
+      std::is_same_v<typename decltype(tensor)::value_type, int>);
+
+  // MatX must use the original pointer without copying the data
+  EXPECT_EQ(tensor.Data(), span.data_handle());
+
+  // Checks the dimensions
+  ExpectShape2(tensor, 2, 3);
+
+  // Checks if MatX can access different elements
+  // Check that MatX row stride matches the mdspan's row stride
+  EXPECT_EQ(tensor.Stride(0), span.mapping().stride(0));
+
+  // Check that MatX column stride matches the mdspan's column stride
+  EXPECT_EQ(tensor.Stride(1), span.mapping().stride(1));
+
+  // Writing through the MatX tensor changes the original memory
+  // Writing to the original memory is visible through MatX
+  tensor(1, 2) = 71;
+  EXPECT_EQ(data[5], 71);
+
+  // If you write on the original memory, it must be visible through MatX
+  data[1] = 72;
+  EXPECT_EQ(tensor(0, 1), 72);
+
+  MATX_EXIT_HANDLER();
+}
+
+TEST(MakeTensorTests, CreatesLayoutLeftDynamicMdspanView)
+{
+  MATX_ENTER_HANDLER();
+
+  // This says the mdspan has 2 dimensions, but their sizes are given later.
+  using extents_type = cuda::std::dextents<index_t, 2>;
+
+  int data[6] = {};
+
+  // Passing 2 and 3 here gives this mdspan its dimensions at runtime.
+  cuda::std::mdspan<int, extents_type, cuda::std::layout_left> span{
+      data, 2, 3};
+
+  auto tensor = make_tensor(span);
+
+  // Verify the mdspan overload returns the expected tensor type
+  static_assert(decltype(tensor)::Rank() == 2);
+  static_assert(
+      std::is_same_v<typename decltype(tensor)::value_type, int>);
+
+  // MatX must use the original pointer without copying the data
+  EXPECT_EQ(tensor.Data(), span.data_handle());
+
+  // Checks the dimensions
+  ExpectShape2(tensor, 2, 3);
+
+  // Checks if MatX can access different elements
+  // Check that MatX row stride matches the mdspan's row stride
+  EXPECT_EQ(tensor.Stride(0), span.mapping().stride(0));
+
+  // Check that MatX column stride matches the mdspan's column stride
+  EXPECT_EQ(tensor.Stride(1), span.mapping().stride(1));
+
+  // If you write on the MatX tensor, it will change the original memory
+  tensor(1, 2) = 81;
+  EXPECT_EQ(data[5], 81);
+
+  // If you write on the original memory, it must be visible through MatX
+  data[2] = 82;
+  EXPECT_EQ(tensor(0, 1), 82);
+
+  MATX_EXIT_HANDLER();
+}
+
+
+// Checks whether make_tensor(span) preserves custom strides
+// that are neither row-major nor column-major
+TEST(MakeTensorTests, CreatesLayoutStrideMdspanView)
+{
+  MATX_ENTER_HANDLER();
+
+  using extents_type = cuda::std::extents<index_t, 2, 3>;
+
+  // Allows custom strides
+  using mapping_type =
+      cuda::std::layout_stride::mapping<extents_type>;
+
+  // The largest accessed position is 1 * 4 + 2 * 1 = 6
+  int data[7] = {};
+
+  // Move 4 positions for each row and 1 for each column
+  const mapping_type mapping{
+      extents_type{},
+      cuda::std::array<index_t, 2>{4, 1}};
+
+  cuda::std::mdspan<int, extents_type, cuda::std::layout_stride> span{
+      data, mapping};
+
+  auto tensor = make_tensor(span);
+
+  static_assert(decltype(tensor)::Rank() == 2);
+  static_assert(
+      std::is_same_v<typename decltype(tensor)::value_type, int>);
+
+  // Checks that MatX uses the same memory
+  EXPECT_EQ(tensor.Data(), span.data_handle());
+
+  // Checks the dimensions
+  ExpectShape2(tensor, 2, 3);
+
+  // Checks that MatX keeps the custom strides
+  EXPECT_EQ(tensor.Stride(0), span.mapping().stride(0));
+  EXPECT_EQ(tensor.Stride(1), span.mapping().stride(1));
+
+  // Position (1, 2) maps to data[6]
+  tensor(1, 2) = 91;
+  EXPECT_EQ(data[6], 91);
+
+  // Position (1, 0) maps to data[4]
+  data[4] = 92;
+  EXPECT_EQ(tensor(1, 0), 92);
+
+  MATX_EXIT_HANDLER();
+}
+
+// Checks that destroying the MatX tensor does not destroy
+// original data's memory 
+TEST(MakeTensorTests, MdspanViewDoesNotOwnData)
+{
+  MATX_ENTER_HANDLER();
+
+  // This unique pointer owns the original memory
+  auto data = std::make_unique<int[]>(6);
+  int *const original_data = data.get();
+
+  {
+    // The mdspan and MatX tensor only borrow the original memory
+    cuda::std::mdspan<int, cuda::std::dextents<index_t, 2>> span{
+        original_data, 2, 3};
+
+    auto tensor = make_tensor(span);
+
+    // Checks that MatX uses the original memory
+    EXPECT_EQ(tensor.Data(), original_data);
+
+    // Writes a value before the tensor is destroyed
+    tensor(1, 2) = 101;
+  }
+
+  // The original memory must still exist after the tensor is destroyed
+  EXPECT_EQ(data.get(), original_data);
+  EXPECT_EQ(original_data[5], 101);
+
+  MATX_EXIT_HANDLER();
+}
+
+// Checks that an mdspan extent or stride that is too large for MatX
+// index_t throws an error instead of being converted to a smaller value.
+TEST(MakeTensorTests, RejectsMdspanValuesOutsideMatXIndexRange)
+{
+  MATX_ENTER_HANDLER();
+
+  int data = 0;
+  const uint64_t oversized =
+      static_cast<uint64_t>(std::numeric_limits<index_t>::max()) + 1ULL;
+
+  // Checks an extent that is too large for MatX index_t
+  {
+    using extents_type = cuda::std::dextents<uint64_t, 1>;
+
+    cuda::std::mdspan<int, extents_type> span{&data, oversized};
+
+    EXPECT_THROW(
+        { [[maybe_unused]] auto tensor = make_tensor(span); },
+        matx::detail::matxException);
+  }
+
+  // Checks a stride that is too large for MatX index_t
+  {
+    using extents_type = cuda::std::extents<uint64_t, 1, 1>;
+    using mapping_type =
+        cuda::std::layout_stride::mapping<extents_type>;
+
+    const mapping_type mapping{
+        extents_type{},
+        cuda::std::array<uint64_t, 2>{oversized, 1}};
+
+    cuda::std::mdspan<int, extents_type, cuda::std::layout_stride> span{
+        &data, mapping};
+
+    EXPECT_THROW(
+        { [[maybe_unused]] auto tensor = make_tensor(span); },
+        matx::detail::matxException);
+  }
 
   MATX_EXIT_HANDLER();
 }

--- a/test/00_tensor/MakeTensorTests.cu
+++ b/test/00_tensor/MakeTensorTests.cu
@@ -41,6 +41,16 @@ using namespace matx;
 
 namespace {
 
+// This kernel helps test operator[] on the GPU
+// Since GoogleTests tests run on CPU, the GPU code is placed in 
+// a CUDA kernel and launched from the test
+#if defined(__cpp_multidimensional_subscript) && (__cpp_multidimensional_subscript >= 202211L)
+  __global__ void TestMultidimensionalSubscriptKernel(detail::tensor_impl_t<int, 2> tensor)
+  {
+    tensor[1, 2] = 27;
+  }
+#endif
+  
 struct CountingAllocator {
   static inline size_t allocations = 0;
   static inline size_t deallocations = 0;
@@ -294,3 +304,50 @@ TEST(MakeTensorTests, CreatesCustomAllocatorTensors)
 
   MATX_EXIT_HANDLER();
 }
+
+#if defined(__cpp_multidimensional_subscript) && (__cpp_multidimensional_subscript >= 202211L)
+  
+  // Tests if operator[] works on CPU
+  TEST(MakeTensorTests, MultidimensionalSubscriptHost)
+  {
+    MATX_ENTER_HANDLER();
+
+    auto tensor = make_tensor<int>({2, 3}, MATX_MANAGED_MEMORY);
+
+    tensor[1, 2] = 17;
+
+
+    // Checks if the new operator[] can read 
+    // the value we wrote using operator[]
+    EXPECT_EQ((tensor[1, 2]), 17);
+
+    // Checks if the old operator() refers to the
+    // same element as new operator[]
+    EXPECT_EQ((tensor(1, 2)), 17);
+
+    // Reads the tensor using the const reference to the tensor
+    const auto &const_tensor = tensor;
+    EXPECT_EQ((const_tensor[1, 2]), 17);
+
+    MATX_EXIT_HANDLER();
+  }
+
+  // Tests if operator[] works on GPU
+  TEST(MakeTensorTests, MultidimensionalSubscriptDevice)
+  {
+    MATX_ENTER_HANDLER();
+
+    auto tensor = make_tensor<int>({2, 3}, MATX_MANAGED_MEMORY);
+
+    detail::tensor_impl_t<int, 2> tensor_impl = tensor;
+    TestMultidimensionalSubscriptKernel<<<1, 1>>>(tensor_impl);
+
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    EXPECT_EQ((tensor[1, 2]), 27);
+    EXPECT_EQ((tensor(1, 2)), 27);
+
+    MATX_EXIT_HANDLER();
+  }
+
+#endif

--- a/test/00_tensor/MakeTensorTests.cu
+++ b/test/00_tensor/MakeTensorTests.cu
@@ -488,6 +488,31 @@ TEST(MakeTensorTests, RejectsMdspanValuesOutsideMatXIndexRange)
   MATX_EXIT_HANDLER();
 }
 
+// Checks that MatX can create a tensor
+// using C++23 std::mdspan
+#if defined(__cpp_lib_mdspan) && (__cpp_lib_mdspan >= 202207L)
+TEST(MakeTensorTests, CreatesStdMdspanView)
+{
+  MATX_ENTER_HANDLER();
+
+  int data[6]{};
+
+  using extents_type = std::extents<index_t, 2, 3>;
+  std::mdspan<int, extents_type> span{data};
+
+  auto tensor = make_tensor(span);
+
+  EXPECT_EQ(tensor.Data(), data);
+  EXPECT_EQ(tensor.Size(0), 2);
+  EXPECT_EQ(tensor.Size(1), 3);
+
+  tensor(1, 2) = 42;
+  EXPECT_EQ(data[5], 42);
+
+  MATX_EXIT_HANDLER();
+}
+#endif
+
 TEST(MakeTensorTests, CreatesDescriptorBackedTensors)
 {
   MATX_ENTER_HANDLER();


### PR DESCRIPTION
## What this does

Adds two features:

1. Create a MatX tensor from an mdspan

`make_tensor` can now create a MatX tensor from a `cuda::std::mdspan`
 
2. Ability to use `tensor[i, j]` with C++23

When the compiler supports C++23 multidimensional indexing, tensors can use:

```cpp
tensor[2, 3] = value;
auto value = tensor[2, 3];
```
## Testing

Added tests for mdspan and operator[]

Built and ran the tensor tests with:

```bash
cmake --build build \
  --target test_00_tensor_MakeTensorTests \
  --parallel 2

./build/test/test_00_tensor_MakeTensorTests \
  --gtest_filter='MakeTensorTests.*Mdspan*'

./build/test/test_00_tensor_MakeTensorTests
````
Testing was done using:

- Google Colab
- Tesla T4 GPU
- CUDA 12.8.93
- NVIDIA driver 580.82.07
- GCC 11.4.0
- CMake 3.31.10
- C++20

The mdspan changes and the full `MakeTensorTests` suite passed with C++20

The new `operator[]` feature requires C++23 multidimensional subscript support,
which is not available with CUDA 12.8. I could not update the CUDA environment
due to administrative permission restrictions

I would really appreciate it if the C++23 tests could be run in a compatible
environment during review.

## Documentation

Updated the documentation with:
- How to create a MatX tensor from an mdspan
- The new C++23 `tensor[i, j]` syntax
- Continued support for `tensor(i, j)` in C++20 and C++23

## Related issue

Closes #582