### PR TITLE
Add bulk SAR mocomp operator

### DIFF
--- a/docs_input/api/signalimage/radar/sar_bulk_mocomp.rst
+++ b/docs_input/api/signalimage/radar/sar_bulk_mocomp.rst
@@ -38,17 +38,14 @@ two-range overload changes reference from initial_reference_range to
 target_reference_range and uses
 :math:`\Delta R_p = R_{\mathrm{target},p} - R_{\mathrm{initial},p}`.
 
-.. code-block:: cpp
+Examples
+~~~~~~~~
 
-   matx::experimental::SarBulkMocompParams params{
-       .phase_reference_frequency = 9.6e9,
-       .sample_frequency_spacing = 3.0e6,
-       .sgn = -1,
-   };
-
-   auto compensated =
-       matx::experimental::sar_bulk_mocomp(fx, range_to_mcp, params);
-   (output = compensated).run(exec);
+.. literalinclude:: ../../../../test/00_operators/sar_bulk_mocomp_test.cu
+   :language: cpp
+   :start-after: example-begin sar-bulk-mocomp-1
+   :end-before: example-end sar-bulk-mocomp-1
+   :dedent:
 
 Phase arithmetic follows the range-offset value type. Float ranges use
 single-precision frequency, phase, and trigonometric arithmetic; double ranges

--- a/docs_input/api/signalimage/radar/sar_bulk_mocomp.rst
+++ b/docs_input/api/signalimage/radar/sar_bulk_mocomp.rst
@@ -52,8 +52,12 @@ target_reference_range and uses
 
 Phase arithmetic follows the range-offset value type. Float ranges use
 single-precision frequency, phase, and trigonometric arithmetic; double ranges
-use double precision. The parameter frequencies are stored as double and
-narrowed for the single-precision path. Other range types, including fltflt and
+use double precision for phase construction and argument reduction. With CUDA,
+when double ranges are combined with ``cuda::std::complex<float>`` FX data, the
+bounded, reduced angle is converted to float for a fast single-precision
+``sincospif`` evaluation. Double-complex FX data retains the full double-precision
+trigonometric path. The parameter frequencies are stored as double and narrowed
+for the single-precision range path. Other range types, including fltflt and
 half precision, are not currently supported. FX values must be
 cuda::std::complex<float> or cuda::std::complex<double>.
 

--- a/docs_input/api/signalimage/radar/sar_bulk_mocomp.rst
+++ b/docs_input/api/signalimage/radar/sar_bulk_mocomp.rst
@@ -1,0 +1,68 @@
+.. _sar_bulk_mocomp_func:
+
+sar_bulk_mocomp
+################
+
+Apply bulk motion compensation to complex SAR phase-history data in the FX
+domain. sar_bulk_mocomp is currently in the matx::experimental namespace
+because its API is subject to change.
+
+The operator is lazy, allocation-free, and composable with other MatX
+expressions. The final two FX dimensions are interpreted as pulse and frequency
+sample, and any leading dimensions are batches:
+
+.. code-block:: text
+
+   fx:           [batch..., pulses, samples]
+   range_offset: [batch..., pulses]
+   result:       [batch..., pulses, samples]
+
+For sample index :math:`n`, the frequency is
+
+.. math::
+
+   f_n = f_{\mathrm{ref}} +
+         \left(n - \left\lfloor N/2 \right\rfloor\right)\Delta f,
+
+where :math:`f_{\mathrm{ref}}` is
+SarBulkMocompParams::phase_reference_frequency and :math:`\Delta f` is
+SarBulkMocompParams::sample_frequency_spacing. For differential reference
+range :math:`\Delta R_p`, the applied correction is
+
+.. math::
+
+   \exp\left(-j\,\mathrm{sgn}\,\frac{4\pi}{c}\,f_n\,\Delta R_p\right).
+
+The one-range overload assumes an initial reference range of zero. The
+two-range overload changes reference from initial_reference_range to
+target_reference_range and uses
+:math:`\Delta R_p = R_{\mathrm{target},p} - R_{\mathrm{initial},p}`.
+
+.. code-block:: cpp
+
+   matx::experimental::SarBulkMocompParams params{
+       .phase_reference_frequency = 9.6e9,
+       .sample_frequency_spacing = 3.0e6,
+       .sgn = -1,
+   };
+
+   auto compensated =
+       matx::experimental::sar_bulk_mocomp(fx, range_to_mcp, params);
+   (output = compensated).run(exec);
+
+Phase arithmetic follows the range-offset value type. Float ranges use
+single-precision frequency, phase, and trigonometric arithmetic; double ranges
+use double precision. The parameter frequencies are stored as double and
+narrowed for the single-precision path. Other range types, including fltflt and
+half precision, are not currently supported. FX values must be
+cuda::std::complex<float> or cuda::std::complex<double>.
+
+Host, CUDA, and CUDAJIT executors are supported. Distributed expressions and
+dynamic-rank inputs are not currently supported.
+
+.. versionadded:: head
+
+.. doxygenfunction:: sar_bulk_mocomp(const FxOp &fx, const TargetRangeOp &target_reference_range, const SarBulkMocompParams &params)
+.. doxygenfunction:: sar_bulk_mocomp(const FxOp &fx, const InitialRangeOp &initial_reference_range, const TargetRangeOp &target_reference_range, const SarBulkMocompParams &params)
+.. doxygenstruct:: matx::experimental::SarBulkMocompParams
+   :members:

--- a/docs_input/executor_compatibility.rst
+++ b/docs_input/executor_compatibility.rst
@@ -190,6 +190,7 @@ existing operators do not implicitly become distributed operations.
    "round", "|yes|", "|yes|", "|yes|", "|no|", "Element-wise expression."
    "rsqrt", "|yes|", "|yes|", "|yes|", "|no|", "Element-wise expression."
    "sar_bp", "|no|", "|yes|", "|no|", "|no|", "CUDA-only SAR backprojection transform."
+   "sar_bulk_mocomp", "|yes|", "|yes|", "|yes|", "|no|", "Experimental element-wise SAR bulk motion-compensation expression."
    "select", "|yes|", "|yes|", "|yes|", "|no|", "Selection expression."
    "shift", "|yes|", "|yes|", "|yes|", "|no|", "View/reindex expression."
    "sign", "|yes|", "|yes|", "|yes|", "|no|", "Element-wise expression."

--- a/examples/sarbp/README.md
+++ b/examples/sarbp/README.md
@@ -115,6 +115,7 @@ real/imag, row-major), written to `output_image.raw` in this example.
 | `-o OUTPUT` | Output file path (default: input with `.raw` extension) |
 | `-u N` | Range upsample factor via zero-padding (default: 1) |
 | `-w {hamming,none}` | Window for range compression (default: hamming) |
+| `--bulk-mocomp` | Apply bulk motion compensation to FX-domain input using the per-pulse `range_to_mcp` values stored by the CPHD converter |
 | `-b {auto,all,0,N}` | Pulses per processing block. `auto` uses the GPU L2 cache size to choose a block size; `all` and `0` use all pulses (default: auto) |
 | `--image-tiles N` | Process the image as N x N tiles during backprojection (default: 1) |
 | `--taylor-fast-third-order` | Add the third-order range term when using `--precision taylor_fast` |
@@ -123,6 +124,15 @@ real/imag, row-major), written to `output_image.raw` in this example.
 | `--warmup` | Warmup GPU kernels and FFT plans before timed run |
 | `--gold FILE` | Validate the output against a golden image (raw `complex<float>`, same format the example writes) and report accuracy metrics (3x3-window correlation and signal-to-error ratio) |
 | `--cmap FILE` | Write the correlation map (raw `float32`) to a file; requires `--gold` |
+
+`--bulk-mocomp` assumes the FX-domain input has not already been bulk motion
+compensated to the stored reference ranges. Applying bulk motion compensation
+to data that has already been motion compensated is not idempotent and results
+in an incorrect phase reference. Bulk mocomp always uses double-precision phase
+arithmetic. With `--precision fltflt`, each per-pulse range-to-MCP block is
+converted from double to float-float on the device after mocomp and before
+backprojection. No extra conversion kernel is used when bulk mocomp is disabled.
+The example reports the bulk-mocomp path time separately from backprojection.
 
 The `--precision` flag controls the arithmetic used by the `sar_bp` operator. For spaceborne SAR, `float` does not provide enough precision to store fractional wavelengths at the range-to-MCP magnitudes (hundreds of km), so pure `float` is not sufficient to produce focused images. The available modes are:
 

--- a/examples/sarbp/README.md
+++ b/examples/sarbp/README.md
@@ -128,11 +128,7 @@ real/imag, row-major), written to `output_image.raw` in this example.
 `--bulk-mocomp` assumes the FX-domain input has not already been bulk motion
 compensated to the stored reference ranges. Applying bulk motion compensation
 to data that has already been motion compensated is not idempotent and results
-in an incorrect phase reference. Bulk mocomp always uses double-precision phase
-arithmetic. With `--precision fltflt`, each per-pulse range-to-MCP block is
-converted from double to float-float on the device after mocomp and before
-backprojection. No extra conversion kernel is used when bulk mocomp is disabled.
-The example reports the bulk-mocomp path time separately from backprojection.
+in an incorrect phase reference.
 
 The `--precision` flag controls the arithmetic used by the `sar_bp` operator. For spaceborne SAR, `float` does not provide enough precision to store fractional wavelengths at the range-to-MCP magnitudes (hundreds of km), so pure `float` is not sufficient to produce focused images. The available modes are:
 

--- a/examples/sarbp/sarbp.cu
+++ b/examples/sarbp/sarbp.cu
@@ -1417,7 +1417,7 @@ int main(int argc, char **argv) {
   std::cout << "Pixel-z mode     : " << pixel_z_arg << std::endl;
   std::cout << "Bulk mocomp      : ";
   if (apply_bulk_mocomp) {
-    std::cout << "enabled (double phase arithmetic)";
+    std::cout << "enabled";
   } else {
     std::cout << "disabled";
   }

--- a/examples/sarbp/sarbp.cu
+++ b/examples/sarbp/sarbp.cu
@@ -238,6 +238,7 @@ struct BpRunCtx {
   bool is_fx_domain;
   bool is_int16_mode;
   bool apply_window;
+  bool apply_bulk_mocomp;
   bool taylor_fast_add_third_order;
   SarBpPixelZMode pixel_z_mode;  // compile-time pixel-z assumption to apply
   int sgn;
@@ -246,6 +247,7 @@ struct BpRunCtx {
   std::string gold_file;
   std::string cmap_file;
   double del_r;
+  matx::experimental::SarBulkMocompParams bulk_mocomp_params;
   SarBpParams params;
   double3 *h_positions;
   double *h_range_to_mcp;
@@ -395,12 +397,10 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
   using PosT = typename std::decay_t<decltype(blk_positions)>::value_type;
   constexpr bool pos_is_fltflt = std::is_same_v<PosT, matx::fltflt>;
 
-  // The host buffers ctx.h_positions / ctx.h_range_to_mcp were declared with
-  // double element types and either hold doubles (standard paths) or
-  // fltflt-encoded bytes (after the in-place conversion done in main when
-  // precision is fltflt). Since the byte sizes are identical between the two
-  // representations, the cudaMemcpyAsync calls below are just byte copies
-  // regardless of which device tensor type is being filled.
+  // The host position buffer contains fltflt-encoded bytes for the FloatFloat
+  // path. The range-to-MCP buffer normally follows the same convention, but
+  // remains double when FloatFloat is combined with bulk mocomp so that mocomp
+  // can use double phase arithmetic before a per-block conversion to fltflt.
   static_assert(3 * sizeof(matx::fltflt) == sizeof(double3),
                 "fltflt[3] must match double3 byte size for the in-place conversion to work");
   static_assert(sizeof(matx::fltflt) == sizeof(double),
@@ -423,29 +423,90 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
         cudaMemcpyHostToDevice, ctx.stream));
   };
 
+  // Pre-allocate GPU block buffers (sized for largest block)
+  auto blk_profiles = make_tensor<complex_t>({ctx.block_size, ctx.output_range_bins}, matx::MATX_DEVICE_MEMORY);
+  tensor_t<complex_t, 2> blk_compressed;
+  tensor_t<complex_t, 2> blk_fx;
+  if (ctx.is_fx_domain) {
+    make_tensor(
+        blk_compressed, {ctx.block_size, ctx.fft_size},
+        matx::MATX_DEVICE_MEMORY);
+    make_tensor(
+        blk_fx, {ctx.block_size, ctx.num_samples_raw},
+        matx::MATX_DEVICE_MEMORY);
+  }
+
+  // int16 interleaved I/Q samples and per-pulse scale (int16 mode only)
+  tensor_t<int16_t, 2> blk_fx_i16;
+  tensor_t<float, 1> blk_ampsf;
+  if (ctx.is_int16_mode && ctx.is_fx_domain) {
+    make_tensor(
+        blk_fx_i16, {ctx.block_size, ctx.num_samples_raw * 2},
+        matx::MATX_DEVICE_MEMORY);
+    make_tensor(
+        blk_ampsf, {ctx.block_size},
+        matx::MATX_DEVICE_MEMORY);
+  }
+
+  // Only FloatFloat with bulk mocomp needs double RTM staging.
+  tensor_t<double, 1> blk_bulk_mocomp_rtm;
+  if constexpr (pos_is_fltflt) {
+    if (ctx.apply_bulk_mocomp) {
+      make_tensor(
+          blk_bulk_mocomp_rtm, {ctx.block_size},
+          matx::MATX_DEVICE_MEMORY);
+    }
+  }
+
   auto upload_rtm = [&](auto &cur_rtm, index_t p0, index_t npulses) {
+    void *destination = cur_rtm.Data();
+    if constexpr (pos_is_fltflt) {
+      if (ctx.apply_bulk_mocomp) {
+        destination = blk_bulk_mocomp_rtm.Data();
+      }
+    }
     MATX_CUDA_CHECK(cudaMemcpyAsync(
-        cur_rtm.Data(),
-        reinterpret_cast<const uint8_t *>(ctx.h_range_to_mcp) + p0 * sizeof(double),
+        destination,
+        reinterpret_cast<const uint8_t *>(ctx.h_range_to_mcp) +
+            p0 * sizeof(double),
         static_cast<size_t>(npulses) * sizeof(double),
         cudaMemcpyHostToDevice, ctx.stream));
   };
 
-  // Pre-allocate GPU block buffers (sized for largest block)
-  auto blk_profiles = make_tensor<complex_t>({ctx.block_size, ctx.output_range_bins}, matx::MATX_DEVICE_MEMORY);
-  auto blk_compressed = ctx.is_fx_domain
-      ? make_tensor<complex_t>({ctx.block_size, ctx.fft_size}, matx::MATX_DEVICE_MEMORY)
-      : make_tensor<complex_t>({1, 1});
-  auto blk_fx = ctx.is_fx_domain
-      ? make_tensor<complex_t>({ctx.block_size, ctx.num_samples_raw}, matx::MATX_DEVICE_MEMORY)
-      : make_tensor<complex_t>({1, 1});
-  // int16 interleaved I/Q samples and per-pulse scale (int16 mode only)
-  auto blk_fx_i16 = (ctx.is_int16_mode && ctx.is_fx_domain)
-      ? make_tensor<int16_t>({ctx.block_size, ctx.num_samples_raw * 2}, matx::MATX_DEVICE_MEMORY)
-      : make_tensor<int16_t>({1, 1});
-  auto blk_ampsf = ctx.is_int16_mode
-      ? make_tensor<float>({ctx.block_size}, matx::MATX_DEVICE_MEMORY)
-      : make_tensor<float>({1});
+  const bool window_in_conversion =
+      ctx.is_int16_mode && ctx.apply_window && !ctx.apply_bulk_mocomp;
+
+  auto apply_fx_preprocessing = [&](auto &cur_fx, auto &cur_rtm, index_t npulses, bool window_already_applied) {
+    if (!ctx.apply_bulk_mocomp) {
+      if (ctx.apply_window && !window_already_applied) {
+        (cur_fx = cur_fx * matx::hamming<1>({npulses, ctx.num_samples_raw})).run(ctx.exec);
+        MATX_CUDA_CHECK(cudaGetLastError());
+      }
+      return;
+    }
+
+    auto run_mocomp = [&](const auto &fx_input, const auto &mocomp_rtm) {
+      (cur_fx = matx::experimental::sar_bulk_mocomp(fx_input, mocomp_rtm, ctx.bulk_mocomp_params)).run(ctx.exec);
+    };
+
+    if constexpr (pos_is_fltflt) {
+      auto cur_bulk_mocomp_rtm = matx::slice(
+          blk_bulk_mocomp_rtm, {0}, {npulses});
+      if (ctx.apply_window && !window_already_applied) {
+        run_mocomp(cur_fx * matx::hamming<1>({npulses, ctx.num_samples_raw}), cur_bulk_mocomp_rtm);
+      } else {
+        run_mocomp(cur_fx, cur_bulk_mocomp_rtm);
+      }
+      (cur_rtm = matx::as_type<matx::fltflt>(cur_bulk_mocomp_rtm))
+          .run(ctx.exec);
+    } else {
+      if (ctx.apply_window && !window_already_applied) {
+        run_mocomp(cur_fx * matx::hamming<1>({npulses, ctx.num_samples_raw}), cur_rtm);
+      } else {
+        run_mocomp(cur_fx, cur_rtm);
+      }
+    }
+  };
 
   // Image tensor --zeroed before first block
   auto image = make_tensor<complex_t>({ctx.image_height, ctx.image_width}, matx::MATX_DEVICE_MEMORY);
@@ -504,7 +565,13 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
                       static_cast<size_t>(npulses) * sizeof(double3), ctx.stream));
       MATX_CUDA_CHECK(cudaMemsetAsync(cur_rtm.Data(), 0,
                       static_cast<size_t>(npulses) * sizeof(double), ctx.stream));
-
+      if constexpr (pos_is_fltflt) {
+        if (ctx.apply_bulk_mocomp) {
+          MATX_CUDA_CHECK(cudaMemsetAsync(
+              blk_bulk_mocomp_rtm.Data(), 0,
+              static_cast<size_t>(npulses) * sizeof(double), ctx.stream));
+        }
+      }
       if (ctx.is_fx_domain) {
         auto cur_fx = matx::slice(blk_fx, {0, 0}, {npulses, ctx.num_samples_raw});
         if (ctx.is_int16_mode) {
@@ -518,13 +585,24 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
           auto q_vals = matx::slice(cur_fx_i16, {0, 1},
                                     {npulses, ctx.num_samples_raw * 2}, {1, 2});
           auto ampsf_b = matx::clone<2>(cur_ampsf, {matxKeepDim, ctx.num_samples_raw});
-          (cur_fx = matx::as_complex_float(
-              matx::as_float(i_vals) * ampsf_b,
-              matx::as_float(q_vals) * ampsf_b)).run(ctx.exec);
+          if (window_in_conversion) {
+            auto win = matx::hamming<1>({npulses, ctx.num_samples_raw});
+            (cur_fx = matx::as_complex_float(
+                matx::as_float(i_vals) * ampsf_b * win,
+                matx::as_float(q_vals) * ampsf_b * win)).run(ctx.exec);
+          } else {
+            (cur_fx = matx::as_complex_float(
+                matx::as_float(i_vals) * ampsf_b,
+                matx::as_float(q_vals) * ampsf_b)).run(ctx.exec);
+          }
+        } else {
+          // Initialize cur_fx to avoid uninitialized memory reads in warmup
+          // kernels.
+          (cur_fx = matx::zeros<complex_t>(
+               {npulses, ctx.num_samples_raw}))
+              .run(ctx.exec);
         }
-        if (ctx.apply_window) {
-          (cur_fx = cur_fx * matx::hamming<1>({npulses, ctx.num_samples_raw})).run(ctx.exec);
-        }
+        apply_fx_preprocessing(cur_fx, cur_rtm, npulses, window_in_conversion);
         auto cur_compressed = matx::slice(blk_compressed, {0, 0}, {npulses, ctx.fft_size});
         if (ctx.sgn == -1) {
           (cur_compressed = matx::ifft(cur_profiles)).run(ctx.exec);
@@ -568,9 +646,17 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
 
   std::vector<cudaEvent_t> ev_bp_start(ctx.num_blocks);
   std::vector<cudaEvent_t> ev_bp_stop(ctx.num_blocks);
+  std::vector<cudaEvent_t> ev_mocomp_start(
+      ctx.apply_bulk_mocomp ? ctx.num_blocks : 0);
+  std::vector<cudaEvent_t> ev_mocomp_stop(
+      ctx.apply_bulk_mocomp ? ctx.num_blocks : 0);
   for (index_t blk = 0; blk < ctx.num_blocks; blk++) {
     MATX_CUDA_CHECK(cudaEventCreate(&ev_bp_start[blk]));
     MATX_CUDA_CHECK(cudaEventCreate(&ev_bp_stop[blk]));
+    if (ctx.apply_bulk_mocomp) {
+      MATX_CUDA_CHECK(cudaEventCreate(&ev_mocomp_start[blk]));
+      MATX_CUDA_CHECK(cudaEventCreate(&ev_mocomp_stop[blk]));
+    }
   }
 
   cudaProfilerStart();
@@ -615,7 +701,7 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
         auto ampsf_b = matx::clone<2>(cur_ampsf, {matxKeepDim, ctx.num_samples_raw});
 
         // Convert int16 -> float, scale by AmpSF, combine to complex<float>
-        if (ctx.apply_window) {
+        if (window_in_conversion) {
           auto win = matx::hamming<1>({npulses, ctx.num_samples_raw});
           (cur_fx = matx::as_complex_float(
               matx::as_float(i_vals) * ampsf_b * win,
@@ -631,11 +717,14 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
                         ctx.h_range_profiles + p0 * ctx.num_samples_raw,
                         static_cast<size_t>(npulses) * static_cast<size_t>(ctx.num_samples_raw) * sizeof(complex_t),
                         cudaMemcpyHostToDevice, ctx.stream));
+      }
 
-        if (ctx.apply_window) {
-          (cur_fx = cur_fx * matx::hamming<1>({npulses, ctx.num_samples_raw})).run(ctx.exec);
-          MATX_CUDA_CHECK(cudaGetLastError());
-        }
+      if (ctx.apply_bulk_mocomp) {
+        MATX_CUDA_CHECK(cudaEventRecord(ev_mocomp_start[blk], ctx.stream));
+      }
+      apply_fx_preprocessing(cur_fx, cur_rtm, npulses, window_in_conversion);
+      if (ctx.apply_bulk_mocomp) {
+        MATX_CUDA_CHECK(cudaEventRecord(ev_mocomp_stop[blk], ctx.stream));
       }
 
       // Zero only the padding region (middle of each row after ifftshift)
@@ -712,10 +801,16 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
   if (ctx.num_blocks > 1) std::cout << std::endl;
 
   float bp_elapsed_ms = 0;
+  float mocomp_elapsed_ms = 0;
   for (index_t blk = 0; blk < ctx.num_blocks; blk++) {
     float blk_ms = 0;
     MATX_CUDA_CHECK(cudaEventElapsedTime(&blk_ms, ev_bp_start[blk], ev_bp_stop[blk]));
     bp_elapsed_ms += blk_ms;
+    if (ctx.apply_bulk_mocomp) {
+      MATX_CUDA_CHECK(cudaEventElapsedTime(
+          &blk_ms, ev_mocomp_start[blk], ev_mocomp_stop[blk]));
+      mocomp_elapsed_ms += blk_ms;
+    }
   }
 
   const double total_backprojections =
@@ -728,6 +823,12 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
             << std::endl;
   std::cout << "  Giga Backprojections: " << total_backprojections / 1e9
             << " (num_pixels * num_pulses)" << std::endl;
+  if (ctx.apply_bulk_mocomp) {
+    std::cout << "Bulk mocomp          : " << mocomp_elapsed_ms / 1000.0f
+              << " s (" << (ctx.apply_window ? "mocomp+window" : "mocomp only")
+              << ") (summed over " << ctx.num_blocks << " block"
+              << (ctx.num_blocks > 1 ? "s" : "") << ")" << std::endl;
+  }
   std::cout << "BP kernels only      : " << bp_elapsed_ms / 1000.0f << " s (summed over "
             << ctx.num_blocks << " block" << (ctx.num_blocks > 1 ? "s" : "") << ")" << std::endl;
   std::cout << "  Rate                : " << bp_gbp_per_sec << " Gbp/s" << std::endl;
@@ -737,6 +838,10 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
   for (index_t blk = 0; blk < ctx.num_blocks; blk++) {
     MATX_CUDA_CHECK(cudaEventDestroy(ev_bp_start[blk]));
     MATX_CUDA_CHECK(cudaEventDestroy(ev_bp_stop[blk]));
+    if (ctx.apply_bulk_mocomp) {
+      MATX_CUDA_CHECK(cudaEventDestroy(ev_mocomp_start[blk]));
+      MATX_CUDA_CHECK(cudaEventDestroy(ev_mocomp_stop[blk]));
+    }
   }
 
   // Write raw binary file
@@ -852,6 +957,7 @@ int main(int argc, char **argv) {
         << "  --cmap <file>          Write the correlation map (raw float32) to a file (requires --gold)\n"
         << "  -u, --upsample <N>     Range upsample factor via zero-padding (default: 1)\n"
         << "  -w, --window <type>    Window for range compression: hamming, none (default: hamming)\n"
+        << "  --bulk-mocomp         Apply bulk motion compensation using per-pulse range_to_mcp\n"
         << "  -b, --block-size <N|0|auto|all>\n"
         << "                          Pulses per block; 0/all use all pulses, auto uses an L2-cache heuristic (default: auto)\n"
         << "  --image-tiles <N>      Process image as N x N tiles (default: 1)\n"
@@ -877,6 +983,7 @@ int main(int argc, char **argv) {
   std::string block_size_arg = "auto";
   index_t image_tiles = 1;
   bool do_warmup = false;
+  bool apply_bulk_mocomp = false;
   bool taylor_fast_add_third_order = false;
   std::string precision_type = "mixed";
   std::string pixel_z_arg = "variable";
@@ -923,6 +1030,8 @@ int main(int argc, char **argv) {
       }
     } else if (std::strcmp(argv[i], "--warmup") == 0) {
       do_warmup = true;
+    } else if (std::strcmp(argv[i], "--bulk-mocomp") == 0) {
+      apply_bulk_mocomp = true;
     } else if (std::strcmp(argv[i], "--taylor-fast-third-order") == 0) {
       taylor_fast_add_third_order = true;
     } else if (std::strcmp(argv[i], "--precision") == 0) {
@@ -1009,6 +1118,8 @@ int main(int argc, char **argv) {
   const bool is_fx_domain   = (hdr.flags & 0x1) != 0;
   const bool is_int16_mode  = (hdr.flags & 0x2) != 0;
   const int sgn             = hdr.sgn;
+  const index_t num_samples_raw = hdr.num_samples_raw > 0
+      ? static_cast<index_t>(hdr.num_samples_raw) : num_range_bins;
 
   if (num_pulses <= 0 || num_range_bins <= 0 ||
       image_width <= 0 || image_height <= 0) {
@@ -1016,6 +1127,11 @@ int main(int argc, char **argv) {
               << ", samples=" << num_range_bins
               << ", image=" << image_height << " x " << image_width
               << std::endl;
+    return 1;
+  }
+
+  if (!std::isfinite(hdr.del_r) || hdr.del_r <= 0.0) {
+    std::cerr << "ERROR: invalid .sarbp del_r: " << hdr.del_r << std::endl;
     return 1;
   }
 
@@ -1052,6 +1168,22 @@ int main(int argc, char **argv) {
               << std::endl;
     return 1;
   }
+
+  if (apply_bulk_mocomp && !is_fx_domain) {
+    std::cerr << "ERROR: --bulk-mocomp requires FX-domain input" << std::endl;
+    return 1;
+  }
+
+  double sample_frequency_spacing = 0.0;
+  if (apply_bulk_mocomp) {
+    // The .sarbp header stores raw FFT range-bin spacing rather than SCSS:
+    // del_r = c / (2 * num_samples_raw * SCSS).
+    sample_frequency_spacing =
+        matx::constants::speed_of_light /
+        (2.0 * static_cast<double>(num_samples_raw) * hdr.del_r);
+  }
+  const matx::experimental::SarBulkMocompParams bulk_mocomp_params{
+      hdr.center_frequency, sample_frequency_spacing, sgn};
 
   MATX_ENTER_HANDLER();
 
@@ -1130,10 +1262,12 @@ int main(int argc, char **argv) {
   fin.close();
   std::cout << "Loaded " << num_pulses << " pulses from .sarbp file" << std::endl;
 
-  // If the user selected the fltflt precision, convert the platform positions
-  // and range_to_mcp values in-place from double to fltflt. Both types are
-  // 8 bytes per scalar (double = 8 bytes, fltflt = 2 * 4 bytes); see the
-  // static_asserts in run_bp_device(). We perform the type-punning via
+  // If the user selected fltflt precision, convert the platform positions
+  // in-place from double to fltflt. Convert range_to_mcp here as well unless
+  // bulk mocomp is enabled. In that case it remains double through upload and
+  // mocomp, then a small device kernel converts each pulse block to fltflt for
+  // backprojection. Both scalar types are 8 bytes; see the static_asserts in
+  // run_bp_device(). We perform the host type-punning via
   // unsigned char* + std::memcpy rather than reinterpret_cast through
   // double*/fltflt*, because the latter would alias the same storage as two
   // incompatible types and is undefined behaviour under strict aliasing.
@@ -1150,21 +1284,21 @@ int main(int argc, char **argv) {
       const matx::fltflt ff(d);
       std::memcpy(slot, &ff, sizeof(matx::fltflt)); // overwrite as fltflt
     }
-    auto *rtm_bytes = reinterpret_cast<unsigned char *>(h_range_to_mcp);
-    for (size_t i = 0; i < static_cast<size_t>(num_pulses); i++) {
-      unsigned char *slot = rtm_bytes + i * sizeof(double);
-      double d;
-      std::memcpy(&d, slot, sizeof(double));
-      const matx::fltflt ff(d);
-      std::memcpy(slot, &ff, sizeof(matx::fltflt));
+    if (!apply_bulk_mocomp) {
+      auto *rtm_bytes = reinterpret_cast<unsigned char *>(h_range_to_mcp);
+      for (size_t i = 0; i < static_cast<size_t>(num_pulses); i++) {
+        unsigned char *slot = rtm_bytes + i * sizeof(double);
+        double d;
+        std::memcpy(&d, slot, sizeof(double));
+        const matx::fltflt ff(d);
+        std::memcpy(slot, &ff, sizeof(matx::fltflt));
+      }
     }
   }
 
   // -------------------------------------------------------------------
   // Compute range compression / upsampling parameters
   // -------------------------------------------------------------------
-  const index_t num_samples_raw = hdr.num_samples_raw > 0
-      ? static_cast<index_t>(hdr.num_samples_raw) : num_range_bins;
   const index_t fft_size = is_fx_domain
       ? (upsample_factor > 1
           ? cuda::next_power_of_two(static_cast<index_t>(num_samples_raw) * static_cast<index_t>(upsample_factor))
@@ -1281,6 +1415,13 @@ int main(int argc, char **argv) {
   }
   std::cout << std::endl;
   std::cout << "Pixel-z mode     : " << pixel_z_arg << std::endl;
+  std::cout << "Bulk mocomp      : ";
+  if (apply_bulk_mocomp) {
+    std::cout << "enabled (double phase arithmetic)";
+  } else {
+    std::cout << "disabled";
+  }
+  std::cout << std::endl;
   std::cout << "Image tiles      : " << image_tiles << " x " << image_tiles
             << std::endl;
 
@@ -1295,9 +1436,10 @@ int main(int argc, char **argv) {
   // range-to-mcp tensors are allocated below with a type that matches
   // `use_fltflt_platform_inputs`: `tensor<double3>` / `tensor<double>` for the
   // standard paths, or `tensor<fltflt>` / `tensor<fltflt>` for the FloatFloat
-  // path. In the fltflt case we already converted the pinned host buffers
-  // in-place from double to fltflt right after the file read above (same byte
-  // layout, no extra storage). The kernel
+  // path. In the fltflt case, platform positions are converted in-place after
+  // the file read. Range-to-MCP values are also converted there unless bulk
+  // mocomp is enabled; that combination retains double RTM through mocomp and
+  // converts each device block to fltflt before backprojection. The kernel
   // template (`SarBp<...>`) already handles both rank-1 (vector-of-double3
   // / -fltflt3-style) and rank-2 (matrix of [pulses, 3]) layouts for
   // platform_positions, so run_bp_device() branches internally only on the
@@ -1319,6 +1461,7 @@ int main(int argc, char **argv) {
       .is_fx_domain          = is_fx_domain,
       .is_int16_mode         = is_int16_mode,
       .apply_window          = apply_window,
+      .apply_bulk_mocomp     = apply_bulk_mocomp,
       .taylor_fast_add_third_order = taylor_fast_add_third_order,
       .pixel_z_mode          = pixel_z_mode,
       .sgn                   = sgn,
@@ -1327,6 +1470,7 @@ int main(int argc, char **argv) {
       .gold_file             = gold_file,
       .cmap_file             = cmap_file,
       .del_r                 = del_r,
+      .bulk_mocomp_params    = bulk_mocomp_params,
       .params                = params,
       .h_positions           = h_positions,
       .h_range_to_mcp        = h_range_to_mcp,

--- a/include/matx/core/constants.h
+++ b/include/matx/core/constants.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (c) 2021, NVIDIA Corporation
+// Copyright (c) 2026, NVIDIA Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -31,42 +31,10 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
-#ifdef __CUDACC__
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600
-#error "MatX requires CUDA compute capability 6.0 or newer."
-#endif
-#include <cuda_runtime_api.h>
-#endif
 
-// defines.h should always be included first. Its definitions may impact
-// the behavior of other headers.
-#include "matx/core/defines.h"
-#include "matx/core/constants.h"
-#include "matx/core/error.h"
-#include "matx/core/log.h"
-#include "matx/file_io/file_io.h"
-#include "matx/core/half_complex.h"
-#include "matx/core/half.h"
-#include "matx/core/nvtx.h"
-#include "matx/core/print.h"
-#include "matx/core/pybind.h"
-#include "matx/core/tensor.h"
-#include "matx/core/dynamic_tensor.h"
-#include "matx/core/sparse_tensor.h"  // sparse support is experimental
-#include "matx/core/make_sparse_tensor.h"
-#include "matx/core/tie.h"
-#include "matx/core/utils.h"
-#include "matx/core/viz.h"
+namespace matx::constants {
 
-#include "matx/executors/executors.h"
-#include "matx/generators/generators.h"
-#include "matx/operators/operators.h"
-#include "matx/transforms/transforms.h"
-#include "matx/streaming/streaming.h"
-#include "matx/core/distributed_tensor.h" // distributed support is experimental
+/** SI speed of light in vacuum, in meters per second. */
+inline constexpr double speed_of_light = 299792458.0;
 
-#include <cuda/std/complex>
-namespace matx {
-  using fcomplex = cuda::std::complex<float>;
-  using dcomplex = cuda::std::complex<double>;
-}
+} // namespace matx::constants

--- a/include/matx/kernels/sar_bp.cuh
+++ b/include/matx/kernels/sar_bp.cuh
@@ -34,12 +34,14 @@
 
 #include <complex>
 #include <cuda.h>
+#include <cuda/std/numbers>
 #include <iomanip>
 #include <memory>
 #include <stdint.h>
 #include <stdio.h>
 #include <vector>
 
+#include "matx/core/constants.h"
 #include "matx/core/utils.h"
 #include "matx/core/type_utils.h"
 #include "matx/core/tensor_utils.h"
@@ -50,9 +52,9 @@
 
 namespace matx {
 
-// SI-defined speed of light in m/s. The speed of light through the atmosphere will be roughly 0.03% slower
-// than this, but it is assumed that any corrections for atmospheric propagation will be done elsewhere.
-static constexpr double SPEED_OF_LIGHT = 299792458.0;
+// Backward-compatibility alias; remove when sar_bp is promoted from experimental.
+[[deprecated("Use matx::constants::speed_of_light instead")]]
+inline constexpr double SPEED_OF_LIGHT = matx::constants::speed_of_light;
 
 #ifdef __CUDACC__
 
@@ -128,7 +130,9 @@ __global__ void SarBpFillPhaseLUT(cuda::std::complex<StorageType> *phase_lut, Co
 {
     const int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= num_range_bins) return;
-    constexpr ComputeType four_pi_over_c = static_cast<ComputeType>(4.0 * M_PI / SPEED_OF_LIGHT);
+    constexpr ComputeType four_pi_over_c =
+        static_cast<ComputeType>(4.0 * cuda::std::numbers::pi /
+                                 matx::constants::speed_of_light);
     // fftshift places zero differential range at floor(N/2). For even N,
     // this is index N/2, the higher-indexed of the two bins adjacent to
     // the array's geometric midpoint (N-1)/2.

--- a/include/matx/operators/operators.h
+++ b/include/matx/operators/operators.h
@@ -100,6 +100,7 @@
 #include "matx/operators/reshape.h"
 #include "matx/operators/reverse.h"
 #include "matx/operators/sar_bp.h"
+#include "matx/operators/sar_bulk_mocomp.h"
 #include "matx/operators/select.h"
 #include "matx/operators/self.h"
 #include "matx/operators/set.h"

--- a/include/matx/operators/sar_bulk_mocomp.h
+++ b/include/matx/operators/sar_bulk_mocomp.h
@@ -1,0 +1,606 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cuda/std/cmath>
+#include <cuda/std/numbers>
+
+#include "matx/core/constants.h"
+#include "matx/core/type_utils.h"
+#include "matx/operators/base_operator.h"
+
+namespace matx {
+namespace experimental {
+
+/**
+ * @brief Parameters for bulk motion compensation of SAR FX data.
+ */
+struct SarBulkMocompParams {
+  /** Frequency represented by sample floor(num_samples / 2), in Hz. */
+  double phase_reference_frequency;
+
+  /** Frequency difference between adjacent samples, in Hz. */
+  double sample_frequency_spacing;
+
+  /** Phase-history sign convention. Must be +1 or -1. */
+  int sgn;
+};
+
+namespace detail {
+
+template <typename FxOp, typename RangeOffsetOp>
+class SarBulkMocompOp
+    : public matx::BaseOp<SarBulkMocompOp<FxOp, RangeOffsetOp>> {
+private:
+  using fx_op_type = matx::detail::base_type_t<FxOp>;
+  using range_offset_op_type = matx::detail::base_type_t<RangeOffsetOp>;
+
+public:
+  using matxop = bool;
+  using value_type = typename fx_op_type::value_type;
+  using range_type = typename range_offset_op_type::value_type;
+  using fx_scalar_type = typename matx::inner_op_type_t<value_type>::type;
+  using self_type = SarBulkMocompOp<FxOp, RangeOffsetOp>;
+
+  template <typename Candidate>
+  static __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ constexpr bool
+  ContainsBlockReduction() {
+    if constexpr (requires {
+                    typename Candidate::matx_jit_contains_block_reduction;
+                  }) {
+      return Candidate::matx_jit_contains_block_reduction::value;
+    } else {
+      return requires { typename Candidate::matx_jit_block_reduction; };
+    }
+  }
+
+  using matx_jit_contains_block_reduction = cuda::std::bool_constant<
+      ContainsBlockReduction<fx_op_type>() ||
+      ContainsBlockReduction<range_offset_op_type>()>;
+
+  template <typename CapType>
+  struct RangeReadCapabilities : CapType::scalar_cap {
+    // The lower-rank range expression is indexed explicitly. Suppress nested
+    // JIT operators' thread-based bounds checks and let leaf tensors check the
+    // mapped range indices instead.
+    static constexpr bool pass_through_threads = CapType::jit;
+  };
+
+#ifdef MATX_EN_JIT
+  struct JIT_Storage {
+    typename matx::detail::inner_storage_or_self_t<fx_op_type> fx_;
+    typename matx::detail::inner_storage_or_self_t<range_offset_op_type>
+        range_offset_;
+    range_type reference_phase_over_pi_per_meter_;
+    range_type sample_phase_over_pi_per_meter_;
+    index_t center_sample_;
+  };
+
+  __MATX_INLINE__ JIT_Storage ToJITStorage() const {
+    return JIT_Storage{matx::detail::to_jit_storage(fx_),
+                       matx::detail::to_jit_storage(range_offset_),
+                       reference_phase_over_pi_per_meter_,
+                       sample_phase_over_pi_per_meter_, center_sample_};
+  }
+
+  __MATX_INLINE__ std::string get_jit_class_name() const {
+    return "JITSarBulkMocomp";
+  }
+
+  __MATX_INLINE__ auto get_jit_op_str() const {
+    const std::string class_name = get_jit_class_name();
+    return cuda::std::make_tuple(
+        class_name,
+        std::string("template <typename FxOp, typename RangeOffsetOp> struct ") +
+            class_name + R"MATX_JIT( {
+  using value_type = typename FxOp::value_type;
+  using range_type = typename RangeOffsetOp::value_type;
+  using fx_scalar_type = typename inner_op_type_t<value_type>::type;
+  using matxop = bool;
+
+  template <typename Candidate>
+  static __MATX_INLINE__ constexpr __MATX_DEVICE__ bool
+  ContainsBlockReduction()
+  {
+    if constexpr (requires {
+                    typename Candidate::matx_jit_contains_block_reduction;
+                  }) {
+      return Candidate::matx_jit_contains_block_reduction::value;
+    } else {
+      return requires { typename Candidate::matx_jit_block_reduction; };
+    }
+  }
+
+  using matx_jit_contains_block_reduction = cuda::std::bool_constant<
+      ContainsBlockReduction<FxOp>() ||
+      ContainsBlockReduction<RangeOffsetOp>()>;
+
+  template <typename CapType>
+  struct RangeReadCapabilities : CapType::scalar_cap {
+    static constexpr bool pass_through_threads = CapType::jit;
+  };
+
+  typename detail::inner_storage_or_self_t<detail::base_type_t<FxOp>> fx_;
+  typename detail::inner_storage_or_self_t<detail::base_type_t<RangeOffsetOp>>
+      range_offset_;
+  range_type reference_phase_over_pi_per_meter_;
+  range_type sample_phase_over_pi_per_meter_;
+  index_t center_sample_;
+
+  template <typename CapType, typename... Is>
+  __MATX_INLINE__ __MATX_DEVICE__ auto operator()(Is... indices) const
+  {
+    static_assert(sizeof...(Is) == Rank(),
+                  "sar_bulk_mocomp index count must match operator rank");
+
+    cuda::std::array<index_t, Rank()> fx_indices{
+        static_cast<index_t>(indices)...};
+    cuda::std::array<index_t, Rank() - 1> range_indices{};
+    MATX_LOOP_UNROLL
+    for (int32_t dim = 0; dim < Rank() - 1; ++dim) {
+      range_indices[dim] = fx_indices[dim];
+    }
+
+    static constexpr bool fuse_block_reduction =
+        CapType::jit && matx_jit_contains_block_reduction::value;
+    using FxCap = cuda::std::conditional_t<
+        fuse_block_reduction &&
+            !ContainsBlockReduction<FxOp>(),
+        typename CapType::scalar_cap, CapType>;
+    using RangeCap = cuda::std::conditional_t<
+        fuse_block_reduction && ContainsBlockReduction<RangeOffsetOp>(),
+        CapType,
+        RangeReadCapabilities<CapType>>;
+
+    const range_type range_offset =
+        get_value<RangeCap>(range_offset_, range_indices);
+    const auto fx_value = get_value<FxCap>(fx_, fx_indices);
+
+    if constexpr (fuse_block_reduction ||
+                  CapType::ept == ElementsPerThread::ONE) {
+      return ApplyCorrection(fx_value, range_offset, fx_indices[Rank() - 1]);
+    } else {
+      constexpr index_t EPT = static_cast<index_t>(CapType::ept);
+      Vector<value_type, EPT> result;
+      const index_t first_sample = fx_indices[Rank() - 1] * EPT;
+      MATX_LOOP_UNROLL
+      for (index_t lane = 0; lane < EPT; ++lane) {
+        result.data[lane] = ApplyCorrection(fx_value.data[lane], range_offset,
+                                            first_sample + lane);
+      }
+      return result;
+    }
+  }
+
+  static __MATX_INLINE__ constexpr __MATX_DEVICE__ int32_t Rank()
+  {
+    return FxOp::Rank();
+  }
+
+  constexpr __MATX_INLINE__ __MATX_DEVICE__ index_t Size(int dim) const
+  {
+    return fx_.Size(dim);
+  }
+
+private:
+  __MATX_INLINE__ __MATX_DEVICE__ value_type
+  ApplyCorrection(const value_type &fx_value, range_type range_offset,
+                  index_t sample) const
+  {
+    const range_type sample_offset =
+        static_cast<range_type>(sample - center_sample_);
+    const range_type phase_over_pi_per_meter =
+        cuda::std::fma(sample_offset, sample_phase_over_pi_per_meter_,
+                       reference_phase_over_pi_per_meter_);
+    const range_type phase_over_pi = phase_over_pi_per_meter * range_offset;
+    range_type sin_phase;
+    range_type cos_phase;
+    if constexpr (cuda::std::is_same_v<range_type, double>) {
+      sincospi(phase_over_pi, &sin_phase, &cos_phase);
+    } else {
+      sincospif(phase_over_pi, &sin_phase, &cos_phase);
+    }
+    const value_type correction{static_cast<fx_scalar_type>(cos_phase),
+                                static_cast<fx_scalar_type>(sin_phase)};
+    return fx_value * correction;
+  }
+};
+)MATX_JIT");
+  }
+#endif
+
+  __MATX_INLINE__ SarBulkMocompOp(const FxOp &fx,
+                                  const RangeOffsetOp &range_offset,
+                                  const SarBulkMocompParams &params)
+      : fx_(fx), range_offset_(range_offset),
+        reference_phase_over_pi_per_meter_(
+            static_cast<range_type>(-static_cast<double>(params.sgn) * 4.0 *
+                                    params.phase_reference_frequency /
+                                    matx::constants::speed_of_light)),
+        sample_phase_over_pi_per_meter_(static_cast<range_type>(
+            -static_cast<double>(params.sgn) * 4.0 *
+            params.sample_frequency_spacing / matx::constants::speed_of_light)),
+        center_sample_(fx.Size(Rank() - 1) / 2) {
+    static_assert(!matx::is_dynamic_rank_op_v<FxOp> &&
+                      !matx::is_dynamic_rank_op_v<RangeOffsetOp>,
+                  "sar_bulk_mocomp does not currently support dynamic-rank "
+                  "inputs");
+    static_assert(
+        !matx::is_distributed_tensor_v<FxOp> &&
+            !matx::is_distributed_expression_v<FxOp> &&
+            !matx::is_distributed_tensor_v<RangeOffsetOp> &&
+            !matx::is_distributed_expression_v<RangeOffsetOp>,
+        "sar_bulk_mocomp does not currently support distributed inputs");
+    static_assert(Rank() >= 2,
+                  "sar_bulk_mocomp requires FX data with rank 2 or greater");
+    static_assert(range_offset_op_type::Rank() == Rank() - 1,
+                  "sar_bulk_mocomp range offset rank must be one less than "
+                  "the FX data rank");
+    static_assert(
+        cuda::std::is_same_v<value_type, cuda::std::complex<float>> ||
+            cuda::std::is_same_v<value_type, cuda::std::complex<double>>,
+        "sar_bulk_mocomp currently supports only complex<float> and "
+        "complex<double> FX data");
+    static_assert(cuda::std::is_same_v<range_type, float> ||
+                      cuda::std::is_same_v<range_type, double>,
+                  "sar_bulk_mocomp currently supports only float and double "
+                  "range-offset value types");
+
+    if (fx_.Size(Rank() - 1) <= 0) {
+      MATX_THROW(matxInvalidSize,
+                 "sar_bulk_mocomp requires at least one frequency sample");
+    }
+    if (params.sgn != -1 && params.sgn != 1) {
+      MATX_THROW(matxInvalidParameter,
+                 "sar_bulk_mocomp sgn must be +1 or -1");
+    }
+    if (static_cast<range_type>(params.sample_frequency_spacing) ==
+        static_cast<range_type>(0)) {
+      MATX_THROW(
+          matxInvalidParameter,
+          "sar_bulk_mocomp sample frequency spacing must be nonzero in the "
+          "range-offset type");
+    }
+
+    MATX_LOOP_UNROLL
+    for (int32_t dim = 0; dim < Rank() - 1; ++dim) {
+      if (range_offset_.Size(dim) != fx_.Size(dim)) {
+        MATX_THROW(
+            matxInvalidSize,
+            "sar_bulk_mocomp range-offset shape must match all FX dimensions "
+            "except the final sample dimension");
+      }
+    }
+
+    MATX_LOG_TRACE("{} constructor: rank={}", str(), Rank());
+  }
+
+  __MATX_INLINE__ std::string str() const {
+    return "sar_bulk_mocomp(" + matx::detail::get_type_str(fx_) + ")";
+  }
+
+  template <typename CapType, typename... Is>
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto
+  operator()(Is... indices) const {
+    static_assert(sizeof...(Is) == Rank(),
+                  "sar_bulk_mocomp index count must match operator rank");
+
+    cuda::std::array<index_t, Rank()> fx_indices{
+        static_cast<index_t>(indices)...};
+    cuda::std::array<index_t, Rank() - 1> range_indices{};
+    MATX_LOOP_UNROLL
+    for (int32_t dim = 0; dim < Rank() - 1; ++dim) {
+      range_indices[dim] = fx_indices[dim];
+    }
+
+    // Always false for the non-JIT path. This is retained here to keep the JIT and non-JIT
+    // implementations as close as possible to help prevent implementation drift.
+    static constexpr bool fuse_block_reduction =
+        CapType::jit && matx_jit_contains_block_reduction::value;
+    using FxCap = cuda::std::conditional_t<
+        fuse_block_reduction &&
+            !ContainsBlockReduction<fx_op_type>(),
+        typename CapType::scalar_cap, CapType>;
+    using RangeCap = cuda::std::conditional_t<
+        fuse_block_reduction &&
+            ContainsBlockReduction<range_offset_op_type>(),
+        CapType,
+        RangeReadCapabilities<CapType>>;
+
+    const range_type range_offset =
+        matx::detail::get_value<RangeCap>(range_offset_, range_indices);
+    const auto fx_value = matx::detail::get_value<FxCap>(fx_, fx_indices);
+
+    if constexpr (fuse_block_reduction ||
+                  CapType::ept == matx::detail::ElementsPerThread::ONE) {
+      return ApplyCorrection(fx_value, range_offset, fx_indices[Rank() - 1]);
+    } else {
+      constexpr index_t EPT = static_cast<index_t>(CapType::ept);
+      matx::detail::Vector<value_type, EPT> result;
+      const index_t first_sample = fx_indices[Rank() - 1] * EPT;
+      MATX_LOOP_UNROLL
+      for (index_t lane = 0; lane < EPT; ++lane) {
+        result.data[lane] = ApplyCorrection(fx_value.data[lane], range_offset,
+                                            first_sample + lane);
+      }
+      return result;
+    }
+  }
+
+  template <typename... Is>
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto
+  operator()(Is... indices) const {
+    return this->template operator()<matx::detail::DefaultCapabilities>(
+        indices...);
+  }
+
+  template <matx::detail::OperatorCapability Cap, typename InType>
+  __MATX_INLINE__ __MATX_HOST__ auto
+  get_capability([[maybe_unused]] InType &in) const {
+    if constexpr (Cap == matx::detail::OperatorCapability::JIT_TYPE_QUERY) {
+#ifdef MATX_EN_JIT
+      const auto fx_jit_name =
+          matx::detail::get_operator_capability<Cap>(fx_, in);
+      const auto range_jit_name =
+          matx::detail::get_operator_capability<Cap>(range_offset_, in);
+      return get_jit_class_name() + "<" + fx_jit_name + "," +
+             range_jit_name + ">";
+#else
+      return "";
+#endif
+    } else if constexpr (Cap ==
+                         matx::detail::OperatorCapability::JIT_CACHE_KEY) {
+#ifdef MATX_EN_JIT
+      auto key = matx::detail::MakeJITCacheKeyForType<self_type>(
+          "JITSarBulkMocomp");
+      matx::detail::HashJITCacheValue(key, Rank());
+      return matx::detail::combine_capabilities<Cap>(
+          key, matx::detail::get_operator_capability<Cap>(fx_, in),
+          matx::detail::get_operator_capability<Cap>(range_offset_, in));
+#else
+      return matx::detail::MakeInvalidJITCacheKey();
+#endif
+    } else if constexpr (Cap ==
+                         matx::detail::OperatorCapability::JIT_CLASS_QUERY) {
+#ifdef MATX_EN_JIT
+      const auto [key, value] = get_jit_op_str();
+      if (in.find(key) == in.end()) {
+        in[key] = value;
+      }
+      matx::detail::get_operator_capability<Cap>(fx_, in);
+      matx::detail::get_operator_capability<Cap>(range_offset_, in);
+      return true;
+#else
+      return false;
+#endif
+    } else if constexpr (Cap ==
+                         matx::detail::OperatorCapability::SUPPORTS_JIT) {
+#ifdef MATX_EN_JIT
+      return matx::detail::combine_capabilities<Cap>(
+          true, matx::detail::get_operator_capability<Cap>(fx_, in),
+          matx::detail::get_operator_capability<Cap>(range_offset_, in));
+#else
+      return false;
+#endif
+    } else if constexpr (
+        Cap == matx::detail::OperatorCapability::ELEMENTS_PER_THREAD ||
+        Cap == matx::detail::OperatorCapability::MAX_EPT_VEC_LOAD) {
+      auto self_has_cap =
+          matx::detail::capability_attributes<Cap>::default_value;
+      if constexpr (matx_jit_contains_block_reduction::value) {
+        if constexpr (ContainsBlockReduction<fx_op_type>() &&
+                      ContainsBlockReduction<range_offset_op_type>()) {
+          return matx::detail::combine_capabilities<Cap>(
+              self_has_cap,
+              matx::detail::get_operator_capability<Cap>(fx_, in),
+              matx::detail::get_operator_capability<Cap>(range_offset_, in));
+        } else if constexpr (ContainsBlockReduction<fx_op_type>()) {
+          return matx::detail::get_operator_capability<Cap>(fx_, in);
+        } else {
+          return matx::detail::get_operator_capability<Cap>(range_offset_, in);
+        }
+      } else {
+        return matx::detail::combine_capabilities<Cap>(
+            self_has_cap,
+            matx::detail::get_operator_capability<Cap>(fx_, in));
+      }
+    } else if constexpr (
+        Cap == matx::detail::OperatorCapability::SET_ELEMENTS_PER_THREAD) {
+      auto fx_in = in;
+      auto range_in = in;
+      if constexpr (matx_jit_contains_block_reduction::value) {
+        if constexpr (!ContainsBlockReduction<fx_op_type>()) {
+          fx_in.ept = matx::detail::ElementsPerThread::ONE;
+        }
+        if constexpr (!ContainsBlockReduction<range_offset_op_type>()) {
+          range_in.ept = matx::detail::ElementsPerThread::ONE;
+        }
+      } else {
+        range_in.ept = matx::detail::ElementsPerThread::ONE;
+      }
+      return matx::detail::combine_capabilities<Cap>(
+          matx::detail::capability_attributes<Cap>::default_value,
+          matx::detail::get_operator_capability<Cap>(fx_, fx_in),
+          matx::detail::get_operator_capability<Cap>(range_offset_, range_in));
+    } else if constexpr (
+        Cap == matx::detail::OperatorCapability::DYN_SHM_SIZE) {
+      return matx::detail::get_operator_capability<Cap>(fx_, in) +
+             matx::detail::get_operator_capability<Cap>(range_offset_, in);
+    } else {
+      auto self_has_cap =
+          matx::detail::capability_attributes<Cap>::default_value;
+      return matx::detail::combine_capabilities<Cap>(
+          self_has_cap, matx::detail::get_operator_capability<Cap>(fx_, in),
+          matx::detail::get_operator_capability<Cap>(range_offset_, in));
+    }
+  }
+
+  static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t
+  Rank() {
+    return fx_op_type::Rank();
+  }
+
+  constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto
+  Size(int dim) const noexcept {
+    return fx_.Size(dim);
+  }
+
+  template <typename ShapeType, typename Executor>
+  __MATX_INLINE__ void PreRun(ShapeType &&shape,
+                              Executor &&exec) const noexcept {
+    if constexpr (matx::is_matx_op<FxOp>()) {
+      fx_.PreRun(cuda::std::forward<ShapeType>(shape),
+                 cuda::std::forward<Executor>(exec));
+    }
+    if constexpr (matx::is_matx_op<RangeOffsetOp>()) {
+      range_offset_.PreRun(cuda::std::forward<ShapeType>(shape),
+                           cuda::std::forward<Executor>(exec));
+    }
+  }
+
+  template <typename ShapeType, typename Executor>
+  __MATX_INLINE__ void PostRun(ShapeType &&shape,
+                               Executor &&exec) const noexcept {
+    if constexpr (matx::is_matx_op<FxOp>()) {
+      fx_.PostRun(cuda::std::forward<ShapeType>(shape),
+                  cuda::std::forward<Executor>(exec));
+    }
+    if constexpr (matx::is_matx_op<RangeOffsetOp>()) {
+      range_offset_.PostRun(cuda::std::forward<ShapeType>(shape),
+                            cuda::std::forward<Executor>(exec));
+    }
+  }
+
+private:
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ value_type
+  ApplyCorrection(const value_type &fx_value, range_type range_offset,
+                  index_t sample) const {
+    const range_type sample_offset =
+        static_cast<range_type>(sample - center_sample_);
+    const range_type phase_over_pi_per_meter = cuda::std::fma(
+        sample_offset, sample_phase_over_pi_per_meter_,
+        reference_phase_over_pi_per_meter_);
+    const range_type phase_over_pi = phase_over_pi_per_meter * range_offset;
+    range_type sin_phase;
+    range_type cos_phase;
+#if defined(__CUDA_ARCH__)
+    if constexpr (cuda::std::is_same_v<range_type, double>) {
+      sincospi(phase_over_pi, &sin_phase, &cos_phase);
+    } else {
+      sincospif(phase_over_pi, &sin_phase, &cos_phase);
+    }
+#else
+    const range_type reduced_phase_over_pi = cuda::std::remainder(
+        phase_over_pi, static_cast<range_type>(2));
+    const range_type phase =
+        static_cast<range_type>(cuda::std::numbers::pi) *
+        reduced_phase_over_pi;
+    sin_phase = cuda::std::sin(phase);
+    cos_phase = cuda::std::cos(phase);
+#endif
+    const value_type correction{static_cast<fx_scalar_type>(cos_phase),
+                                static_cast<fx_scalar_type>(sin_phase)};
+    return fx_value * correction;
+  }
+
+  mutable fx_op_type fx_;
+  mutable range_offset_op_type range_offset_;
+  range_type reference_phase_over_pi_per_meter_;
+  range_type sample_phase_over_pi_per_meter_;
+  index_t center_sample_;
+};
+
+} // namespace detail
+
+/**
+ * @brief Apply bulk motion compensation to SAR phase-history data in the FX
+ * domain.
+ *
+ * The final two dimensions of \p fx are interpreted as pulse and frequency
+ * sample. Every leading dimension is a batch dimension. The range offset must
+ * match all FX dimensions except the final frequency-sample dimension.
+ *
+ * Sample floor(num_samples / 2) has frequency
+ * \p params.phase_reference_frequency. The operator applies
+ * exp(j * -sgn * 4*pi/c * frequency * target_reference_range) to every FX
+ * sample. Phase arithmetic uses the value type of \p target_reference_range,
+ * which must currently be float or double.
+ *
+ * @tparam FxOp FX tensor or operator type.
+ * @tparam TargetRangeOp Target-reference-range tensor or operator type.
+ * @param fx Complex FX-domain data with shape [batch..., pulses, samples].
+ * @param target_reference_range Target per-pulse reference range with shape
+ * [batch..., pulses].
+ * @param params Frequency grid and phase-sign parameters.
+ * @return A lazy, allocation-free motion-compensated operator.
+ */
+template <typename FxOp, typename TargetRangeOp>
+  requires (is_matx_op_c<FxOp> && is_matx_op_c<TargetRangeOp>)
+__MATX_INLINE__ auto
+sar_bulk_mocomp(const FxOp &fx, const TargetRangeOp &target_reference_range,
+                const SarBulkMocompParams &params) {
+  return detail::SarBulkMocompOp<FxOp, TargetRangeOp>(
+      fx, target_reference_range, params);
+}
+
+/**
+ * @brief Change the bulk motion-compensation reference of SAR FX data.
+ *
+ * This overload can be used to effectively change the motion-compensation
+ * point. It applies compensation for target_reference_range minus
+ * initial_reference_range. Both range operators must have the same shape as
+ * all FX dimensions except its final frequency-sample dimension.
+ *
+ * @tparam FxOp FX tensor or operator type.
+ * @tparam InitialRangeOp Initial-reference-range tensor or operator type.
+ * @tparam TargetRangeOp Target-reference-range tensor or operator type.
+ * @param fx Complex FX-domain data with shape [batch..., pulses, samples].
+ * @param initial_reference_range Existing per-pulse reference range.
+ * @param target_reference_range Desired per-pulse reference range.
+ * @param params Frequency grid and phase-sign parameters.
+ * @return A lazy, allocation-free reference-change operator.
+ */
+template <typename FxOp, typename InitialRangeOp, typename TargetRangeOp>
+  requires (is_matx_op_c<FxOp> && is_matx_op_c<InitialRangeOp> &&
+            is_matx_op_c<TargetRangeOp>)
+__MATX_INLINE__ auto
+sar_bulk_mocomp(const FxOp &fx, const InitialRangeOp &initial_reference_range,
+                const TargetRangeOp &target_reference_range,
+                const SarBulkMocompParams &params) {
+  return detail::SarBulkMocompOp<FxOp, decltype(target_reference_range -
+                                                initial_reference_range)>(
+      fx, target_reference_range - initial_reference_range, params);
+}
+
+} // namespace experimental
+} // namespace matx

--- a/include/matx/operators/sar_bulk_mocomp.h
+++ b/include/matx/operators/sar_bulk_mocomp.h
@@ -225,7 +225,23 @@ private:
     const range_type phase_over_pi = phase_over_pi_per_meter * range_offset;
     range_type sin_phase;
     range_type cos_phase;
-    if constexpr (cuda::std::is_same_v<range_type, double>) {
+    if constexpr (cuda::std::is_same_v<range_type, double> &&
+                  cuda::std::is_same_v<fx_scalar_type, float>) {
+      // Keep the range-sensitive phase construction and argument reduction in
+      // double, but evaluate the bounded angle with single-precision sincospif.
+      // This avoids the costly full-range double-precision sincospi path on
+      // GPUs with reduced FP64 throughput without first narrowing the large
+      // unreduced phase.
+      const double periods = cuda::std::nearbyint(phase_over_pi * 0.5);
+      const double reduced_phase_over_pi =
+          cuda::std::fma(periods, -2.0, phase_over_pi);
+      float fast_sin_phase;
+      float fast_cos_phase;
+      sincospif(static_cast<float>(reduced_phase_over_pi), &fast_sin_phase,
+                &fast_cos_phase);
+      sin_phase = fast_sin_phase;
+      cos_phase = fast_cos_phase;
+    } else if constexpr (cuda::std::is_same_v<range_type, double>) {
       sincospi(phase_over_pi, &sin_phase, &cos_phase);
     } else {
       sincospif(phase_over_pi, &sin_phase, &cos_phase);
@@ -514,7 +530,22 @@ private:
     range_type sin_phase;
     range_type cos_phase;
 #if defined(__CUDA_ARCH__)
-    if constexpr (cuda::std::is_same_v<range_type, double>) {
+    if constexpr (cuda::std::is_same_v<range_type, double> &&
+                  cuda::std::is_same_v<fx_scalar_type, float>) {
+      // A float output cannot retain double-precision trig results. Reduce the
+      // large phase modulo 2 in double before converting the bounded angle to
+      // float, which makes the lower-cost sincospif path accurate enough for
+      // the destination type.
+      const double periods = cuda::std::nearbyint(phase_over_pi * 0.5);
+      const double reduced_phase_over_pi =
+          cuda::std::fma(periods, -2.0, phase_over_pi);
+      float fast_sin_phase;
+      float fast_cos_phase;
+      sincospif(static_cast<float>(reduced_phase_over_pi), &fast_sin_phase,
+                &fast_cos_phase);
+      sin_phase = fast_sin_phase;
+      cos_phase = fast_cos_phase;
+    } else if constexpr (cuda::std::is_same_v<range_type, double>) {
       sincospi(phase_over_pi, &sin_phase, &cos_phase);
     } else {
       sincospif(phase_over_pi, &sin_phase, &cos_phase);
@@ -553,8 +584,10 @@ private:
  * Sample floor(num_samples / 2) has frequency
  * \p params.phase_reference_frequency. The operator applies
  * exp(j * -sgn * 4*pi/c * frequency * target_reference_range) to every FX
- * sample. Phase arithmetic uses the value type of \p target_reference_range,
- * which must currently be float or double.
+ * sample. Phase construction and reduction use the value type of
+ * \p target_reference_range, which must currently be float or double. On CUDA,
+ * double-range phase for complex<float> FX data uses a float trigonometric
+ * evaluation after double-precision argument reduction.
  *
  * @tparam FxOp FX tensor or operator type.
  * @tparam TargetRangeOp Target-reference-range tensor or operator type.

--- a/include/matx/transforms/sar_bp.h
+++ b/include/matx/transforms/sar_bp.h
@@ -34,9 +34,11 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cuda/std/numbers>
 #include <type_traits>
 
 #include "matx/core/cache.h"
+#include "matx/core/constants.h"
 #include "matx/core/error.h"
 #include "matx/core/nvtx.h"
 #include "matx/core/tensor.h"
@@ -177,7 +179,9 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
     constexpr bool NoTaylorFastThirdOrder = false;
     if (phase_lut_optimization) {
       constexpr bool PhaseLUT = true;
-      const double phase_correction_partial = 4.0 * M_PI * params.del_r * (params.center_frequency / SPEED_OF_LIGHT);
+      const double phase_correction_partial =
+          4.0 * cuda::std::numbers::pi * params.del_r *
+          (params.center_frequency / matx::constants::speed_of_light);
 
       const size_t workspace_elem_size = (params.compute_type == SarBpComputeType::Double) ?
         sizeof(cuda::std::complex<double>) : sizeof(cuda::std::complex<float>);
@@ -214,7 +218,9 @@ inline void sar_bp_impl(OutImageType &out, const InitialImageType &initial_image
       }
     } else {
       constexpr bool PhaseLUT = false;
-      const double phase_correction_partial = 4.0 * M_PI * (params.center_frequency / SPEED_OF_LIGHT);
+      const double phase_correction_partial =
+          4.0 * cuda::std::numbers::pi *
+          (params.center_frequency / matx::constants::speed_of_light);
       if (params.compute_type == SarBpComputeType::Double) {
         SarBp<SarBpComputeType::Double, OutImageType, InitialImageType, RangeProfilesType, PlatPosType, VoxLocType, RangeToMcpType, PhaseLUT, IsUnitStride, NoTaylorFastThirdOrder, PixelZMode, IdxT><<<grid, block, 0, stream>>>(
           out, initial_image, range_profiles, platform_positions, voxel_locations, range_to_mcp, dr_inv, phase_correction_partial, nullptr);

--- a/test/00_operators/CMakeLists.txt
+++ b/test/00_operators/CMakeLists.txt
@@ -55,6 +55,7 @@ set(OPERATOR_TEST_FILES
   repmat_test.cu
   reshape_test.cu
   reverse_test.cu
+  sar_bulk_mocomp_test.cu
   shift_test.cu
   simple_executor_accessor_test.cu
   slice_and_reduce_test.cu

--- a/test/00_operators/sar_bulk_mocomp_test.cu
+++ b/test/00_operators/sar_bulk_mocomp_test.cu
@@ -189,6 +189,20 @@ using SarBulkMocompTestTypes =
 
 TYPED_TEST_SUITE(SarBulkMocompTests, SarBulkMocompTestTypes);
 
+template <typename Executor>
+class SarBulkMocompMixedPrecisionGPUTests : public ::testing::Test {};
+
+#ifdef MATX_EN_JIT
+using SarBulkMocompMixedPrecisionGPUExecutorTypes =
+    ::testing::Types<cudaExecutor, CUDAJITExecutor>;
+#else
+using SarBulkMocompMixedPrecisionGPUExecutorTypes =
+    ::testing::Types<cudaExecutor>;
+#endif
+
+TYPED_TEST_SUITE(SarBulkMocompMixedPrecisionGPUTests,
+                 SarBulkMocompMixedPrecisionGPUExecutorTypes);
+
 #ifdef MATX_EN_JIT
 template <typename RangeType>
 class SarBulkMocompJITTests : public ::testing::Test {};
@@ -383,6 +397,49 @@ TEST(SarBulkMocompTests, PhasePrecisionFollowsRangeType) {
                 2.0e-6);
     EXPECT_NEAR(out_float(0, sample).imag(), expected_float_output.imag(),
                 2.0e-6);
+  }
+  MATX_EXIT_HANDLER();
+}
+
+TYPED_TEST(SarBulkMocompMixedPrecisionGPUTests,
+           FloatOutputPreservesDoublePhaseReduction) {
+  MATX_ENTER_HANDLER();
+  constexpr index_t pulses = 5;
+  constexpr index_t samples = 17;
+  TypeParam exec{};
+
+  auto fx = make_tensor<Complex<float>>({pulses, samples}, MATX_MANAGED_MEMORY);
+  auto ranges = make_tensor<double>({pulses}, MATX_MANAGED_MEMORY);
+  auto output =
+      make_tensor<Complex<float>>({pulses, samples}, MATX_MANAGED_MEMORY);
+
+  // Cover ordinary offsets, spaceborne slant ranges, negative offsets, and a
+  // very large phase whose fractional cycle would be lost if it were narrowed
+  // to float before reduction.
+  const double range_values[pulses] = {
+      0.125, 1.25, 725000.125, -725000.375, 8000000.0625};
+  for (index_t pulse = 0; pulse < pulses; ++pulse) {
+    ranges(pulse) = range_values[pulse];
+    for (index_t sample = 0; sample < samples; ++sample) {
+      fx(pulse, sample) =
+          Complex<float>{0.75f + 0.125f * static_cast<float>(pulse),
+                         -0.5f + 0.03125f * static_cast<float>(sample)};
+    }
+  }
+
+  const experimental::SarBulkMocompParams params{9.6e9, 27500.0, -1};
+  (output = experimental::sar_bulk_mocomp(fx, ranges, params)).run(exec);
+  exec.sync();
+
+  for (index_t pulse = 0; pulse < pulses; ++pulse) {
+    for (index_t sample = 0; sample < samples; ++sample) {
+      const auto input = Complex<double>{fx(pulse, sample).real(),
+                                         fx(pulse, sample).imag()};
+      const auto expected = ExpectedCorrection(input, ranges(pulse), sample,
+                                               samples, params);
+      EXPECT_NEAR(output(pulse, sample).real(), expected.real(), 1.0e-6);
+      EXPECT_NEAR(output(pulse, sample).imag(), expected.imag(), 1.0e-6);
+    }
   }
   MATX_EXIT_HANDLER();
 }

--- a/test/00_operators/sar_bulk_mocomp_test.cu
+++ b/test/00_operators/sar_bulk_mocomp_test.cu
@@ -213,15 +213,6 @@ using SarBulkMocompMixedPrecisionGPUExecutorTypes =
 TYPED_TEST_SUITE(SarBulkMocompMixedPrecisionGPUTests,
                  SarBulkMocompMixedPrecisionGPUExecutorTypes);
 
-#ifdef MATX_EN_JIT
-template <typename RangeType>
-class SarBulkMocompJITTests : public ::testing::Test {};
-
-using SarBulkMocompJITTestTypes = ::testing::Types<float, double>;
-
-TYPED_TEST_SUITE(SarBulkMocompJITTests, SarBulkMocompJITTestTypes);
-#endif
-
 } // namespace
 
 TYPED_TEST(SarBulkMocompTests, Rank2OddAndEvenFrequencyGrids) {
@@ -235,12 +226,11 @@ TYPED_TEST(SarBulkMocompTests, Rank2OddAndEvenFrequencyGrids) {
   MATX_EXIT_HANDLER();
 }
 
-#ifdef MATX_EN_JIT
-TYPED_TEST(SarBulkMocompJITTests, TransformBackedRangeOffset) {
+TYPED_TEST(SarBulkMocompTests, TransformBackedRangeOffset) {
   MATX_ENTER_HANDLER();
-  using RangeType = TypeParam;
+  using RangeType = cuda::std::tuple_element_t<0, TypeParam>;
   using FxType = Complex<RangeType>;
-  using ExecType = CUDAJITExecutor;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
   constexpr index_t pulses = 3;
   constexpr index_t samples = 32;
@@ -289,7 +279,6 @@ TYPED_TEST(SarBulkMocompJITTests, TransformBackedRangeOffset) {
   }
   MATX_EXIT_HANDLER();
 }
-#endif
 
 TYPED_TEST(SarBulkMocompTests, BatchedReferenceChangeAndComposition) {
   MATX_ENTER_HANDLER();

--- a/test/00_operators/sar_bulk_mocomp_test.cu
+++ b/test/00_operators/sar_bulk_mocomp_test.cu
@@ -135,13 +135,13 @@ void RunRank2ReferenceCase(ExecType &exec, index_t num_samples, int sgn) {
 
   constexpr auto memory_space = TestMemorySpace<ExecType>();
   auto fx = make_tensor<FxType>({num_pulses, num_samples}, memory_space);
-  auto ranges = make_tensor<RangeType>({num_pulses}, memory_space);
+  auto range_to_mcp = make_tensor<RangeType>({num_pulses}, memory_space);
   auto output = make_tensor<FxType>({num_pulses, num_samples}, memory_space);
 
   for (index_t pulse = 0; pulse < num_pulses; ++pulse) {
     const auto pulse_value = static_cast<RangeType>(pulse);
-    ranges(pulse) = static_cast<RangeType>(1.25) +
-                    static_cast<RangeType>(0.5) * pulse_value;
+    range_to_mcp(pulse) = static_cast<RangeType>(1.25) +
+                          static_cast<RangeType>(0.5) * pulse_value;
     for (index_t sample = 0; sample < num_samples; ++sample) {
       const auto sample_value = static_cast<RangeType>(sample);
       fx(pulse, sample) =
@@ -153,22 +153,32 @@ void RunRank2ReferenceCase(ExecType &exec, index_t num_samples, int sgn) {
     }
   }
 
-  const experimental::SarBulkMocompParams params{1.25e6, 2.5e4, sgn};
-  (output = experimental::sar_bulk_mocomp(fx, ranges, params)).run(exec);
+  // example-begin sar-bulk-mocomp-1
+  const experimental::SarBulkMocompParams params{
+      .phase_reference_frequency = 9.6e9,
+      .sample_frequency_spacing = 2.5e4,
+      .sgn = sgn,
+  };
+
+  auto compensated =
+      experimental::sar_bulk_mocomp(fx, range_to_mcp, params);
+  (output = compensated).run(exec);
+  // example-end sar-bulk-mocomp-1
   exec.sync();
 
   const double tolerance = std::is_same_v<RangeType, float> ? 2.0e-5 : 1.0e-12;
   for (index_t pulse = 0; pulse < num_pulses; ++pulse) {
     for (index_t sample = 0; sample < num_samples; ++sample) {
-      const auto expected = ExpectedCorrection(fx(pulse, sample), ranges(pulse),
-                                               sample, num_samples, params);
+      const auto expected = ExpectedCorrection(
+          fx(pulse, sample), range_to_mcp(pulse), sample, num_samples, params);
       EXPECT_NEAR(output(pulse, sample).real(), expected.real(), tolerance);
       EXPECT_NEAR(output(pulse, sample).imag(), expected.imag(), tolerance);
     }
   }
 
   // Applying the opposite range offset in place should recover the input.
-  (output = experimental::sar_bulk_mocomp(output, -ranges, params)).run(exec);
+  (output = experimental::sar_bulk_mocomp(output, -range_to_mcp, params))
+      .run(exec);
   exec.sync();
   for (index_t pulse = 0; pulse < num_pulses; ++pulse) {
     for (index_t sample = 0; sample < num_samples; ++sample) {

--- a/test/00_operators/sar_bulk_mocomp_test.cu
+++ b/test/00_operators/sar_bulk_mocomp_test.cu
@@ -1,0 +1,446 @@
+////////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, NVIDIA Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <cmath>
+#include <cuda/std/numbers>
+#include <type_traits>
+
+#include "matx.h"
+#include "operator_test_types.hpp"
+#include "test_types.h"
+#include "utilities.h"
+
+using namespace matx;
+using namespace matx::test;
+
+namespace {
+
+template <typename T> using Complex = cuda::std::complex<T>;
+
+template <typename FxOp, typename TargetRangeOp>
+concept CanApplySarBulkMocomp = requires(
+    const FxOp &fx, const TargetRangeOp &target_reference_range,
+    const experimental::SarBulkMocompParams &params) {
+  experimental::sar_bulk_mocomp(fx, target_reference_range, params);
+};
+
+template <typename FxOp, typename InitialRangeOp, typename TargetRangeOp>
+concept CanChangeSarBulkMocompReference = requires(
+    const FxOp &fx, const InitialRangeOp &initial_reference_range,
+    const TargetRangeOp &target_reference_range,
+    const experimental::SarBulkMocompParams &params) {
+  experimental::sar_bulk_mocomp(fx, initial_reference_range,
+                                target_reference_range, params);
+};
+
+template <typename Op, int DynamicSharedMemoryBytes>
+class DynamicSharedMemoryOp
+    : public BaseOp<DynamicSharedMemoryOp<Op, DynamicSharedMemoryBytes>> {
+private:
+  using op_type = matx::detail::base_type_t<Op>;
+  op_type op_;
+
+public:
+  using matxop = bool;
+  using value_type = typename op_type::value_type;
+
+  explicit DynamicSharedMemoryOp(const Op &op) : op_(op) {}
+
+  static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t
+  Rank() {
+    return op_type::Rank();
+  }
+
+  __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t
+  Size(int32_t dim) const {
+    return op_.Size(dim);
+  }
+
+  template <matx::detail::OperatorCapability Cap, typename InType>
+  auto get_capability(InType &in) const {
+    if constexpr (Cap == matx::detail::OperatorCapability::DYN_SHM_SIZE) {
+      return DynamicSharedMemoryBytes;
+    } else {
+      return matx::detail::get_operator_capability<Cap>(op_, in);
+    }
+  }
+};
+
+template <typename ExecType> constexpr matxMemorySpace_t TestMemorySpace() {
+  if constexpr (is_cuda_executor_v<ExecType>) {
+    return MATX_MANAGED_MEMORY;
+  } else {
+    return MATX_HOST_MALLOC_MEMORY;
+  }
+}
+
+template <typename RangeType>
+Complex<RangeType>
+ExpectedCorrection(Complex<RangeType> input, RangeType range_offset,
+                   index_t sample, index_t num_samples,
+                   const experimental::SarBulkMocompParams &params) {
+  const auto center_sample = num_samples / 2;
+  const RangeType reference_phase_over_pi_per_meter = static_cast<RangeType>(
+      -static_cast<double>(params.sgn) * 4.0 *
+      params.phase_reference_frequency / matx::constants::speed_of_light);
+  const RangeType sample_phase_over_pi_per_meter = static_cast<RangeType>(
+      -static_cast<double>(params.sgn) * 4.0 * params.sample_frequency_spacing /
+      matx::constants::speed_of_light);
+  const RangeType phase_over_pi_per_meter =
+      std::fma(static_cast<RangeType>(sample - center_sample),
+               sample_phase_over_pi_per_meter,
+               reference_phase_over_pi_per_meter);
+  const RangeType phase_over_pi = phase_over_pi_per_meter * range_offset;
+  const double phase =
+      cuda::std::numbers::pi * static_cast<double>(phase_over_pi);
+  const Complex<RangeType> phasor{
+      static_cast<RangeType>(std::cos(phase)),
+      static_cast<RangeType>(std::sin(phase))};
+  return input * phasor;
+}
+
+template <typename RangeType, typename ExecType>
+void RunRank2ReferenceCase(ExecType &exec, index_t num_samples, int sgn) {
+  using FxType = Complex<RangeType>;
+  constexpr index_t num_pulses = 3;
+
+  constexpr auto memory_space = TestMemorySpace<ExecType>();
+  auto fx = make_tensor<FxType>({num_pulses, num_samples}, memory_space);
+  auto ranges = make_tensor<RangeType>({num_pulses}, memory_space);
+  auto output = make_tensor<FxType>({num_pulses, num_samples}, memory_space);
+
+  for (index_t pulse = 0; pulse < num_pulses; ++pulse) {
+    const auto pulse_value = static_cast<RangeType>(pulse);
+    ranges(pulse) = static_cast<RangeType>(1.25) +
+                    static_cast<RangeType>(0.5) * pulse_value;
+    for (index_t sample = 0; sample < num_samples; ++sample) {
+      const auto sample_value = static_cast<RangeType>(sample);
+      fx(pulse, sample) =
+          FxType{static_cast<RangeType>(0.25) + pulse_value +
+                     static_cast<RangeType>(0.125) * sample_value,
+                 static_cast<RangeType>(-0.5) +
+                     static_cast<RangeType>(0.25) * pulse_value -
+                     static_cast<RangeType>(0.0625) * sample_value};
+    }
+  }
+
+  const experimental::SarBulkMocompParams params{1.25e6, 2.5e4, sgn};
+  (output = experimental::sar_bulk_mocomp(fx, ranges, params)).run(exec);
+  exec.sync();
+
+  const double tolerance = std::is_same_v<RangeType, float> ? 2.0e-5 : 1.0e-12;
+  for (index_t pulse = 0; pulse < num_pulses; ++pulse) {
+    for (index_t sample = 0; sample < num_samples; ++sample) {
+      const auto expected = ExpectedCorrection(fx(pulse, sample), ranges(pulse),
+                                               sample, num_samples, params);
+      EXPECT_NEAR(output(pulse, sample).real(), expected.real(), tolerance);
+      EXPECT_NEAR(output(pulse, sample).imag(), expected.imag(), tolerance);
+    }
+  }
+
+  // Applying the opposite range offset in place should recover the input.
+  (output = experimental::sar_bulk_mocomp(output, -ranges, params)).run(exec);
+  exec.sync();
+  for (index_t pulse = 0; pulse < num_pulses; ++pulse) {
+    for (index_t sample = 0; sample < num_samples; ++sample) {
+      EXPECT_NEAR(output(pulse, sample).real(), fx(pulse, sample).real(),
+                  2.0 * tolerance);
+      EXPECT_NEAR(output(pulse, sample).imag(), fx(pulse, sample).imag(),
+                  2.0 * tolerance);
+    }
+  }
+}
+
+template <typename TensorType>
+class SarBulkMocompTests : public ::testing::Test {};
+
+using SarBulkMocompTestTypes =
+    TupleToTypes<TypedCartesianProduct<cuda::std::tuple<float, double>,
+                                       ExecutorTypesAllWithJIT>::type>::type;
+
+TYPED_TEST_SUITE(SarBulkMocompTests, SarBulkMocompTestTypes);
+
+#ifdef MATX_EN_JIT
+template <typename RangeType>
+class SarBulkMocompJITTests : public ::testing::Test {};
+
+using SarBulkMocompJITTestTypes = ::testing::Types<float, double>;
+
+TYPED_TEST_SUITE(SarBulkMocompJITTests, SarBulkMocompJITTestTypes);
+#endif
+
+} // namespace
+
+TYPED_TEST(SarBulkMocompTests, Rank2OddAndEvenFrequencyGrids) {
+  MATX_ENTER_HANDLER();
+  using RangeType = cuda::std::tuple_element_t<0, TypeParam>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  ExecType exec{};
+  RunRank2ReferenceCase<RangeType>(exec, 7, -1);
+  RunRank2ReferenceCase<RangeType>(exec, 8, 1);
+  MATX_EXIT_HANDLER();
+}
+
+#ifdef MATX_EN_JIT
+TYPED_TEST(SarBulkMocompJITTests, TransformBackedRangeOffset) {
+  MATX_ENTER_HANDLER();
+  using RangeType = TypeParam;
+  using FxType = Complex<RangeType>;
+  using ExecType = CUDAJITExecutor;
+
+  constexpr index_t pulses = 3;
+  constexpr index_t samples = 32;
+  constexpr index_t range_terms = 16;
+  ExecType exec{};
+  constexpr auto memory_space = TestMemorySpace<ExecType>();
+
+  auto fx = make_tensor<FxType>({pulses, samples}, memory_space);
+  auto range_components =
+      make_tensor<RangeType>({pulses, range_terms}, memory_space);
+  auto output = make_tensor<FxType>({pulses, samples}, memory_space);
+
+  for (index_t pulse = 0; pulse < pulses; ++pulse) {
+    for (index_t term = 0; term < range_terms; ++term) {
+      range_components(pulse, term) =
+          static_cast<RangeType>(0.125) * static_cast<RangeType>(pulse + 1) +
+          static_cast<RangeType>(0.015625) * static_cast<RangeType>(term + 1);
+    }
+    for (index_t sample = 0; sample < samples; ++sample) {
+      fx(pulse, sample) = FxType{
+          static_cast<RangeType>(1.0) +
+              static_cast<RangeType>(0.25) * static_cast<RangeType>(pulse),
+          static_cast<RangeType>(-0.5) +
+              static_cast<RangeType>(0.03125) * static_cast<RangeType>(sample)};
+    }
+  }
+
+  const experimental::SarBulkMocompParams params{2.5e6, 5.0e4, -1};
+  (output =
+       experimental::sar_bulk_mocomp(fx, sum(range_components, {1}), params))
+      .run(exec);
+  exec.sync();
+
+  const double tolerance = std::is_same_v<RangeType, float> ? 2.0e-5 : 1.0e-12;
+  for (index_t pulse = 0; pulse < pulses; ++pulse) {
+    RangeType range_offset = static_cast<RangeType>(0);
+    for (index_t term = 0; term < range_terms; ++term) {
+      range_offset += range_components(pulse, term);
+    }
+    for (index_t sample = 0; sample < samples; ++sample) {
+      const auto expected = ExpectedCorrection(fx(pulse, sample), range_offset,
+                                               sample, samples, params);
+      EXPECT_NEAR(output(pulse, sample).real(), expected.real(), tolerance);
+      EXPECT_NEAR(output(pulse, sample).imag(), expected.imag(), tolerance);
+    }
+  }
+  MATX_EXIT_HANDLER();
+}
+#endif
+
+TYPED_TEST(SarBulkMocompTests, BatchedReferenceChangeAndComposition) {
+  MATX_ENTER_HANDLER();
+  using RangeType = cuda::std::tuple_element_t<0, TypeParam>;
+  using FxType = Complex<RangeType>;
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+
+  constexpr index_t batches = 2;
+  constexpr index_t pulses = 3;
+  constexpr index_t samples = 8;
+  ExecType exec{};
+  constexpr auto memory_space = TestMemorySpace<ExecType>();
+
+  auto fx = make_tensor<FxType>({batches, pulses, samples}, memory_space);
+  auto initial_ranges = make_tensor<RangeType>({batches, pulses}, memory_space);
+  auto target_ranges = make_tensor<RangeType>({batches, pulses}, memory_space);
+  auto output = make_tensor<FxType>({batches, pulses, samples}, memory_space);
+  auto restored = make_tensor<FxType>({batches, pulses, samples}, memory_space);
+
+  for (index_t batch = 0; batch < batches; ++batch) {
+    const auto batch_value = static_cast<RangeType>(batch);
+    for (index_t pulse = 0; pulse < pulses; ++pulse) {
+      const auto pulse_value = static_cast<RangeType>(pulse);
+      initial_ranges(batch, pulse) =
+          static_cast<RangeType>(0.5) +
+          static_cast<RangeType>(0.25) * batch_value +
+          static_cast<RangeType>(0.125) * pulse_value;
+      target_ranges(batch, pulse) = static_cast<RangeType>(2.0) +
+                                    static_cast<RangeType>(0.5) * batch_value +
+                                    static_cast<RangeType>(0.25) * pulse_value;
+      for (index_t sample = 0; sample < samples; ++sample) {
+        const auto sample_value = static_cast<RangeType>(sample);
+        fx(batch, pulse, sample) =
+            FxType{static_cast<RangeType>(1.0) + batch_value +
+                       static_cast<RangeType>(0.25) * pulse_value,
+                   static_cast<RangeType>(-0.5) +
+                       static_cast<RangeType>(0.125) * sample_value};
+      }
+    }
+  }
+
+  const experimental::SarBulkMocompParams params{2.5e6, 5.0e4, -1};
+  (output = experimental::sar_bulk_mocomp(
+                fx * static_cast<RangeType>(2),
+                initial_ranges, target_ranges, params))
+      .run(exec);
+  (restored = experimental::sar_bulk_mocomp(output, target_ranges,
+                                            initial_ranges, params) /
+              FxType{static_cast<RangeType>(2), static_cast<RangeType>(0)})
+      .run(exec);
+  exec.sync();
+
+  const double tolerance = std::is_same_v<RangeType, float> ? 3.0e-5 : 2.0e-12;
+  for (index_t batch = 0; batch < batches; ++batch) {
+    for (index_t pulse = 0; pulse < pulses; ++pulse) {
+      for (index_t sample = 0; sample < samples; ++sample) {
+        const RangeType delta =
+            target_ranges(batch, pulse) - initial_ranges(batch, pulse);
+        const auto expected =
+            ExpectedCorrection(fx(batch, pulse, sample), delta, sample, samples,
+                               params) *
+            FxType{static_cast<RangeType>(2), static_cast<RangeType>(0)};
+        EXPECT_NEAR(output(batch, pulse, sample).real(), expected.real(),
+                    tolerance);
+        EXPECT_NEAR(output(batch, pulse, sample).imag(), expected.imag(),
+                    tolerance);
+        EXPECT_NEAR(restored(batch, pulse, sample).real(),
+                    fx(batch, pulse, sample).real(), tolerance);
+        EXPECT_NEAR(restored(batch, pulse, sample).imag(),
+                    fx(batch, pulse, sample).imag(), tolerance);
+      }
+    }
+  }
+  MATX_EXIT_HANDLER();
+}
+
+TEST(SarBulkMocompTests, PhasePrecisionFollowsRangeType) {
+  MATX_ENTER_HANDLER();
+  SingleThreadedHostExecutor exec{};
+
+  auto fx_double =
+      make_tensor<Complex<double>>({1, 5}, MATX_HOST_MALLOC_MEMORY);
+  auto range_float = make_tensor<float>({1}, MATX_HOST_MALLOC_MEMORY);
+  auto out_double =
+      make_tensor<Complex<double>>({1, 5}, MATX_HOST_MALLOC_MEMORY);
+  range_float(0) = 3.25f;
+
+  auto fx_float = make_tensor<Complex<float>>({1, 5}, MATX_HOST_MALLOC_MEMORY);
+  auto range_double = make_tensor<double>({1}, MATX_HOST_MALLOC_MEMORY);
+  auto out_float = make_tensor<Complex<float>>({1, 5}, MATX_HOST_MALLOC_MEMORY);
+  range_double(0) = 4.5;
+  for (index_t sample = 0; sample < 5; ++sample) {
+    fx_double(0, sample) = Complex<double>{1.0, -0.25};
+    fx_float(0, sample) = Complex<float>{1.0f, 0.5f};
+  }
+
+  const experimental::SarBulkMocompParams params{9.6e9, 3.0e6, -1};
+  (out_double = experimental::sar_bulk_mocomp(fx_double, range_float, params))
+      .run(exec);
+  (out_float = experimental::sar_bulk_mocomp(fx_float, range_double, params))
+      .run(exec);
+  exec.sync();
+
+  for (index_t sample = 0; sample < 5; ++sample) {
+    const auto expected_double_phase = ExpectedCorrection(
+        Complex<float>{1.0f, -0.25f}, range_float(0), sample, 5, params);
+    EXPECT_NEAR(out_double(0, sample).real(), expected_double_phase.real(),
+                2.0e-5);
+    EXPECT_NEAR(out_double(0, sample).imag(), expected_double_phase.imag(),
+                2.0e-5);
+
+    const auto expected_float_output = ExpectedCorrection(
+        Complex<double>{1.0, 0.5}, range_double(0), sample, 5, params);
+    EXPECT_NEAR(out_float(0, sample).real(), expected_float_output.real(),
+                2.0e-6);
+    EXPECT_NEAR(out_float(0, sample).imag(), expected_float_output.imag(),
+                2.0e-6);
+  }
+  MATX_EXIT_HANDLER();
+}
+
+TEST(SarBulkMocompTests, DynamicSharedMemoryIsAdditive) {
+  MATX_ENTER_HANDLER();
+  auto fx = make_tensor<Complex<float>>({3, 8}, MATX_HOST_MALLOC_MEMORY);
+  auto ranges = make_tensor<float>({3}, MATX_HOST_MALLOC_MEMORY);
+  const DynamicSharedMemoryOp<decltype(fx), 4096> fx_with_shmem{fx};
+  const DynamicSharedMemoryOp<decltype(ranges), 3072> ranges_with_shmem{
+      ranges};
+
+  const auto op = experimental::sar_bulk_mocomp(
+      fx_with_shmem, ranges_with_shmem,
+      experimental::SarBulkMocompParams{1.0e6, 1.0e4, -1});
+  EXPECT_EQ(
+      matx::detail::get_operator_capability<
+          matx::detail::OperatorCapability::DYN_SHM_SIZE>(op),
+      7168);
+  MATX_EXIT_HANDLER();
+}
+
+TEST(SarBulkMocompTests, ValidatesParametersAndShape) {
+  MATX_ENTER_HANDLER();
+  auto fx = make_tensor<Complex<float>>({3, 8}, MATX_HOST_MALLOC_MEMORY);
+  auto good_ranges = make_tensor<float>({3}, MATX_HOST_MALLOC_MEMORY);
+  auto bad_ranges = make_tensor<float>({2}, MATX_HOST_MALLOC_MEMORY);
+
+  using FxType = decltype(fx);
+  using RangeType = decltype(good_ranges);
+  static_assert(CanApplySarBulkMocomp<FxType, RangeType>);
+  static_assert(!CanApplySarBulkMocomp<FxType, double>);
+  static_assert(!CanApplySarBulkMocomp<double, RangeType>);
+  static_assert(
+      CanChangeSarBulkMocompReference<FxType, RangeType, RangeType>);
+  static_assert(
+      !CanChangeSarBulkMocompReference<FxType, double, RangeType>);
+  static_assert(
+      !CanChangeSarBulkMocompReference<FxType, RangeType, double>);
+
+  EXPECT_THROW(
+      (experimental::sar_bulk_mocomp(
+          fx, bad_ranges, experimental::SarBulkMocompParams{1.0e6, 1.0e4, -1})),
+      matx::detail::matxException);
+  EXPECT_THROW(
+      (experimental::sar_bulk_mocomp(
+          fx, good_ranges, experimental::SarBulkMocompParams{1.0e6, 1.0e4, 0})),
+      matx::detail::matxException);
+  EXPECT_THROW(
+      (experimental::sar_bulk_mocomp(
+          fx, good_ranges, experimental::SarBulkMocompParams{1.0e6, 0.0, -1})),
+      matx::detail::matxException);
+  auto op = experimental::sar_bulk_mocomp(
+      fx, good_ranges, experimental::SarBulkMocompParams{1.0e6, 1.0e4, -1});
+#ifdef MATX_EN_JIT
+  EXPECT_TRUE(jit_supported(op));
+#else
+  EXPECT_FALSE(jit_supported(op));
+#endif
+  MATX_EXIT_HANDLER();
+}

--- a/test/00_transform/SarBp.cu
+++ b/test/00_transform/SarBp.cu
@@ -37,6 +37,7 @@
 #include "gtest/gtest.h"
 #include "prerun_tester.h"
 #include <cuda/std/complex>
+#include <cuda/std/numbers>
 
 using namespace matx;
 
@@ -456,7 +457,9 @@ TYPED_TEST(SarBpTestDoubleType, PointTarget)
       (h_antenna_phase_centers[i].z) * (h_antenna_phase_centers[i].z));
     const double ideal_dR = R_to_target - h_range_to_mcp[i];
     const double ideal_bin = ideal_dR / bp_params.del_r + bin_offset;
-    const double ideal_phase = -4.0 * M_PI * ideal_dR * (bp_params.center_frequency / SPEED_OF_LIGHT);
+    const double ideal_phase =
+        -4.0 * cuda::std::numbers::pi * ideal_dR *
+        (bp_params.center_frequency / matx::constants::speed_of_light);
     double sinx, cosx;
     ::sincos(ideal_phase, &sinx, &cosx);
     const cuda::std::complex<double> sample = cuda::std::complex<double>{cosx, sinx};
@@ -775,7 +778,9 @@ TYPED_TEST(SarBpTestDoubleType, PixelZIsFixedNonZeroHeight)
       (h_apc[i].z - pixel_z) * (h_apc[i].z - pixel_z));
     const double dR = R - h_rtm[i];
     const double ideal_bin = dR / bp_params.del_r + bin_offset;
-    const double ideal_phase = -4.0 * M_PI * dR * (bp_params.center_frequency / SPEED_OF_LIGHT);
+    const double ideal_phase =
+        -4.0 * cuda::std::numbers::pi * dR *
+        (bp_params.center_frequency / matx::constants::speed_of_light);
     double sinx, cosx;
     ::sincos(ideal_phase, &sinx, &cosx);
     const cuda::std::complex<double> sample{cosx, sinx};


### PR DESCRIPTION
Add an experimental operator to apply bulk motion compensation to frequency domain SAR phase history history. It applies a frequency-dependent phase ramp to each pulse, referencing its phase to the specified per-pulse reference range.

Add a --bulk-mocomp option to the sarbp example that applies bulk mocomp based on the reference ranges contained in the CPHD file (or in the sarbp input file, which is typically generated from a CPHD). Applying mocomp to data that has already been mocomped will effectively reference the phase to the wrong point (i.e., mocomp is not idempotent and applying it multiple times will generate errors). Most CPHD files are already mocomped, so this option is for special cases where the data is not mocomped or the sarbp input file was generated with non-mocomped data.