### PR TITLE
Use modern CMake package root behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.30.4)
 
-if(POLICY CMP0144)
-    # Preserve current behavior: CI may export upper-case package root variables
-    # that should not override dependencies fetched through CPM.
-    cmake_policy(SET CMP0144 OLD)
-endif()
 set(MATX_VERSION 1.0.0)
 
 # Use the vendored rapids-cmake copy for GPU architecture discovery unless a parent

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -8,6 +8,7 @@
     },
     "nvbench" : {
       "version" : "0.0",
+      "always_download" : true,
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/nvbench.git",
       "git_tag" : "dc59f98ecd4a75b322be5f71b7ecf6b6c7c65a6f"

--- a/docs_input/build.rst
+++ b/docs_input/build.rst
@@ -124,8 +124,9 @@ executing the binary.
 
 Benchmarks
 ----------
-MatX uses the NVBench software for the benchmarking framework. Like other packages, NVBench will be download using CPM according to
-the methods mentioned above.
+MatX uses the NVBench software for the benchmarking framework. MatX always resolves its tested NVBench commit through CPM so that
+package-root environment variables cannot select a different installation. Offline builds can provide the source through the CPM
+cache or ``CPM_nvbench_SOURCE``.
 
 NVBench has a small library that will be compiled on the first ``make`` run. With ``-DMATX_BUILD_BENCHMARKS=ON``, CMake emits one executable per
 benchmark source file under ``build/bench``, named ``bench_<subdir>_<basename>`` (for example ``bench_00_transform_matmul``). You can build a


### PR DESCRIPTION
Using old policy 0144 was causing issues for Holoscan and not really needed anymore by MatX.