### PR TITLE
Optimize transposed tensor reductions

### DIFF
--- a/bench/00_operators/reduction.cu
+++ b/bench/00_operators/reduction.cu
@@ -112,6 +112,33 @@ void reduce_0d_cub_permute(nvbench::state &state, nvbench::type_list<ValueType>)
 NVBENCH_BENCH_TYPES(reduce_0d_cub_permute, NVBENCH_TYPE_AXES(reduce_types))
   .add_int64_power_of_two_axis("Tensor Size", nvbench::range(6, 7, 1));  
 
+template <typename ValueType>
+void reduce_transposed_matrix(nvbench::state &state,
+                              nvbench::type_list<ValueType>)
+{
+  const index_t size = static_cast<index_t>(state.get_int64("Tensor Size"));
+
+  auto input = make_tensor<ValueType>({size, size});
+  auto output = make_tensor<ValueType>({size});
+  auto transposed = input.Permute({1, 0});
+
+  state.add_element_count(input.TotalSize(), "NumElements");
+  state.add_global_memory_reads<ValueType>(input.TotalSize(), "DataSize");
+  state.add_global_memory_writes<ValueType>(output.TotalSize());
+
+  input.PrefetchDevice(0);
+  output.PrefetchDevice(0);
+  (output = matx::sum(transposed)).run();
+
+  state.exec([&transposed, &output](nvbench::launch &launch) {
+    (output = matx::sum(transposed))
+        .run(static_cast<cudaStream_t>(launch.get_stream()));
+  });
+}
+NVBENCH_BENCH_TYPES(reduce_transposed_matrix,
+                    NVBENCH_TYPE_AXES(reduce_types))
+  .add_int64_power_of_two_axis("Tensor Size", nvbench::range(6, 12, 1));
+
 
 ////////////////////////////////////////////////////////////////////////////////
 ///

--- a/docs_input/api/manipulation/selecting/reduce.rst
+++ b/docs_input/api/manipulation/selecting/reduce.rst
@@ -5,6 +5,10 @@ reduce
 
 Reduces the input  using a generic reduction operator and optionally store the indices of the reduction
 
+For CUDA tensor views whose final two dimensions are a transpose of contiguous
+storage, a reduction of the innermost dimension uses coalesced tiled loads.
+Other permutations and strided layouts retain the general CUB iterator path.
+
 .. versionadded:: 0.6.0
 
 .. doxygenfunction:: reduce(const InType &in, ReduceOp op, bool init = true)

--- a/docs_input/api/math/sumprod/sum.rst
+++ b/docs_input/api/math/sumprod/sum.rst
@@ -5,6 +5,11 @@ sum
 
 Reduces the input by the sum of values across the specified axes.
 
+On CUDA, reducing the innermost dimension of a tensor view produced by
+transposing the final two dimensions uses a tiled fast path. This keeps reads
+coalesced without materializing the transpose. Other permutations and strided
+views continue to use the general reduction path.
+
 .. versionadded:: 0.6.0
 
 .. doxygenfunction:: sum(const InType &in, const int (&dims)[D])

--- a/include/matx/transforms/cub.h
+++ b/include/matx/transforms/cub.h
@@ -116,6 +116,187 @@ struct UniqueParams_t {
 
 struct EmptyParams_t {};
 
+#ifdef __CUDACC__
+
+// A last-two-dimension transpose followed by a one-dimensional reduction is a
+// particularly poor fit for CUB's random-access iterator path: threads in a
+// warp walk the same (strided) output segment instead of adjacent input
+// elements.  This kernel assigns adjacent x threads to adjacent output
+// segments and splits each segment across y threads, keeping the global loads
+// coalesced while reducing the partials in shared memory.
+constexpr int TransposedReduceBlockX = 32;
+constexpr int TransposedReduceBlockY = 8;
+
+template <typename OutputTensor, typename InputTensor, typename ReduceOp,
+          bool IncludeInit>
+__global__ void TransposedMatrixReduceKernel(
+    OutputTensor out, InputTensor in, ReduceOp reduce_op,
+    typename InputTensor::value_type init, index_t output_elements)
+{
+  using value_type = typename InputTensor::value_type;
+
+  __shared__ value_type partials[TransposedReduceBlockY]
+                                [TransposedReduceBlockX];
+  __shared__ bool valid[TransposedReduceBlockY][TransposedReduceBlockX];
+
+  const int x = static_cast<int>(threadIdx.x);
+  const int y = static_cast<int>(threadIdx.y);
+  const index_t output_idx =
+      static_cast<index_t>(blockIdx.x) * TransposedReduceBlockX + x;
+
+  bool has_value = false;
+  value_type partial{};
+
+  if (output_idx < output_elements) {
+    const auto out_idx = detail::GetIdxFromAbs(out, output_idx);
+    cuda::std::array<index_t, InputTensor::Rank()> in_idx{};
+    for (int dim = 0; dim < OutputTensor::Rank(); ++dim) {
+      in_idx[dim] = out_idx[dim];
+    }
+
+    for (index_t row = y; row < in.Size(InputTensor::Rank() - 1);
+         row += TransposedReduceBlockY) {
+      in_idx[InputTensor::Rank() - 1] = row;
+      const value_type value = in(in_idx);
+      partial = has_value ? reduce_op(partial, value) : value;
+      has_value = true;
+    }
+  }
+
+  if (has_value) {
+    partials[y][x] = partial;
+  }
+  valid[y][x] = has_value;
+  __syncthreads();
+
+  for (int offset = TransposedReduceBlockY / 2; offset > 0; offset /= 2) {
+    if (y < offset && valid[y + offset][x]) {
+      if (valid[y][x]) {
+        partials[y][x] = reduce_op(partials[y][x], partials[y + offset][x]);
+      }
+      else {
+        partials[y][x] = partials[y + offset][x];
+        valid[y][x] = true;
+      }
+    }
+    __syncthreads();
+  }
+
+  if (y == 0 && output_idx < output_elements) {
+    value_type result = partials[0][x];
+    if constexpr (IncludeInit) {
+      result = valid[0][x] ? reduce_op(init, result) : init;
+    }
+    out(detail::GetIdxFromAbs(out, output_idx)) = result;
+  }
+}
+
+template <typename OutputTensor, typename InputTensor>
+__MATX_INLINE__ bool IsTransposedMatrixReduction(const OutputTensor &out,
+                                                  const InputTensor &in)
+{
+  if constexpr (!is_tensor_view_v<OutputTensor> ||
+                !is_tensor_view_v<InputTensor> || InputTensor::Rank() < 2 ||
+                OutputTensor::Rank() + 1 != InputTensor::Rank()) {
+    return false;
+  }
+  else {
+    constexpr int in_rank = InputTensor::Rank();
+
+    for (int dim = 0; dim < OutputTensor::Rank(); ++dim) {
+      if (out.Size(dim) != in.Size(dim)) {
+        return false;
+      }
+    }
+
+    // CUB defines the empty-range behavior for each built-in reduction. Keep
+    // that behavior rather than entering a kernel with no partial value.
+    if (in.Size(in_rank - 1) == 0) {
+      return false;
+    }
+
+    // Exact layout of a contiguous tensor with the final two dimensions
+    // swapped. Restricting the fast path to this layout preserves support for
+    // arbitrary slices and permutations through the generic iterator path.
+    if (in.Stride(in_rank - 2) != 1 ||
+        in.Stride(in_rank - 1) != in.Size(in_rank - 2)) {
+      return false;
+    }
+
+    index_t expected_stride = in.Size(in_rank - 2) * in.Size(in_rank - 1);
+    for (int dim = in_rank - 3; dim >= 0; --dim) {
+      if (in.Stride(dim) != expected_stride) {
+        return false;
+      }
+      expected_stride *= in.Size(dim);
+    }
+
+    return true;
+  }
+}
+
+template <bool IncludeInit, typename OutputTensor, typename InputTensor,
+          typename ReduceOp>
+__MATX_INLINE__ bool TryTransposedMatrixReduce(
+    OutputTensor &out, const InputTensor &in, ReduceOp reduce_op,
+    typename InputTensor::value_type init, cudaStream_t stream)
+{
+  if constexpr (is_tensor_view_v<OutputTensor> &&
+                is_tensor_view_v<InputTensor> && InputTensor::Rank() >= 2 &&
+                OutputTensor::Rank() + 1 == InputTensor::Rank()) {
+    if (!IsTransposedMatrixReduction(out, in)) {
+      return false;
+    }
+
+    const index_t output_elements = TotalSize(out);
+    if (output_elements == 0) {
+      return true;
+    }
+
+    const dim3 threads{TransposedReduceBlockX, TransposedReduceBlockY, 1};
+    const dim3 blocks{
+        static_cast<unsigned int>((output_elements +
+                                   TransposedReduceBlockX - 1) /
+                                  TransposedReduceBlockX),
+        1, 1};
+    TransposedMatrixReduceKernel<OutputTensor, InputTensor, ReduceOp,
+                                 IncludeInit>
+        <<<blocks, threads, 0, stream>>>(out, in, reduce_op, init,
+                                        output_elements);
+    MATX_CUDA_CHECK_LAST_ERROR();
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+
+struct TransposedSumReduce {
+  template <typename T>
+  __MATX_INLINE__ __MATX_DEVICE__ T operator()(const T &a, const T &b) const
+  {
+    return a + b;
+  }
+};
+
+struct TransposedMinReduce {
+  template <typename T>
+  __MATX_INLINE__ __MATX_DEVICE__ T operator()(const T &a, const T &b) const
+  {
+    return a < b ? a : b;
+  }
+};
+
+struct TransposedMaxReduce {
+  template <typename T>
+  __MATX_INLINE__ __MATX_DEVICE__ T operator()(const T &a, const T &b) const
+  {
+    return a > b ? a : b;
+  }
+};
+
+#endif
+
 
 
 template <typename OutputTensor, typename InputOperator, CUBOperation_t op, typename CParams = EmptyParams_t>
@@ -1859,6 +2040,10 @@ void cub_reduce(OutputTensor &a_out, const InputOperator &a, typename InputOpera
 {
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+  if (detail::TryTransposedMatrixReduce<true>(a_out, a, ReduceOp{}, init,
+                                               stream)) {
+    return;
+  }
   const cudaExecutor exec{stream};
   // Get parameters required by these tensors
   using param_type = typename detail::ReduceParams_t<ReduceOp, typename InputOperator::value_type>;
@@ -1918,6 +2103,11 @@ void cub_sum(OutputTensor &a_out, const InputOperator &a,
 
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+  if (detail::TryTransposedMatrixReduce<true>(
+          a_out, a, detail::TransposedSumReduce{},
+          typename InputOperator::value_type{}, stream)) {
+    return;
+  }
   const cudaExecutor exec{stream};
 
 #ifndef MATX_DISABLE_CUB_CACHE
@@ -1968,6 +2158,11 @@ void cub_min(OutputTensor &a_out, const InputOperator &a,
 {
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+  if (detail::TryTransposedMatrixReduce<false>(
+          a_out, a, detail::TransposedMinReduce{},
+          typename InputOperator::value_type{}, stream)) {
+    return;
+  }
   const cudaExecutor exec{stream};
 
 #ifndef MATX_DISABLE_CUB_CACHE
@@ -2020,6 +2215,11 @@ void cub_max(OutputTensor &a_out, const InputOperator &a,
 {
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
+  if (detail::TryTransposedMatrixReduce<false>(
+          a_out, a, detail::TransposedMaxReduce{},
+          typename InputOperator::value_type{}, stream)) {
+    return;
+  }
   const cudaExecutor exec{stream};
 #ifndef MATX_DISABLE_CUB_CACHE
   auto params =

--- a/test/00_operators/ReductionTests.cu
+++ b/test/00_operators/ReductionTests.cu
@@ -572,6 +572,145 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, PermutedReduce)
   MATX_EXIT_HANDLER();
 }
 
+TYPED_TEST(ReductionTestsNumericNonComplex, TransposedMatrixReduce)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+
+  // Odd dimensions exercise partial tiles in both the output and reduction
+  // directions. Rank three also verifies that batches retain their offsets.
+  constexpr index_t batches = 3;
+  constexpr index_t rows = 19;
+  constexpr index_t columns = 37;
+  tensor_t<TestType, 3> input({batches, rows, columns});
+  tensor_t<TestType, 2> sum_out({batches, columns});
+  tensor_t<TestType, 2> prod_out({batches, columns});
+  tensor_t<TestType, 2> min_out({batches, columns});
+  tensor_t<TestType, 2> max_out({batches, columns});
+
+  for (index_t batch = 0; batch < batches; ++batch) {
+    for (index_t row = 0; row < rows; ++row) {
+      for (index_t column = 0; column < columns; ++column) {
+        input(batch, row, column) =
+            static_cast<TestType>(row == 0 ? 2 : 1);
+      }
+    }
+  }
+
+  const auto transposed = input.Permute({0, 2, 1});
+  (sum_out = sum(transposed)).run(exec);
+  (prod_out = prod(transposed)).run(exec);
+  (min_out = min(transposed)).run(exec);
+  (max_out = max(transposed)).run(exec);
+  exec.sync();
+
+  for (index_t batch = 0; batch < batches; ++batch) {
+    for (index_t column = 0; column < columns; ++column) {
+      ASSERT_TRUE(MatXUtils::MatXTypeCompare(sum_out(batch, column),
+                                             static_cast<TestType>(rows + 1)));
+      ASSERT_TRUE(MatXUtils::MatXTypeCompare(prod_out(batch, column),
+                                             static_cast<TestType>(2)));
+      ASSERT_TRUE(MatXUtils::MatXTypeCompare(min_out(batch, column),
+                                             static_cast<TestType>(1)));
+      ASSERT_TRUE(MatXUtils::MatXTypeCompare(max_out(batch, column),
+                                             static_cast<TestType>(2)));
+    }
+  }
+
+  // A plain non-contiguous slice is intentionally not treated as a transpose;
+  // it must continue through the general reduction fallback.
+  const cuda::std::array<index_t, 3> slice_firsts{0, 0, 0};
+  const cuda::std::array<index_t, 3> slice_ends{batches, rows, columns};
+  const cuda::std::array<index_t, 3> slice_strides{1, 1, 2};
+  auto sliced = input.Slice(slice_firsts, slice_ends, slice_strides);
+  tensor_t<TestType, 2> sliced_sum({batches, rows});
+  (sliced_sum = sum(sliced)).run(exec);
+  exec.sync();
+
+  for (index_t batch = 0; batch < batches; ++batch) {
+    for (index_t row = 0; row < rows; ++row) {
+      TestType expected{};
+      for (index_t column = 0; column < sliced.Size(2); ++column) {
+        expected += input(batch, row, column * 2);
+      }
+      ASSERT_TRUE(MatXUtils::MatXTypeCompare(sliced_sum(batch, row), expected));
+    }
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(ReductionTestsComplex, TransposedMatrixSum)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  using InnerType = typename inner_op_type_t<TestType>::type;
+
+  ExecType exec{};
+  constexpr index_t rows = 11;
+  constexpr index_t columns = 35;
+  tensor_t<TestType, 2> input({rows, columns});
+  tensor_t<TestType, 1> output({columns});
+
+  for (index_t row = 0; row < rows; ++row) {
+    for (index_t column = 0; column < columns; ++column) {
+      input(row, column) = TestType{static_cast<InnerType>(1)};
+    }
+  }
+
+  (output = sum(input.Permute({1, 0}))).run(exec);
+  exec.sync();
+
+  for (index_t column = 0; column < columns; ++column) {
+    const TestType expected{static_cast<InnerType>(rows)};
+    ASSERT_TRUE(MatXUtils::MatXTypeCompare(output(column), expected));
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(ReductionTestsFloatHalf, TransposedMatrixReduce)
+{
+  MATX_ENTER_HANDLER();
+  using TestType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+  constexpr index_t rows = 13;
+  constexpr index_t columns = 33;
+  tensor_t<TestType, 2> input({rows, columns});
+  tensor_t<TestType, 1> sum_out({columns});
+  tensor_t<TestType, 1> min_out({columns});
+  tensor_t<TestType, 1> max_out({columns});
+
+  for (index_t row = 0; row < rows; ++row) {
+    for (index_t column = 0; column < columns; ++column) {
+      input(row, column) = static_cast<TestType>(row == 0 ? 2 : 1);
+    }
+  }
+
+  const auto transposed = input.Permute({1, 0});
+  (sum_out = sum(transposed)).run(exec);
+  (min_out = min(transposed)).run(exec);
+  (max_out = max(transposed)).run(exec);
+  exec.sync();
+
+  for (index_t column = 0; column < columns; ++column) {
+    ASSERT_TRUE(MatXUtils::MatXTypeCompare(
+        sum_out(column), static_cast<TestType>(rows + 1)));
+    ASSERT_TRUE(MatXUtils::MatXTypeCompare(
+        min_out(column), static_cast<TestType>(1)));
+    ASSERT_TRUE(MatXUtils::MatXTypeCompare(
+        max_out(column), static_cast<TestType>(2)));
+  }
+
+  MATX_EXIT_HANDLER();
+}
+
 TYPED_TEST(ReductionTestsNumericNonComplexAllExecs, Any)
 {
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;


### PR DESCRIPTION
When running a reduction on a matrix-transposed tensor (the last two dimensions are permuted), CUB doesn't have an optimal path for this and uses a non-optimal iterator path with uncoalesced loads. 

Results vs old CUB dispatch: 
<img width="615" height="287" alt="image" src="https://github.com/user-attachments/assets/a76a64c9-14ac-42c6-8efe-51121ff9acd8" />
