### PR TITLE
Fix ctest command in README to point at build/test (Issue #1231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ cmake -S . -B build \
   -DMATX_BUILD_EXAMPLES=ON \
   -DMATX_BUILD_TESTS=ON
 cmake --build build -j
-ctest --test-dir build
+ctest --test-dir build/test
 ```
 
 MatX currently fully supports Linux with alpha support for Windows. A C++20 build environment is required. GPU builds require the CUDA Toolkit and a supported host compiler; consult the [build guide](https://nvidia.github.io/MatX/build.html) for exact current versions, optional backends, offline setup, and CPU support.


### PR DESCRIPTION
enable_testing() is only called in test/CMakeLists.txt, not the top-level CMakeLists.txt, so ctest --test-dir build finds no tests when run from the repo root.

Fixes #1231: Change 'build' to 'build/test'.

With the fix, ctest runs the test suite from the repo root.