### PR TITLE
Use CCCL type traits when possible

### DIFF
--- a/bench/00_misc/fltflt_arithmetic.cu
+++ b/bench/00_misc/fltflt_arithmetic.cu
@@ -325,7 +325,7 @@ __global__ void iterative_fma_kernel(T* __restrict__ result, int64_t size, int32
     for (int32_t i = 0; i < iterations; i++) {
       #pragma unroll
       for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           acc[ilp] = fltflt_fma(val_a, acc[ilp], val_b);
         } else {
           acc[ilp] = val_a * acc[ilp] + val_b;
@@ -525,7 +525,7 @@ __global__ void iterative_sqrt_fast_kernel(T* __restrict__ result, int64_t size,
 
     #pragma unroll
     for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-      if constexpr (std::is_same_v<T, fltflt>) {
+      if constexpr (cuda::std::is_same_v<T, fltflt>) {
         val[ilp] = fltflt_sqrt_fast(init_val);
       } else {
         val[ilp] = sqrt(init_val);
@@ -536,7 +536,7 @@ __global__ void iterative_sqrt_fast_kernel(T* __restrict__ result, int64_t size,
     for (int32_t i = 1; i < iterations; i++) {
       #pragma unroll
       for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           val[ilp] = fltflt_sqrt_fast(val[ilp]);
         } else {
           val[ilp] = sqrt(val[ilp]);
@@ -607,7 +607,7 @@ __global__ void iterative_norm3d_kernel(T* __restrict__ result, int64_t size, in
       #pragma unroll
       for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
         T norm;
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           norm = fltflt_norm3d(dx[ilp], dy, dz);
         } else {
           norm = sqrt(dx[ilp] * dx[ilp] + dy * dy + dz * dz);
@@ -616,7 +616,7 @@ __global__ void iterative_norm3d_kernel(T* __restrict__ result, int64_t size, in
         // Add the computed norm and subtract off the approximate
         // expected norm to keep dx in a stable range while preventing
         // the compiler from optimizing away the computation.
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           // fltflt addition/subtraction is expensive and we do not want to bias the benchmark
           // too much, so at least keep the expected norm as a float rather than fltflt to
           // reduce the cost of the subtraction.
@@ -754,7 +754,7 @@ __global__ void iterative_fma_approx_kernel(T* __restrict__ result, int64_t size
     for (int32_t i = 0; i < iterations; i++) {
       #pragma unroll
       for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           acc[ilp] = fltflt_fma_approx(val_a, acc[ilp], val_b);
         } else {
           acc[ilp] = val_a * acc[ilp] + val_b;
@@ -820,7 +820,7 @@ __global__ void iterative_madd_kernel(T* __restrict__ result, int64_t size, int3
     for (int32_t i = 0; i < iterations; i++) {
       #pragma unroll
       for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           // Explicitly separate multiply and add for fltflt
           acc[ilp] = fltflt_add(fltflt_mul(val_a, acc[ilp]), val_b);
         } else {
@@ -881,9 +881,9 @@ __global__ void iterative_round_kernel(T* __restrict__ result, int64_t size, int
 
     #pragma unroll
     for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-      if constexpr (std::is_same_v<T, fltflt>) {
+      if constexpr (cuda::std::is_same_v<T, fltflt>) {
         val[ilp] = fltflt_round_to_nearest(init_val);
-      } else if constexpr (std::is_same_v<T, float>) {
+      } else if constexpr (cuda::std::is_same_v<T, float>) {
         val[ilp] = nearbyintf(init_val);
       } else {
         val[ilp] = nearbyint(init_val);
@@ -895,9 +895,9 @@ __global__ void iterative_round_kernel(T* __restrict__ result, int64_t size, int
     for (int32_t i = 1; i < iterations; i++) {
       #pragma unroll
       for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           val[ilp] = fltflt_round_to_nearest(val[ilp]);
-        } else if constexpr (std::is_same_v<T, float>) {
+        } else if constexpr (cuda::std::is_same_v<T, float>) {
           val[ilp] = nearbyintf(val[ilp]);
         } else {
           val[ilp] = nearbyint(val[ilp]);
@@ -957,9 +957,9 @@ __global__ void iterative_fmod_kernel(T* __restrict__ result, int64_t size, int3
 
     #pragma unroll
     for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-      if constexpr (std::is_same_v<T, fltflt>) {
+      if constexpr (cuda::std::is_same_v<T, fltflt>) {
         val[ilp] = fltflt_fmod(init_val, divisor);
-      } else if constexpr (std::is_same_v<T, float>) {
+      } else if constexpr (cuda::std::is_same_v<T, float>) {
         val[ilp] = fmodf(init_val, divisor);
       } else {
         val[ilp] = fmod(init_val, divisor);
@@ -970,10 +970,10 @@ __global__ void iterative_fmod_kernel(T* __restrict__ result, int64_t size, int3
     for (int32_t i = 1; i < iterations; i++) {
       #pragma unroll
       for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           val[ilp] = val[ilp].hi + fltflt_fmod(init_val, divisor);
           asm volatile("" : "+f"(val[ilp].hi), "+f"(val[ilp].lo));
-        } else if constexpr (std::is_same_v<T, float>) {
+        } else if constexpr (cuda::std::is_same_v<T, float>) {
           val[ilp] = val[ilp] + fmodf(init_val, divisor);
           asm volatile("" : "+f"(val[ilp]));
         } else {
@@ -981,7 +981,7 @@ __global__ void iterative_fmod_kernel(T* __restrict__ result, int64_t size, int3
           asm volatile("" : "+d"(val[ilp]));
         }
       }
-      if constexpr (std::is_same_v<T, float>) {
+      if constexpr (cuda::std::is_same_v<T, float>) {
         // fp32 add is full-rate, no benefit from a bit-twiddle here.
         init_val += 2048.0f;
       } else {
@@ -1042,9 +1042,9 @@ __global__ void iterative_trunc_kernel(T* __restrict__ result, int64_t size, int
 
     #pragma unroll
     for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-      if constexpr (std::is_same_v<T, fltflt>) {
+      if constexpr (cuda::std::is_same_v<T, fltflt>) {
         val[ilp] = fltflt_round_toward_zero(init_val);
-      } else if constexpr (std::is_same_v<T, float>) {
+      } else if constexpr (cuda::std::is_same_v<T, float>) {
         val[ilp] = truncf(init_val);
       } else {
         val[ilp] = trunc(init_val);
@@ -1055,10 +1055,10 @@ __global__ void iterative_trunc_kernel(T* __restrict__ result, int64_t size, int
     for (int32_t i = 1; i < iterations; i++) {
       #pragma unroll
       for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           val[ilp] = val[ilp].hi + fltflt_round_toward_zero(init_val);
           asm volatile("" : "+f"(val[ilp].hi), "+f"(val[ilp].lo));
-        } else if constexpr (std::is_same_v<T, float>) {
+        } else if constexpr (cuda::std::is_same_v<T, float>) {
           val[ilp] = val[ilp] + truncf(init_val);
           asm volatile("" : "+f"(val[ilp]));
         } else {
@@ -1066,7 +1066,7 @@ __global__ void iterative_trunc_kernel(T* __restrict__ result, int64_t size, int
           asm volatile("" : "+d"(val[ilp]));
         }
       }
-      if constexpr (std::is_same_v<T, float>) {
+      if constexpr (cuda::std::is_same_v<T, float>) {
         // fp32 add is full-rate, no benefit from a bit-twiddle here.
         init_val += 2048.0f;
       } else {
@@ -1127,9 +1127,9 @@ __global__ void iterative_floor_kernel(T* __restrict__ result, int64_t size, int
 
     #pragma unroll
     for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-      if constexpr (std::is_same_v<T, fltflt>) {
+      if constexpr (cuda::std::is_same_v<T, fltflt>) {
         val[ilp] = fltflt_floor(init_val);
-      } else if constexpr (std::is_same_v<T, float>) {
+      } else if constexpr (cuda::std::is_same_v<T, float>) {
         val[ilp] = floorf(init_val);
       } else {
         val[ilp] = floor(init_val);
@@ -1140,10 +1140,10 @@ __global__ void iterative_floor_kernel(T* __restrict__ result, int64_t size, int
     for (int32_t i = 1; i < iterations; i++) {
       #pragma unroll
       for (int ilp = 0; ilp < ILP_FACTOR; ilp++) {
-        if constexpr (std::is_same_v<T, fltflt>) {
+        if constexpr (cuda::std::is_same_v<T, fltflt>) {
           val[ilp] = val[ilp].hi + fltflt_floor(init_val);
           asm volatile("" : "+f"(val[ilp].hi), "+f"(val[ilp].lo));
-        } else if constexpr (std::is_same_v<T, float>) {
+        } else if constexpr (cuda::std::is_same_v<T, float>) {
           val[ilp] = val[ilp] + floorf(init_val);
           asm volatile("" : "+f"(val[ilp]));
         } else {
@@ -1151,7 +1151,7 @@ __global__ void iterative_floor_kernel(T* __restrict__ result, int64_t size, int
           asm volatile("" : "+d"(val[ilp]));
         }
       }
-      if constexpr (std::is_same_v<T, float>) {
+      if constexpr (cuda::std::is_same_v<T, float>) {
         // fp32 add is full-rate, no benefit from a bit-twiddle here.
         init_val += 2048.0f;
       } else {
@@ -1222,7 +1222,7 @@ __global__ void iterative_cast2dbl_kernel(double* __restrict__ result, int64_t s
         acc[ilp] = static_cast<double>(src_val);
         asm volatile("" : "+d"(acc[ilp]));
       }
-      if constexpr (std::is_same_v<T, float>) {
+      if constexpr (cuda::std::is_same_v<T, float>) {
         // fp32 add is full-rate, no benefit from a bit-twiddle here.
         src_val = src_val + static_cast<T>(0.0001);
       } else {
@@ -1294,7 +1294,7 @@ __global__ void iterative_cast2fltflt_kernel(fltflt* __restrict__ result, int64_
         acc[ilp] = static_cast<fltflt>(src_val);
         asm volatile("" : "+f"(acc[ilp].hi), "+f"(acc[ilp].lo));
       }
-      if constexpr (std::is_same_v<T, float>) {
+      if constexpr (cuda::std::is_same_v<T, float>) {
         // fp32 add is full-rate, no benefit from a bit-twiddle here.
         src_val = src_val + static_cast<T>(0.0001);
       } else {

--- a/docs_input/api/type_traits.rst
+++ b/docs_input/api/type_traits.rst
@@ -13,7 +13,6 @@ Type Manipulation
 =================
 
 .. doxygentypedef:: matx::promote_half_t
-.. doxygenstruct:: matx::remove_cvref
 
 Concepts (C++20)
 ================

--- a/examples/channelize_poly_bench.cu
+++ b/examples/channelize_poly_bench.cu
@@ -54,10 +54,10 @@ constexpr int NUM_ITERATIONS = 20;
 
 template <typename T>
 const char *TypeName() {
-  if constexpr (std::is_same_v<T, float>) return "float";
-  else if constexpr (std::is_same_v<T, double>) return "double";
-  else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) return "complex<float>";
-  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) return "complex<double>";
+  if constexpr (cuda::std::is_same_v<T, float>) return "float";
+  else if constexpr (cuda::std::is_same_v<T, double>) return "double";
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) return "complex<float>";
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) return "complex<double>";
   else return "unknown";
 }
 

--- a/examples/sarbp/sarbp.cu
+++ b/examples/sarbp/sarbp.cu
@@ -394,7 +394,7 @@ template <typename PosTensor, typename RtmTensor, typename VoxLocOp>
 static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
                          const VoxLocOp &voxel_locations, const BpRunCtx &ctx)
 {
-  using PosT = typename std::decay_t<decltype(blk_positions)>::value_type;
+  using PosT = typename cuda::std::decay_t<decltype(blk_positions)>::value_type;
   constexpr bool pos_is_fltflt = cuda::std::is_same_v<PosT, matx::fltflt>;
 
   // The host position buffer contains fltflt-encoded bytes for the FloatFloat

--- a/examples/sarbp/sarbp.cu
+++ b/examples/sarbp/sarbp.cu
@@ -395,7 +395,7 @@ static int run_bp_device(PosTensor blk_positions, RtmTensor blk_rtm,
                          const VoxLocOp &voxel_locations, const BpRunCtx &ctx)
 {
   using PosT = typename std::decay_t<decltype(blk_positions)>::value_type;
-  constexpr bool pos_is_fltflt = std::is_same_v<PosT, matx::fltflt>;
+  constexpr bool pos_is_fltflt = cuda::std::is_same_v<PosT, matx::fltflt>;
 
   // The host position buffer contains fltflt-encoded bytes for the FloatFloat
   // path. The range-to-MCP buffer normally follows the same convention, but

--- a/include/matx/core/allocator.h
+++ b/include/matx/core/allocator.h
@@ -53,7 +53,7 @@ namespace matx {
 
 /**
  * @brief Space where memory is stored (also called Kind in some contexts)
- * 
+ *
  */
 enum matxMemorySpace_t {
   MATX_MANAGED_MEMORY,      ///< CUDA managed memory or CUDA Unified Memory (UM) from cudaMallocManaged
@@ -117,13 +117,13 @@ struct MemTracker {
       // these cases if they know the issue.
       MATX_THROW(matxInvalidParameter, "Couldn't find pointer in allocation cache");
   #else
-      return;      
-  #endif    
+      return;
+  #endif
     }
 
     size_t bytes = iter->second.size;
 
-    MATX_LOG_DEBUG("Deallocating memory: ptr={}, {} bytes, space={}, remaining={} bytes", 
+    MATX_LOG_DEBUG("Deallocating memory: ptr={}, {} bytes, space={}, remaining={} bytes",
                    ptr, bytes, static_cast<int>(iter->second.kind), matxMemoryStats.currentBytesAllocated - bytes);
 
     matxMemoryStats.currentBytesAllocated -= bytes;
@@ -151,7 +151,7 @@ struct MemTracker {
       break;
     case MATX_ASYNC_DEVICE_MEMORY:
       if (is_cuda_free()) {
-        if constexpr (std::is_same_v<no_stream_t, StreamType>) {
+        if constexpr (cuda::std::is_same_v<no_stream_t, StreamType>) {
           cudaFreeAsync(ptr, iter->second.stream);
         }
         else {
@@ -163,7 +163,7 @@ struct MemTracker {
       MATX_THROW(matxInvalidType, "Invalid memory type");
     }
 
-    allocationMap.erase(ptr);    
+    allocationMap.erase(ptr);
   }
 
   struct no_stream_t{};
@@ -177,13 +177,13 @@ struct MemTracker {
   auto deallocate(void *ptr, cudaStream_t stream) {
     [[maybe_unused]] std::unique_lock lck(memory_mtx);
     deallocate_internal(ptr, valid_stream_t{stream});
-  }    
+  }
 
   void allocate(void **ptr, size_t bytes,
                       matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                       cudaStream_t stream = 0) {
     [[maybe_unused]] cudaError_t err = cudaSuccess;
-    
+
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
 
     if (ptr == nullptr) {
@@ -203,9 +203,9 @@ struct MemTracker {
         space = MATX_HOST_MEMORY;
       }
     }
-    
+
     MATX_LOG_DEBUG("Allocating memory: {} bytes, space={}, stream={}", bytes, static_cast<int>(space), reinterpret_cast<void*>(stream));
-    
+
     switch (space) {
     case MATX_MANAGED_MEMORY:
       err = cudaMallocManaged(ptr, bytes);
@@ -226,7 +226,7 @@ struct MemTracker {
       MATX_THROW(matxInvalidType, "Invalid memory kind when allocating!");
     };
 
-    MATX_ASSERT_STR_EXP(err, cudaSuccess, matxOutOfMemory, 
+    MATX_ASSERT_STR_EXP(err, cudaSuccess, matxOutOfMemory,
       "Failed to allocate memory. May be an asynchronous error from another CUDA call");
 
     if (*ptr == nullptr) {
@@ -251,7 +251,7 @@ struct MemTracker {
     [[maybe_unused]] std::unique_lock lck(memory_mtx);
     auto iter = allocationMap.find(ptr);
 
-    return iter != allocationMap.end();    
+    return iter != allocationMap.end();
   }
 
   matxMemorySpace_t get_pointer_kind(void *ptr) {
@@ -311,9 +311,9 @@ __MATX_INLINE__ void FreeAllocations() {
 
 /**
  * @brief Determine if a pointer is printable by the host
- * 
+ *
  * Pointers are printable if they're either a managed or pinned memory pointer
- * 
+ *
  * @param mem Memory space
  * @return True is pointer can be printed from the host
  */
@@ -324,9 +324,9 @@ __MATX_INLINE__ bool HostPrintable(matxMemorySpace_t mem)
 
 /**
  * @brief Determine if a pointer is printable by the device
- * 
+ *
  * Pointers are printable if they're either a managed or device memory pointer
- * 
+ *
  * @param mem Memory space
  * @return True is pointer can be printed from the device
  */
@@ -338,7 +338,7 @@ __MATX_INLINE__ bool DevicePrintable(matxMemorySpace_t mem)
 
 /**
  * @brief Get memory statistics
- * 
+ *
  * @param current Current memory usage
  * @param total Total memory usage
  * @param max Maximum memory usage
@@ -353,7 +353,7 @@ __MATX_INLINE__ void matxGetMemoryStats(size_t *current, size_t *total, size_t *
 
 /**
  * @brief Check if a pointer was allocated
- * 
+ *
  * @param ptr Pointer
  * @return True if allocator
  */
@@ -380,7 +380,7 @@ __MATX_INLINE__ matxMemorySpace_t GetPointerKind(void *ptr)
 
 /**
  * @brief Print memory statistics to stdout
- * 
+ *
  */
 __MATX_INLINE__ void matxPrintMemoryStatistics()
 {
@@ -396,9 +396,9 @@ __MATX_INLINE__ void matxPrintMemoryStatistics()
 
 /**
  * @brief Allocate memory
- * 
+ *
  * Can be used for managed, pinned, malloced, device, and async device allocations
- * 
+ *
  * @param ptr Pointer to store allocated pointer
  * @param bytes Bytes to allocate
  * @param space Memory space
@@ -409,7 +409,7 @@ __MATX_INLINE__ void matxAlloc(void **ptr, size_t bytes,
                       cudaStream_t stream = 0)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
-  
+
   return GetAllocMap().allocate(ptr, bytes, space, stream);
 }
 
@@ -417,7 +417,7 @@ __MATX_INLINE__ void matxAlloc(void **ptr, size_t bytes,
 __MATX_INLINE__ void matxFree(void *ptr)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
-  
+
   return GetAllocMap().deallocate(ptr);
 }
 
@@ -429,7 +429,7 @@ __MATX_INLINE__ void matxFree(void *ptr, cudaStream_t stream)
 }
 
 /**
-  Update the stream a pointer in the cache is using. This should be used when the call wants to use 
+  Update the stream a pointer in the cache is using. This should be used when the call wants to use
   memory that was allocated in stream A inside of stream B. The caller must ensure that the pointer
   and stream being used are valid.
 */
@@ -441,15 +441,15 @@ __MATX_INLINE__ void update_stream(void *ptr, cudaStream_t stream)
 
 /**
  * @brief Allocator following the PMR interface using the internal MatX allocator/deallocator
- * 
+ *
  */
 template <typename T>
 struct matx_allocator {
-  friend void swap([[maybe_unused]] matx_allocator<T> &lhs, [[maybe_unused]] matx_allocator<T> &rhs) noexcept  { }   
+  friend void swap([[maybe_unused]] matx_allocator<T> &lhs, [[maybe_unused]] matx_allocator<T> &rhs) noexcept  { }
 
   /**
    * @brief Allocate memory of at least ``size`` bytes
-   * 
+   *
    * @param size Size of allocation in bytes
    * @return Pointer to allocated memory, or nullptr on error
    */
@@ -462,14 +462,14 @@ struct matx_allocator {
 
   /**
    * @brief Deallocate memory of at least ``size`` bytes
-   * 
+   *
    * @param ptr Pointer to allocated data
    * @param size Size of previously-allocated memory in bytes
    */
   __MATX_INLINE__ void deallocate(void *ptr, [[maybe_unused]] size_t size)
   {
     matxFree(ptr);
-  }  
+  }
 };
 
 __MATX_INLINE__ std::string SpaceString(matxMemorySpace_t space) {

--- a/include/matx/core/capabilities.h
+++ b/include/matx/core/capabilities.h
@@ -433,7 +433,7 @@ namespace detail {
   template <OperatorCapability Cap, typename OperatorType, typename InType>
   __MATX_INLINE__ __MATX_HOST__ typename capability_attributes<Cap>::type
   get_operator_capability(const OperatorType& op, InType& in) {
-    static_assert(std::is_same_v<remove_cvref_t<InType>, typename capability_attributes<Cap>::input_type>, "Input type mismatch");
+    static_assert(cuda::std::is_same_v<remove_cvref_t<InType>, typename capability_attributes<Cap>::input_type>, "Input type mismatch");
     if constexpr (is_matx_jit_class<OperatorType>) {
       if constexpr (requires { op.template get_capability<Cap, InType>(in); }) {
         return op.template get_capability<Cap, InType>(in);
@@ -533,9 +533,9 @@ namespace detail {
       ChildCapTypes... child_vals) // These will also be capability_attributes<Cap>::type
   {
     using CapType = typename capability_attributes<Cap>::type;
-    static_assert(std::is_same_v<SelfCapType, CapType>, "Self capability type mismatch.");
+    static_assert(cuda::std::is_same_v<SelfCapType, CapType>, "Self capability type mismatch.");
     // Ensure all child_vals are also CapType (checked by caller context or can add static_asserts here too)
-    // ( (static_assert(std::is_same_v<ChildCapTypes, CapType>,"Child capability type mismatch.")), ...); // C++17 fold for static_assert
+    // ( (static_assert(cuda::std::is_same_v<ChildCapTypes, CapType>,"Child capability type mismatch.")), ...); // C++17 fold for static_assert
 
     CapabilityQueryType query_type = get_query_type(Cap);
     CapType children_aggregated_val{};
@@ -543,11 +543,11 @@ namespace detail {
     // Step 1: Aggregate children capabilities
     if constexpr (sizeof...(ChildCapTypes) == 0) {
       // No children: result is the identity for the query type.
-      if constexpr (std::is_same_v<CapType, bool>) {
+      if constexpr (cuda::std::is_same_v<CapType, bool>) {
         children_aggregated_val = (query_type == CapabilityQueryType::AND_QUERY) ?
                                   capability_attributes<Cap>::and_identity :
                                   capability_attributes<Cap>::or_identity;
-      } else if constexpr (std::is_same_v<CapType, int> || is_scoped_enum_v<CapType>) {
+      } else if constexpr (cuda::std::is_same_v<CapType, int> || is_scoped_enum_v<CapType>) {
         MATX_IGNORE_WARNING_PUSH_GCC("-Wduplicated-branches")
         if (query_type == CapabilityQueryType::MIN_QUERY) {
           children_aggregated_val = capability_attributes<Cap>::min_identity;
@@ -561,16 +561,16 @@ namespace detail {
           children_aggregated_val = capability_attributes<Cap>::default_value; // Fallback
         }
         MATX_IGNORE_WARNING_POP_GCC
-      } else if constexpr (std::is_same_v<CapType, std::string>) {
+      } else if constexpr (cuda::std::is_same_v<CapType, std::string>) {
         children_aggregated_val = capability_attributes<Cap>::default_value;
-      } else if constexpr (std::is_same_v<CapType, JITCacheKey>) {
+      } else if constexpr (cuda::std::is_same_v<CapType, JITCacheKey>) {
         children_aggregated_val = MakeJITCacheKeyForType<void>("children");
       } else {
         // Fallback for other types, should be defined in capability_attributes
         children_aggregated_val = capability_attributes<Cap>::default_value;
       }
     } else { // One or more children
-      if constexpr (std::is_same_v<CapType, bool>) {
+      if constexpr (cuda::std::is_same_v<CapType, bool>) {
           if (query_type == CapabilityQueryType::OR_QUERY) {
               children_aggregated_val = capability_attributes<Cap>::or_identity;
               ((children_aggregated_val = children_aggregated_val || child_vals), ...);
@@ -578,7 +578,7 @@ namespace detail {
               children_aggregated_val = capability_attributes<Cap>::and_identity;
               ((children_aggregated_val = children_aggregated_val && child_vals), ...);
           }
-      } else if constexpr (std::is_same_v<CapType, int> || is_scoped_enum_v<CapType>) {
+      } else if constexpr (cuda::std::is_same_v<CapType, int> || is_scoped_enum_v<CapType>) {
           if (query_type == CapabilityQueryType::MIN_QUERY) {
               children_aggregated_val = capability_attributes<Cap>::min_identity;
               // C++17 way to apply cuda::std::min over a parameter pack
@@ -600,14 +600,14 @@ namespace detail {
               // Not implemented for other query types.
               MATX_ASSERT_STR(false, matxInvalidParameter, "Not implemented for other query types.");
           }
-      } else if constexpr (std::is_same_v<CapType, std::string>) {
+      } else if constexpr (cuda::std::is_same_v<CapType, std::string>) {
         if (query_type == CapabilityQueryType::STR_CAT_QUERY) {
           children_aggregated_val = capability_attributes<Cap>::default_value;
           ((children_aggregated_val += child_vals), ...);
         } else {
           children_aggregated_val = capability_attributes<Cap>::default_value;
         }
-      } else if constexpr (std::is_same_v<CapType, JITCacheKey>) {
+      } else if constexpr (cuda::std::is_same_v<CapType, JITCacheKey>) {
         if (query_type == CapabilityQueryType::HASH_QUERY) {
           children_aggregated_val = MakeJITCacheKeyForType<void>("children");
           ((children_aggregated_val = CombineJITCacheKeys(children_aggregated_val, child_vals)), ...);
@@ -651,7 +651,7 @@ namespace detail {
     }
 
     // Step 2: Combine self's capability with the children's combined result.
-    if constexpr (std::is_same_v<CapType, bool>) {
+    if constexpr (cuda::std::is_same_v<CapType, bool>) {
         // Optimize when identity values make the operation redundant
         if (query_type == CapabilityQueryType::OR_QUERY) {
             // self_val || or_identity
@@ -667,7 +667,7 @@ namespace detail {
             }
             return self_val && children_aggregated_val;
         }
-    } else if constexpr (std::is_same_v<CapType, int> || is_scoped_enum_v<CapType>) {
+    } else if constexpr (cuda::std::is_same_v<CapType, int> || is_scoped_enum_v<CapType>) {
         if (query_type == CapabilityQueryType::MIN_QUERY) {
             return static_cast<CapType>(cuda::std::min(static_cast<int>(self_val), static_cast<int>(children_aggregated_val)));
         } else if (query_type == CapabilityQueryType::MAX_QUERY) {
@@ -678,14 +678,14 @@ namespace detail {
             MATX_ASSERT_STR(false, matxInvalidParameter, "Not implemented for other query types.");
             return self_val;
         }
-    } else if constexpr (std::is_same_v<CapType, std::string>) {
+    } else if constexpr (cuda::std::is_same_v<CapType, std::string>) {
         if (query_type == CapabilityQueryType::STR_CAT_QUERY) {
             return self_val + children_aggregated_val;
         } else {
             MATX_ASSERT_STR(false, matxInvalidParameter, "Not implemented for other query types.");
             return self_val;
         }
-    } else if constexpr (std::is_same_v<CapType, JITCacheKey>) {
+    } else if constexpr (cuda::std::is_same_v<CapType, JITCacheKey>) {
         if (query_type == CapabilityQueryType::HASH_QUERY) {
           return CombineJITCacheKeys(self_val, children_aggregated_val);
         } else {

--- a/include/matx/core/capabilities.h
+++ b/include/matx/core/capabilities.h
@@ -99,7 +99,7 @@ namespace detail {
 
   template <typename T>
   __MATX_INLINE__ __MATX_HOST__ void HashJITCacheValue(JITCacheKey &key, const T &value) {
-    static_assert(std::is_trivially_copyable_v<T>, "JIT cache key values must be trivially copyable");
+    static_assert(cuda::std::is_trivially_copyable_v<T>, "JIT cache key values must be trivially copyable");
     HashJITCacheBytes(key, &value, sizeof(T));
     HashJITCacheByte(key, 0xfe);
   }

--- a/include/matx/core/distributed_tensor.h
+++ b/include/matx/core/distributed_tensor.h
@@ -503,7 +503,7 @@ public:
     static_assert(Out::Rank() == RANK,
                   "Regular and distributed tensor ranks must match");
     static_assert(
-        std::is_same_v<remove_cvref_t<typename Out::value_type>,
+        cuda::std::is_same_v<remove_cvref_t<typename Out::value_type>,
                        remove_cvref_t<T>>,
         "Distributed-to-regular assignment requires identical element types");
 
@@ -523,7 +523,7 @@ public:
     const auto out_location = PointerLocation(out.Data());
     bool copied_replica = false;
     for (const auto &fragment : local_fragments_) {
-      if constexpr (std::is_same_v<Distribution,
+      if constexpr (cuda::std::is_same_v<Distribution,
                                    replicated_distribution_t<RANK>>) {
         if (copied_replica) {
           continue;
@@ -619,7 +619,7 @@ public:
     static_assert(
         is_distributed_tensor_v<Out>,
         "Distributed copies require a distributed tensor destination");
-    static_assert(std::is_same_v<typename Out::value_type, T>,
+    static_assert(cuda::std::is_same_v<typename Out::value_type, T>,
                   "Distributed copies require identical element types");
     ValidateCompatibleOutput(out, executor);
 
@@ -707,7 +707,7 @@ private:
     static_assert(Other::Rank() == RANK,
                   "Distributed operands must have the same rank");
     static_assert(
-        std::is_same_v<typename Other::distribution_type, Distribution>,
+        cuda::std::is_same_v<typename Other::distribution_type, Distribution>,
         "Distributed operands must use the same distribution type");
     matx::detail::DistributedCheck(
         context_id_ == other.ContextId() && context_id_ == executor.ContextId(),
@@ -814,7 +814,7 @@ public:
                  ...),
                 "Distributed apply inputs must have the same rank");
   static_assert(
-      (std::is_same_v<typename remove_cvref_t<Inputs>::distribution_type,
+      (cuda::std::is_same_v<typename remove_cvref_t<Inputs>::distribution_type,
                       distribution_type> &&
        ...),
       "Distributed apply inputs must use the same distribution type");
@@ -834,10 +834,10 @@ public:
     static_assert(Out::Rank() == Rank(),
                   "Distributed apply output rank must match its inputs");
     static_assert(
-        std::is_same_v<typename Out::value_type, value_type>,
+        cuda::std::is_same_v<typename Out::value_type, value_type>,
         "Distributed apply result and output types must match exactly");
     static_assert(
-        std::is_same_v<typename Out::distribution_type, distribution_type>,
+        cuda::std::is_same_v<typename Out::distribution_type, distribution_type>,
         "Distributed apply output distribution type must match its inputs");
 
     matx::detail::DistributedCheck(
@@ -857,7 +857,7 @@ public:
           out_fragment.endpoint, [&](cudaExecutor &local_executor) {
             auto local_op = MakeLocalOp(out_fragment.distribution_index);
             static_assert(
-                std::is_same_v<
+                cuda::std::is_same_v<
                     remove_cvref_t<typename decltype(local_op)::value_type>,
                     remove_cvref_t<typename Out::value_type>>,
                 "Distributed apply callable result must exactly match the "
@@ -959,7 +959,7 @@ public:
     static_assert(Out::Rank() == first_input_type::Rank(),
                   "First-pass distributed local transforms preserve rank");
     static_assert(
-        std::is_same_v<remove_cvref_t<typename Out::value_type>,
+        cuda::std::is_same_v<remove_cvref_t<typename Out::value_type>,
                        remove_cvref_t<ValueType>>,
         "Distributed local transform output type does not match");
 

--- a/include/matx/core/iterator.h
+++ b/include/matx/core/iterator.h
@@ -70,7 +70,7 @@ struct RandomOperatorIterator {
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorIterator(const OperatorBaseType &t, stride_type offset) : t_(t), offset_(offset) {}
 
   template<typename T = OperatorType>
-    requires (!std::is_same_v<T, OperatorBaseType>)
+    requires (!cuda::std::is_same_v<T, OperatorBaseType>)
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ RandomOperatorIterator(OperatorBaseType &&t, stride_type offset) : t_(t), offset_(offset) {}
 
   /**

--- a/include/matx/core/make_sparse_tensor.h
+++ b/include/matx/core/make_sparse_tensor.h
@@ -237,7 +237,7 @@ auto make_tensor_dia(ValTensor &val, CrdTensor &off,
   Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(off.Size(0)), space);
   // Construct DIA-I/J.
-  using DIA = std::conditional_t<cuda::std::is_same_v<IDX, DIA_INDEX_I>, DIAI, DIAJ>;
+  using DIA = cuda::std::conditional_t<cuda::std::is_same_v<IDX, DIA_INDEX_I>, DIAI, DIAJ>;
   return sparse_tensor_t<VAL, CRD, POS, DIA>(
       shape, val.GetStorage(),
       {off.GetStorage(), makeEmptyStorage<CRD>()},
@@ -277,7 +277,7 @@ auto make_tensor_uniform_batched_dia(ValTensor &val, CrdTensor &off,
   Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(off.Size(0)), space);
   // Construct Batched DIA-I/J.
-  using DIA = std::conditional_t<cuda::std::is_same_v<IDX, DIA_INDEX_I>,
+  using DIA = cuda::std::conditional_t<cuda::std::is_same_v<IDX, DIA_INDEX_I>,
                                  BatchedDIAIUniform, BatchedDIAJUniform>;
   return sparse_tensor_t<VAL, CRD, POS, DIA>(
       shape, val.GetStorage(),
@@ -316,7 +316,7 @@ auto make_tensor_uniform_batched_tri_dia(ValTensor &val,
   Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(3), space);
   // Construct Batched DIA-I/J.
-  using DIA = std::conditional_t<cuda::std::is_same_v<IDX, DIA_INDEX_I>,
+  using DIA = cuda::std::conditional_t<cuda::std::is_same_v<IDX, DIA_INDEX_I>,
                                  BatchedDIAIUniform, BatchedDIAJUniform>;
   return sparse_tensor_t<VAL, CRD, POS, DIA>(
       shape, val.GetStorage(), {std::move(off), makeEmptyStorage<CRD>()},

--- a/include/matx/core/make_sparse_tensor.h
+++ b/include/matx/core/make_sparse_tensor.h
@@ -222,7 +222,7 @@ auto make_tensor_dia(ValTensor &val, CrdTensor &off,
   // Proper structure.
   MATX_STATIC_ASSERT_STR(ValTensor::Rank() == 1 && CrdTensor::Rank() == 1,
                          matxInvalidParameter, "data arrays should be rank-1");
-  if constexpr (std::is_same_v<IDX, DIA_INDEX_I>) {
+  if constexpr (cuda::std::is_same_v<IDX, DIA_INDEX_I>) {
     MATX_ASSERT_STR(val.Size(0) == shape[0] * off.Size(0), matxInvalidParameter,
                     "data arrays should contain all diagonals (by row index)");
   } else {
@@ -237,7 +237,7 @@ auto make_tensor_dia(ValTensor &val, CrdTensor &off,
   Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(off.Size(0)), space);
   // Construct DIA-I/J.
-  using DIA = std::conditional_t<std::is_same_v<IDX, DIA_INDEX_I>, DIAI, DIAJ>;
+  using DIA = std::conditional_t<cuda::std::is_same_v<IDX, DIA_INDEX_I>, DIAI, DIAJ>;
   return sparse_tensor_t<VAL, CRD, POS, DIA>(
       shape, val.GetStorage(),
       {off.GetStorage(), makeEmptyStorage<CRD>()},
@@ -260,7 +260,7 @@ auto make_tensor_uniform_batched_dia(ValTensor &val, CrdTensor &off,
   // Proper structure.
   MATX_STATIC_ASSERT_STR(ValTensor::Rank() == 1 && CrdTensor::Rank() == 1,
                          matxInvalidParameter, "data arrays should be rank-1");
-  if constexpr (std::is_same_v<IDX, DIA_INDEX_I>) {
+  if constexpr (cuda::std::is_same_v<IDX, DIA_INDEX_I>) {
     MATX_ASSERT_STR(val.Size(0) == shape[0] * shape[1] * off.Size(0),
                     matxInvalidParameter,
                     "data arrays should contain all diagonals (by row index)");
@@ -277,7 +277,7 @@ auto make_tensor_uniform_batched_dia(ValTensor &val, CrdTensor &off,
   Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(off.Size(0)), space);
   // Construct Batched DIA-I/J.
-  using DIA = std::conditional_t<std::is_same_v<IDX, DIA_INDEX_I>,
+  using DIA = std::conditional_t<cuda::std::is_same_v<IDX, DIA_INDEX_I>,
                                  BatchedDIAIUniform, BatchedDIAJUniform>;
   return sparse_tensor_t<VAL, CRD, POS, DIA>(
       shape, val.GetStorage(),
@@ -295,7 +295,7 @@ auto make_tensor_uniform_batched_tri_dia(ValTensor &val,
   // Proper structure.
   MATX_STATIC_ASSERT_STR(ValTensor::Rank() == 1, matxInvalidParameter,
                          "data array should be rank-1");
-  if constexpr (std::is_same_v<IDX, DIA_INDEX_I>) {
+  if constexpr (cuda::std::is_same_v<IDX, DIA_INDEX_I>) {
     MATX_ASSERT_STR(
         val.Size(0) == shape[0] * shape[1] * 3, matxInvalidParameter,
         "data arrays should contain all three diagonals (by row index)");
@@ -316,7 +316,7 @@ auto make_tensor_uniform_batched_tri_dia(ValTensor &val,
   Storage<POS> tp = makeZeroStorage<POS>(2, space);
   setVal(tp.data() + 1, static_cast<POS>(3), space);
   // Construct Batched DIA-I/J.
-  using DIA = std::conditional_t<std::is_same_v<IDX, DIA_INDEX_I>,
+  using DIA = std::conditional_t<cuda::std::is_same_v<IDX, DIA_INDEX_I>,
                                  BatchedDIAIUniform, BatchedDIAJUniform>;
   return sparse_tensor_t<VAL, CRD, POS, DIA>(
       shape, val.GetStorage(), {std::move(off), makeEmptyStorage<CRD>()},

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -299,7 +299,7 @@ auto make_tensor_p( [[maybe_unused]] const std::initializer_list<detail::no_size
   MATX_LOG_DEBUG("make_tensor_p<T>(0D, space, stream): space={}, stream={}",
                  static_cast<int>(space), reinterpret_cast<void*>(stream));
 
-  cuda::std::array<index_t, 0> shape;
+  cuda::std::array<index_t, 0> shape{};
   return make_tensor_p<T, decltype(shape)>(std::move(shape), space, stream);
 }
 

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -840,17 +840,17 @@ void validate_dlpack_tensor_type(const DLTensor &dt) {
     case kDLComplex: {
       switch (dt.dtype.bits) {
         case 128: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, cuda::std::complex<double>>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, cuda::std::complex<double>>>(
               "DLPack dtype mismatch: code=kDLComplex bits=128 requires MatX base scalar type cuda::std::complex<double>");
           break;
         }
         case 64: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, cuda::std::complex<float>>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, cuda::std::complex<float>>>(
               "DLPack dtype mismatch: code=kDLComplex bits=64 requires MatX base scalar type cuda::std::complex<float>");
           break;
         }
         case 32: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, matxFp16Complex>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, matxFp16Complex>>(
               "DLPack dtype mismatch: code=kDLComplex bits=32 requires MatX base scalar type matxFp16Complex");
           break;
         }
@@ -863,17 +863,17 @@ void validate_dlpack_tensor_type(const DLTensor &dt) {
     case kDLFloat: {
       switch (dt.dtype.bits) {
         case 64: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, double>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, double>>(
               "DLPack dtype mismatch: code=kDLFloat bits=64 requires MatX base scalar type double");
           break;
         }
         case 32: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, float>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, float>>(
               "DLPack dtype mismatch: code=kDLFloat bits=32 requires MatX base scalar type float");
           break;
         }
         case 16: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, matxFp16>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, matxFp16>>(
               "DLPack dtype mismatch: code=kDLFloat bits=16 requires MatX base scalar type matxFp16");
           break;
         }
@@ -885,7 +885,7 @@ void validate_dlpack_tensor_type(const DLTensor &dt) {
     case kDLBfloat: {
       switch (dt.dtype.bits) {
         case 16: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, matxBf16>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, matxBf16>>(
               "DLPack dtype mismatch: code=kDLBfloat bits=16 requires MatX base scalar type matxBf16");
           break;
         }
@@ -897,22 +897,22 @@ void validate_dlpack_tensor_type(const DLTensor &dt) {
     case kDLInt: {
       switch (dt.dtype.bits) {
         case 64: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, int64_t>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, int64_t>>(
               "DLPack dtype mismatch: code=kDLInt bits=64 requires MatX base scalar type int64_t");
           break;
         }
         case 32: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, int32_t>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, int32_t>>(
               "DLPack dtype mismatch: code=kDLInt bits=32 requires MatX base scalar type int32_t");
           break;
         }
         case 16: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, int16_t>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, int16_t>>(
               "DLPack dtype mismatch: code=kDLInt bits=16 requires MatX base scalar type int16_t");
           break;
         }
         case 8: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, int8_t>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, int8_t>>(
               "DLPack dtype mismatch: code=kDLInt bits=8 requires MatX base scalar type int8_t");
           break;
         }
@@ -924,22 +924,22 @@ void validate_dlpack_tensor_type(const DLTensor &dt) {
     case kDLUInt: {
       switch (dt.dtype.bits) {
         case 64: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, uint64_t>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, uint64_t>>(
               "DLPack dtype mismatch: code=kDLUInt bits=64 requires MatX base scalar type uint64_t");
           break;
         }
         case 32: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, uint32_t>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, uint32_t>>(
               "DLPack dtype mismatch: code=kDLUInt bits=32 requires MatX base scalar type uint32_t");
           break;
         }
         case 16: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, uint16_t>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, uint16_t>>(
               "DLPack dtype mismatch: code=kDLUInt bits=16 requires MatX base scalar type uint16_t");
           break;
         }
         case 8: {
-          validate_dlpack_dtype<std::is_same_v<ScalarT, uint8_t>>(
+          validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, uint8_t>>(
               "DLPack dtype mismatch: code=kDLUInt bits=8 requires MatX base scalar type uint8_t");
           break;
         }
@@ -949,7 +949,7 @@ void validate_dlpack_tensor_type(const DLTensor &dt) {
       break;
     }
     case kDLBool: {
-      validate_dlpack_dtype<std::is_same_v<ScalarT, bool>>(
+      validate_dlpack_dtype<cuda::std::is_same_v<ScalarT, bool>>(
           "DLPack dtype mismatch: code=kDLBool requires MatX base scalar type bool");
       break;
     }

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -58,14 +58,14 @@ auto make_tensor( const index_t (&shape)[RANK],
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                   cudaStream_t stream = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   std::string shape_str = "[";
   for (int i = 0; i < RANK; i++) {
     if (i > 0) shape_str += ",";
     shape_str += std::to_string(shape[i]);
   }
   shape_str += "]";
-  MATX_LOG_DEBUG("make_tensor<T,RANK>(shape, space, stream): shape={}, space={}, stream={}", 
+  MATX_LOG_DEBUG("make_tensor<T,RANK>(shape, space, stream): shape={}, space={}, stream={}",
                  shape_str, static_cast<int>(space), reinterpret_cast<void*>(stream));
 
   DefaultDescriptor<RANK> desc{shape};
@@ -84,10 +84,10 @@ template <typename T, typename ShapeType>
   requires (!is_matx_descriptor<ShapeType> && !std::is_array_v<remove_cvref_t<ShapeType>>)
 auto make_tensor(Storage<T> storage, ShapeType &&shape) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   MATX_LOG_DEBUG("make_tensor<T,ShapeType>(storage, shape): ptr={}", reinterpret_cast<const void*>(storage.data()));
 
-  constexpr int RANK = static_cast<int>(cuda::std::tuple_size<typename remove_cvref<ShapeType>::type>::value);
+  constexpr int RANK = static_cast<int>(cuda::std::tuple_size<remove_cvref_t<ShapeType>>::value);
   DefaultDescriptor<RANK> desc{std::forward<ShapeType>(shape)};
   return tensor_t<T, RANK, decltype(desc)>{std::move(storage), std::move(desc)};
 }
@@ -107,14 +107,14 @@ void make_tensor( TensorType &tensor,
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                   cudaStream_t stream = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   std::string shape_str = "[";
   for (int i = 0; i < TensorType::Rank(); i++) {
     if (i > 0) shape_str += ",";
     shape_str += std::to_string(shape[i]);
   }
   shape_str += "]";
-  MATX_LOG_DEBUG("make_tensor(tensor&, shape, space, stream): shape={}, space={}, stream={}", 
+  MATX_LOG_DEBUG("make_tensor(tensor&, shape, space, stream): shape={}, space={}, stream={}",
                  shape_str, static_cast<int>(space), reinterpret_cast<void*>(stream));
 
   auto tmp = make_tensor<typename TensorType::value_type, TensorType::Rank()>(shape, space, stream);
@@ -135,14 +135,14 @@ auto make_tensor_p( const index_t (&shape)[RANK],
                     matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                     cudaStream_t stream = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   std::string shape_str = "[";
   for (int i = 0; i < RANK; i++) {
     if (i > 0) shape_str += ",";
     shape_str += std::to_string(shape[i]);
   }
   shape_str += "]";
-  MATX_LOG_DEBUG("make_tensor_p<T,RANK>(shape, space, stream): shape={}, space={}, stream={}", 
+  MATX_LOG_DEBUG("make_tensor_p<T,RANK>(shape, space, stream): shape={}, space={}, stream={}",
                  shape_str, static_cast<int>(space), reinterpret_cast<void*>(stream));
 
   DefaultDescriptor<RANK> desc{shape};
@@ -170,17 +170,17 @@ auto make_tensor( ShapeType &&shape,
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                   cudaStream_t stream = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
-  MATX_LOG_DEBUG("make_tensor<T,ShapeType>(shape, space, stream): space={}, stream={}", 
+
+  MATX_LOG_DEBUG("make_tensor<T,ShapeType>(shape, space, stream): space={}, stream={}",
                  static_cast<int>(space), reinterpret_cast<void*>(stream));
 
-  constexpr int rank = static_cast<int>(cuda::std::tuple_size<typename remove_cvref<ShapeType>::type>::value);
+  constexpr int rank = static_cast<int>(cuda::std::tuple_size<remove_cvref_t<ShapeType>>::value);
   DefaultDescriptor<rank> desc{std::move(shape)};
 
   auto storage = make_owning_storage<T>(desc.TotalSize(), space, stream);
 
   return tensor_t<T,
-    cuda::std::tuple_size<typename remove_cvref<ShapeType>::type>::value,
+    cuda::std::tuple_size<remove_cvref_t<ShapeType>>::value,
     decltype(desc)>{std::move(storage), std::move(desc)};
 }
 
@@ -204,8 +204,8 @@ auto make_tensor( TensorType &tensor,
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                   cudaStream_t stream = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
-  MATX_LOG_DEBUG("make_tensor(tensor&, shape, space, stream): space={}, stream={}", 
+
+  MATX_LOG_DEBUG("make_tensor(tensor&, shape, space, stream): space={}, stream={}",
                  static_cast<int>(space), reinterpret_cast<void*>(stream));
 
   auto tmp = make_tensor<typename TensorType::value_type, ShapeType>(std::forward<ShapeType>(shape), space, stream);
@@ -231,15 +231,15 @@ auto make_tensor_p( ShapeType &&shape,
                     matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                     cudaStream_t stream = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
-  MATX_LOG_DEBUG("make_tensor_p<T,ShapeType>(shape, space, stream): space={}, stream={}", 
+
+  MATX_LOG_DEBUG("make_tensor_p<T,ShapeType>(shape, space, stream): space={}, stream={}",
                  static_cast<int>(space), reinterpret_cast<void*>(stream));
 
-  DefaultDescriptor<static_cast<int>(cuda::std::tuple_size<typename remove_cvref<ShapeType>::type>::value)> desc{std::move(shape)};
+  DefaultDescriptor<static_cast<int>(cuda::std::tuple_size<remove_cvref_t<ShapeType>>::value)> desc{std::move(shape)};
 
   auto storage = make_owning_storage<T>(desc.TotalSize(), space, stream);
   return new tensor_t<T,
-  cuda::std::tuple_size<typename remove_cvref<ShapeType>::type>::value,
+  cuda::std::tuple_size<remove_cvref_t<ShapeType>>::value,
   decltype(desc)>{std::move(storage), std::move(desc)};
 }
 
@@ -257,7 +257,7 @@ template <typename T>
 auto make_tensor( [[maybe_unused]] const std::initializer_list<detail::no_size_t> t,
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                   cudaStream_t stream = 0) {
-  MATX_LOG_DEBUG("make_tensor<T>(0D, space, stream): space={}, stream={}", 
+  MATX_LOG_DEBUG("make_tensor<T>(0D, space, stream): space={}, stream={}",
                  static_cast<int>(space), reinterpret_cast<void*>(stream));
   using shape_t = cuda::std::array<index_t, 0>;
   return make_tensor<T, shape_t>(shape_t{}, space, stream);
@@ -277,7 +277,7 @@ template <typename TensorType>
 auto make_tensor( TensorType &tensor,
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                   cudaStream_t stream = 0) {
-  MATX_LOG_DEBUG("make_tensor(tensor&, 0D, space, stream): space={}, stream={}", 
+  MATX_LOG_DEBUG("make_tensor(tensor&, 0D, space, stream): space={}, stream={}",
                  static_cast<int>(space), reinterpret_cast<void*>(stream));
   auto tmp = make_tensor<typename TensorType::value_type>({}, space, stream);
   tensor.Shallow(tmp);
@@ -296,7 +296,7 @@ template <typename T>
 auto make_tensor_p( [[maybe_unused]] const std::initializer_list<detail::no_size_t> t,
                     matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                     cudaStream_t stream = 0) {
-  MATX_LOG_DEBUG("make_tensor_p<T>(0D, space, stream): space={}, stream={}", 
+  MATX_LOG_DEBUG("make_tensor_p<T>(0D, space, stream): space={}, stream={}",
                  static_cast<int>(space), reinterpret_cast<void*>(stream));
 
   cuda::std::array<index_t, 0> shape;
@@ -319,14 +319,14 @@ auto make_tensor( T *data,
                   const index_t (&shape)[RANK],
                   bool owning = false) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   std::string shape_str = "[";
   for (int i = 0; i < RANK; i++) {
     if (i > 0) shape_str += ",";
     shape_str += std::to_string(shape[i]);
   }
   shape_str += "]";
-  MATX_LOG_DEBUG("make_tensor<T,RANK>(data, shape, owning): ptr={}, shape={}, owning={}", 
+  MATX_LOG_DEBUG("make_tensor<T,RANK>(data, shape, owning): ptr={}, shape={}, owning={}",
                  reinterpret_cast<void*>(data), shape_str, owning);
 
   DefaultDescriptor<RANK> desc{shape};
@@ -351,14 +351,14 @@ auto make_tensor( TensorType &tensor,
                   typename TensorType::value_type *data,
                   const index_t (&shape)[TensorType::Rank()]) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   std::string shape_str = "[";
   for (int i = 0; i < TensorType::Rank(); i++) {
     if (i > 0) shape_str += ",";
     shape_str += std::to_string(shape[i]);
   }
   shape_str += "]";
-  MATX_LOG_DEBUG("make_tensor(tensor&, data, shape): ptr={}, shape={}", 
+  MATX_LOG_DEBUG("make_tensor(tensor&, data, shape): ptr={}, shape={}",
                  reinterpret_cast<void*>(data), shape_str);
 
   auto tmp = make_tensor<typename TensorType::value_type, TensorType::Rank()>(data, shape, false);
@@ -384,11 +384,11 @@ auto make_tensor( T *data,
                   ShapeType &&shape,
                   bool owning = false) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
-  MATX_LOG_DEBUG("make_tensor<T,ShapeType>(data, shape, owning): ptr={}, owning={}", 
+
+  MATX_LOG_DEBUG("make_tensor<T,ShapeType>(data, shape, owning): ptr={}, owning={}",
                  reinterpret_cast<void*>(data), owning);
 
-  constexpr int RANK = static_cast<int>(cuda::std::tuple_size<typename remove_cvref<ShapeType>::type>::value);
+  constexpr int RANK = static_cast<int>(cuda::std::tuple_size<remove_cvref_t<ShapeType>>::value);
   DefaultDescriptor<RANK>
     desc{std::forward<ShapeType>(shape)};
   auto storage = owning ? make_owning_storage<T>(desc.TotalSize()) : make_non_owning_storage<T>(data, desc.TotalSize());
@@ -412,9 +412,9 @@ auto make_tensor( TensorType &tensor,
                   typename TensorType::value_type *data,
                   typename TensorType::shape_container &&shape) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   MATX_LOG_DEBUG("make_tensor(tensor&, data, shape): ptr={}", reinterpret_cast<void*>(data));
-  
+
   auto tmp = make_tensor<typename TensorType::value_type, typename TensorType::shape_container>(data, std::forward<typename TensorType::shape_container>(shape), false);
   tensor.Shallow(tmp);
 }
@@ -433,7 +433,7 @@ template <typename T>
 auto make_tensor( T *ptr,
                   [[maybe_unused]] const std::initializer_list<detail::no_size_t> t,
                   bool owning = false) {
-  MATX_LOG_DEBUG("make_tensor<T>(ptr, 0D, owning): ptr={}, owning={}", 
+  MATX_LOG_DEBUG("make_tensor<T>(ptr, 0D, owning): ptr={}, owning={}",
                  reinterpret_cast<void*>(ptr), owning);
   cuda::std::array<index_t, 0> shape{};
   return make_tensor<T, decltype(shape)>(ptr, std::move(shape), owning);
@@ -478,11 +478,11 @@ auto make_tensor_p( T *const data,
                     ShapeType &&shape,
                     bool owning = false) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
-  MATX_LOG_DEBUG("make_tensor_p<T,ShapeType>(data, shape, owning): ptr={}, owning={}", 
+
+  MATX_LOG_DEBUG("make_tensor_p<T,ShapeType>(data, shape, owning): ptr={}, owning={}",
                  reinterpret_cast<const void*>(data), owning);
 
-  constexpr int RANK = static_cast<int>(cuda::std::tuple_size<typename remove_cvref<ShapeType>::type>::value);
+  constexpr int RANK = static_cast<int>(cuda::std::tuple_size<remove_cvref_t<ShapeType>>::value);
   DefaultDescriptor<RANK>
     desc{std::forward<ShapeType>(shape)};
   auto storage = owning ? make_owning_storage<T>(desc.TotalSize()) : make_non_owning_storage<T>(data, desc.TotalSize());
@@ -502,7 +502,7 @@ template <typename T, int RANK, typename Allocator>
 auto make_tensor( const index_t (&shape)[RANK],
                   Allocator&& alloc) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   std::string shape_str = "[";
   for (int i = 0; i < RANK; i++) {
     if (i > 0) shape_str += ",";
@@ -531,10 +531,10 @@ template <typename T, typename ShapeType, typename Allocator>
 auto make_tensor( ShapeType &&shape,
                   Allocator&& alloc) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   MATX_LOG_DEBUG("make_tensor<T,ShapeType,Allocator>(shape, alloc)");
 
-  constexpr int RANK = static_cast<int>(cuda::std::tuple_size<typename remove_cvref<ShapeType>::type>::value);
+  constexpr int RANK = static_cast<int>(cuda::std::tuple_size<remove_cvref_t<ShapeType>>::value);
   DefaultDescriptor<RANK> desc{std::forward<ShapeType>(shape)};
   auto storage = make_owning_storage<T>(desc.TotalSize(), std::forward<Allocator>(alloc));
   return tensor_t<T, RANK, decltype(desc)>{std::move(storage), std::move(desc)};
@@ -556,7 +556,7 @@ void make_tensor( TensorType &tensor,
                   const index_t (&shape)[TensorType::Rank()],
                   Allocator&& alloc) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   std::string shape_str = "[";
   for (int i = 0; i < TensorType::Rank(); i++) {
     if (i > 0) shape_str += ",";
@@ -586,7 +586,7 @@ void make_tensor( TensorType &tensor,
                   ShapeType &&shape,
                   Allocator&& alloc) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   MATX_LOG_DEBUG("make_tensor(tensor&, shape, alloc)");
 
   auto tmp = make_tensor<typename TensorType::value_type>(std::forward<ShapeType>(shape), std::forward<Allocator>(alloc));
@@ -611,11 +611,11 @@ auto make_tensor( T* const data,
                   D &&desc,
                   bool owning = false) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
-  MATX_LOG_DEBUG("make_tensor<T,D>(data, desc, owning): ptr={}, owning={}", 
+
+  MATX_LOG_DEBUG("make_tensor<T,D>(data, desc, owning): ptr={}, owning={}",
                  reinterpret_cast<const void*>(data), owning);
 
-  using Dstrip = typename remove_cvref<D>::type;
+  using Dstrip = remove_cvref_t<D>;
   auto storage = owning ? make_owning_storage<T>(desc.TotalSize()) : make_non_owning_storage<T>(data, desc.TotalSize());
   return tensor_t<T, Dstrip::Rank(), Dstrip>{std::move(storage), std::forward<D>(desc)};
 }
@@ -637,7 +637,7 @@ auto make_tensor( TensorType &tensor,
                   typename TensorType::value_type* const data,
                   typename TensorType::desc_type &&desc) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   MATX_LOG_DEBUG("make_tensor(tensor&, data, desc): ptr={}", reinterpret_cast<const void*>(data));
 
   // This tensor should be non-owning regardless of the original ownership since it will go out of scope at the end of the function
@@ -659,11 +659,11 @@ auto make_tensor( D &&desc,
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                   cudaStream_t stream = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
-  MATX_LOG_DEBUG("make_tensor<T,D>(desc, space, stream): space={}, stream={}", 
+
+  MATX_LOG_DEBUG("make_tensor<T,D>(desc, space, stream): space={}, stream={}",
                  static_cast<int>(space), reinterpret_cast<void*>(stream));
 
-  using Dstrip = typename remove_cvref<D>::type;
+  using Dstrip = remove_cvref_t<D>;
 
   auto storage = make_owning_storage<T>(desc.TotalSize(), space, stream);
   return tensor_t<T, Dstrip::Rank(), Dstrip>{std::move(storage), std::forward<D>(desc)};
@@ -685,8 +685,8 @@ auto make_tensor( TensorType &&tensor,
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                   cudaStream_t stream = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
-  MATX_LOG_DEBUG("make_tensor(tensor&&, desc, space, stream): space={}, stream={}", 
+
+  MATX_LOG_DEBUG("make_tensor(tensor&&, desc, space, stream): space={}, stream={}",
                  static_cast<int>(space), reinterpret_cast<void*>(stream));
 
   auto tmp = make_tensor<typename TensorType::value_type, typename TensorType::desc_type>(std::forward<typename TensorType::desc_type>(desc), space, stream);
@@ -712,7 +712,7 @@ auto make_tensor( T *const data,
                   const index_t (&strides)[RANK],
                   bool owning = false) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   std::string shape_str = "[";
   std::string strides_str = "[";
   for (int i = 0; i < RANK; i++) {
@@ -722,7 +722,7 @@ auto make_tensor( T *const data,
   }
   shape_str += "]";
   strides_str += "]";
-  MATX_LOG_DEBUG("make_tensor<T,RANK>(data, shape, strides, owning): ptr={}, shape={}, strides={}, owning={}", 
+  MATX_LOG_DEBUG("make_tensor<T,RANK>(data, shape, strides, owning): ptr={}, shape={}, strides={}, owning={}",
                  reinterpret_cast<const void*>(data), shape_str, strides_str, owning);
 
 #ifdef _MSC_VER
@@ -756,7 +756,7 @@ auto make_tensor( TensorType &tensor,
                   const index_t (&shape)[TensorType::Rank()],
                   const index_t (&strides)[TensorType::Rank()]) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   std::string shape_str = "[";
   std::string strides_str = "[";
   for (int i = 0; i < TensorType::Rank(); i++) {
@@ -766,7 +766,7 @@ auto make_tensor( TensorType &tensor,
   }
   shape_str += "]";
   strides_str += "]";
-  MATX_LOG_DEBUG("make_tensor(tensor&, data, shape, strides): ptr={}, shape={}, strides={}", 
+  MATX_LOG_DEBUG("make_tensor(tensor&, data, shape, strides): ptr={}, shape={}, strides={}",
                  reinterpret_cast<const void*>(data), shape_str, strides_str);
 
   auto tmp = make_tensor<typename TensorType::value_type, TensorType::Rank()>(data, shape, strides, false);
@@ -785,7 +785,7 @@ auto make_tensor( TensorType &tensor,
 template <typename T, index_t I, index_t ...Is>
 auto make_tensor() {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   MATX_LOG_DEBUG("make_tensor<T,I,Is...>()");
 
   static_tensor_desc_t<I, Is...> desc{};
@@ -1107,7 +1107,7 @@ template <typename TensorType>
 auto make_tensor( TensorType &tensor,
                   const DLManagedTensor dlp_tensor) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   MATX_LOG_DEBUG("make_tensor(tensor&, DLManagedTensor): ptr={}", dlp_tensor.dl_tensor.data);
 
   using T = typename TensorType::value_type;

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -81,7 +81,7 @@ auto make_tensor( const index_t (&shape)[RANK],
  * @returns New tensor
  **/
 template <typename T, typename ShapeType>
-  requires (!is_matx_descriptor<ShapeType> && !std::is_array_v<remove_cvref_t<ShapeType>>)
+  requires (!is_matx_descriptor<ShapeType> && !cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
 auto make_tensor(Storage<T> storage, ShapeType &&shape) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
@@ -165,7 +165,7 @@ auto make_tensor_p( const index_t (&shape)[RANK],
 template <typename T, typename ShapeType>
   requires (!is_matx_shape<ShapeType> &&
             !is_matx_descriptor<ShapeType> &&
-            !std::is_array_v<remove_cvref_t<ShapeType>>)
+            !cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
 auto make_tensor( ShapeType &&shape,
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                   cudaStream_t stream = 0) {
@@ -198,7 +198,7 @@ auto make_tensor( ShapeType &&shape,
  *
  **/
 template <typename TensorType, typename ShapeType>
-  requires (is_tensor<TensorType> && !is_dynamic_tensor_v<TensorType> && !std::is_array_v<remove_cvref_t<ShapeType>>)
+  requires (is_tensor<TensorType> && !is_dynamic_tensor_v<TensorType> && !cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
 auto make_tensor( TensorType &tensor,
                   ShapeType &&shape,
                   matxMemorySpace_t space = MATX_MANAGED_MEMORY,
@@ -226,7 +226,7 @@ auto make_tensor( TensorType &tensor,
  **/
 template <typename T, typename ShapeType>
   requires (!is_matx_shape<ShapeType> &&
-            !std::is_array_v<remove_cvref_t<ShapeType>>)
+            !cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
 auto make_tensor_p( ShapeType &&shape,
                     matxMemorySpace_t space = MATX_MANAGED_MEMORY,
                     cudaStream_t stream = 0) {
@@ -378,7 +378,7 @@ auto make_tensor( TensorType &tensor,
  **/
 template <typename T, typename ShapeType>
   requires (!is_matx_descriptor<ShapeType> &&
-            !std::is_array_v<remove_cvref_t<ShapeType>> &&
+            !cuda::std::is_array_v<remove_cvref_t<ShapeType>> &&
             is_tuple_c<remove_cvref_t<ShapeType>>)
 auto make_tensor( T *data,
                   ShapeType &&shape,
@@ -472,7 +472,7 @@ auto make_tensor( TensorType &tensor,
  **/
 template <typename T, typename ShapeType>
   requires (!is_matx_descriptor<ShapeType> &&
-            !std::is_array_v<remove_cvref_t<ShapeType>> &&
+            !cuda::std::is_array_v<remove_cvref_t<ShapeType>> &&
             is_tuple_c<remove_cvref_t<ShapeType>>)
 auto make_tensor_p( T *const data,
                     ShapeType &&shape,
@@ -527,7 +527,7 @@ auto make_tensor( const index_t (&shape)[RANK],
  **/
 template <typename T, typename ShapeType, typename Allocator>
   requires (!is_matx_shape<ShapeType> && !is_matx_descriptor<ShapeType> &&
-            !std::is_array_v<remove_cvref_t<ShapeType>>)
+            !cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
 auto make_tensor( ShapeType &&shape,
                   Allocator&& alloc) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
@@ -581,7 +581,7 @@ void make_tensor( TensorType &tensor,
  **/
 template <typename TensorType, typename ShapeType, typename Allocator>
   requires (is_tensor<TensorType> && !is_dynamic_tensor_v<TensorType> &&
-            !std::is_array_v<remove_cvref_t<ShapeType>>)
+            !cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
 void make_tensor( TensorType &tensor,
                   ShapeType &&shape,
                   Allocator&& alloc) {
@@ -1082,7 +1082,7 @@ auto make_dlpack_tensor_view(std::shared_ptr<Owner> owner,
 template <typename TensorType>
 void validate_dlpack_read_only_import(uint64_t flags) {
   if ((flags & DLPACK_FLAG_BITMASK_READ_ONLY) != 0U) {
-    validate_dlpack_condition(std::is_const_v<typename TensorType::value_type>, matxInvalidType,
+    validate_dlpack_condition(cuda::std::is_const_v<typename TensorType::value_type>, matxInvalidType,
                               "Read-only DLPack tensors must be imported as const MatX tensors");
   }
 }

--- a/include/matx/core/make_tensor.h
+++ b/include/matx/core/make_tensor.h
@@ -824,7 +824,7 @@ void validate_dlpack_dtype(const char *message)
 
 template <typename T, index_t Rank>
 void validate_dlpack_tensor_type(const DLTensor &dt) {
-  using BaseT = std::remove_cv_t<T>;
+  using BaseT = cuda::std::remove_cv_t<T>;
   using LaneInfo = detail::DLPackLaneInfo<BaseT>;
   using ScalarT = typename LaneInfo::scalar_type;
   constexpr uint16_t lanes = LaneInfo::lanes;
@@ -961,7 +961,7 @@ void validate_dlpack_tensor_type(const DLTensor &dt) {
 template <typename T>
 T *dlpack_data_pointer(const DLTensor &dt)
 {
-  using BaseT = std::remove_cv_t<T>;
+  using BaseT = cuda::std::remove_cv_t<T>;
 
   validate_dlpack_condition(dt.data != nullptr, matxInvalidParameter,
                             "DLPack data cannot be null for MatX tensors");
@@ -979,7 +979,7 @@ constexpr uint64_t dlpack_max_addressable_elements()
 {
   const auto index_max = static_cast<uint64_t>(std::numeric_limits<index_t>::max());
   const auto storage_max = static_cast<uint64_t>(
-      std::numeric_limits<size_t>::max() / sizeof(std::remove_cv_t<T>));
+      std::numeric_limits<size_t>::max() / sizeof(cuda::std::remove_cv_t<T>));
   return index_max < storage_max ? index_max : storage_max;
 }
 

--- a/include/matx/core/operator_utils.h
+++ b/include/matx/core/operator_utils.h
@@ -101,7 +101,7 @@ namespace matx {
         matxMemorySpace_t host_memory_space = MATX_HOST_MEMORY) {
 
       const auto ttl_size = cuda::std::accumulate(shape.begin(), shape.end(), static_cast<index_t>(1),
-                                  cuda::std::multiplies<index_t>()) * sizeof(typename TensorType::value_type);      
+                                  cuda::std::multiplies<index_t>()) * sizeof(typename TensorType::value_type);
 
       if constexpr (is_cuda_executor_v<Executor>) {
         matxAlloc((void**)ptr, ttl_size, MATX_ASYNC_DEVICE_MEMORY, ex.getStream());
@@ -149,9 +149,9 @@ namespace matx {
         return val;
       }
     }
-    #endif  
+    #endif
   }
-}; 
+};
 #endif
 
 // RTC and nvcc
@@ -194,8 +194,8 @@ namespace matx {
       else {
         return Vector<ValueType, static_cast<size_t>(CapType::ept)>{};
       }
-    }   
-  
+    }
+
 
     /**
       * @brief Returns an N-D coordinate as an array corresponding to the absolute index abs
@@ -355,7 +355,7 @@ namespace matx {
         using seq = offset_sequence_t<sizeof...(Is) - RANK, cuda::std::make_index_sequence<RANK>>;
         auto tup = cuda::std::make_tuple(indices...);
         auto sliced_tup = select_tuple(std::forward<decltype(tup)>(tup), seq{});
-        return cuda::std::apply([&] (auto... args) {                 
+        return cuda::std::apply([&] (auto... args) {
           return cuda::std::forward<T>(i).template operator()<CapType>(args...);
         }, sliced_tup);
       }
@@ -369,7 +369,7 @@ namespace matx {
         // If we're only indexing with the same number of arguments as the rank of the operator, just return operator()
         return cuda::std::apply([&i](auto... args) -> decltype(auto) {
           return cuda::std::forward<T>(i).template operator()<CapType>(args...);
-        }, idx);        
+        }, idx);
       }
       else
       {
@@ -379,7 +379,7 @@ namespace matx {
           return cuda::std::forward<T>(i).template operator()<CapType>(args...);
         }, nbc_idx);
       }
-    }    
+    }
 
 
     template <typename CapType, typename T, typename... Is>
@@ -418,19 +418,19 @@ namespace matx {
       {
         return i;
       }
-    }   
+    }
 
     // Returns an address of a pointer of type T aligned to new address
     template <typename T>
     constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T *AlignAddr(uint8_t *addr)
     {
-      if (((uint64_t)addr % std::alignment_of_v<T>) != 0) {
+      if (((uint64_t)addr % cuda::std::alignment_of_v<T>) != 0) {
         return reinterpret_cast<T *>(
-            ((uint64_t)addr + (std::alignment_of_v<T> - 1)) /
-            std::alignment_of_v<T> * std::alignment_of_v<T>);
+            ((uint64_t)addr + (cuda::std::alignment_of_v<T> - 1)) /
+            cuda::std::alignment_of_v<T> * cuda::std::alignment_of_v<T>);
       }
 
       return reinterpret_cast<T *>(addr);
-    }    
+    }
   }
 }

--- a/include/matx/core/print.h
+++ b/include/matx/core/print.h
@@ -68,34 +68,34 @@ namespace matx {
         const auto fmt_s = ("% ."s + prec + "e ");
         fprintf(fp, fmt_s.c_str(), val);
       }
-      else if constexpr (std::is_same_v<T, long long int>) {
+      else if constexpr (cuda::std::is_same_v<T, long long int>) {
         fprintf(fp, "% lld ", val);
       }
-      else if constexpr (std::is_same_v<T, int64_t>) {
+      else if constexpr (cuda::std::is_same_v<T, int64_t>) {
         fprintf(fp, "% " PRId64 " ", val);
       }
-      else if constexpr (std::is_same_v<T, int32_t>) {
+      else if constexpr (cuda::std::is_same_v<T, int32_t>) {
         fprintf(fp, "% " PRId32 " ", val);
       }
-      else if constexpr (std::is_same_v<T, int16_t>) {
+      else if constexpr (cuda::std::is_same_v<T, int16_t>) {
         fprintf(fp, "% " PRId16 " ", val);
       }
-      else if constexpr (std::is_same_v<T, int8_t>) {
+      else if constexpr (cuda::std::is_same_v<T, int8_t>) {
         fprintf(fp, "% " PRId8 " ", val);
       }
-      else if constexpr (std::is_same_v<T, uint64_t>) {
+      else if constexpr (cuda::std::is_same_v<T, uint64_t>) {
         fprintf(fp, "+%" PRIu64 " ", val);
       }
-      else if constexpr (std::is_same_v<T, uint32_t>) {
+      else if constexpr (cuda::std::is_same_v<T, uint32_t>) {
         fprintf(fp, "+%" PRIu32 " ", val);
       }
-      else if constexpr (std::is_same_v<T, uint16_t>) {
+      else if constexpr (cuda::std::is_same_v<T, uint16_t>) {
         fprintf(fp, "+%" PRIu16 " ", val);
       }
-      else if constexpr (std::is_same_v<T, uint8_t>) {
+      else if constexpr (cuda::std::is_same_v<T, uint8_t>) {
         fprintf(fp, "+%" PRIu8 " ", val);
       }
-      else if constexpr (std::is_same_v<T, bool>) {
+      else if constexpr (cuda::std::is_same_v<T, bool>) {
         fprintf(fp, "% d ", val);
       }
     }
@@ -108,31 +108,31 @@ namespace matx {
      */
     template <typename T> static std::string GetTensorTypeString()
     {
-      if constexpr (std::is_same_v<T, bool>)
+      if constexpr (cuda::std::is_same_v<T, bool>)
         return "bool";
-      if constexpr (std::is_same_v<T, int32_t>)
+      if constexpr (cuda::std::is_same_v<T, int32_t>)
         return "int32_t";
-      if constexpr (std::is_same_v<T, uint32_t>)
+      if constexpr (cuda::std::is_same_v<T, uint32_t>)
         return "uint32_t";
-      if constexpr (std::is_same_v<T, int64_t>)
+      if constexpr (cuda::std::is_same_v<T, int64_t>)
         return "int64_t";
-      if constexpr (std::is_same_v<T, uint64_t>)
+      if constexpr (cuda::std::is_same_v<T, uint64_t>)
         return "uint64_t";
-      if constexpr (std::is_same_v<T, float> )
+      if constexpr (cuda::std::is_same_v<T, float> )
         return "float";
-      if constexpr (std::is_same_v<T, matxFp16>)
+      if constexpr (cuda::std::is_same_v<T, matxFp16>)
         return "float16";
-      if constexpr (std::is_same_v<T, matxBf16>)
+      if constexpr (cuda::std::is_same_v<T, matxBf16>)
         return "bfloat16";
-      if constexpr (std::is_same_v<T, double>)
+      if constexpr (cuda::std::is_same_v<T, double>)
         return "double";
-      if constexpr (std::is_same_v<T, cuda::std::complex<double>> || std::is_same_v<T, std::complex<double>>)
+      if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>> || cuda::std::is_same_v<T, std::complex<double>>)
         return "complex<double>";
-      if constexpr (std::is_same_v<T, cuda::std::complex<float>> || std::is_same_v<T, std::complex<float>>)
+      if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>> || cuda::std::is_same_v<T, std::complex<float>>)
         return "complex<float>";
-      if constexpr (std::is_same_v<T, matxFp16Complex>)
+      if constexpr (cuda::std::is_same_v<T, matxFp16Complex>)
         return "complex<float16>";
-      if constexpr (std::is_same_v<T, matxBf16Complex>)
+      if constexpr (cuda::std::is_same_v<T, matxBf16Complex>)
         return "complex<bfloat16>";
 
       return "unknown";

--- a/include/matx/core/print.h
+++ b/include/matx/core/print.h
@@ -63,7 +63,7 @@ namespace matx {
         const auto fmt_s = ("% ."s + prec + "e ");
         fprintf(fp, fmt_s.c_str(), static_cast<float>(val));
       }
-      else if constexpr (std::is_floating_point_v<T>) {
+      else if constexpr (cuda::std::is_floating_point_v<T>) {
         const auto prec = std::to_string(PRINT_PRECISION);
         const auto fmt_s = ("% ."s + prec + "e ");
         fprintf(fp, fmt_s.c_str(), val);
@@ -486,7 +486,7 @@ namespace matx {
     }
 
     template <typename Op, typename... Args>
-      requires (((std::is_integral_v<Args>)&&...) &&
+      requires (((cuda::std::is_integral_v<Args>)&&...) &&
                 (Op::Rank() == 0 || sizeof...(Args) > 0))
     void DevicePrint(FILE*fp, [[maybe_unused]] const Op &op, [[maybe_unused]] Args... dims) {
   #ifdef __CUDACC__
@@ -524,7 +524,7 @@ namespace matx {
      * @param dims Number of values to print for each dimension
      */
     template <typename Op, typename... Args>
-      requires (((std::is_integral_v<Args>)&&...) &&
+      requires (((cuda::std::is_integral_v<Args>)&&...) &&
                 (Op::Rank() == 0 || sizeof...(Args) > 0))
     void PrintData(FILE* fp, const Op &op, Args... dims) {
       MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
@@ -660,7 +660,7 @@ namespace matx {
    */
   #ifndef DOXYGEN_ONLY
   template <typename Op, typename... Args>
-    requires (((std::is_integral_v<Args>)&&...) &&
+    requires (((cuda::std::is_integral_v<Args>)&&...) &&
               (Op::Rank() == 0 || sizeof...(Args) > 0))
   #else
   template <typename Op, typename... Args>

--- a/include/matx/core/pybind.h
+++ b/include/matx/core/pybind.h
@@ -163,24 +163,24 @@ public:
   template <typename T> static auto GetNumpyDtype()
   {
     auto np = pybind11::module_::import("numpy");
-    if constexpr (std::is_same_v<T, int32_t>)
+    if constexpr (cuda::std::is_same_v<T, int32_t>)
       return np.attr("dtype")("i4");
-    if constexpr (std::is_same_v<T, uint32_t>)
+    if constexpr (cuda::std::is_same_v<T, uint32_t>)
       return np.attr("dtype")("u4");
-    if constexpr (std::is_same_v<T, int64_t>)
+    if constexpr (cuda::std::is_same_v<T, int64_t>)
       return np.attr("dtype")("i8");
-    if constexpr (std::is_same_v<T, uint64_t>)
+    if constexpr (cuda::std::is_same_v<T, uint64_t>)
       return np.attr("dtype")("u8");
-    if constexpr (std::is_same_v<T, float> || is_matx_half_v<T>)
+    if constexpr (cuda::std::is_same_v<T, float> || is_matx_half_v<T>)
       return np.attr("dtype")("float32");
-    if constexpr (std::is_same_v<T, double>)
+    if constexpr (cuda::std::is_same_v<T, double>)
       return np.attr("dtype")("float64");
-    if constexpr (std::is_same_v<T, cuda::std::complex<double>> ||
-                  std::is_same_v<T, std::complex<double>>) {
+    if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>> ||
+                  cuda::std::is_same_v<T, std::complex<double>>) {
       return np.attr("dtype")("complex128");
     }
-    if constexpr (std::is_same_v<T, cuda::std::complex<float>> ||
-                  std::is_same_v<T, std::complex<float>> ||
+    if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>> ||
+                  cuda::std::is_same_v<T, std::complex<float>> ||
                   is_complex_half_v<T>) {
       return np.attr("dtype")("complex64");
     }
@@ -350,7 +350,7 @@ public:
 
   /**
    * @brief Converts an absolute (flat) index to multi-dimensional indices
-   * 
+   *
    * Local utility function to avoid circular header dependencies
    *
    * @param op Operator or tensor
@@ -435,7 +435,7 @@ public:
       // Iterate through all elements
       for (index_t i = 0; i < ten.TotalSize(); i++) {
         auto indices = AbsToIdx(ten, i);
-        
+
         // Use cuda::std::apply to expand indices and access both arrays
         cuda::std::apply([&](auto&&... idx) {
           ten(idx...) = ConvertComplex(ften.at(idx...));
@@ -480,14 +480,14 @@ public:
       // Iterate through all elements
       for (index_t i = 0; i < ten.TotalSize(); i++) {
         auto indices = AbsToIdx(ten, i);
-        
+
         // Use cuda::std::apply to expand indices and access both arrays
         cuda::std::apply([&](auto&&... idx) {
           ften.mutable_at(idx...) = ConvertComplex(ten(idx...));
         }, indices);
       }
 
-      return ften;      
+      return ften;
     }
     else {
       const auto tshape = ten.Shape();
@@ -496,10 +496,10 @@ public:
       std::vector<pybind11::ssize_t> strides{tstrides.begin(), tstrides.end()};
       std::for_each(strides.begin(), strides.end(), [](pybind11::ssize_t &x) {
         x *= sizeof(tensor_type);
-      });      
+      });
 
       auto buf = pybind11::buffer_info(
-          ten.Data(), 
+          ten.Data(),
           sizeof(tensor_type),
           pybind11::format_descriptor<ntype>::format(),
           RANK,
@@ -507,7 +507,7 @@ public:
           strides
       );
 
-      return pybind11::array_t<ntype, pybind11::array::c_style | pybind11::array::forcecast>(buf);      
+      return pybind11::array_t<ntype, pybind11::array::c_style | pybind11::array::forcecast>(buf);
     }
   }
 
@@ -518,7 +518,7 @@ public:
   CompareOutput(const TensorType &ten,
                 const std::string fname, double thresh, bool debug = false)
   {
-    using raw_type = typename TensorType::value_type;    
+    using raw_type = typename TensorType::value_type;
     using ntype = matx_convert_complex_type<raw_type>;
     using ctype = matx_convert_cuda_complex_type<raw_type>;
     auto resobj = res_dict[fname.c_str()];
@@ -539,19 +539,19 @@ public:
       // Iterate through all elements
       for (index_t i = 0; i < ten.TotalSize(); i++) {
         auto indices = AbsToIdx(ten, i);
-        
+
         // Use cuda::std::apply to expand indices and compare values
         auto comparison_failed = cuda::std::apply([&](auto&&... idx) {
           auto file_val = ften.at(idx...);
           auto ten_val = ConvertComplex(ten(idx...));
-          return !CompareVals(ten_val, file_val, thresh, fname, debug) ? 
-                 std::make_optional(std::make_pair(ten_val, file_val)) : 
+          return !CompareVals(ten_val, file_val, thresh, fname, debug) ?
+                 std::make_optional(std::make_pair(ten_val, file_val)) :
                  std::nullopt;
         }, indices);
-        
+
         if (comparison_failed) {
-          return TestFailResult<ctype>{Index2Str(indices), fname, 
-                                       comparison_failed->first, 
+          return TestFailResult<ctype>{Index2Str(indices), fname,
+                                       comparison_failed->first,
                                        comparison_failed->second,
                                        thresh};
         }

--- a/include/matx/core/storage.h
+++ b/include/matx/core/storage.h
@@ -106,13 +106,13 @@ namespace matx
 
     // Owning constructor with any allocator that has allocate/deallocate methods
     template<typename Allocator>
-      requires has_allocator_interface_any<std::decay_t<Allocator>>
+      requires has_allocator_interface_any<cuda::std::decay_t<Allocator>>
     Storage(size_t size, Allocator&& alloc)
       : size_(size) {
       if (size == 0) {
         // For zero size, create empty storage without allocation
         data_ = std::shared_ptr<T>();
-      } else if constexpr (cuda::std::is_pointer_v<std::decay_t<Allocator>>) {
+      } else if constexpr (cuda::std::is_pointer_v<cuda::std::decay_t<Allocator>>) {
         // Handle allocator pointers (any pointer to object with allocate/deallocate methods)
         T* ptr = static_cast<T*>(alloc->allocate(size * sizeof(T)));
         data_ = std::shared_ptr<T>(ptr, [size, alloc](T* p) {

--- a/include/matx/core/storage.h
+++ b/include/matx/core/storage.h
@@ -55,7 +55,7 @@ namespace matx
    * @brief Concept to detect duck-typed allocator pointer interface
    */
   template<typename T>
-  concept has_allocator_ptr_interface_c = std::is_pointer_v<T> && requires(T alloc, size_t sz, void* ptr) {
+  concept has_allocator_ptr_interface_c = cuda::std::is_pointer_v<T> && requires(T alloc, size_t sz, void* ptr) {
     { alloc->allocate(sz) } -> std::convertible_to<void*>;
     { alloc->deallocate(ptr, sz) } -> std::same_as<void>;
   };
@@ -72,7 +72,7 @@ namespace matx
 
   /**
    * @brief Unified storage class for both owning and non-owning pointers
-   * 
+   *
    * Supports duck-typed custom allocators while avoiding virtual functions
    * and pointer members in tensors.
    */
@@ -87,11 +87,11 @@ namespace matx
     Storage() : size_(0), data_() {}
 
     // Non-owning constructor - wraps existing pointer
-    Storage(T* ptr, size_t size) 
+    Storage(T* ptr, size_t size)
       : size_(size), data_(ptr, [](T*){}) {}
-    
+
     // Owning constructor with default allocator
-    Storage(size_t size) 
+    Storage(size_t size)
       : size_(size) {
       if (size == 0) {
         // For zero size, create empty storage without allocation
@@ -103,7 +103,7 @@ namespace matx
         });
       }
     }
-    
+
     // Owning constructor with any allocator that has allocate/deallocate methods
     template<typename Allocator>
       requires has_allocator_interface_any<std::decay_t<Allocator>>
@@ -112,7 +112,7 @@ namespace matx
       if (size == 0) {
         // For zero size, create empty storage without allocation
         data_ = std::shared_ptr<T>();
-      } else if constexpr (std::is_pointer_v<std::decay_t<Allocator>>) {
+      } else if constexpr (cuda::std::is_pointer_v<std::decay_t<Allocator>>) {
         // Handle allocator pointers (any pointer to object with allocate/deallocate methods)
         T* ptr = static_cast<T*>(alloc->allocate(size * sizeof(T)));
         data_ = std::shared_ptr<T>(ptr, [size, alloc](T* p) {
@@ -126,11 +126,11 @@ namespace matx
         });
       }
     }
-    
+
     // Constructor from existing shared_ptr
     Storage(std::shared_ptr<T> ptr, size_t size)
       : size_(size), data_(ptr) {}
-    
+
     // Owning constructor with memory space
     Storage(size_t size, matxMemorySpace_t space, cudaStream_t stream = 0)
       : size_(size) {
@@ -152,7 +152,7 @@ namespace matx
     size_t size() const noexcept { return size_; }
     size_t capacity() const noexcept { return size_; }
     size_t use_count() const noexcept { return data_.use_count(); }
-    
+
     // Iterator interface
     iterator begin() noexcept { return data(); }
     iterator end() noexcept { return data() + size(); }

--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -956,7 +956,7 @@ MATX_LOOP_UNROLL
    *   Shape of tensor
    */
   template <typename ShapeType>
-    requires (!std::is_pointer_v<remove_cvref_t<ShapeType>>)
+    requires (!cuda::std::is_pointer_v<remove_cvref_t<ShapeType>>)
   __MATX_HOST__ __MATX_INLINE__ void
   Reset(T *const data, ShapeType &&shape) noexcept
   {
@@ -1545,7 +1545,7 @@ MATX_LOOP_UNROLL
       mt->version.major = DLPACK_MAJOR_VERSION;
       mt->version.minor = DLPACK_MINOR_VERSION;
       mt->flags = 0;
-      if constexpr (std::is_const_v<T>) {
+      if constexpr (cuda::std::is_const_v<T>) {
         mt->flags |= DLPACK_FLAG_BITMASK_READ_ONLY;
       }
     }

--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -1473,8 +1473,8 @@ MATX_LOOP_UNROLL
 
   template <typename ManagedType>
   ManagedType *ToDlPackImpl() const {
-    static_assert(std::is_same_v<ManagedType, DLManagedTensorVersioned> ||
-      std::is_same_v<ManagedType, DLManagedTensor>,
+    static_assert(cuda::std::is_same_v<ManagedType, DLManagedTensorVersioned> ||
+      cuda::std::is_same_v<ManagedType, DLManagedTensor>,
       "Unsupported DLPack managed tensor type");
 
     auto *mt = new ManagedType;
@@ -1541,7 +1541,7 @@ MATX_LOOP_UNROLL
     mt->manager_ctx = t_copy;
     mt->deleter = &self_type::template FreeDLPackCommon_<ManagedType>;
 
-    if constexpr (std::is_same_v<ManagedType, DLManagedTensorVersioned>) {
+    if constexpr (cuda::std::is_same_v<ManagedType, DLManagedTensorVersioned>) {
       mt->version.major = DLPACK_MAJOR_VERSION;
       mt->version.minor = DLPACK_MINOR_VERSION;
       mt->flags = 0;

--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -799,7 +799,7 @@ public:
     using Type = typename U::value_type;
     // Static descriptors have no runtime constructor, so fall back to a
     // dynamic descriptor whose shape/stride types match the original.
-    using OutDesc = std::conditional_t<
+    using OutDesc = cuda::std::conditional_t<
       is_matx_static_descriptor<Desc>,
       tensor_desc_cr_ds_t<typename Desc::shape_type, typename Desc::stride_type, RANK>,
       Desc>;
@@ -852,7 +852,7 @@ MATX_LOOP_UNROLL
     using Type = typename U::value_type;
     // Static descriptors have no runtime constructor, so fall back to a
     // dynamic descriptor whose shape/stride types match the original.
-    using OutDesc = std::conditional_t<
+    using OutDesc = cuda::std::conditional_t<
       is_matx_static_descriptor<Desc>,
       tensor_desc_cr_ds_t<typename Desc::shape_type, typename Desc::stride_type, RANK>,
       Desc>;

--- a/include/matx/core/tensor_impl.h
+++ b/include/matx/core/tensor_impl.h
@@ -181,8 +181,8 @@ class tensor_impl_t {
            detail::array_to_string(desc_.Shape()),
            detail::array_to_string(desc_.Strides()))
       );
-    }    
-#endif     
+    }
+#endif
 
     __MATX_INLINE__ tensor_impl_t(const tensor_impl_t &) = default;
     __MATX_INLINE__ tensor_impl_t(tensor_impl_t &&) = default;
@@ -772,7 +772,7 @@ MATX_IGNORE_WARNING_POP_GCC
 
         [[maybe_unused]] typename Desc::stride_type stride_mult;
 
-        if constexpr (std::is_same_v<StrideType, detail::NoStride>) {
+        if constexpr (cuda::std::is_same_v<StrideType, detail::NoStride>) {
           stride_mult = 1;
         }
         else {
@@ -1223,7 +1223,7 @@ MATX_IGNORE_WARNING_POP_GCC
     __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ decltype(auto) operator()(Is... indices) const noexcept
     {
       return this->template operator()<DefaultCapabilities>(indices...);
-    }    
+    }
 
     /**
      * operator() getter
@@ -1397,7 +1397,7 @@ MATX_IGNORE_WARNING_POP_GCC
 #else
         return "";
 #endif
-      } 
+      }
       else if constexpr (Cap == OperatorCapability::JIT_CACHE_KEY) {
 #ifdef MATX_EN_JIT
         auto key = detail::MakeJITCacheKeyForType<self_type>("JITTensorImpl");
@@ -1418,7 +1418,7 @@ MATX_IGNORE_WARNING_POP_GCC
       else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
 #ifdef MATX_EN_JIT
         const auto [key, value] = get_jit_op_str();
-      
+
         // Insert into the map if the key doesn't exist
         if (in.find(key) == in.end()) {
           in[key] = value;
@@ -1431,7 +1431,7 @@ MATX_IGNORE_WARNING_POP_GCC
       }
       else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
         // Check if this tensor's memory overlaps with the query input range
-        static_assert(std::is_same_v<remove_cvref_t<InType>, detail::AliasedMemoryQueryInput>, 
+        static_assert(cuda::std::is_same_v<remove_cvref_t<InType>, detail::AliasedMemoryQueryInput>,
                       "ALIASED_MEMORY capability requires AliasedMemoryQueryInput");
 
         // Rank 0 (scalars) don't need aliasing checks
@@ -1442,8 +1442,8 @@ MATX_IGNORE_WARNING_POP_GCC
           return false;
         }
         else {
-          // The logic to detect overlaps is as follows: If we have a complete overlap (first and last pointers are identical), 
-          // ie (a = a), then we need to check if the tensor is contiguous or if the input permutes the input and output. If either 
+          // The logic to detect overlaps is as follows: If we have a complete overlap (first and last pointers are identical),
+          // ie (a = a), then we need to check if the tensor is contiguous or if the input permutes the input and output. If either
           // of those are true then this will alias. Otherwise we have a partial overlap. For a partial overlap we always say this
           // can alias.
 
@@ -1452,7 +1452,7 @@ MATX_IGNORE_WARNING_POP_GCC
             return &(const_cast<tensor_impl_t*>(this)->operator()(static_cast<index_t>(Is*0)...));
           };
           void* tensor_start = static_cast<void*>(const_cast<T*>(get_first(cuda::std::make_index_sequence<Rank()>{})));
-          
+
           // Get address of last element using operator()(Size(0)-1, Size(1)-1, ...)
           auto get_last = [this]<size_t... Is>(cuda::std::index_sequence<Is...>) {
             return &(const_cast<tensor_impl_t*>(this)->operator()(static_cast<index_t>(Size(Is)-1)...));
@@ -1460,14 +1460,14 @@ MATX_IGNORE_WARNING_POP_GCC
           void* tensor_end = static_cast<void*>(static_cast<char*>(static_cast<void*>(const_cast<T*>(get_last(cuda::std::make_index_sequence<Rank()>{})))) + sizeof(T));
 
           bool complete_overlap = tensor_start == in.start_ptr && tensor_end == in.end_ptr;
-          if (complete_overlap) {      
+          if (complete_overlap) {
             MATX_LOG_TRACE("Complete overlap of tensors. Contiguous: {}", IsContiguous());
             return !IsContiguous() || in.permutes_input_output;
           }
-          
+
           // Check for overlap: two ranges [a1, a2) and [b1, b2) overlap if a1 < b2 && b1 < a2
           bool overlaps = (tensor_start < in.end_ptr) && (in.start_ptr < tensor_end);
-          
+
           MATX_LOG_TRACE("Overlap of tensors: {}", overlaps);
           return overlaps;
         }
@@ -1621,8 +1621,8 @@ MATX_IGNORE_WARNING_POP_GCC
       // Get the capability of the current operator node itself
       // The derived class's get_capability_impl will handle the specific logic for that operator type,
       // including querying children if it's a composite operator.
-      return false; 
-    } 
+      return false;
+    }
 
 
   protected:

--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -249,12 +249,12 @@ namespace matx
       // We can assume that if a transform is passed to the input then PreRun has already completed
       // on the transform and we can use the internal pointer
       return make_tensor<typename Op::value_type>(op.Data(), Shape(op));
-    }    
+    }
     else if constexpr (!is_tensor_view_v<Op>) {
       if constexpr (is_cuda_executor_v<Executor>) {
-        return make_tensor<typename remove_cvref<Op>::value_type>(op.Shape(), MATX_ASYNC_DEVICE_MEMORY, exec.getStream());
+        return make_tensor<remove_cvref_t<Op>>(op.Shape(), MATX_ASYNC_DEVICE_MEMORY, exec.getStream());
       } else {
-        return make_tensor<typename remove_cvref<Op>::value_type>(op.Shape(), MATX_HOST_MALLOC_MEMORY);
+        return make_tensor<remove_cvref_t<Op>>(op.Shape(), MATX_HOST_MALLOC_MEMORY);
       }
     } else {
       return op;

--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -189,7 +189,7 @@ namespace matx
 
     template <typename T> constexpr DLDataType TypeToDLPackType()
     {
-      using BaseT = std::remove_cv_t<T>;
+      using BaseT = cuda::std::remove_cv_t<T>;
       using LaneInfo = DLPackLaneInfo<BaseT>;
       using ScalarT = typename LaneInfo::scalar_type;
       constexpr uint16_t lanes = LaneInfo::lanes;

--- a/include/matx/core/tensor_utils.h
+++ b/include/matx/core/tensor_utils.h
@@ -115,47 +115,47 @@ namespace matx
 
     template <typename T> __MATX_INLINE__ std::string to_short_str() {
       if constexpr (!is_complex_v<T>) {
-        if constexpr (std::is_same_v<T, bool>)
+        if constexpr (cuda::std::is_same_v<T, bool>)
           return "b";
-        if constexpr (std::is_same_v<T, int32_t>)
+        if constexpr (cuda::std::is_same_v<T, int32_t>)
           return "i32";
-        if constexpr (std::is_same_v<T, uint32_t>)
+        if constexpr (cuda::std::is_same_v<T, uint32_t>)
           return "u32";
-        if constexpr (std::is_same_v<T, int64_t>)
+        if constexpr (cuda::std::is_same_v<T, int64_t>)
           return "i64";
-        if constexpr (std::is_same_v<T, uint64_t>)
+        if constexpr (cuda::std::is_same_v<T, uint64_t>)
           return "u64";
-        if constexpr (std::is_same_v<T, float>)
+        if constexpr (cuda::std::is_same_v<T, float>)
           return "f32";
-        if constexpr (std::is_same_v<T, double>)
+        if constexpr (cuda::std::is_same_v<T, double>)
           return "f64";
-        if constexpr (std::is_same_v<T, matxFp16>)
+        if constexpr (cuda::std::is_same_v<T, matxFp16>)
           return "f16";
-        if constexpr (std::is_same_v<T, matxBf16>)
+        if constexpr (cuda::std::is_same_v<T, matxBf16>)
           return "bf16";
         else
           return "x" + std::to_string(sizeof(T)*8);
       }
       else {
-        if constexpr (std::is_same_v<T, matxFp16ComplexPlanar>)
+        if constexpr (cuda::std::is_same_v<T, matxFp16ComplexPlanar>)
           return "f16cp";
-        if constexpr (std::is_same_v<T, matxBf16ComplexPlanar>)
+        if constexpr (cuda::std::is_same_v<T, matxBf16ComplexPlanar>)
           return "bf16cp";
-        if constexpr (std::is_same_v<T, matxFp16Complex>)
+        if constexpr (cuda::std::is_same_v<T, matxFp16Complex>)
           return "f16c";
-        if constexpr (std::is_same_v<T, matxBf16Complex>)
+        if constexpr (cuda::std::is_same_v<T, matxBf16Complex>)
           return "bf16c";
-        if constexpr (std::is_same_v<typename T::value_type, int32_t>)
+        if constexpr (cuda::std::is_same_v<typename T::value_type, int32_t>)
           return "i32c";
-        if constexpr (std::is_same_v<typename T::value_type, uint32_t>)
+        if constexpr (cuda::std::is_same_v<typename T::value_type, uint32_t>)
           return "u32c";
-        if constexpr (std::is_same_v<typename T::value_type, int64_t>)
+        if constexpr (cuda::std::is_same_v<typename T::value_type, int64_t>)
           return "i64c";
-        if constexpr (std::is_same_v<typename T::value_type, uint64_t>)
+        if constexpr (cuda::std::is_same_v<typename T::value_type, uint64_t>)
           return "u64c";
-        if constexpr (std::is_same_v<typename T::value_type, float>)
+        if constexpr (cuda::std::is_same_v<typename T::value_type, float>)
           return "f32c";
-        if constexpr (std::is_same_v<typename T::value_type, double>)
+        if constexpr (cuda::std::is_same_v<typename T::value_type, double>)
           return "f64c";
         else
           return "x" + std::to_string(sizeof(typename T::value_type)*8) + "c";
@@ -194,45 +194,45 @@ namespace matx
       using ScalarT = typename LaneInfo::scalar_type;
       constexpr uint16_t lanes = LaneInfo::lanes;
 
-      if constexpr (std::is_same_v<ScalarT, cuda::std::complex<float>> ||
-                    std::is_same_v<ScalarT, std::complex<float>>)
+      if constexpr (cuda::std::is_same_v<ScalarT, cuda::std::complex<float>> ||
+                    cuda::std::is_same_v<ScalarT, std::complex<float>>)
         return {kDLComplex, 64, lanes};
-      if constexpr (std::is_same_v<ScalarT, cuda::std::complex<double>> ||
-                    std::is_same_v<ScalarT, std::complex<double>>)
+      if constexpr (cuda::std::is_same_v<ScalarT, cuda::std::complex<double>> ||
+                    cuda::std::is_same_v<ScalarT, std::complex<double>>)
         return {kDLComplex, 128, lanes};
-      if constexpr (std::is_same_v<ScalarT, matxFp16>)
+      if constexpr (cuda::std::is_same_v<ScalarT, matxFp16>)
         return {kDLFloat, 16, lanes};
-      if constexpr (std::is_same_v<ScalarT, matxBf16>)
+      if constexpr (cuda::std::is_same_v<ScalarT, matxBf16>)
         return {kDLBfloat, 16, lanes};
-      if constexpr (std::is_same_v<ScalarT, matxFp16Complex>)
+      if constexpr (cuda::std::is_same_v<ScalarT, matxFp16Complex>)
         return {kDLComplex, 32, lanes};
-      if constexpr (std::is_same_v<ScalarT, matxBf16Complex>)
+      if constexpr (cuda::std::is_same_v<ScalarT, matxBf16Complex>)
         return {kDLComplex, 32, lanes}; // Wrong, but no other choice
-      if constexpr (std::is_same_v<ScalarT, matxFp16ComplexPlanar>)
+      if constexpr (cuda::std::is_same_v<ScalarT, matxFp16ComplexPlanar>)
         return {kDLComplex, 32, lanes};
-      if constexpr (std::is_same_v<ScalarT, matxBf16ComplexPlanar>)
+      if constexpr (cuda::std::is_same_v<ScalarT, matxBf16ComplexPlanar>)
         return {kDLComplex, 32, lanes}; // Wrong, but no other choice
-      if constexpr (std::is_same_v<ScalarT, float>)
+      if constexpr (cuda::std::is_same_v<ScalarT, float>)
         return {kDLFloat, 32, lanes};
-      if constexpr (std::is_same_v<ScalarT, double>)
+      if constexpr (cuda::std::is_same_v<ScalarT, double>)
         return {kDLFloat, 64, lanes};
-      if constexpr (std::is_same_v<ScalarT, int8_t>)
+      if constexpr (cuda::std::is_same_v<ScalarT, int8_t>)
         return {kDLInt, 8, lanes};
-      if constexpr (std::is_same_v<ScalarT, int16_t>)
+      if constexpr (cuda::std::is_same_v<ScalarT, int16_t>)
         return {kDLInt, 16, lanes};
-      if constexpr (std::is_same_v<ScalarT, int32_t>)
+      if constexpr (cuda::std::is_same_v<ScalarT, int32_t>)
         return {kDLInt, 32, lanes};
-      if constexpr (std::is_same_v<ScalarT, int64_t>)
+      if constexpr (cuda::std::is_same_v<ScalarT, int64_t>)
         return {kDLInt, 64, lanes};
-      if constexpr (std::is_same_v<ScalarT, uint8_t>)
+      if constexpr (cuda::std::is_same_v<ScalarT, uint8_t>)
         return {kDLUInt, 8, lanes};
-      if constexpr (std::is_same_v<ScalarT, uint16_t>)
+      if constexpr (cuda::std::is_same_v<ScalarT, uint16_t>)
         return {kDLUInt, 16, lanes};
-      if constexpr (std::is_same_v<ScalarT, uint32_t>)
+      if constexpr (cuda::std::is_same_v<ScalarT, uint32_t>)
         return {kDLUInt, 32, lanes};
-      if constexpr (std::is_same_v<ScalarT, uint64_t>)
+      if constexpr (cuda::std::is_same_v<ScalarT, uint64_t>)
         return {kDLUInt, 64, lanes};
-      if constexpr (std::is_same_v<ScalarT, bool>)
+      if constexpr (cuda::std::is_same_v<ScalarT, bool>)
   #if DLPACK_VERSION >= 80
         return {kDLBool, 8, lanes};
   #else

--- a/include/matx/core/type_utils.h
+++ b/include/matx/core/type_utils.h
@@ -54,20 +54,20 @@
 
 
 namespace matx {
-  
+
 
 /**
  * @brief Determine if a type is a MatX executor
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_executor = requires {
   typename remove_cvref_t<T>::matx_executor;
 };
 
 // Legacy function for backwards compatibility
-template <typename T> 
+template <typename T>
 constexpr bool is_executor_t()
 {
   return requires { typename remove_cvref_t<T>::matx_executor; };
@@ -75,83 +75,83 @@ constexpr bool is_executor_t()
 
 /**
  * @brief Determine if a type is a CUDA JIT executor
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
-concept is_jit_cuda_executor = std::is_same_v<remove_cvref_t<T>, CUDAJITExecutor>;
+template <typename T>
+concept is_jit_cuda_executor = cuda::std::is_same_v<remove_cvref_t<T>, CUDAJITExecutor>;
 
 // Legacy function for backwards compatibility
-template <typename T> 
+template <typename T>
 constexpr bool is_jit_cuda_executor_t()
 {
-  return std::is_same_v<remove_cvref_t<T>, CUDAJITExecutor>;
+  return cuda::std::is_same_v<remove_cvref_t<T>, CUDAJITExecutor>;
 }
 
 /**
  * @brief Determine if a type is a host executor
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_host_executor = requires {
   typename remove_cvref_t<T>::host_executor;
 };
 
 // Legacy variable for backwards compatibility
-template <typename T> 
+template <typename T>
 inline constexpr bool is_host_executor_v = requires { typename remove_cvref_t<T>::host_executor; };
 
 /**
  * @brief Determine if a type is a select threads host executor
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
-concept is_select_threads_host_executor = std::is_same_v<remove_cvref_t<T>, matx::SelectThreadsHostExecutor>;
+template <typename T>
+concept is_select_threads_host_executor = cuda::std::is_same_v<remove_cvref_t<T>, matx::SelectThreadsHostExecutor>;
 
 // Legacy variable for backwards compatibility
-template <typename T> 
-inline constexpr bool is_select_threads_host_executor_v = std::is_same_v<remove_cvref_t<T>, matx::SelectThreadsHostExecutor>;
+template <typename T>
+inline constexpr bool is_select_threads_host_executor_v = cuda::std::is_same_v<remove_cvref_t<T>, matx::SelectThreadsHostExecutor>;
 
 /**
  * @brief Determine if a type is a std::complex variant
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
 concept is_std_complex = requires {
-  requires std::is_same_v<remove_cvref_t<T>, std::complex<typename remove_cvref_t<T>::value_type>>;
+  requires cuda::std::is_same_v<remove_cvref_t<T>, std::complex<typename remove_cvref_t<T>::value_type>>;
 };
 
 // Legacy variable for backwards compatibility
 template <typename T>
-inline constexpr bool is_std_complex_v = requires { 
-  requires std::is_same_v<remove_cvref_t<T>, std::complex<typename remove_cvref_t<T>::value_type>>;
+inline constexpr bool is_std_complex_v = requires {
+  requires cuda::std::is_same_v<remove_cvref_t<T>, std::complex<typename remove_cvref_t<T>::value_type>>;
 };
 
 
 /**
  * @brief Determine if a type is a smart pointer (unique or shared)
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
 concept is_smart_ptr = requires {
-  requires std::is_same_v<T, std::shared_ptr<typename T::element_type>> ||
-           std::is_same_v<T, std::unique_ptr<typename T::element_type>>;
+  requires cuda::std::is_same_v<T, std::shared_ptr<typename T::element_type>> ||
+           cuda::std::is_same_v<T, std::unique_ptr<typename T::element_type>>;
 };
 
 // Legacy variable for backwards compatibility
-template <typename T> 
+template <typename T>
 inline constexpr bool is_smart_ptr_v = requires {
-  requires std::is_same_v<T, std::shared_ptr<typename T::element_type>> ||
-           std::is_same_v<T, std::unique_ptr<typename T::element_type>>;
+  requires cuda::std::is_same_v<T, std::shared_ptr<typename T::element_type>> ||
+           cuda::std::is_same_v<T, std::unique_ptr<typename T::element_type>>;
 };
 
 /**
  * @brief Determine if a type is a MatX storage type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -165,7 +165,7 @@ inline constexpr bool is_matx_storage_v = requires { typename remove_cvref_t<T>:
 
 /**
  * @brief Determine if a type is a MatX storage container
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -188,14 +188,14 @@ inline constexpr bool is_matx_storage_container_v = requires { typename remove_c
 template <typename T>
 concept has_index_cmp_op = requires {
   typename remove_cvref_t<T>::index_cmp_op;
-  requires std::is_same_v<typename remove_cvref_t<T>::index_cmp_op, bool>;
+  requires cuda::std::is_same_v<typename remove_cvref_t<T>::index_cmp_op, bool>;
 };
 
 // Legacy variable for backwards compatibility
 template <typename T>
 inline constexpr bool has_index_cmp_op_v = requires {
   typename remove_cvref_t<T>::index_cmp_op;
-  requires std::is_same_v<typename remove_cvref_t<T>::index_cmp_op, bool>;
+  requires cuda::std::is_same_v<typename remove_cvref_t<T>::index_cmp_op, bool>;
 };
 
 
@@ -228,41 +228,41 @@ typedef enum {
 
 template <typename T> constexpr MatXDataType_t TypeToInt()
 {
-  if constexpr (std::is_same_v<T, cuda::std::complex<float>>)
+  if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>)
     return MATX_TYPE_COMPLEX_FP32;
-  if constexpr (std::is_same_v<T, cuda::std::complex<double>>)
+  if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>)
     return MATX_TYPE_COMPLEX_FP64;
-  if constexpr (std::is_same_v<T, matxFp16>)
+  if constexpr (cuda::std::is_same_v<T, matxFp16>)
     return MATX_TYPE_FP16;
-  if constexpr (std::is_same_v<T, matxBf16>)
+  if constexpr (cuda::std::is_same_v<T, matxBf16>)
     return MATX_TYPE_BF16;
-  if constexpr (std::is_same_v<T, matxFp16Complex>)
+  if constexpr (cuda::std::is_same_v<T, matxFp16Complex>)
     return MATX_TYPE_COMPLEX_FP16;
-  if constexpr (std::is_same_v<T, matxBf16Complex>)
+  if constexpr (cuda::std::is_same_v<T, matxBf16Complex>)
     return MATX_TYPE_COMPLEX_BF16;
-  if constexpr (std::is_same_v<T, matxFp16ComplexPlanar>)
+  if constexpr (cuda::std::is_same_v<T, matxFp16ComplexPlanar>)
     return MATX_TYPE_COMPLEX_FP16;
-  if constexpr (std::is_same_v<T, matxBf16ComplexPlanar>)
+  if constexpr (cuda::std::is_same_v<T, matxBf16ComplexPlanar>)
     return MATX_TYPE_COMPLEX_BF16;
-  if constexpr (std::is_same_v<T, float>)
+  if constexpr (cuda::std::is_same_v<T, float>)
     return MATX_TYPE_FP32;
-  if constexpr (std::is_same_v<T, double>)
+  if constexpr (cuda::std::is_same_v<T, double>)
     return MATX_TYPE_FP64;
-  if constexpr (std::is_same_v<T, int8_t>)
+  if constexpr (cuda::std::is_same_v<T, int8_t>)
     return MATX_TYPE_INT8;
-  if constexpr (std::is_same_v<T, int16_t>)
+  if constexpr (cuda::std::is_same_v<T, int16_t>)
     return MATX_TYPE_INT16;
-  if constexpr (std::is_same_v<T, int32_t>)
+  if constexpr (cuda::std::is_same_v<T, int32_t>)
     return MATX_TYPE_INT32;
-  if constexpr (std::is_same_v<T, int64_t>)
+  if constexpr (cuda::std::is_same_v<T, int64_t>)
     return MATX_TYPE_INT64;
-  if constexpr (std::is_same_v<T, uint8_t>)
+  if constexpr (cuda::std::is_same_v<T, uint8_t>)
     return MATX_TYPE_UINT8;
-  if constexpr (std::is_same_v<T, uint16_t>)
+  if constexpr (cuda::std::is_same_v<T, uint16_t>)
     return MATX_TYPE_UINT16;
-  if constexpr (std::is_same_v<T, uint32_t>)
+  if constexpr (cuda::std::is_same_v<T, uint32_t>)
     return MATX_TYPE_UINT32;
-  if constexpr (std::is_same_v<T, uint64_t>)
+  if constexpr (cuda::std::is_same_v<T, uint64_t>)
     return MATX_TYPE_UINT64;
 
 MATX_IGNORE_WARNING_NEXT_LINE_MSVC(4702)
@@ -323,40 +323,40 @@ template <> struct IntToType<MATX_TYPE_UINT64> {
 
 template <typename T> constexpr cudaDataType_t MatXTypeToCudaType()
 {
-  if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+  if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
     return CUDA_C_32F;
   }
-  if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+  if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
     return CUDA_C_64F;
   }
-  if constexpr (std::is_same_v<T, int8_t>) {
+  if constexpr (cuda::std::is_same_v<T, int8_t>) {
     return CUDA_R_8I;
   }
-  if constexpr (std::is_same_v<T, int>) {
+  if constexpr (cuda::std::is_same_v<T, int>) {
     return CUDA_R_32I;
   }
-  if constexpr (std::is_same_v<T, float>) {
+  if constexpr (cuda::std::is_same_v<T, float>) {
     return CUDA_R_32F;
   }
-  if constexpr (std::is_same_v<T, double>) {
+  if constexpr (cuda::std::is_same_v<T, double>) {
     return CUDA_R_64F;
   }
-  if constexpr (std::is_same_v<T, matxFp16>) {
+  if constexpr (cuda::std::is_same_v<T, matxFp16>) {
     return CUDA_R_16F;
   }
-  if constexpr (std::is_same_v<T, matxBf16>) {
+  if constexpr (cuda::std::is_same_v<T, matxBf16>) {
     return CUDA_R_16BF;
   }
-  if constexpr (std::is_same_v<T, matxFp16Complex>) {
+  if constexpr (cuda::std::is_same_v<T, matxFp16Complex>) {
     return CUDA_C_16F;
   }
-  if constexpr (std::is_same_v<T, matxBf16Complex>) {
+  if constexpr (cuda::std::is_same_v<T, matxBf16Complex>) {
     return CUDA_C_16BF;
   }
-  if constexpr (std::is_same_v<T, matxFp16ComplexPlanar>) {
+  if constexpr (cuda::std::is_same_v<T, matxFp16ComplexPlanar>) {
     return CUDA_C_16F;
   }
-  if constexpr (std::is_same_v<T, matxBf16ComplexPlanar>) {
+  if constexpr (cuda::std::is_same_v<T, matxBf16ComplexPlanar>) {
     return CUDA_C_16BF;
   }
 
@@ -366,16 +366,16 @@ MATX_IGNORE_WARNING_NEXT_LINE_MSVC(4702)
 
 template <typename T> constexpr cublasComputeType_t MatXTypeToCudaComputeType()
 {
-  if constexpr (std::is_same_v<T, cuda::std::complex<float>> ||
-                std::is_same_v<T, float> || is_matx_half_v<T> ||
-                std::is_same_v<T, matxFp16Complex> ||
-                std::is_same_v<T, matxBf16Complex> ||
-                std::is_same_v<T, matxFp16ComplexPlanar> ||
-                std::is_same_v<T, matxBf16ComplexPlanar>) {
+  if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>> ||
+                cuda::std::is_same_v<T, float> || is_matx_half_v<T> ||
+                cuda::std::is_same_v<T, matxFp16Complex> ||
+                cuda::std::is_same_v<T, matxBf16Complex> ||
+                cuda::std::is_same_v<T, matxFp16ComplexPlanar> ||
+                cuda::std::is_same_v<T, matxBf16ComplexPlanar>) {
     return CUBLAS_COMPUTE_32F;
   }
-  if constexpr (std::is_same_v<T, cuda::std::complex<double>> ||
-                std::is_same_v<T, double>) {
+  if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>> ||
+                cuda::std::is_same_v<T, double>) {
     return CUBLAS_COMPUTE_64F;
   }
 
@@ -385,16 +385,16 @@ MATX_IGNORE_WARNING_NEXT_LINE_MSVC(4702)
 
 template <typename T>
 constexpr cusparseIndexType_t MatXTypeToCuSparseIndexType() {
-  if constexpr (std::is_same_v<T, uint16_t>) {
+  if constexpr (cuda::std::is_same_v<T, uint16_t>) {
     return CUSPARSE_INDEX_16U;
   }
-  if constexpr (std::is_same_v<T, int32_t>) {
+  if constexpr (cuda::std::is_same_v<T, int32_t>) {
     return CUSPARSE_INDEX_32I;
   }
-  if constexpr (std::is_same_v<T, int64_t>) {
+  if constexpr (cuda::std::is_same_v<T, int64_t>) {
     return CUSPARSE_INDEX_64I;
   }
-  if constexpr (std::is_same_v<T, index_t>) {
+  if constexpr (cuda::std::is_same_v<T, index_t>) {
     return CUSPARSE_INDEX_64I;
   }
   else { // Should not happen

--- a/include/matx/core/type_utils_both.h
+++ b/include/matx/core/type_utils_both.h
@@ -67,7 +67,7 @@ enum class MemoryLayout {
 
 /**
  * @brief Determine if a type is NoShape
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -96,16 +96,10 @@ struct shape_rank_t<detail::NoShape> {
 
 /**
  * @brief Removes cv and reference qualifiers on a type
- * 
+ *
  * @tparam T Type to remove qualifiers
  */
-template< class T >
-struct remove_cvref {
-    using type = cuda::std::remove_cv_t<cuda::std::remove_reference_t<T>>; ///< Type after removal
-};  
-
-template <typename T>
-using remove_cvref_t = typename remove_cvref<T>::type;
+using cuda::std::remove_cvref_t;
 
 template <typename T, int RANK, typename Desc, typename Data> class tensor_impl_t;
 template <typename T, int RANK, typename Desc> class tensor_t;
@@ -141,16 +135,16 @@ inline constexpr bool is_dynamic_rank_op_v =
 
 /**
  * @brief Determine if a type is a MatX tie type
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_mtie_c = requires {
   typename remove_cvref_t<T>::mtie_type;
 };
 
 // Legacy function for backwards compatibility
-template <typename T> 
+template <typename T>
 constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_mtie()
 {
   return requires { typename remove_cvref_t<T>::mtie_type; };
@@ -159,16 +153,16 @@ constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_mtie()
 
 /**
  * @brief Determine if a type is a MatX operator
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_matx_op_c = requires {
   typename remove_cvref_t<T>::matxop;
 };
 
 // Legacy function for backwards compatibility
-template <typename T> 
+template <typename T>
 constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_op()
 {
   return requires { typename remove_cvref_t<T>::matxop; };
@@ -176,36 +170,36 @@ constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_op()
 
 /**
  * @brief Determine if a type is a MatX tensor set operator
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_matx_tensor_set_op = requires {
   typename remove_cvref_t<T>::tensor_type::tensor_view;
 };
 
 /**
  * @brief Determine if a type is a MatX transform set operator
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_matx_transform_set_op = requires {
   typename remove_cvref_t<T>::op_type::matx_transform_op;
 };
 
 /**
  * @brief Determine if a type is a MatX transform operator
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_matx_transform_op_c = requires {
   typename remove_cvref_t<T>::matx_transform_op;
 };
 
 // Legacy function for backwards compatibility
-template <typename T> 
+template <typename T>
 constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_transform_op()
 {
   return requires { typename remove_cvref_t<T>::matx_transform_op; };
@@ -213,22 +207,22 @@ constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_transform_op()
 
 /**
  * @brief Determine if a type has can_alias trait
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept has_can_alias_c = requires {
   typename remove_cvref_t<T>::can_alias;
 };
 
 /**
  * @brief Determine if operator can alias
- * 
+ *
  * Returns true if the type is a transform operator and has the can_alias trait set
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 constexpr __MATX_HOST__ __MATX_DEVICE__ bool can_alias()
 {
   return is_matx_transform_op<T>() && (requires { typename remove_cvref_t<T>::can_alias; });
@@ -236,10 +230,10 @@ constexpr __MATX_HOST__ __MATX_DEVICE__ bool can_alias()
 
 /**
  * @brief Determine if a type has op_type member
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept has_matx_op_type = requires {
   typename T::op_type;
 };
@@ -248,16 +242,16 @@ concept has_matx_op_type = requires {
 
 /**
  * @brief Determine if a type is a MatX set operator
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_matx_set_op_c = requires {
   typename remove_cvref_t<T>::matx_setop;
 };
 
 // Legacy function for backwards compatibility
-template <typename T> 
+template <typename T>
 constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_set_op()
 {
   return requires { typename remove_cvref_t<T>::matx_setop; };
@@ -267,16 +261,16 @@ constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_set_op()
 
 /**
  * @brief Determine if a type is a left hand side operator
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_matx_op_lvalue_c = requires {
   typename T::matxoplvalue;
 };
 
 // Legacy function for backwards compatibility
-template <typename T> 
+template <typename T>
 constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_op_lvalue()
 {
   return requires { typename T::matxoplvalue; };
@@ -284,7 +278,7 @@ constexpr __MATX_HOST__ __MATX_DEVICE__ bool is_matx_op_lvalue()
 
 /**
  * @brief Determine if a type is a MatX tensor_t
- * 
+ *
  * @tparam T Type to test
  */
 template< class T >
@@ -298,7 +292,7 @@ inline constexpr bool is_tensor_t_v = requires { typename remove_cvref_t<T>::ten
 
 /**
  * @brief Determine if a type is a MatX tensor_impl_t
- * 
+ *
  * @tparam T Type to test
  */
 template< class T >
@@ -312,7 +306,7 @@ inline constexpr bool is_tensor_impl_v = requires { typename remove_cvref_t<T>::
 
 /**
  * @brief Determine if a type is a MatX tensor
- * 
+ *
  * @tparam T Type to test
  */
 template< class T >
@@ -330,7 +324,7 @@ inline constexpr bool is_tensor_view_v = is_tensor_v<T>;
 
 /**
  * @brief Determine if a type is a cuda::std::tuple
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -344,7 +338,7 @@ template <typename> struct is_tuple: cuda::std::false_type {};
 template <typename ...T> struct is_tuple<cuda::std::tuple<T...>>: cuda::std::true_type {};
 
 template <typename T>
-inline constexpr bool is_settable_xform_v = (requires { typename remove_cvref_t<T>::matx_setop; }) && 
+inline constexpr bool is_settable_xform_v = (requires { typename remove_cvref_t<T>::matx_setop; }) &&
                                              (requires { typename remove_cvref_t<T>::op_type::matx_transform_op; });
 
 
@@ -352,7 +346,7 @@ inline constexpr bool is_settable_xform_v = (requires { typename remove_cvref_t<
 
 /**
  * @brief Determine if a type is a MatX reduction
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -366,7 +360,7 @@ inline constexpr bool is_matx_reduction_v = requires { typename T::matx_reduce; 
 
 /**
  * @brief Determine if a type is a MatX index reduction type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -380,7 +374,7 @@ inline constexpr bool is_matx_index_reduction_v = requires { typename T::matx_re
 
 /**
  * @brief Determine if a type is not allowed to use CUB for reductions
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -397,7 +391,7 @@ inline constexpr bool is_matx_no_cub_reduction_v = requires { typename T::matx_n
 
 /**
  * @brief Determine if a type is a cuda::std::complex variant
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -416,10 +410,10 @@ inline constexpr bool is_cuda_complex_v = requires {
 
 /**
  * @brief Determine if a type is a device executor
- * 
+ *
  * @tparam T Type to test
  */
-template <typename T> 
+template <typename T>
 concept is_cuda_executor = requires {
   typename remove_cvref_t<T>::cuda_executor;
 };
@@ -437,7 +431,7 @@ inline constexpr bool is_distributed_executor_v =
 
 /**
  * @brief Determine if a type is a CUDA executor but NOT a JIT CUDA executor
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -463,10 +457,10 @@ inline constexpr bool is_cuda_jit_executor_v = requires { typename remove_cvref_
 
 /**
  * @brief Determine if a type is a complex type (any type supported)
- * 
+ *
  * @tparam T Type to test
  */
-template <class T> 
+template <class T>
 concept is_complex = cuda::std::is_same_v<remove_cvref_t<T>, cuda::std::complex<float>> ||
                      cuda::std::is_same_v<remove_cvref_t<T>, cuda::std::complex<double>> ||
                      cuda::std::is_same_v<remove_cvref_t<T>, matxFp16Complex> ||
@@ -475,7 +469,7 @@ concept is_complex = cuda::std::is_same_v<remove_cvref_t<T>, cuda::std::complex<
                      cuda::std::is_same_v<remove_cvref_t<T>, matxBf16ComplexPlanar>;
 
 // Legacy variable for backwards compatibility
-template <class T> 
+template <class T>
 inline constexpr bool is_complex_v = cuda::std::is_same_v<remove_cvref_t<T>, cuda::std::complex<float>> ||
                                      cuda::std::is_same_v<remove_cvref_t<T>, cuda::std::complex<double>> ||
                                      cuda::std::is_same_v<remove_cvref_t<T>, matxFp16Complex> ||
@@ -550,46 +544,46 @@ struct inner_op_type_t {
 };
 
 template <is_complex T>
-struct inner_op_type_t<T> { 
+struct inner_op_type_t<T> {
   using type = typename T::value_type;
 };
 
 
 /**
  * @brief Determine if a type is a BF16 type
- * 
+ *
  * @tparam T Type to test
  */
-template <class T> 
+template <class T>
 concept is_bf16_type = cuda::std::is_same_v<T, matxBf16Complex> ||
                        cuda::std::is_same_v<T, matxBf16ComplexPlanar> ||
                        cuda::std::is_same_v<T, matxBf16>;
 
 // Legacy variable for backwards compatibility
-template <class T> 
+template <class T>
 inline constexpr bool is_bf16_type_v = cuda::std::is_same_v<T, matxBf16Complex> ||
                                        cuda::std::is_same_v<T, matxBf16ComplexPlanar> ||
                                        cuda::std::is_same_v<T, matxBf16>;
 
 /**
  * @brief Determine if a type is an FP16 type
- * 
+ *
  * @tparam T Type to test
  */
-template <class T> 
+template <class T>
 concept is_fp16_type = cuda::std::is_same_v<T, matxFp16Complex> ||
                        cuda::std::is_same_v<T, matxFp16ComplexPlanar> ||
                        cuda::std::is_same_v<T, matxFp16>;
 
 // Legacy variable for backwards compatibility
-template <class T> 
+template <class T>
 inline constexpr bool is_fp16_type_v = cuda::std::is_same_v<T, matxFp16Complex> ||
                                        cuda::std::is_same_v<T, matxFp16ComplexPlanar> ||
                                        cuda::std::is_same_v<T, matxFp16>;
 
 /**
  * @brief Determine if the inner type is an FP32 type
- * 
+ *
  * @tparam T Type to test
  */
 template<typename T>
@@ -597,7 +591,7 @@ inline constexpr bool is_fp32_inner_type_v = cuda::std::is_same_v<typename inner
 
 /**
  * @brief Determine if the inner type is an FP64 type
- * 
+ *
  * @tparam T Type to test
  */
 template<typename T>
@@ -605,7 +599,7 @@ inline constexpr bool is_fp64_inner_type_v = cuda::std::is_same_v<typename inner
 
 /**
  * @brief Determine if a type is a MatX shape type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -616,11 +610,11 @@ concept is_matx_shape = requires {
 // Legacy variable for backwards compatibility
 template <typename T>
 inline constexpr bool is_matx_shape_v = requires { typename remove_cvref_t<T>::matx_shape; };
- 
+
 
 /**
  * @brief Determine if a type is a complex half precision type
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -643,7 +637,7 @@ inline constexpr bool is_planar_complex_v =
 
 /**
  * @brief Tests if a type is a half precision floating point
- * 
+ *
  * @tparam T Type to test
  * @return True if half precision floating point
  */
@@ -654,7 +648,7 @@ template <typename T> constexpr inline __MATX_HOST__ __MATX_DEVICE__ bool IsHalf
 
 /**
  * @brief Determine if a type is a MatX half precision wrapper (either matxFp16 or matxBf16)
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -668,21 +662,21 @@ inline constexpr bool is_matx_half_v = cuda::std::is_same_v<cuda::std::remove_cv
 
 /**
  * @brief Determine if a type is half precision (either __half or __nv_bfloat16)
- * 
+ *
  * @tparam T Type to test
  */
-template <class T> 
+template <class T>
 concept is_half = cuda::std::is_same_v<cuda::std::remove_cv_t<T>, __half> ||
                   cuda::std::is_same_v<cuda::std::remove_cv_t<T>, __nv_bfloat16>;
 
 // Legacy variable for backwards compatibility
-template <class T> 
+template <class T>
 inline constexpr bool is_half_v = cuda::std::is_same_v<cuda::std::remove_cv_t<T>, __half> ||
                                   cuda::std::is_same_v<cuda::std::remove_cv_t<T>, __nv_bfloat16>;
 
 /**
  * @brief Determine if a type is a MatX custom type (half precision wrappers)
- * 
+ *
  * @tparam T Type to test
  */
 template <class T>
@@ -716,7 +710,7 @@ struct extract_value_type_impl<T> {
 
 /**
  * @brief Extract the value_type type
- * 
+ *
  * @tparam T Type to extract from
  */
 template <typename T>
@@ -724,7 +718,7 @@ using extract_value_type_t = typename detail::extract_value_type_impl<cuda::std:
 
 /**
  * @brief Promote half precision floating point value to fp32, or leave untouched if not half
- * 
+ *
  * @tparam T Type to convert
  */
 template <typename T>
@@ -732,7 +726,7 @@ using promote_half_t = typename cuda::std::conditional_t<is_half_v<T> || is_matx
 
 /**
  * @brief Determine if a type is a MatX descriptor
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -746,7 +740,7 @@ inline constexpr bool is_matx_descriptor_v = requires { typename remove_cvref_t<
 
 /**
  * @brief Determine if a type is a MatX static descriptor
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -760,43 +754,43 @@ inline constexpr bool is_matx_static_descriptor_v = requires { typename remove_c
 
 
 namespace detail {
-  
-template <typename T> 
+
+template <typename T>
 struct convert_matx_type {
   using type = T;
 };
 
-template <> 
+template <>
 struct convert_matx_type<matxFp16> {
   using type = __half;
 };
 
-template <> 
+template <>
 struct convert_matx_type<matxBf16> {
   using type = __nv_bfloat16;
 };
 
 
 
-template <typename T> 
+template <typename T>
 using convert_matx_type_t = typename convert_matx_type<T>::type;
 
-template <typename T> 
+template <typename T>
 struct convert_half_to_matx_half {
   using type = T;
 };
 
-template <> 
+template <>
 struct convert_half_to_matx_half<__half> {
   using type = matxFp16;
 };
 
-template <> 
+template <>
 struct convert_half_to_matx_half<__nv_bfloat16> {
   using type = matxBf16;
 };
 
-template <typename T> 
+template <typename T>
 using convert_half_to_matx_half_t = typename convert_half_to_matx_half<T>::type;
 
 
@@ -816,24 +810,24 @@ constexpr __MATX_HOST__ __MATX_DEVICE__ cuda::std::array<cuda::std::remove_cv_t<
 
 
 
-template <typename T> 
+template <typename T>
 struct complex_from_scalar {
   using type = T;
 };
 
-template <typename T> 
+template <typename T>
   requires (cuda::std::is_same_v<float, T> || cuda::std::is_same_v<double, T>)
 struct complex_from_scalar<T> {
   using type = cuda::std::complex<T>;
 };
 
-template <typename T> 
+template <typename T>
   requires (is_matx_half<T> || is_half<T>)
 struct complex_from_scalar<T> {
   using type = matxHalfComplex<typename convert_half_to_matx_half<T>::type>;
 };
 
-template <typename T> using complex_from_scalar_t = typename complex_from_scalar<typename remove_cvref<T>::type>::type;
+template <typename T> using complex_from_scalar_t = typename complex_from_scalar<remove_cvref_t<T>>::type;
 
 
 
@@ -853,7 +847,7 @@ struct cuda_complex_type_of
 template <class C>
 using matx_convert_cuda_complex_type =
     typename cuda::std::conditional_t<!is_complex_v<C>, identity<C>,
-                                cuda_complex_type_of<C>>::type;                                
+                                cuda_complex_type_of<C>>::type;
 
 #ifndef __CUDACC_RTC__
 template <class C>
@@ -865,7 +859,7 @@ struct complex_type_of
 template <class C>
 using matx_convert_complex_type =
     typename cuda::std::conditional_t<!is_complex_v<C>, identity<C>,
-                                complex_type_of<C>>::type;                         
+                                complex_type_of<C>>::type;
 #endif
 
 template <class T, class = void> struct value_type {
@@ -935,30 +929,30 @@ struct permute_rank {
 template <typename T1>
 struct permute_rank<T1, no_permute_t> {
   static const int rank = 0;
-};  
+};
 
 
 
 template <typename T, int RANK, typename Storage, typename Desc> class tensor_t;
 template <typename T, int RANK, typename Desc, typename Data> class tensor_impl_t;
 // Traits for casting down to impl tensor conditionally
-template <typename T> 
+template <typename T>
 struct base_type {
   using type = T;
 };
 
-template <is_tensor_t T> 
+template <is_tensor_t T>
 struct base_type<T> {
   using type = tensor_impl_t<typename T::value_type, T::Rank(), typename T::desc_type, typename T::data_type>;
 };
 
-template <typename T> using base_type_t = typename base_type<typename remove_cvref<T>::type>::type;
+template <typename T> using base_type_t = typename base_type<remove_cvref_t<T>>::type;
 
 }
 
 /**
  * @brief Determine if a type is a MatX sparse data type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -971,7 +965,7 @@ template <typename T>
 inline constexpr bool is_sparse_data_v = requires { typename remove_cvref_t<T>::sparse_data; };
 /**
  * @brief Determine if a type is a MatX sparse tensor type
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -994,7 +988,7 @@ namespace detail {
 
 /**
  * @brief Determine if a type is std::array or cuda::std::array
- * 
+ *
  * @tparam T Type to test
  */
 template<typename T>
@@ -1007,14 +1001,14 @@ concept is_std_array_c = requires {
 namespace detail {
   template<typename T> struct is_std_array : cuda::std::false_type {};
   template<typename T, size_t N> struct is_std_array<cuda::std::array<T, N>> : cuda::std::true_type {};
-#ifndef __CUDACC_RTC__  
+#ifndef __CUDACC_RTC__
   template<typename T, size_t N> struct is_std_array<std::array<T, N>> : cuda::std::true_type {};
 #endif
   template <typename T> inline constexpr bool is_std_array_v = is_std_array_c<T>;
 
 /**
  * @brief Determine if a type is a MatX JIT class
- * 
+ *
  * @tparam T Type to test
  */
 template <typename T>
@@ -1031,56 +1025,56 @@ struct is_matx_jit_class_impl<T, cuda::std::void_t<typename remove_cvref_t<T>::e
     : cuda::std::true_type {};
 
 template <typename T>
-inline constexpr bool is_matx_jit_class_v = (requires { typename remove_cvref_t<T>::matxop; }) || 
+inline constexpr bool is_matx_jit_class_v = (requires { typename remove_cvref_t<T>::matxop; }) ||
                                             (requires { typename remove_cvref_t<T>::emits_jit_str; });
-  
-}  
+
+}
 
 namespace detail {
-  template <typename T> 
+  template <typename T>
   struct inner_precision {
     using type = T;
   };
 
-  template <> 
+  template <>
   struct inner_precision<cuda::std::complex<float>> {
     using type = float;
-  };  
+  };
 
-  template <> 
+  template <>
   struct inner_precision<cuda::std::complex<double>> {
     using type = double;
-  };  
-  
-  template <> 
+  };
+
+  template <>
   struct inner_precision<matxFp16> {
     using type = __half;
   };
-  
-  template <> 
+
+  template <>
   struct inner_precision<matxBf16> {
     using type = __nv_bfloat16;
   };
-  
-  template <> 
+
+  template <>
   struct inner_precision<matxFp16Complex> {
     using type = __half;
   };
-  
-  template <> 
+
+  template <>
   struct inner_precision<matxFp16ComplexPlanar> {
     using type = __half;
   };
-  
-  template <> 
+
+  template <>
   struct inner_precision<matxBf16Complex> {
     using type = __nv_bfloat16;
   };
-  
-  template <> 
+
+  template <>
   struct inner_precision<matxBf16ComplexPlanar> {
     using type = __nv_bfloat16;
-  };  
+  };
 }
 
 namespace detail {
@@ -1089,16 +1083,16 @@ namespace detail {
   struct VecTypeSelector {
     // Helper to make static_assert dependent on template parameters
     static constexpr bool always_false = sizeof(T) == 0;
-  
+
     static_assert(N >= 1 && N <= 4, "VecTypeSelector only supports vector sizes 1, 2, 3, and 4");
     static_assert(always_false, "VecTypeSelector: No specialization available for this type and size combination. Check the documentation for supported types.");
   };
-  
+
   template <> struct VecTypeSelector<float, 1> { using type = float1; };
   template <> struct VecTypeSelector<float, 2> { using type = float2; };
   template <> struct VecTypeSelector<float, 3> { using type = float3; };
   template <> struct VecTypeSelector<float, 4> { using type = float4; };
-  
+
   template <> struct VecTypeSelector<double, 1> { using type = double1; };
   template <> struct VecTypeSelector<double, 2> { using type = double2; };
   template <> struct VecTypeSelector<double, 3> { using type = double3; };
@@ -1107,37 +1101,37 @@ namespace detail {
   #else
   template <> struct VecTypeSelector<double, 4> { using type = double4; };
   #endif
-  
+
   template <> struct VecTypeSelector<char, 1> { using type = char1; };
   template <> struct VecTypeSelector<char, 2> { using type = char2; };
   template <> struct VecTypeSelector<char, 3> { using type = char3; };
   template <> struct VecTypeSelector<char, 4> { using type = char4; };
-  
+
   template <> struct VecTypeSelector<unsigned char, 1> { using type = uchar1; };
   template <> struct VecTypeSelector<unsigned char, 2> { using type = uchar2; };
   template <> struct VecTypeSelector<unsigned char, 3> { using type = uchar3; };
   template <> struct VecTypeSelector<unsigned char, 4> { using type = uchar4; };
-  
+
   template <> struct VecTypeSelector<short, 1> { using type = short1; };
   template <> struct VecTypeSelector<short, 2> { using type = short2; };
   template <> struct VecTypeSelector<short, 3> { using type = short3; };
   template <> struct VecTypeSelector<short, 4> { using type = short4; };
-  
+
   template <> struct VecTypeSelector<unsigned short, 1> { using type = ushort1; };
   template <> struct VecTypeSelector<unsigned short, 2> { using type = ushort2; };
   template <> struct VecTypeSelector<unsigned short, 3> { using type = ushort3; };
   template <> struct VecTypeSelector<unsigned short, 4> { using type = ushort4; };
-  
+
   template <> struct VecTypeSelector<int, 1> { using type = int1; };
   template <> struct VecTypeSelector<int, 2> { using type = int2; };
   template <> struct VecTypeSelector<int, 3> { using type = int3; };
   template <> struct VecTypeSelector<int, 4> { using type = int4; };
-  
+
   template <> struct VecTypeSelector<unsigned int, 1> { using type = uint1; };
   template <> struct VecTypeSelector<unsigned int, 2> { using type = uint2; };
   template <> struct VecTypeSelector<unsigned int, 3> { using type = uint3; };
   template <> struct VecTypeSelector<unsigned int, 4> { using type = uint4; };
-  
+
   template <> struct VecTypeSelector<long, 1> { using type = long1; };
   template <> struct VecTypeSelector<long, 2> { using type = long2; };
   template <> struct VecTypeSelector<long, 3> { using type = long3; };
@@ -1146,7 +1140,7 @@ namespace detail {
   #else
   template <> struct VecTypeSelector<long, 4> { using type = long4; };
   #endif
-  
+
   template <> struct VecTypeSelector<unsigned long, 1> { using type = ulong1; };
   template <> struct VecTypeSelector<unsigned long, 2> { using type = ulong2; };
   template <> struct VecTypeSelector<unsigned long, 3> { using type = ulong3; };
@@ -1155,7 +1149,7 @@ namespace detail {
   #else
   template <> struct VecTypeSelector<unsigned long, 4> { using type = ulong4; };
   #endif
-  
+
   template <> struct VecTypeSelector<long long, 1> { using type = longlong1; };
   template <> struct VecTypeSelector<long long, 2> { using type = longlong2; };
   template <> struct VecTypeSelector<long long, 3> { using type = longlong3; };
@@ -1164,7 +1158,7 @@ namespace detail {
   #else
   template <> struct VecTypeSelector<long long, 4> { using type = longlong4; };
   #endif
-  
+
   template <> struct VecTypeSelector<unsigned long long, 1> { using type = ulonglong1; };
   template <> struct VecTypeSelector<unsigned long long, 2> { using type = ulonglong2; };
   template <> struct VecTypeSelector<unsigned long long, 3> { using type = ulonglong3; };
@@ -1173,25 +1167,25 @@ namespace detail {
   #else
   template <> struct VecTypeSelector<unsigned long long, 4> { using type = ulonglong4; };
   #endif
-  
+
   template <typename... Ts>
   struct AggregateToVec {
     static_assert(sizeof...(Ts) > 0, "AggregateToVec requires at least one type");
-  
+
   private:
     static constexpr bool any_half = ((is_half_v<Ts> || is_matx_half_v<Ts>) || ...);
-  
+
   public:
     using common_type = cuda::std::common_type_t<Ts...>;
-  
+
     static_assert(!cuda::std::is_void_v<common_type>, "Types must have a common type");
     static_assert(!any_half,  "zipvec does not support input operators with half types");
-  
+
     using type = typename VecTypeSelector<common_type, sizeof...(Ts)>::type;
   };
-  
+
   template <typename... Ts>
-  using AggregateToVecType = typename AggregateToVec<Ts...>::type;  
+  using AggregateToVecType = typename AggregateToVec<Ts...>::type;
 
   template <typename T>
   struct DLPackLaneInfo {

--- a/include/matx/core/utils.h
+++ b/include/matx/core/utils.h
@@ -94,7 +94,7 @@ bool SizesMatch(const Op1 &op1, const Op2 &op2) {
 
 
 template <int RANK, typename T>
-  requires (!std::is_array_v<remove_cvref_t<T>>)
+  requires (!cuda::std::is_array_v<remove_cvref_t<T>>)
 auto __MATX_INLINE__ getPermuteDims(T dims) {
   constexpr auto D = dims.size();
   cuda::std::array<int, RANK> perm;

--- a/include/matx/core/utils.h
+++ b/include/matx/core/utils.h
@@ -208,7 +208,7 @@ __MATX_HOST__ __MATX_DEVICE__ __MATX_INLINE__ auto madd( const T1 &x, const T2 &
     Z.imag(Z.imag() + xr*yi);
 
     return Z;
-  } else if constexpr (std::is_same_v<T4, matxFp16Complex>) {
+  } else if constexpr (cuda::std::is_same_v<T4, matxFp16Complex>) {
     //__half2 X = make_half2(x.real(), x.imag());
     //__half2 Y = make_half2(y.real(), y.imag());
     //__half2 Z = make_half2(z.real(), z.imag());
@@ -299,80 +299,80 @@ template <typename T>
 __MATX_INLINE__ __MATX_HOST__  std::string type_to_string()
 {
   // Handle standard POD types
-  if constexpr (std::is_same_v<T, float>) {
+  if constexpr (cuda::std::is_same_v<T, float>) {
     return "float";
   }
-  else if constexpr (std::is_same_v<T, double>) {
+  else if constexpr (cuda::std::is_same_v<T, double>) {
     return "double";
   }
-  else if constexpr (std::is_same_v<T, int>) {
+  else if constexpr (cuda::std::is_same_v<T, int>) {
     return "int";
   }
-  else if constexpr (std::is_same_v<T, unsigned int>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned int>) {
     return "unsigned int";
   }
-  else if constexpr (std::is_same_v<T, long>) {
+  else if constexpr (cuda::std::is_same_v<T, long>) {
     return "long";
   }
-  else if constexpr (std::is_same_v<T, unsigned long>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned long>) {
     return "unsigned long";
   }
-  else if constexpr (std::is_same_v<T, long long>) {
+  else if constexpr (cuda::std::is_same_v<T, long long>) {
     return "long long";
   }
-  else if constexpr (std::is_same_v<T, unsigned long long>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned long long>) {
     return "unsigned long long";
   }
-  else if constexpr (std::is_same_v<T, short>) {
+  else if constexpr (cuda::std::is_same_v<T, short>) {
     return "short";
   }
-  else if constexpr (std::is_same_v<T, unsigned short>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned short>) {
     return "unsigned short";
   }
-  else if constexpr (std::is_same_v<T, char>) {
+  else if constexpr (cuda::std::is_same_v<T, char>) {
     return "char";
   }
-  else if constexpr (std::is_same_v<T, signed char>) {
+  else if constexpr (cuda::std::is_same_v<T, signed char>) {
     return "signed char";
   }
-  else if constexpr (std::is_same_v<T, unsigned char>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned char>) {
     return "unsigned char";
   }
-  else if constexpr (std::is_same_v<T, bool>) {
+  else if constexpr (cuda::std::is_same_v<T, bool>) {
     return "bool";
   }
-  else if constexpr (std::is_same_v<T, __half>) {
+  else if constexpr (cuda::std::is_same_v<T, __half>) {
     return "__half";
   }
-  else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+  else if constexpr (cuda::std::is_same_v<T, __nv_bfloat16>) {
     return "__nv_bfloat16";
   }
-  else if constexpr (std::is_same_v<T, matxFp16>) {
+  else if constexpr (cuda::std::is_same_v<T, matxFp16>) {
     return "matx::matxFp16";
   }
-  else if constexpr (std::is_same_v<T, matxBf16>) {
+  else if constexpr (cuda::std::is_same_v<T, matxBf16>) {
     return "matx::matxBf16";
   }
-  else if constexpr (std::is_same_v<T, matxFp16Complex>) {
+  else if constexpr (cuda::std::is_same_v<T, matxFp16Complex>) {
     return "matx::matxFp16Complex";
   }
-  else if constexpr (std::is_same_v<T, matxBf16Complex>) {
+  else if constexpr (cuda::std::is_same_v<T, matxBf16Complex>) {
     return "matx::matxBf16Complex";
   }
-  else if constexpr (std::is_same_v<T, matxFp16ComplexPlanar>) {
+  else if constexpr (cuda::std::is_same_v<T, matxFp16ComplexPlanar>) {
     return "matx::matxFp16ComplexPlanar";
   }
-  else if constexpr (std::is_same_v<T, matxBf16ComplexPlanar>) {
+  else if constexpr (cuda::std::is_same_v<T, matxBf16ComplexPlanar>) {
     return "matx::matxBf16ComplexPlanar";
   }
   // CCCL complex types
-  else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
     return "cuda::std::complex<float>";
   }
-  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
     return "cuda::std::complex<double>";
   }
-  else if constexpr (std::is_same_v<T, index_t>) {
+  else if constexpr (cuda::std::is_same_v<T, index_t>) {
     return "index_t";
   }
   // fallback: use typeid if available, or unknown
@@ -385,49 +385,49 @@ __MATX_INLINE__ __MATX_HOST__  std::string type_to_string()
 template <typename T>
 __MATX_INLINE__ __MATX_HOST__  std::string type_to_string_c_name()
 {
-  if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+  if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
     return "cuda_std_complex_float";
   }
-  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
     return "cuda_std_complex_double";
   }
-  else if constexpr (std::is_same_v<T, unsigned int>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned int>) {
     return "unsigned_int";
   }
-  else if constexpr (std::is_same_v<T, unsigned long>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned long>) {
     return "unsigned_long";
   }
-  else if constexpr (std::is_same_v<T, unsigned long long>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned long long>) {
     return "unsigned_long_long";
   }
-  else if constexpr (std::is_same_v<T, unsigned short>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned short>) {
     return "unsigned_short";
   }
-  else if constexpr (std::is_same_v<T, unsigned char>) {
+  else if constexpr (cuda::std::is_same_v<T, unsigned char>) {
     return "unsigned_char";
   }
-  else if constexpr (std::is_same_v<T, signed char>) {
+  else if constexpr (cuda::std::is_same_v<T, signed char>) {
     return "signed_char";
   }
-  else if constexpr (std::is_same_v<T, long long>) {
+  else if constexpr (cuda::std::is_same_v<T, long long>) {
     return "long_long";
   }
-  else if constexpr (std::is_same_v<T, matxFp16>) {
+  else if constexpr (cuda::std::is_same_v<T, matxFp16>) {
     return "matx_matxFp16";
   }
-  else if constexpr (std::is_same_v<T, matxBf16>) {
+  else if constexpr (cuda::std::is_same_v<T, matxBf16>) {
     return "matx_matxBf16";
-  }  
-  else if constexpr (std::is_same_v<T, matxFp16Complex>) {
+  }
+  else if constexpr (cuda::std::is_same_v<T, matxFp16Complex>) {
     return "matx_matxFp16Complex";
   }
-  else if constexpr (std::is_same_v<T, matxBf16Complex>) {
+  else if constexpr (cuda::std::is_same_v<T, matxBf16Complex>) {
     return "matx_matxBf16Complex";
   }
-  else if constexpr (std::is_same_v<T, matxFp16ComplexPlanar>) {
+  else if constexpr (cuda::std::is_same_v<T, matxFp16ComplexPlanar>) {
     return "matx_matxFp16ComplexPlanar";
   }
-  else if constexpr (std::is_same_v<T, matxBf16ComplexPlanar>) {
+  else if constexpr (cuda::std::is_same_v<T, matxBf16ComplexPlanar>) {
     return "matx_matxBf16ComplexPlanar";
   }
   else {
@@ -449,17 +449,17 @@ auto get_jit_class_or_pod_name(const T& op)
 
 /**
  * @brief Convert a number to a valid C++ symbol/identifier string
- * 
+ *
  * Formats a numeric value as a string that can be used in C++ variable names.
  * For complex numbers, the format is "r{real}_i{imag}".
  * For non-complex numbers, the format is the string representation of the value.
- * Special characters like '.' and '-' are replaced with 'p' (for point) and 
+ * Special characters like '.' and '-' are replaced with 'p' (for point) and
  * 'n' (for negative) respectively.
- * 
+ *
  * @tparam T Numeric type (can be complex or non-complex)
  * @param val Numeric value to convert
  * @return String representation safe for use in C++ identifiers
- * 
+ *
  * @example
  * number_to_symbol(cuda::std::complex<float>{1.5, -2.3}) returns "r1p5_in2p3"
  * number_to_symbol(3.14f) returns "3p14"

--- a/include/matx/core/vector.h
+++ b/include/matx/core/vector.h
@@ -151,7 +151,7 @@ struct is_vector<T, cuda::std::void_t<typename T::matx_vec>>
 
 
 template< class T >
-inline constexpr bool is_vector_v = detail::is_vector<typename remove_cvref<T>::type>::value;
+inline constexpr bool is_vector_v = detail::is_vector<remove_cvref_t<T>>::value;
 
 
 

--- a/include/matx/executors/support.h
+++ b/include/matx/executors/support.h
@@ -51,7 +51,7 @@ namespace matx {
   #define MATX_EN_CPU_MATMUL 1
 #else
   #define MATX_EN_CPU_MATMUL 0
-#endif  
+#endif
 
 // Solver
 #if defined(MATX_EN_NVPL) || defined(MATX_EN_OPENBLAS_LAPACK)
@@ -104,10 +104,10 @@ constexpr bool Check2DConvSupport() {
 template <typename Exec, typename T>
 constexpr bool CheckMatMulSupport() {
   if constexpr (is_host_executor_v<Exec>) {
-    if constexpr (std::is_same_v<T, float> ||
-                  std::is_same_v<T, double> ||
-                  std::is_same_v<T, cuda::std::complex<float>> ||
-                  std::is_same_v<T, cuda::std::complex<double>>) {
+    if constexpr (cuda::std::is_same_v<T, float> ||
+                  cuda::std::is_same_v<T, double> ||
+                  cuda::std::is_same_v<T, cuda::std::complex<float>> ||
+                  cuda::std::is_same_v<T, cuda::std::complex<double>>) {
       return MATX_EN_CPU_MATMUL;
     } else {
       return false;

--- a/include/matx/generators/bartlett.h
+++ b/include/matx/generators/bartlett.h
@@ -62,7 +62,7 @@ namespace matx
 
         __MATX_INLINE__ auto get_jit_op_str() const {
           std::string func_name = get_jit_class_name();
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::string("template <typename T> struct " + func_name + " {\n") +
@@ -160,7 +160,7 @@ namespace matx
     requires (!cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
   inline auto bartlett(ShapeType &&s)
              {
-               constexpr int RANK = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+               constexpr int RANK = cuda::std::tuple_size<cuda::std::decay_t<ShapeType>>::value;
                static_assert(RANK > Dim);
                detail::Bartlett<T> h( *(s.begin() + Dim));
                return detail::matxGenerator1D_t<detail::Bartlett<T>, Dim, ShapeType>(std::forward<ShapeType>(s), h);

--- a/include/matx/generators/blackman.h
+++ b/include/matx/generators/blackman.h
@@ -62,7 +62,7 @@ namespace matx
 
         __MATX_INLINE__ auto get_jit_op_str() const {
           std::string func_name = get_jit_class_name();
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::string("template <typename T> struct " + func_name + " {\n") +
@@ -161,7 +161,7 @@ namespace matx
     requires (!cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
   inline auto blackman(ShapeType &&s)
              {
-               constexpr int RANK = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+               constexpr int RANK = cuda::std::tuple_size<cuda::std::decay_t<ShapeType>>::value;
                static_assert(RANK > Dim);
                detail::Blackman<T> h( *(s.begin() + Dim));
                return detail::matxGenerator1D_t<detail::Blackman<T>, Dim, ShapeType>(std::forward<ShapeType>(s), h);

--- a/include/matx/generators/diag.h
+++ b/include/matx/generators/diag.h
@@ -37,7 +37,7 @@
 namespace matx
 {
   namespace detail {
-    template <typename T, typename ShapeType> 
+    template <typename T, typename ShapeType>
       class Diag : public BaseOp<Diag<T, ShapeType>>{
       static constexpr int RANK = shape_rank_t<ShapeType>::value;
 
@@ -61,7 +61,7 @@ namespace matx
 
       __MATX_INLINE__ std::string get_jit_class_name() const {
         std::string val_str;
-        if constexpr (std::is_floating_point_v<T>) {
+        if constexpr (cuda::std::is_floating_point_v<T>) {
           val_str = std::format("{}", val_);
         } else {
           val_str = std::to_string(val_);
@@ -75,7 +75,7 @@ namespace matx
         for (int i = 0; i < Rank(); ++i) {
           out_dims_[i] = Size(i);
         }
-        
+
         return cuda::std::make_tuple(
           func_name,
           std::format("template <typename T> struct {} {{\n"
@@ -138,7 +138,7 @@ namespace matx
         else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
           const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
           return my_cap;
-        } else {        
+        } else {
           return detail::capability_attributes<Cap>::default_value;
         }
       }
@@ -168,7 +168,7 @@ namespace matx
           return index_t(0);
         }
       }
-      static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { 
+      static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() {
         if constexpr (!is_noshape_v<ShapeType>) {
           return RANK;
         }
@@ -190,7 +190,7 @@ namespace matx
    * can be deduced by other contexts.
    *
    * @tparam T Data type
-   * 
+   *
    * @param val Value to return
    *
    */
@@ -229,7 +229,7 @@ namespace matx
    *
    * @tparam T Data type
    * @tparam RANK Rank of input
-   * 
+   *
    * @param s Array of operator dimensions
    * @param val Value to return
    *
@@ -280,7 +280,7 @@ namespace matx
    *
    * eye() returns 1 on all elements on the diagonals of a tensor, and 0 otherwise.
    * In other words, if the index of every dimension is the same, a 1 is returned,
-   * otherwise a zero is returned. This version of eye() is shapeless and can be indexed 
+   * otherwise a zero is returned. This version of eye() is shapeless and can be indexed
    * using any input dimension and it will return a valid value. It is preferred to use
    * it over the shaped versions if the shape can be deduced by other contexts.
    *

--- a/include/matx/generators/flattop.h
+++ b/include/matx/generators/flattop.h
@@ -48,7 +48,7 @@ namespace matx
         static constexpr T a1 = static_cast<T>(0.41663158);
         static constexpr T a2 = static_cast<T>(0.277263158);
         static constexpr T a3 = static_cast<T>(0.083578947);
-        static constexpr T a4 = static_cast<T>(0.006947368);  
+        static constexpr T a4 = static_cast<T>(0.006947368);
 
       public:
         using value_type = T;
@@ -69,7 +69,7 @@ namespace matx
 
         __MATX_INLINE__ auto get_jit_op_str() const {
           std::string func_name = get_jit_class_name();
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::string("template <typename T> struct " + func_name + " {\n") +
@@ -109,7 +109,7 @@ namespace matx
         {
           return detail::ApplyGeneratorVecFunc<CapType, T>([this](index_t idx) {
             static constexpr T tmp_pi = cuda::std::numbers::pi;
-            return  a0  
+            return  a0
               - a1 * cuda::std::cos(static_cast<T>(2)*tmp_pi*idx / (size_ - 1))
               + a2 * cuda::std::cos(static_cast<T>(4)*tmp_pi*idx / (size_ - 1))
               - a3 * cuda::std::cos(static_cast<T>(6)*tmp_pi*idx / (size_ - 1))
@@ -182,7 +182,7 @@ namespace matx
     requires (!cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
   inline auto flattop(ShapeType &&s)
              {
-               constexpr int RANK = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+               constexpr int RANK = cuda::std::tuple_size<cuda::std::decay_t<ShapeType>>::value;
                static_assert(RANK > Dim);
                detail::FlatTop<T> h( *(s.begin() + Dim));
                return detail::matxGenerator1D_t<detail::FlatTop<T>, Dim, ShapeType>(std::forward<ShapeType>(s), h);

--- a/include/matx/generators/generator1d.h
+++ b/include/matx/generators/generator1d.h
@@ -36,13 +36,13 @@
 namespace matx
 {
   namespace detail {
-    template <typename Generator1D, int Dim, typename ShapeType> 
+    template <typename Generator1D, int Dim, typename ShapeType>
     class matxGenerator1D_t : public BaseOp<matxGenerator1D_t<Generator1D, Dim, ShapeType>>{
       public:
         // dummy type to signal this is a matxop
         using matxop = bool;
         using value_type = typename Generator1D::value_type;
-        static constexpr int RANK = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+        static constexpr int RANK = cuda::std::tuple_size<cuda::std::decay_t<ShapeType>>::value;
 
         __MATX_INLINE__ std::string str() const { return "gen1d"; }
 
@@ -58,14 +58,14 @@ namespace matx
             else {
               return detail::capability_attributes<Cap>::default_value;
             }
-          } 
-          else if constexpr (Cap == OperatorCapability::JIT_TYPE_QUERY || 
+          }
+          else if constexpr (Cap == OperatorCapability::JIT_TYPE_QUERY ||
                              Cap == OperatorCapability::JIT_CLASS_QUERY ||
                              Cap == OperatorCapability::SUPPORTS_JIT) {
             // Forward JIT-related capabilities to the generator
             return f_.template get_capability<Cap>(in);
           }
-          else {          
+          else {
             return detail::capability_attributes<Cap>::default_value;
           }
         }

--- a/include/matx/generators/hamming.h
+++ b/include/matx/generators/hamming.h
@@ -63,7 +63,7 @@ namespace matx
 
         __MATX_INLINE__ auto get_jit_op_str() const {
           std::string func_name = get_jit_class_name();
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::string("template <typename T> struct " + func_name + " {\n") +
@@ -83,7 +83,7 @@ namespace matx
 #endif
 
         __MATX_INLINE__ std::string str() const { return "hamming"; }
-	
+
         inline __MATX_HOST__ __MATX_DEVICE__ Hamming(index_t size) : size_(size){
 #ifndef __CUDA_ARCH__
           MATX_LOG_TRACE("Hamming constructor: size={}", size);
@@ -91,12 +91,12 @@ namespace matx
         };
 
         template <typename CapType>
-        inline __MATX_HOST__ __MATX_DEVICE__ auto operator()(index_t i) const 
+        inline __MATX_HOST__ __MATX_DEVICE__ auto operator()(index_t i) const
         {
           return detail::ApplyGeneratorVecFunc<CapType, T>([this](index_t idx) { return T(.54) - T(.46) * cuda::std::cos(T(2 * M_PI) * T(idx) / T(size_ - 1)); }, i);
         }
 
-        inline __MATX_HOST__ __MATX_DEVICE__ auto operator()(index_t i) const 
+        inline __MATX_HOST__ __MATX_DEVICE__ auto operator()(index_t i) const
         {
           return this->operator()<DefaultCapabilities>(i);
         }
@@ -162,7 +162,7 @@ namespace matx
     requires (!cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
   inline auto hamming(ShapeType &&s)
              {
-               constexpr int RANK = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+               constexpr int RANK = cuda::std::tuple_size<cuda::std::decay_t<ShapeType>>::value;
                static_assert(RANK > Dim);
                detail::Hamming<T> h( *(s.begin() + Dim));
                return detail::matxGenerator1D_t<detail::Hamming<T>, Dim, ShapeType>(std::forward<ShapeType>(s), h);

--- a/include/matx/generators/hanning.h
+++ b/include/matx/generators/hanning.h
@@ -63,7 +63,7 @@ namespace matx
 
         __MATX_INLINE__ auto get_jit_op_str() const {
           std::string func_name = get_jit_class_name();
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::string("template <typename T> struct " + func_name + " {\n") +
@@ -161,7 +161,7 @@ namespace matx
     requires (!cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
   inline auto hanning(ShapeType &&s)
              {
-               constexpr int RANK = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+               constexpr int RANK = cuda::std::tuple_size<cuda::std::decay_t<ShapeType>>::value;
                static_assert(RANK > Dim);
                detail::Hanning<T> h( *(s.begin() + Dim));
                return detail::matxGenerator1D_t<detail::Hanning<T>, Dim, ShapeType>(std::forward<ShapeType>(s), h);

--- a/include/matx/generators/linspace.h
+++ b/include/matx/generators/linspace.h
@@ -63,7 +63,7 @@ namespace matx
 
         __MATX_INLINE__ auto get_jit_op_str() const {
           std::string func_name = get_jit_class_name();
-          
+
           std::string steps_init = "{ ";
           std::string firsts_init = "{ ";
           for (int i = 0; i < NUM_RC; i++) {
@@ -76,7 +76,7 @@ namespace matx
           }
           steps_init += " }";
           firsts_init += " }";
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::format("template <typename T> struct {} {{\n"
@@ -115,16 +115,16 @@ namespace matx
 
         __MATX_INLINE__ std::string str() const { return "linspace"; }
 
-        static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() { 
+        static inline constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() {
           if constexpr (NUM_RC == 1) {
-            return 1; 
+            return 1;
           }
           else {
             return 2;
           }
-        }  
+        }
 
-        inline LinspaceOp(const T (&firsts)[NUM_RC], const T (&lasts)[NUM_RC], index_t count, int axis) 
+        inline LinspaceOp(const T (&firsts)[NUM_RC], const T (&lasts)[NUM_RC], index_t count, int axis)
         {
           MATX_LOG_TRACE("LinspaceOp constructor: NUM_RC={}, count={}, axis={}", NUM_RC, count, axis);
           axis_ = axis;
@@ -165,14 +165,14 @@ namespace matx
           else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return my_cap;
-          } else {          
+          } else {
             auto self_has_cap = detail::capability_attributes<Cap>::default_value;
             return self_has_cap;
           }
         }
 
         template <typename CapType, typename... Is>
-        __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ auto operator()(Is... indices) const { 
+        __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ auto operator()(Is... indices) const {
           static_assert(sizeof...(indices) == Rank(), "Number of indices incorrect in linspace");
           cuda::std::array idx{indices...};
           if constexpr (sizeof...(indices) == 1) {
@@ -187,7 +187,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ auto operator()(Is... indices) const { 
+        __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ auto operator()(Is... indices) const {
           return this->operator()<DefaultCapabilities>(indices...);
         }
 
@@ -202,7 +202,7 @@ namespace matx
             return count_;
           }
         }
-      }        
+      }
     };
   }
 
@@ -213,20 +213,20 @@ namespace matx
    * Creates a set of values using starts and stops that are linearly-
    * spaced apart over the set of values. Distance is determined
    * by the count parameter
-   * 
+   *
    * @tparam NUM_RC Number of rows or columns, depending on the axis
    * @tparam T Type of the values
    * @param firsts First values
    * @param lasts Last values
    * @param count Number of values in a row or column, depending on the axis
    * @param axis Axis to operate over
-   * @return Operator with linearly-spaced values 
+   * @return Operator with linearly-spaced values
    */
   template <int NUM_RC, typename T = float>
   inline auto linspace(const T (&firsts)[NUM_RC], const T (&lasts)[NUM_RC], index_t count, int axis = 0)
   {
     return detail::LinspaceOp<T, NUM_RC>(firsts, lasts, count, axis);
-  }   
+  }
 
   /**
    * @brief Create a linearly-spaced vector of values
@@ -234,13 +234,13 @@ namespace matx
    * Creates a set of values using startsand stop that are linearly-
    * spaced apart over the set of values. Distance is determined
    * by the count parameter
-   * 
+   *
    * @tparam T Type of the values
    * @param first First value
    * @param last Last value
    * @param count Number of values in a row or column, depending on the axis
    * @param axis Axis to operate over
-   * @return Operator with linearly-spaced values 
+   * @return Operator with linearly-spaced values
    */
   template <typename T = float>
   inline auto linspace(T first, T last, index_t count, int axis = 0)
@@ -256,23 +256,23 @@ namespace matx
    * Creates a set of values using a start and end that are linearly-
    * spaced apart over the set of values. Distance is determined
    * by the shape and selected dimension.
-   * 
+   *
    * @tparam Dim Dimension to operate over
    * @tparam NUM_RC Rank of shape
    * @tparam T Operator type
    * @param s Array of sizes
    * @param first First value
    * @param last Last value
-   * @return Operator with linearly-spaced values 
+   * @return Operator with linearly-spaced values
    */
   template <int Dim, int NUM_RC, typename T>
-  [[deprecated("Use matx::linspace(T first, T last, index_t count, int axis = 0) instead.")]]  
+  [[deprecated("Use matx::linspace(T first, T last, index_t count, int axis = 0) instead.")]]
   inline auto linspace([[maybe_unused]]const index_t (&s)[NUM_RC], T first, T last)
   {
     const T firsts[] = {first};
-    const T lasts[] = {last};   
+    const T lasts[] = {last};
     return linspace(firsts, lasts, NUM_RC, 0);
-  }  
+  }
 
   /**
    * @brief Create a linearly-spaced range of values
@@ -280,25 +280,25 @@ namespace matx
    * Creates a set of values using a start and end that are linearly-
    * spaced apart over the set of values. Distance is determined
    * by the shape and selected dimension.
-   * 
+   *
    * @tparam T Operator type
    * @tparam Dim Dimension to operate over
    * @tparam ShapeType Shape type
    * @param s Shape object
    * @param first First value
    * @param last Last value
-   * @return Operator with linearly-spaced values 
+   * @return Operator with linearly-spaced values
    */
   template <int Dim, typename ShapeType, typename T>
     requires (!cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
-  [[deprecated("Use matx::linspace(T first, T last, index_t count, int axis = 0) instead.")]]           
+  [[deprecated("Use matx::linspace(T first, T last, index_t count, int axis = 0) instead.")]]
   inline auto linspace(ShapeType &&s, T first, T last)
   {
-    constexpr int NUM_RC = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+    constexpr int NUM_RC = cuda::std::tuple_size<cuda::std::decay_t<ShapeType>>::value;
     static_assert(NUM_RC > Dim);
     auto count =  *(s.begin() + Dim);
     const T firsts[] = {first};
-    const T lasts[] = {last};       
+    const T lasts[] = {last};
     return linspace(firsts, lasts, count, 0);
-  }  
+  }
 } // end namespace matx

--- a/include/matx/generators/logspace.h
+++ b/include/matx/generators/logspace.h
@@ -62,7 +62,7 @@ namespace matx
 
         __MATX_INLINE__ auto get_jit_op_str() const {
           std::string func_name = get_jit_class_name();
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::format("template <typename RangeOp> struct {} {{\n"
@@ -91,7 +91,7 @@ namespace matx
 #endif
 
         __MATX_INLINE__ std::string str() const { return "logspace"; }
-	
+
         inline Logspace(T first, T last, index_t count)
         {
 #ifdef __CUDA_ARCH__
@@ -129,7 +129,7 @@ namespace matx
             }
           };
 
-          return detail::ApplyVecFunc<CapType, value_type>(log_func, range_val); 
+          return detail::ApplyVecFunc<CapType, value_type>(log_func, range_val);
         }
 
         template <OperatorCapability Cap, typename InType>
@@ -167,11 +167,11 @@ namespace matx
           else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
             return my_cap;
-          } else {          
+          } else {
             auto self_has_cap = detail::capability_attributes<Cap>::default_value;
             return self_has_cap;
           }
-        }       
+        }
 
 
         __MATX_DEVICE__ __MATX_HOST__ __MATX_INLINE__ auto operator()(index_t idx) const
@@ -194,20 +194,20 @@ namespace matx
    * Creates a set of values using a start and end that are log10-
    * spaced apart over the set of values. Distance is determined
    * by the shape and selected dimension.
-   * 
+   *
    * @tparam T Operator type
    * @tparam Dim Dimension to operate over
    * @tparam ShapeType Shape type
    * @param s Shape object
    * @param first First value
    * @param last Last value
-   * @return Operator with log10-spaced values 
+   * @return Operator with log10-spaced values
    */
   template <int Dim, typename ShapeType, typename T = float>
     requires (!cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
   inline auto logspace(ShapeType &&s, T first, T last)
              {
-               constexpr int RANK = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+               constexpr int RANK = cuda::std::tuple_size<cuda::std::decay_t<ShapeType>>::value;
                static_assert(RANK > Dim);
                auto count = *(s.begin() + Dim);
                detail::Logspace<T> l(first, last, count);
@@ -220,14 +220,14 @@ namespace matx
    * Creates a set of values using a start and end that are log10-
    * spaced apart over the set of values. Distance is determined
    * by the shape and selected dimension.
-   * 
+   *
    * @tparam T Operator type
    * @tparam Dim Dimension to operate over
    * @tparam ShapeType Shape type
    * @param s Shape object
    * @param first First value
    * @param last Last value
-   * @return Operator with log10-spaced values 
+   * @return Operator with log10-spaced values
    */
   template <int Dim, int RANK, typename T = float>
     inline auto logspace(const index_t (&s)[RANK], T first, T last)

--- a/include/matx/generators/random.h
+++ b/include/matx/generators/random.h
@@ -216,16 +216,16 @@ namespace detail {
       mutable bool init_ = false;
 
       static constexpr bool is_float_random_v =
-        std::is_same_v<T, float> ||
-        std::is_same_v<T, double> ||
-        std::is_same_v<T, cuda::std::complex<float>> ||
-        std::is_same_v<T, cuda::std::complex<double>>;
+        cuda::std::is_same_v<T, float> ||
+        cuda::std::is_same_v<T, double> ||
+        cuda::std::is_same_v<T, cuda::std::complex<float>> ||
+        cuda::std::is_same_v<T, cuda::std::complex<double>>;
 
       static constexpr bool is_integral_random_v =
-        std::is_same_v<T, uint32_t> ||
-        std::is_same_v<T,  int32_t> ||
-        std::is_same_v<T, uint64_t> ||
-        std::is_same_v<T,  int64_t>;
+        cuda::std::is_same_v<T, uint32_t> ||
+        cuda::std::is_same_v<T,  int32_t> ||
+        cuda::std::is_same_v<T, uint64_t> ||
+        cuda::std::is_same_v<T,  int64_t>;
 
       union{
         randFloatParams<inner_t> fParams_;
@@ -263,7 +263,7 @@ namespace detail {
       {
         using out_t = remove_cvref_t<Out>;
         if constexpr (RANK > 0 && is_float_random_v && requires { typename out_t::value_type; }) {
-          return std::is_same_v<typename out_t::value_type, T> &&
+          return cuda::std::is_same_v<typename out_t::value_type, T> &&
                  requires(out_t &o) {
                    o.IsContiguous();
                    o.Data();
@@ -370,7 +370,7 @@ namespace detail {
 
         index_t gen_count = count;
         const bool has_tail = fParams_.dist_ == NORMAL &&
-                              (std::is_same_v<T, float> || std::is_same_v<T, double>) &&
+                              (cuda::std::is_same_v<T, float> || cuda::std::is_same_v<T, double>) &&
                               ((gen_count % 2) != 0);
         if (has_tail) {
           // cuRAND normal generation requires an even count; the odd tail is filled below.
@@ -378,7 +378,7 @@ namespace detail {
         }
 
         if (gen_count > 0) {
-          if constexpr (std::is_same_v<T, float>) {
+          if constexpr (cuda::std::is_same_v<T, float>) {
             if (fParams_.dist_ == UNIFORM) {
               ret = curandGenerateUniform(gen.Get(), data, static_cast<size_t>(gen_count));
             }
@@ -386,7 +386,7 @@ namespace detail {
               ret = curandGenerateNormal(gen.Get(), data, static_cast<size_t>(gen_count), 0.0f, 1.0f);
             }
           }
-          else if constexpr (std::is_same_v<T, double>) {
+          else if constexpr (cuda::std::is_same_v<T, double>) {
             if (fParams_.dist_ == UNIFORM) {
               ret = curandGenerateUniformDouble(gen.Get(), data, static_cast<size_t>(gen_count));
             }
@@ -394,7 +394,7 @@ namespace detail {
               ret = curandGenerateNormalDouble(gen.Get(), data, static_cast<size_t>(gen_count), 0.0, 1.0);
             }
           }
-          else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+          else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
             auto *real_data = reinterpret_cast<float *>(data);
             if (fParams_.dist_ == UNIFORM) {
               ret = curandGenerateUniform(gen.Get(), real_data, static_cast<size_t>(gen_count) * 2);
@@ -403,7 +403,7 @@ namespace detail {
               ret = curandGenerateNormal(gen.Get(), real_data, static_cast<size_t>(gen_count) * 2, 0.0f, 1.0f);
             }
           }
-          else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+          else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
             auto *real_data = reinterpret_cast<double *>(data);
             if (fParams_.dist_ == UNIFORM) {
               ret = curandGenerateUniformDouble(gen.Get(), real_data, static_cast<size_t>(gen_count) * 2);
@@ -674,7 +674,7 @@ namespace detail {
         for (int i = RANK - 2; i >= 0; i--) {
           strides_[i] = strides_[i+1] * s[i+1];
         }
-        
+
         MATX_LOG_TRACE("RandomOp constructor: rank={}, total_size={}, seed={}", RANK, total_size_, seed);
       }
 
@@ -682,7 +682,7 @@ namespace detail {
       __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
         if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
           return cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
-        } 
+        }
         else if constexpr (Cap == OperatorCapability::SUPPORTS_JIT) {
 #ifdef MATX_EN_JIT
           return CanUseJITRandom();
@@ -735,8 +735,8 @@ namespace detail {
           }
 #endif
           return false;
-        }  
-        else {        
+        }
+        else {
           auto self_has_cap = capability_attributes<Cap>::default_value;
           return self_has_cap;
         }
@@ -888,24 +888,24 @@ namespace detail {
 
 #else
         if constexpr (
-                     std::is_same_v<T, float>  ||
-                     std::is_same_v<T, double> ||
-                     std::is_same_v<T, cuda::std::complex<float>> ||
-                     std::is_same_v<T, cuda::std::complex<double>>
+                     cuda::std::is_same_v<T, float>  ||
+                     cuda::std::is_same_v<T, double> ||
+                     cuda::std::is_same_v<T, cuda::std::complex<float>> ||
+                     cuda::std::is_same_v<T, cuda::std::complex<double>>
                      )
         {
 
           if (fParams_.dist_ == UNIFORM) {
-            if constexpr (std::is_same_v<T, float>) {
+            if constexpr (cuda::std::is_same_v<T, float>) {
               curandGenerateUniform(gen_, &val.data[0], static_cast<int>(CapType::ept));
             }
-            else if constexpr (std::is_same_v<T, double>) {
+            else if constexpr (cuda::std::is_same_v<T, double>) {
               curandGenerateUniformDouble(gen_, &val.data[0], static_cast<int>(CapType::ept));
             }
-            else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+            else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
               curandGenerateUniform(gen_, reinterpret_cast<float*>(&val.data[0]), static_cast<int>(CapType::ept) * 2);
             }
-            else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+            else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
               curandGenerateUniformDouble(gen_, reinterpret_cast<double*>(&val.data[0]), static_cast<int>(CapType::ept) * 2);
             }
 
@@ -915,16 +915,16 @@ namespace detail {
             }
           }
           else if (fParams_.dist_ == NORMAL) {
-            if constexpr (std::is_same_v<T, float>) {
+            if constexpr (cuda::std::is_same_v<T, float>) {
               curandGenerateNormal(gen_, &val.data[0], static_cast<int>(CapType::ept), 0.0f, 1.0f);
             }
-            else if constexpr (std::is_same_v<T, double>) {
+            else if constexpr (cuda::std::is_same_v<T, double>) {
               curandGenerateNormalDouble(gen_, &val.data[0], static_cast<int>(CapType::ept), 0.0, 1.0);
             }
-            else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+            else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
               curandGenerateNormal(gen_, reinterpret_cast<float*>(&val.data[0]), static_cast<int>(CapType::ept) * 2, 0.0f, 1.0f);
             }
-            else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+            else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
               curandGenerateNormalDouble(gen_, reinterpret_cast<double*>(&val.data[0]), static_cast<int>(CapType::ept) * 2, 0.0, 1.0);
             }
 
@@ -941,10 +941,10 @@ namespace detail {
           }
         }
         else if constexpr(
-                         std::is_same_v<T, uint32_t> ||
-                         std::is_same_v<T,  int32_t> ||
-                         std::is_same_v<T, uint64_t> ||
-                         std::is_same_v<T,  int64_t>
+                         cuda::std::is_same_v<T, uint32_t> ||
+                         cuda::std::is_same_v<T,  int32_t> ||
+                         cuda::std::is_same_v<T, uint64_t> ||
+                         cuda::std::is_same_v<T,  int64_t>
                          )
         {
           MATX_LOOP_UNROLL
@@ -1092,10 +1092,10 @@ namespace detail {
   __MATX_INLINE__ auto random(ShapeType &&s, Distribution_t dist, uint64_t seed = 0, LowerType alpha = 1, LowerType beta = 0)
   {
     static_assert(
-                  std::is_same_v<T, float> ||
-                  std::is_same_v<T, double> ||
-                  std::is_same_v<T, cuda::std::complex<float>> ||
-                  std::is_same_v<T, cuda::std::complex<double>>,
+                  cuda::std::is_same_v<T, float> ||
+                  cuda::std::is_same_v<T, double> ||
+                  cuda::std::is_same_v<T, cuda::std::complex<float>> ||
+                  cuda::std::is_same_v<T, cuda::std::complex<double>>,
                   "random only supports floating point or complex floating point data types"
 
                  );
@@ -1148,10 +1148,10 @@ namespace detail {
   __MATX_INLINE__ auto randomi(ShapeType &&s, uint64_t seed = 0, LowerType min = 0, LowerType max = 100)
   {
     static_assert(
-                  std::is_same_v<T, uint32_t> ||
-                  std::is_same_v<T,  int32_t> ||
-                  std::is_same_v<T, uint64_t> ||
-                  std::is_same_v<T,  int64_t> ,
+                  cuda::std::is_same_v<T, uint32_t> ||
+                  cuda::std::is_same_v<T,  int32_t> ||
+                  cuda::std::is_same_v<T, uint64_t> ||
+                  cuda::std::is_same_v<T,  int64_t> ,
                   "randomi only supports signed and unsigned integral types"
                  );
 

--- a/include/matx/generators/random.h
+++ b/include/matx/generators/random.h
@@ -483,7 +483,7 @@ namespace detail {
 
       static __MATX_INLINE__ std::string JITValueLiteral(inner_t value)
       {
-        if constexpr (std::is_floating_point_v<inner_t>) {
+        if constexpr (cuda::std::is_floating_point_v<inner_t>) {
           std::ostringstream oss;
           oss << std::setprecision(std::numeric_limits<inner_t>::max_digits10) << value;
           auto out = oss.str();
@@ -979,7 +979,7 @@ namespace detail {
       __MATX_INLINE__ __MATX_HOST__ bool CanDirectFill(const Out &out) const noexcept
       {
         using out_t = remove_cvref_t<Out>;
-        if constexpr (!std::is_assignable_v<typename out_t::value_type &, T> || out_t::Rank() != RANK) {
+        if constexpr (!cuda::std::is_assignable_v<typename out_t::value_type &, T> || out_t::Rank() != RANK) {
           return false;
         }
         else {

--- a/include/matx/generators/range.h
+++ b/include/matx/generators/range.h
@@ -70,7 +70,7 @@ namespace matx
 
         __MATX_INLINE__ auto get_jit_op_str() const {
           std::string func_name = get_jit_class_name();
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::format("template <typename T> struct {} {{\n"
@@ -179,7 +179,7 @@ MATX_IGNORE_WARNING_POP_GCC
     requires (!cuda::std::is_array_v<remove_cvref_t<ShapeType>>)
   inline auto range(ShapeType &&s, T first, T step)
              {
-               constexpr int RANK = cuda::std::tuple_size<std::decay_t<ShapeType>>::value;
+               constexpr int RANK = cuda::std::tuple_size<cuda::std::decay_t<ShapeType>>::value;
                static_assert(RANK > Dim);
                detail::Range<T> r(first, step);
                return detail::matxGenerator1D_t<detail::Range<T>, Dim, ShapeType>(std::forward<ShapeType>(s), r);

--- a/include/matx/kernels/channelize_poly.cuh
+++ b/include/matx/kernels/channelize_poly.cuh
@@ -64,7 +64,7 @@ namespace cpoly {
 } // namespace cpoly
 } // namespace detail
 
-#ifdef __CUDACC__ 
+#ifdef __CUDACC__
 
 namespace detail {
 
@@ -977,7 +977,7 @@ __global__ void ChannelizePoly1D_FusedChan(OutType output, InType input, FilterT
     for (int t = tid; t < NUM_CHAN*NUM_CHAN; t += THREADS) {
         const int i = t / NUM_CHAN;
         const int j = t % NUM_CHAN;
-        if constexpr (std::is_same_v<AccumType, double>) {
+        if constexpr (cuda::std::is_same_v<AccumType, double>) {
             const double arg = 2.0 * M_PI * j * i / NUM_CHAN;
             double sinx, cosx;
             sincos(arg, &sinx, &cosx);

--- a/include/matx/kernels/conv.cuh
+++ b/include/matx/kernels/conv.cuh
@@ -59,7 +59,7 @@ __global__ void Conv1D(OutType d_out, InType d_in, FilterType d_filter,
 
   size_t filter_bytes = filter_len * sizeof(ftype_strip);
   // pad bytes to alignmetn of InType
-  int align = std::alignment_of_v<intype_strip>;
+  int align = cuda::std::alignment_of_v<intype_strip>;
   filter_bytes = (filter_bytes + align - 1) / align * align;
 
   intype_strip *s_data = reinterpret_cast<intype_strip*>(&s_exch1d[filter_bytes]);

--- a/include/matx/operators/ambgfun.h
+++ b/include/matx/operators/ambgfun.h
@@ -55,7 +55,7 @@ namespace matx
         cuda::std::array<index_t, 2> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpX>::value_type, 2> tmp_out_;
         mutable typename remove_cvref_t<OpX>::value_type *ptr = nullptr;
-        mutable bool prerun_done_ = false;         
+        mutable bool prerun_done_ = false;
 
       public:
         using matxop = bool;
@@ -63,8 +63,8 @@ namespace matx
         using matx_transform_op = bool;
         using ambgfun_xform_op = bool;
 
-        __MATX_INLINE__ std::string str() const { 
-          if constexpr (std::is_same_v<OpY, EmptyY>) {
+        __MATX_INLINE__ std::string str() const {
+          if constexpr (cuda::std::is_same_v<OpY, EmptyY>) {
             return "ambgfun(" + get_type_str(x_) + ")";
           }
           else {
@@ -72,21 +72,21 @@ namespace matx
           }
         }
 
-        __MATX_INLINE__ AmbgFunOp(const OpX &x, const OpY &y, double fs, AMBGFunCutType_t cut, float cut_val) : 
+        __MATX_INLINE__ AmbgFunOp(const OpX &x, const OpY &y, double fs, AMBGFunCutType_t cut, float cut_val) :
               x_(x), y_(y), fs_(fs), cut_(cut), cut_val_(cut_val) {
           MATX_LOG_TRACE("{} constructor: fs={}, cut={}", str(), fs, static_cast<int>(cut));
-          static_assert(OpX::Rank() == 1, "Input to ambgfun must be rank 1");                
+          static_assert(OpX::Rank() == 1, "Input to ambgfun must be rank 1");
           if (cut == AMBGFUN_CUT_TYPE_2D) {
             out_dims_[0] = 2 * x_.Size(0) - 1;
             out_dims_[1] = (index_t)cuda::std::pow(2.0, (double)std::ceil(std::log2(2 * x_.Size(0) - 1)));
           }
           else if (cut == AMBGFUN_CUT_TYPE_DELAY) {
             out_dims_[0] = 1;
-            out_dims_[1] = (index_t)cuda::std::pow(2.0, (double)std::ceil(std::log2(2 * x_.Size(0) - 1)));            
+            out_dims_[1] = (index_t)cuda::std::pow(2.0, (double)std::ceil(std::log2(2 * x_.Size(0) - 1)));
           }
           else if (cut == AMBGFUN_CUT_TYPE_DOPPLER) {
             out_dims_[0] = 1;
-            out_dims_[1] = 2 * x_.Size(0) - 1;               
+            out_dims_[1] = 2 * x_.Size(0) - 1;
           }
           else {
             MATX_ASSERT_STR(false, matxInvalidParameter, "Invalid cut type in ambgfun()");
@@ -105,19 +105,19 @@ namespace matx
         {
           return tmp_out_.template operator()<DefaultCapabilities>(indices...);
         }
-        
+
         template <OperatorCapability Cap, typename InType>
         __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
           // No specific capabilities enforced
           auto self_has_cap = capability_attributes<Cap>::default_value;
-          if constexpr (std::is_same_v<OpY, EmptyY>) {
+          if constexpr (cuda::std::is_same_v<OpY, EmptyY>) {
             // Single-input ambgfun: only combine capabilities from x_
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(x_, in));
           } else {
             // Two-input ambgfun: combine capabilities from both x_ and y_
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(x_, in), detail::get_operator_capability<Cap>(y_, in));
           }
-        }          
+        }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {
@@ -128,7 +128,7 @@ namespace matx
           return out_dims_[dim];
         }
 
-        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }   
+        __MATX_HOST__ __MATX_INLINE__ auto Data() const noexcept { return ptr; }
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
@@ -142,12 +142,12 @@ namespace matx
         {
           if constexpr (is_matx_op<OpX>()) {
             x_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }     
+          }
 
           if constexpr (is_matx_op<OpY>()) {
             y_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }             
-        }      
+          }
+        }
 
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -156,7 +156,7 @@ namespace matx
             return;
           }
 
-          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));         
+          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
@@ -251,7 +251,7 @@ __MATX_INLINE__ auto ambgfun(const XTensor &x,
                     double fs, AMBGFunCutType_t cut, float cut_val = 0.0)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  
+
   detail::EmptyY nil;
   return detail::AmbgFunOp(x, nil, fs, cut, cut_val);
 }

--- a/include/matx/operators/argsort.h
+++ b/include/matx/operators/argsort.h
@@ -56,7 +56,7 @@ namespace detail {
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<index_t, OpA::Rank()> tmp_out_;
       mutable index_t *ptr = nullptr;
-      mutable bool prerun_done_ = false; 
+      mutable bool prerun_done_ = false;
       mutable ElementsPerThread current_ept_ = ElementsPerThread::ONE;
       mutable int current_groups_per_block_ = 1;
 
@@ -68,7 +68,7 @@ namespace detail {
       using sort_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "argsort()"; }
-      __MATX_INLINE__ ArgsortOp(const OpA &a, const SortDirection_t dir) : a_(a), dir_(dir) { 
+      __MATX_INLINE__ ArgsortOp(const OpA &a, const SortDirection_t dir) : a_(a), dir_(dir) {
         MATX_LOG_TRACE("{} constructor: rank={}, dir={}", str(), Rank(), static_cast<int>(dir));
         for (int r = 0; r < Rank(); r++) {
           out_dims_[r] = a_.Size(r);
@@ -180,7 +180,7 @@ namespace detail {
         }
         else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
 #ifdef MATX_EN_JIT
-          static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
+          static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
                         "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type");
           const auto [key, value] = get_jit_op_str();
           if (in.find(key) == in.end()) {
@@ -193,7 +193,7 @@ namespace detail {
 #endif
         }
         else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-          static_assert(std::is_same_v<remove_cvref_t<InType>, EPTQueryInput>, "ELEMENTS_PER_THREAD capability requires EPTQueryInput as input type");
+          static_assert(cuda::std::is_same_v<remove_cvref_t<InType>, EPTQueryInput>, "ELEMENTS_PER_THREAD capability requires EPTQueryInput as input type");
 #if defined(MATX_EN_JIT) && defined(__CUDACC__)
           if (in.jit) {
             const auto max_ept = static_cast<ElementsPerThread>(MaxJitElementsPerThread());
@@ -286,7 +286,7 @@ namespace detail {
       {
         return out_dims_[dim];
       }
-      
+
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
         argsort_impl(cuda::std::get<0>(out), a_, dir_, ex);
@@ -298,8 +298,8 @@ namespace detail {
       {
         if constexpr (is_matx_op<OpA>()) {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        }          
-      }      
+        }
+      }
 
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -308,7 +308,7 @@ namespace detail {
           return;
         }
 
-        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));     
+        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 

--- a/include/matx/operators/at.h
+++ b/include/matx/operators/at.h
@@ -77,7 +77,7 @@ namespace matx
 
         __MATX_INLINE__ auto get_jit_op_str() const {
           std::string func_name = get_jit_class_name();
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::format("template <typename Op> struct {} {{\n"
@@ -206,7 +206,7 @@ namespace matx
 
 #ifndef DOXYGEN_ONLY
   template <typename Op, typename... Is>
-    requires ((std::is_integral_v<Is>) && ...)
+    requires ((cuda::std::is_integral_v<Is>) && ...)
 #else
   template <typename Op, typename... Is>
 #endif

--- a/include/matx/operators/base_operator.h
+++ b/include/matx/operators/base_operator.h
@@ -45,7 +45,7 @@ namespace matx
   namespace detail {
     /**
      * @brief Helper to get memory range from a tensor/lvalue for aliasing check
-     * 
+     *
      * @tparam T Type of the lvalue
      * @param lval The lvalue to get memory range from
      * @return AliasedMemoryQueryInput with start and end pointers
@@ -55,19 +55,19 @@ namespace matx
       // Handle both direct tensor views and operators with lvalue capability (like reshape, slice, etc.)
       if constexpr ((is_tensor_view_v<T> || is_matx_op_lvalue<T>()) && T::Rank() > 0) {
         using value_type = typename T::value_type;
-        
+
         // Get address of first element using operator()(0, 0, ...)
         auto get_first = [&lval]<size_t... Is>(cuda::std::index_sequence<Is...>) {
           return &(const_cast<T&>(lval)(static_cast<index_t>(Is*0)...));
         };
         auto* start = static_cast<void*>(const_cast<value_type*>(get_first(cuda::std::make_index_sequence<T::Rank()>{})));
-        
+
         // Get address of last element using operator()(Size(0)-1, Size(1)-1, ...)
         auto get_last = [&lval]<size_t... Is>(cuda::std::index_sequence<Is...>) {
           return &(const_cast<T&>(lval)(static_cast<index_t>(lval.Size(Is)-1)...));
         };
         auto* end = static_cast<void*>(const_cast<value_type*>(get_last(cuda::std::make_index_sequence<T::Rank()>{})) + 1);
-        
+
         return AliasedMemoryQueryInput{false, is_prerun, start, end};
       }
       else {
@@ -78,7 +78,7 @@ namespace matx
 
     /**
      * @brief Check if RHS operator aliases with LHS memory range
-     * 
+     *
      * @tparam RHS Type of the right-hand side operator
      * @tparam LHS Type of the left-hand side operator
      * @param rhs The right-hand side operator
@@ -88,14 +88,14 @@ namespace matx
      */
     template <typename LHS, typename RHS>
     __MATX_INLINE__ __MATX_HOST__ bool check_aliased_memory([[maybe_unused]] const LHS& lhs, [[maybe_unused]] const RHS& rhs, [[maybe_unused]] bool is_prerun) {
-#ifdef MATX_EN_UNSAFE_ALIAS_DETECTION      
+#ifdef MATX_EN_UNSAFE_ALIAS_DETECTION
       auto mem_range = get_memory_range(lhs, is_prerun);
-      
+
       // If we got null pointers, no aliasing is possible
       if (mem_range.start_ptr == nullptr || mem_range.end_ptr == nullptr) {
         return false;
       }
-      
+
       // Query the RHS operator to see if it uses aliased memory
       return get_operator_capability<OperatorCapability::ALIASED_MEMORY>(rhs, mem_range);
 #else
@@ -105,21 +105,21 @@ namespace matx
 
     /**
      * @brief Check if mtie operation has aliased memory between LHS elements and RHS
-     * 
+     *
      * @tparam MtieType Type of the mtie object
      * @param mtie_obj The mtie object to check
      */
     template <typename MtieType>
     __MATX_INLINE__ __MATX_HOST__ void check_mtie_aliased_memory([[maybe_unused]] const MtieType& mtie_obj) {
-#ifdef MATX_EN_UNSAFE_ALIAS_DETECTION      
+#ifdef MATX_EN_UNSAFE_ALIAS_DETECTION
       constexpr size_t tuple_size = cuda::std::tuple_size_v<decltype(mtie_obj.ts_)>;
-      
+
       // Get the RHS (last element of the tuple)
       auto& rhs = cuda::std::get<tuple_size - 1>(mtie_obj.ts_);
-      
+
       // Check each LHS element (all elements except the last one)
       bool has_alias = false;
-      
+
       // Use C++20 template lambda with index_sequence
       [&]<size_t... Is>(cuda::std::index_sequence<Is...>) {
         ([&] {
@@ -131,17 +131,17 @@ namespace matx
           }
         }(), ...);
       }(cuda::std::make_index_sequence<tuple_size>{});
-      
+
       if (has_alias) {
         MATX_THROW(matxInvalidParameter, "Aliased memory detected: One or more LHS tensors overlap with RHS memory");
       }
-#endif      
+#endif
     }
   } // namespace detail
 
   /**
    * @brief Provides a base class with functions common to all operators
-   * 
+   *
    * @tparam T Type of operator
    */
   template <typename T>
@@ -173,7 +173,7 @@ namespace matx
       public:
         /**
          * @brief Launch work in an arbitrary executor
-         * 
+         *
          * @tparam Ex Executor type
          * @param ex Executor
          */
@@ -214,7 +214,7 @@ namespace matx
             }
             else if constexpr (is_matx_transform_op<typename T::op_type>() && is_tensor_view_v<typename T::tensor_type>) {
               // If we're doing a simple set operation from a transform we take a shorcut to avoid the extra
-              // async allocation we'd normally have to do   
+              // async allocation we'd normally have to do
               if (!can_alias<decltype(tp->get_rhs())>() && detail::check_aliased_memory(tp->get_lhs(), tp->get_rhs(), false)) {
                 MATX_THROW(matxInvalidParameter, "Possible aliased memory detected: LHS and RHS memory ranges overlap");
               }
@@ -246,7 +246,7 @@ namespace matx
 
               using lhs_value_type = remove_cvref_t<typename T::tensor_type::value_type>;
               using rhs_value_type = remove_cvref_t<typename T::op_type::value_type>;
-              constexpr bool same_value_type = std::is_same_v<lhs_value_type, rhs_value_type>;
+              constexpr bool same_value_type = cuda::std::is_same_v<lhs_value_type, rhs_value_type>;
 
               if (same_value_type &&
                   tp->get_lhs().IsContiguous() &&
@@ -275,16 +275,16 @@ namespace matx
               if constexpr (is_matx_op<T>()) {
                 tp->PreRun(tp->Shape(), ex);
               }
-              
+
               ex.Exec(*tp);
 
               if constexpr (is_matx_op<T>()) {
                 tp->PostRun(tp->Shape(), ex);
-              }              
+              }
             }
           }
           else {
-            // These can be operators like custom operators that take an output as a parameter. In those cases we cannot 
+            // These can be operators like custom operators that take an output as a parameter. In those cases we cannot
             // check for aliasing since we don't control the operator.
 
             if constexpr (is_matx_op<T>()) {
@@ -296,12 +296,12 @@ namespace matx
             if constexpr (is_matx_op<T>()) {
               tp->PostRun(tp->Shape(), ex);
             }
-          }  
+          }
         }
 
         /**
          * @brief Launch kernel in a GPU stream
-         * 
+         *
          * @param stream CUDA stream
          */
         __MATX_INLINE__ void run(cudaStream_t stream = 0)
@@ -312,7 +312,7 @@ namespace matx
 
         /**
          * @brief Launch work in a GPU stream and record an event
-         * 
+         *
          * @param ev CUDA event
          * @param stream CUDA stream
          */
@@ -326,7 +326,7 @@ namespace matx
 
         /**
          * @brief Function to run before the executor
-         * 
+         *
          * @tparam ShapeType Type of shape
          * @tparam Executor Executor type
          * @param shape Shape
@@ -339,7 +339,7 @@ namespace matx
 
         /**
          * @brief Function to run before the executor
-         * 
+         *
          * @tparam ShapeType Type of shape
          * @tparam Executor Executor type
          * @param shape Shape
@@ -384,7 +384,7 @@ namespace matx
    * @brief Pprovides a base class for reducing the boilerplate code needed
    * when defining an operator. This is particularly useful in user code with
    * many custom operators that don't want to repeat the Size and Rank functions.
-   * 
+   *
    * @tparam T Type of operator
    * @tparam RankOp Type of operator providing rank information
    */
@@ -400,7 +400,7 @@ namespace matx
 
       /**
        * @brief Construct a new Base Op Custom object
-       * 
+       *
        * @param size Size of each dimension
        */
       __MATX_INLINE__ BaseOpCustom(const cuda::std::array<index_t, RankOp::Rank()> &size) :
@@ -408,17 +408,17 @@ namespace matx
 
       /**
        * @brief Return rank of operator
-       * 
+       *
        * @return Operator rank
        */
       static __MATX_INLINE__ constexpr int32_t Rank()
       {
         return RankOp::Rank();
-      }  
+      }
 
       /**
        * @brief Return size of operator on a given dimension
-       * 
+       *
        * @return Operator size on dimension dim
        */
       index_t __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ Size(int dim) const

--- a/include/matx/operators/binary_operators.h
+++ b/include/matx/operators/binary_operators.h
@@ -61,7 +61,7 @@ namespace matx
    * @return Product result
    */
   template <typename T, typename S>
-    requires (!cuda::std::is_same_v<T, S> && std::is_arithmetic_v<S>)
+    requires (!cuda::std::is_same_v<T, S> && cuda::std::is_arithmetic_v<S>)
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__
   auto operator*(const cuda::std::complex<T> &c, S n) -> cuda::std::complex<T>
   {
@@ -78,7 +78,7 @@ namespace matx
    * @return Product result
    */
   template <typename T, typename S>
-    requires (!cuda::std::is_same_v<T, S> && std::is_arithmetic_v<S>)
+    requires (!cuda::std::is_same_v<T, S> && cuda::std::is_arithmetic_v<S>)
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__
   auto operator*(S n, const cuda::std::complex<T> &c) -> cuda::std::complex<T>
   {

--- a/include/matx/operators/binary_operators.h
+++ b/include/matx/operators/binary_operators.h
@@ -61,7 +61,7 @@ namespace matx
    * @return Product result
    */
   template <typename T, typename S>
-    requires (!std::is_same_v<T, S> && std::is_arithmetic_v<S>)
+    requires (!cuda::std::is_same_v<T, S> && std::is_arithmetic_v<S>)
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__
   auto operator*(const cuda::std::complex<T> &c, S n) -> cuda::std::complex<T>
   {
@@ -78,7 +78,7 @@ namespace matx
    * @return Product result
    */
   template <typename T, typename S>
-    requires (!std::is_same_v<T, S> && std::is_arithmetic_v<S>)
+    requires (!cuda::std::is_same_v<T, S> && std::is_arithmetic_v<S>)
   __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__
   auto operator*(S n, const cuda::std::complex<T> &c) -> cuda::std::complex<T>
   {

--- a/include/matx/operators/cast.h
+++ b/include/matx/operators/cast.h
@@ -139,10 +139,10 @@ namespace matx
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           auto cast_func = [](const auto &val) {
-            return static_cast<NewType>(val);   
+            return static_cast<NewType>(val);
           };
 
-          return ApplyVecFunc<CapType, NewType>(cast_func, get_value<CapType>(op_, indices...));        
+          return ApplyVecFunc<CapType, NewType>(cast_func, get_value<CapType>(op_, indices...));
         }
 
         template <typename... Is>
@@ -314,7 +314,7 @@ namespace matx
         {
           auto cast_func = [](const auto &real, const auto &imag) {
             using inner_type = typename inner_op_type_t<NewType>::type;
-            return NewType(static_cast<inner_type>(real),static_cast<inner_type>(imag));            
+            return NewType(static_cast<inner_type>(real),static_cast<inner_type>(imag));
           };
 
           const auto real_val = get_value<CapType>(real_op_, indices...);
@@ -363,7 +363,7 @@ namespace matx
 #endif
           }
           else if constexpr (Cap == OperatorCapability::DYN_SHM_SIZE) {
-            return 
+            return
               detail::get_operator_capability<Cap>(real_op_, in) +
               detail::get_operator_capability<Cap>(imag_op_, in);
           }
@@ -433,7 +433,7 @@ namespace matx
   template <typename NewType, typename T>
     auto __MATX_INLINE__ as_type(T t)
     {
-      if constexpr (std::is_same_v<NewType, typename T::value_type>) {
+      if constexpr (cuda::std::is_same_v<NewType, typename T::value_type>) {
         // optimized path when type is the same to avoid creating unecessary operators
         return t;
       } else {

--- a/include/matx/operators/conv.h
+++ b/include/matx/operators/conv.h
@@ -54,7 +54,7 @@ namespace matx
     class Conv1DOp : public BaseOp<Conv1DOp<OpA, OpB, PermDims>>
     {
       private:
-        using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>,
+        using out_t = cuda::std::conditional_t<is_complex_v<typename OpA::value_type>,
               typename OpA::value_type, typename OpB::value_type>;
         constexpr static int max_rank = cuda::std::max(OpA::Rank(), OpB::Rank());
         typename detail::base_type_t<OpA> a_;
@@ -286,7 +286,7 @@ namespace detail {
   class Conv2DOp : public BaseOp<Conv2DOp<OpA, OpB, PermDims>>
   {
     private:
-      using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>,
+      using out_t = cuda::std::conditional_t<is_complex_v<typename OpA::value_type>,
             typename OpA::value_type, typename OpB::value_type>;
       constexpr static int max_rank = cuda::std::max(OpA::Rank(), OpB::Rank());
       OpA a_;

--- a/include/matx/operators/conv.h
+++ b/include/matx/operators/conv.h
@@ -54,7 +54,7 @@ namespace matx
     class Conv1DOp : public BaseOp<Conv1DOp<OpA, OpB, PermDims>>
     {
       private:
-        using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>, 
+        using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>,
               typename OpA::value_type, typename OpB::value_type>;
         constexpr static int max_rank = cuda::std::max(OpA::Rank(), OpB::Rank());
         typename detail::base_type_t<OpA> a_;
@@ -65,7 +65,7 @@ namespace matx
         cuda::std::array<index_t, max_rank> out_dims_;
         mutable detail::tensor_impl_t<out_t, max_rank> tmp_out_;
         mutable out_t *ptr = nullptr;
-        mutable bool prerun_done_ = false; 
+        mutable bool prerun_done_ = false;
 
       public:
         using matxop = bool;
@@ -73,22 +73,22 @@ namespace matx
         using matx_transform_op = bool;
         using conv_xform_op = bool;
 
-        __MATX_INLINE__ std::string str() const { 
+        __MATX_INLINE__ std::string str() const {
           return "conv1d(" + get_type_str(a_) + "," + get_type_str(b_)  + ")";
         }
 
-        __MATX_INLINE__ Conv1DOp(const OpA &A, const OpB &B, matxConvCorrMode_t mode, matxConvCorrMethod_t method, PermDims perm) : 
+        __MATX_INLINE__ Conv1DOp(const OpA &A, const OpB &B, matxConvCorrMode_t mode, matxConvCorrMethod_t method, PermDims perm) :
               a_(A), b_(B), mode_(mode), method_(method), perm_(perm) {
           MATX_LOG_TRACE("{} constructor: mode={}, method={}", str(), static_cast<int>(mode), static_cast<int>(method));
-          MATX_ASSERT_STR((!is_matx_type_v<typename OpA::value_type> && !is_matx_type_v<typename OpB::value_type>) || 
-                          method == MATX_C_METHOD_DIRECT, 
+          MATX_ASSERT_STR((!is_matx_type_v<typename OpA::value_type> && !is_matx_type_v<typename OpB::value_type>) ||
+                          method == MATX_C_METHOD_DIRECT,
             matxInvalidType, "FFT convolutions do not support half precision float currently");
 
           index_t min_axis;
           index_t max_axis;
 
           // Currently when using the axis parameter the rank of inputs must be equal
-          if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+          if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
             for (int r = 0; r < Rank(); r++) {
               const int axis = perm[r];
               if (axis == Rank() - 1) {
@@ -151,7 +151,7 @@ namespace matx
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return this->operator()<DefaultCapabilities>(indices...);
-        }     
+        }
 
         template <OperatorCapability Cap, typename InType>
         __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
@@ -161,7 +161,7 @@ namespace matx
             auto b_cap = detail::get_operator_capability<Cap>(b_, in);
             return combine_capabilities<Cap>(my_cap, a_cap, b_cap);
           }
-          
+
           auto self_has_cap = capability_attributes<Cap>::default_value;
           auto a_cap = detail::get_operator_capability<Cap>(a_, in);
           auto b_cap = detail::get_operator_capability<Cap>(b_, in);
@@ -181,9 +181,9 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          MATX_STATIC_ASSERT_STR((Rank() == cuda::std::tuple_element_t<0, remove_cvref_t<Out>>::Rank()), 
+          MATX_STATIC_ASSERT_STR((Rank() == cuda::std::tuple_element_t<0, remove_cvref_t<Out>>::Rank()),
                 matxInvalidParameter, "conv1d: inputs and outputs must have same rank to use conv1d with axis parameter");
-          if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+          if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
             conv1d_impl(permute(cuda::std::get<0>(out), perm_), a_, b_, mode_, method_, ex);
           }
           else {
@@ -196,12 +196,12 @@ namespace matx
         {
           if constexpr (is_matx_op<OpA>()) {
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }     
+          }
 
           if constexpr (is_matx_op<OpB>()) {
             b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }           
-        }      
+          }
+        }
 
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -210,7 +210,7 @@ namespace matx
             return;
           }
 
-          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
+          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
@@ -223,7 +223,7 @@ namespace matx
         {
           if constexpr (is_matx_op<OpA>()) {
             a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }     
+          }
 
           if constexpr (is_matx_op<OpB>()) {
             b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
@@ -238,7 +238,7 @@ namespace matx
 
 /**
  * @brief 1D convolution
- * 
+ *
  * @tparam In1Type Type of first input
  * @tparam In2Type Type of second input
  * @param i1 First input operator
@@ -250,13 +250,13 @@ template <typename In1Type, typename In2Type>
 __MATX_INLINE__ auto conv1d(const In1Type &i1, const In2Type &i2,
                    matxConvCorrMode_t mode = MATX_C_MODE_FULL,
                    matxConvCorrMethod_t method = MATX_C_METHOD_DIRECT) {
-  return detail::Conv1DOp(i1, i2, mode, method, detail::no_permute_t{});     
-}  
+  return detail::Conv1DOp(i1, i2, mode, method, detail::no_permute_t{});
+}
 
 
 /**
  * @brief 1D convolution
- * 
+ *
  * @tparam In1Type Type of first input
  * @tparam In2Type Type of second input
  * @param i1 First input operator
@@ -275,7 +275,7 @@ __MATX_INLINE__ auto conv1d(const In1Type &i1, const In2Type &i2,
   auto perm = detail::getPermuteDims<std::max(In1Type::Rank(), In2Type::Rank())>(axis);
 
   auto in1 = permute(i1, perm);
-  auto in2 = permute(i2, perm);                    
+  auto in2 = permute(i2, perm);
   return detail::Conv1DOp(in1, in2, mode, method, perm);
 }
 
@@ -286,7 +286,7 @@ namespace detail {
   class Conv2DOp : public BaseOp<Conv2DOp<OpA, OpB, PermDims>>
   {
     private:
-      using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>, 
+      using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>,
             typename OpA::value_type, typename OpB::value_type>;
       constexpr static int max_rank = cuda::std::max(OpA::Rank(), OpB::Rank());
       OpA a_;
@@ -295,7 +295,7 @@ namespace detail {
       PermDims perm_;
       cuda::std::array<index_t, max_rank> out_dims_;
       mutable ::matx::detail::tensor_impl_t<out_t, max_rank> tmp_out_;
-      mutable out_t *ptr = nullptr; 
+      mutable out_t *ptr = nullptr;
 
     public:
       using matxop = bool;
@@ -303,20 +303,20 @@ namespace detail {
       using matx_transform_op = bool;
       using conv_xform_op = bool;
 
-      __MATX_INLINE__ std::string str() const { 
+      __MATX_INLINE__ std::string str() const {
         return "conv2d(" + get_type_str(a_) + "," + get_type_str(b_)  + ")";
       }
 
-      __MATX_INLINE__ Conv2DOp(const OpA &A, const OpB &B, matxConvCorrMode_t mode, PermDims perm) : 
+      __MATX_INLINE__ Conv2DOp(const OpA &A, const OpB &B, matxConvCorrMode_t mode, PermDims perm) :
             a_(A), b_(B), mode_(mode), perm_(perm) {
         MATX_LOG_TRACE("{} constructor: mode={}", str(), static_cast<int>(mode));
         // Currently when using the axis parameter the rank of inputs must be equal
-        if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+        if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
           for (int r = 0; r < Rank(); r++) {
             const int axis = perm[r];
             if (axis >= Rank() - 2) {
               const auto max_axis = cuda::std::max(a_.Size(r), b_.Size(r));
-              const auto min_axis = cuda::std::min(a_.Size(r), b_.Size(r));          
+              const auto min_axis = cuda::std::min(a_.Size(r), b_.Size(r));
               if (mode_ == MATX_C_MODE_FULL) {
                 out_dims_[axis] = a_.Size(r) + b_.Size(r) - 1;
               }
@@ -325,12 +325,12 @@ namespace detail {
               }
               else if (mode_ == MATX_C_MODE_VALID) {
                 out_dims_[axis] = max_axis - min_axis + 1;
-              }                  
+              }
             }
             else {
               out_dims_[axis] = b_.Size(r);
             }
-          }                     
+          }
         }
         else {
           if constexpr (OpA::Rank() > OpB::Rank()) {
@@ -385,13 +385,13 @@ namespace detail {
           auto b_cap = detail::get_operator_capability<Cap>(b_, in);
           return combine_capabilities<Cap>(my_cap, a_cap, b_cap);
         }
-        
+
         auto self_has_cap = capability_attributes<Cap>::default_value;
-        // NOTE: Conv2D is FFT only, which can support different EPTs. 
+        // NOTE: Conv2D is FFT only, which can support different EPTs.
         // However, the underlying FFTs are currently called without EPT.
         // For now, let's assume it inherits, but this might need refinement
         // if specific EPT > 1 is to be plumbed through conv2d's FFTs.
-        
+
         auto a_cap = detail::get_operator_capability<Cap>(a_, in);
         auto b_cap = detail::get_operator_capability<Cap>(b_, in);
         return combine_capabilities<Cap>(self_has_cap, a_cap, b_cap);
@@ -410,7 +410,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+        if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
           conv2d_impl(permute(cuda::std::get<0>(out), perm_), a_, b_, mode_, ex);
         }
         else {
@@ -423,17 +423,17 @@ namespace detail {
       {
         if constexpr (is_matx_op<OpA>()) {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        }     
+        }
 
         if constexpr (is_matx_op<OpB>()) {
           b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        }           
-      }      
+        }
+      }
 
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));           
+        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
@@ -445,20 +445,20 @@ namespace detail {
       {
         if constexpr (is_matx_op<OpA>()) {
           a_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        }     
+        }
 
         if constexpr (is_matx_op<OpB>()) {
           b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        } 
+        }
 
         matxFree(ptr);
-      }     
+      }
     };
   }
 
 /**
  * @brief 2D convolution
- * 
+ *
  * @tparam In1Type Type of first input
  * @tparam In2Type Type of second input
  * @param i1 First input operator
@@ -468,13 +468,13 @@ namespace detail {
 template <typename In1Type, typename In2Type>
 __MATX_INLINE__ auto conv2d(const In1Type &i1, const In2Type &i2,
                    matxConvCorrMode_t mode) {
-  return detail::Conv2DOp(i1, i2, mode, detail::no_permute_t{});     
-}  
+  return detail::Conv2DOp(i1, i2, mode, detail::no_permute_t{});
+}
 
 
 /**
  * @brief 2D convolution
- * 
+ *
  * @tparam In1Type Type of first input
  * @tparam In2Type Type of second input
  * @param i1 First input operator
@@ -491,7 +491,7 @@ __MATX_INLINE__ auto conv2d(const In1Type &i1, const In2Type &i2,
   auto perm = detail::getPermuteDims<std::max(In1Type::Rank(), In2Type::Rank())>(axis);
 
   auto in1 = permute(i1, perm);
-  auto in2 = permute(i2, perm);                    
+  auto in2 = permute(i2, perm);
   return detail::Conv2DOp(in1, in2, mode, perm);
 }
 

--- a/include/matx/operators/corr.h
+++ b/include/matx/operators/corr.h
@@ -46,7 +46,7 @@ namespace matx
     class CorrOp : public BaseOp<CorrOp<OpA, OpB, PermDims>>
     {
       private:
-        using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>, 
+        using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>,
               typename OpA::value_type, typename OpB::value_type>;
         constexpr static int max_rank = cuda::std::max(OpA::Rank(), OpB::Rank());
         typename detail::base_type_t<OpA> a_;
@@ -57,7 +57,7 @@ namespace matx
         cuda::std::array<index_t, max_rank> out_dims_;
         mutable detail::tensor_impl_t<out_t, max_rank> tmp_out_;
         mutable out_t *ptr = nullptr;
-        mutable bool prerun_done_ = false; 
+        mutable bool prerun_done_ = false;
 
       public:
         using matxop = bool;
@@ -65,21 +65,21 @@ namespace matx
         using matx_transform_op = bool;
         using conv_xform_op = bool;
 
-        __MATX_INLINE__ std::string str() const { 
+        __MATX_INLINE__ std::string str() const {
           return "conv1d(" + get_type_str(a_) + "," + get_type_str(b_)  + ")";
         }
 
-        __MATX_INLINE__ CorrOp(const OpA &A, const OpB &B, matxConvCorrMode_t mode, [[maybe_unused]] matxConvCorrMethod_t method, PermDims perm) : 
+        __MATX_INLINE__ CorrOp(const OpA &A, const OpB &B, matxConvCorrMode_t mode, [[maybe_unused]] matxConvCorrMethod_t method, PermDims perm) :
               a_(A), b_(B), mode_(mode), method_(method), perm_(perm) {
           MATX_LOG_TRACE("{} constructor: mode={}, method={}", str(), static_cast<int>(mode), static_cast<int>(method));
           // Currently when using the axis parameter the rank of inputs must be equal
-          if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+          if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
             for (int r = 0; r < Rank(); r++) {
               const int axis = perm[r];
               if (axis == Rank() - 1) {
                 const auto max_axis = cuda::std::max(a_.Size(r), b_.Size(r));
                 const auto min_axis = cuda::std::min(a_.Size(r), b_.Size(r));
-              
+
                 if (mode_ == MATX_C_MODE_FULL) {
                   out_dims_[axis] = a_.Size(r) + b_.Size(r) - 1;
                 }
@@ -88,12 +88,12 @@ namespace matx
                 }
                 else if (mode_ == MATX_C_MODE_VALID) {
                   out_dims_[axis] = max_axis - min_axis + 1;
-                }                  
+                }
               }
               else {
                 out_dims_[axis] = b_.Size(r);
               }
-            }                      
+            }
           }
           else {
             if constexpr (OpA::Rank() > OpB::Rank()) {
@@ -117,7 +117,7 @@ namespace matx
             }
             else if (mode_ == MATX_C_MODE_VALID) {
               out_dims_[max_rank-1] = max_axis - min_axis + 1;
-            }                
+            }
           }
         }
 
@@ -142,7 +142,7 @@ namespace matx
           // However, the reference example for conv1d had direct EPT=1 for direct method.
           // For now, using the standard combine for a_ and b_.
           // If specific EPT handling for method_ (direct/FFT) is needed, it can be added.
-          return combine_capabilities<Cap>(self_has_cap, 
+          return combine_capabilities<Cap>(self_has_cap,
                                            detail::get_operator_capability<Cap>(a_, in),
                                            detail::get_operator_capability<Cap>(b_, in));
         }
@@ -158,9 +158,9 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          MATX_STATIC_ASSERT_STR((Rank() == cuda::std::tuple_element_t<0, remove_cvref_t<Out>>::Rank()), 
+          MATX_STATIC_ASSERT_STR((Rank() == cuda::std::tuple_element_t<0, remove_cvref_t<Out>>::Rank()),
                 matxInvalidParameter, "corr: inputs and outputs must have same rank to use corr with axis parameter");
-          if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+          if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
             corr_impl(permute(cuda::std::get<0>(out), perm_), a_, b_, mode_, method_, ex);
           }
           else {
@@ -173,12 +173,12 @@ namespace matx
         {
           if constexpr (is_matx_op<OpA>()) {
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }     
+          }
 
           if constexpr (is_matx_op<OpB>()) {
             b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }           
-        }      
+          }
+        }
 
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -187,7 +187,7 @@ namespace matx
             return;
           }
 
-          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));        
+          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
@@ -204,18 +204,18 @@ namespace matx
 
           if constexpr (is_matx_op<OpB>()) {
             b_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          } 
+          }
 
           matxFree(ptr);
           ptr = nullptr;
           prerun_done_ = false;
-        }          
+        }
     };
   }
 
 /**
  * @brief Correlate two input operators
- * 
+ *
  * @tparam In1Type Type of first input
  * @tparam In2Type Type of second input
  * @param i1 First input operator
@@ -226,13 +226,13 @@ namespace matx
 template <typename In1Type, typename In2Type>
 __MATX_INLINE__ auto corr(const In1Type &i1, const In2Type &i2,
                    matxConvCorrMode_t mode, [[maybe_unused]] matxConvCorrMethod_t method) {
-  return detail::CorrOp(i1, i2, mode, method, detail::no_permute_t{});     
-}  
+  return detail::CorrOp(i1, i2, mode, method, detail::no_permute_t{});
+}
 
 
 /**
  * @brief Correlate two input operators
- * 
+ *
  * @tparam In1Type Type of first input
  * @tparam In2Type Type of second input
  * @param i1 First input operator
@@ -250,7 +250,7 @@ __MATX_INLINE__ auto corr(const In1Type &i1, const In2Type &i2,
   auto perm = detail::getPermuteDims<std::max(In1Type::Rank(), In2Type::Rank())>(axis);
 
   auto in1 = permute(i1, perm);
-  auto in2 = permute(i2, perm);                    
+  auto in2 = permute(i2, perm);
   return detail::CorrOp(in1, in2, mode, method, perm);
 }
 

--- a/include/matx/operators/corr.h
+++ b/include/matx/operators/corr.h
@@ -46,7 +46,7 @@ namespace matx
     class CorrOp : public BaseOp<CorrOp<OpA, OpB, PermDims>>
     {
       private:
-        using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>,
+        using out_t = cuda::std::conditional_t<is_complex_v<typename OpA::value_type>,
               typename OpA::value_type, typename OpB::value_type>;
         constexpr static int max_rank = cuda::std::max(OpA::Rank(), OpB::Rank());
         typename detail::base_type_t<OpA> a_;

--- a/include/matx/operators/cumsum.h
+++ b/include/matx/operators/cumsum.h
@@ -54,7 +54,7 @@ namespace detail {
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
-      mutable bool prerun_done_ = false;  
+      mutable bool prerun_done_ = false;
       mutable ElementsPerThread current_ept_ = ElementsPerThread::ONE;
       mutable int current_groups_per_block_ = 1;
 
@@ -65,7 +65,7 @@ namespace detail {
       using cumsum_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "cumsum()"; }
-      __MATX_INLINE__ CumSumOp(const OpA &a) : a_(a) { 
+      __MATX_INLINE__ CumSumOp(const OpA &a) : a_(a) {
         MATX_LOG_TRACE("{} constructor: rank={}", str(), Rank());
         for (int r = 0; r < Rank(); r++) {
           out_dims_[r] = a_.Size(r);
@@ -168,7 +168,7 @@ namespace detail {
       };
 
       template <OperatorCapability Cap, typename InType>
-      __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {      
+      __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
         if constexpr (Cap == OperatorCapability::BLOCK_DIM) {
 #if defined(MATX_EN_JIT) && defined(__CUDACC__)
           const int block_threads = CurrentBlockThreads();
@@ -180,7 +180,7 @@ namespace detail {
         }
         else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
 #ifdef MATX_EN_JIT
-          static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>, 
+          static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
                         "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type");
           const auto [key, value] = get_jit_op_str();
           if (in.find(key) == in.end()) {
@@ -193,7 +193,7 @@ namespace detail {
 #endif
         }
         else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-          static_assert(std::is_same_v<remove_cvref_t<InType>, EPTQueryInput>, "ELEMENTS_PER_THREAD capability requires EPTQueryInput as input type");
+          static_assert(cuda::std::is_same_v<remove_cvref_t<InType>, EPTQueryInput>, "ELEMENTS_PER_THREAD capability requires EPTQueryInput as input type");
 #if defined(MATX_EN_JIT) && defined(__CUDACC__)
           if (in.jit) {
             const auto max_ept = static_cast<ElementsPerThread>(MaxJitElementsPerThread());
@@ -213,7 +213,7 @@ namespace detail {
 #else
           supported = false;
 #endif
-          return combine_capabilities<Cap>(supported, detail::get_operator_capability<Cap>(a_, in));      
+          return combine_capabilities<Cap>(supported, detail::get_operator_capability<Cap>(a_, in));
         }
         else if constexpr (Cap == OperatorCapability::SET_ELEMENTS_PER_THREAD) {
 #ifdef MATX_EN_JIT
@@ -300,8 +300,8 @@ namespace detail {
       {
         if constexpr (is_matx_op<OpA>()) {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        }         
-      }      
+        }
+      }
 
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -310,7 +310,7 @@ namespace detail {
           return;
         }
 
-        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));      
+        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 

--- a/include/matx/operators/fft.h
+++ b/include/matx/operators/fft.h
@@ -64,7 +64,7 @@ namespace matx
         PermDims perm_;
         FFTNorm norm_;
         cuda::std::array<index_t, OpA::Rank()> out_dims_;
-        using ttype = std::conditional_t<is_complex_v<typename OpA::value_type>,
+        using ttype = cuda::std::conditional_t<is_complex_v<typename OpA::value_type>,
                                           typename OpA::value_type,
                                           typename scalar_to_complex<typename OpA::value_type>::ctype>;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in fft
@@ -78,7 +78,7 @@ namespace matx
       public:
         using matxop = bool;
         using input_type = typename OpA::value_type;
-        using value_type = std::conditional_t<is_complex_v<input_type>,
+        using value_type = cuda::std::conditional_t<is_complex_v<input_type>,
           input_type,
           typename scalar_to_complex<input_type>::ctype>;
         using matx_transform_op = bool;
@@ -547,7 +547,7 @@ namespace matx
                     "Distributed FFT requires a batch dimension followed by "
                     "the transform dimension");
       using input_type = typename remove_cvref_t<OpA>::value_type;
-      using output_type = std::conditional_t<
+      using output_type = cuda::std::conditional_t<
           is_complex_v<input_type>, input_type,
           typename detail::scalar_to_complex<input_type>::ctype>;
       auto local_fft = [fft_size_, norm](const auto &local_a) {
@@ -776,7 +776,7 @@ namespace matx
         PermDims perm_;
         FFTNorm norm_;
         cuda::std::array<index_t, OpA::Rank()> out_dims_;
-        using ttype = std::conditional_t<is_complex_v<typename OpA::value_type>,
+        using ttype = cuda::std::conditional_t<is_complex_v<typename OpA::value_type>,
                                           typename OpA::value_type,
                                           typename scalar_to_complex<typename OpA::value_type>::ctype>;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in fft

--- a/include/matx/operators/fft.h
+++ b/include/matx/operators/fft.h
@@ -44,7 +44,7 @@
 #include "matx/transforms/fft/fft_cuda.h"
 #ifdef MATX_EN_CPU_FFT
   #include "matx/transforms/fft/fft_fftw.h"
-#endif  
+#endif
 
 #if defined(MATX_EN_MATHDX) && defined (__CUDACC__)
   #include "cuComplex.h"
@@ -64,8 +64,8 @@ namespace matx
         PermDims perm_;
         FFTNorm norm_;
         cuda::std::array<index_t, OpA::Rank()> out_dims_;
-        using ttype = std::conditional_t<is_complex_v<typename OpA::value_type>, 
-                                          typename OpA::value_type, 
+        using ttype = std::conditional_t<is_complex_v<typename OpA::value_type>,
+                                          typename OpA::value_type,
                                           typename scalar_to_complex<typename OpA::value_type>::ctype>;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in fft
         mutable detail::tensor_impl_t<ttype, OpA::Rank()> tmp_out_;
@@ -98,9 +98,9 @@ namespace matx
         JIT_Storage ToJITStorage() const {
           return JIT_Storage{detail::to_jit_storage(a_)};
         }
-#endif             
-        
-        __MATX_INLINE__ std::string str() const { 
+#endif
+
+        __MATX_INLINE__ std::string str() const {
           if constexpr (Direction == detail::FFTDirection::FORWARD) {
             return "fft(" + get_type_str(a_) + ")";
           }
@@ -121,7 +121,7 @@ namespace matx
 
           if (fft_size_ != 0) {
             if constexpr (Type == detail::FFTType::C2C) {
-              if constexpr (std::is_same_v<PermDims, no_permute_t>) {
+              if constexpr (cuda::std::is_same_v<PermDims, no_permute_t>) {
                 out_dims_[rt_rank - 1] = fft_size_;
               }
               else {
@@ -130,7 +130,7 @@ namespace matx
             }
             else if constexpr (Type == detail::FFTType::R2C) {
               // R2C transforms pack the results in fft_size_/2 + 1 complex elements
-              if constexpr (std::is_same_v<PermDims, no_permute_t>) {
+              if constexpr (cuda::std::is_same_v<PermDims, no_permute_t>) {
                 out_dims_[rt_rank - 1] = fft_size_ / 2 + 1;
               }
               else {
@@ -138,7 +138,7 @@ namespace matx
               }
             }
             else {
-              if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+              if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
                 out_dims_[perm_[rt_rank-1]] = 2 * (fft_size_ - 1);
               }
               else {
@@ -158,14 +158,14 @@ namespace matx
             // create a temporary, then this will be a C2C transform and the output length
             // will match the input length.
             if constexpr (Type == detail::FFTType::C2C) {
-              if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+              if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
                 fft_size_ = a.Size(perm_[rt_rank-1]);
               } else {
                 fft_size_ = a.Size(rt_rank - 1);
               }
             }
             else if constexpr (Type == detail::FFTType::R2C) { // R2C is N/2+1
-              if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+              if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
                 out_dims_[perm_[rt_rank-1]] = out_dims_[perm_[rt_rank-1]] / 2 + 1;
               }
               else {
@@ -174,7 +174,7 @@ namespace matx
             }
             else {
               // C2R is 2*(N-1) unless overridden
-              if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+              if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
                 out_dims_[perm_[rt_rank-1]] = 2 * (out_dims_[perm_[rt_rank-1]] - 1);
               }
               else {
@@ -189,7 +189,7 @@ namespace matx
             dx_fft_helper_.set_fft_type(DeduceFFTTransformType<typename scalar_to_complex<typename OpA::value_type>::ctype, value_type>());
             dx_fft_helper_.set_direction(Direction);
             dx_fft_helper_.set_cc(cc);
-            dx_fft_helper_.set_method(cuFFTDxMethod::SHARED);           
+            dx_fft_helper_.set_method(cuFFTDxMethod::SHARED);
 
             bool contiguous = false;
             if constexpr (is_tensor_view_v<OpA>) {
@@ -227,7 +227,7 @@ namespace matx
                  "  using value_type = cuda::std::conditional_t<is_complex_v<input_type>, input_type, typename scalar_to_complex<input_type>::ctype>;\n" +
                  "  typename detail::inner_storage_or_self_t<detail::base_type_t<OpA>> a_;\n" +
                  "  constexpr static cuda::std::array<index_t, " + std::to_string(actual_rank) + "> out_dims_ = { " +
-                 detail::array_to_string(out_dims_, actual_rank) + " };\n" +             
+                 detail::array_to_string(out_dims_, actual_rank) + " };\n" +
                  "  template <typename CapType, typename... Is>\n" +
                  "  __MATX_INLINE__ __MATX_DEVICE__  decltype(auto) operator()(Is... indices) const\n" +
                  "  {\n" +
@@ -243,7 +243,7 @@ namespace matx
                  "  }\n" +
                  "};\n")
           );
-        }     
+        }
 #endif
 
         template <typename CapType, typename... Is>
@@ -289,24 +289,24 @@ namespace matx
             bool supported = true;
             if (!dx_fft_helper_.template CheckJITSizeAndTypeRequirements<OpA>()) {
               supported = false;
-            } 
+            }
             else {
               supported = dx_fft_helper_.IsSupported();
             }
 
             auto result = combine_capabilities<Cap>(supported, detail::get_operator_capability<Cap>(a_, in));
             MATX_LOG_DEBUG("SUPPORTS_JIT: {}", result);
-            return result;      
+            return result;
           }
           else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
             // Get the capability string and add to map
             const auto [key, value] = get_jit_op_str();
-      
+
             // Insert into the map if the key doesn't exist
             if (in.find(key) == in.end()) {
               in[key] = value;
             }
-            
+
             // Also handle child operators
             detail::get_operator_capability<Cap>(a_, in);
 
@@ -331,7 +331,7 @@ namespace matx
                 const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::INVALID, ElementsPerThread::INVALID};
                 auto result = combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(a_, in));
                 MATX_LOG_DEBUG("ELEMENTS_PER_THREAD (JIT unsupported): [{},{}]", static_cast<int>(result[0]), static_cast<int>(result[1]));
-                return result;                
+                return result;
               }
             }
             else {
@@ -358,7 +358,7 @@ namespace matx
             else {
               ffts_per_block_candidate = 1;
             }
-            
+
             cuda::std::array<int, 2> groups_per_block = {1, ffts_per_block_candidate};
             auto result = combine_capabilities<Cap>(groups_per_block, detail::get_operator_capability<Cap>(a_, in));
             MATX_LOG_DEBUG("GROUPS_PER_BLOCK: [{},{}]", result[0], result[1]);
@@ -372,7 +372,7 @@ namespace matx
           }
           else if constexpr (Cap == OperatorCapability::GLOBAL_KERNEL) {
             // If MathDx is enabled we always return false. Other checks on size and type may prevent JIT compilation.
-            MATX_LOG_DEBUG("GLOBAL_KERNEL: false");            
+            MATX_LOG_DEBUG("GLOBAL_KERNEL: false");
             return false;
           }
           else if constexpr (Cap == OperatorCapability::SET_GROUPS_PER_BLOCK) {
@@ -389,11 +389,11 @@ namespace matx
           }
           else if constexpr (Cap == OperatorCapability::GENERATE_LTOIR) {
             auto result = combine_capabilities<Cap>(
-                dx_fft_helper_.GenerateLTOIR(in.ltoir_symbols), 
+                dx_fft_helper_.GenerateLTOIR(in.ltoir_symbols),
                 detail::get_operator_capability<Cap>(a_, in));
             MATX_LOG_DEBUG("GENERATE_LTOIR: {}", result);
             return result;
-          }    
+          }
           else if constexpr (Cap == OperatorCapability::JIT_TYPE_QUERY) {
             // No need to use combine_capabilities here since we're just returning a string.
             const auto inner_op_jit_name = detail::get_operator_capability<Cap>(a_, in);
@@ -402,7 +402,7 @@ namespace matx
             return result;
           }
           else if constexpr (Cap == OperatorCapability::ASYNC_LOADS_REQUESTED) {
-            // If this is a contiguous tensor input we want to do an async load so that we decrease register pressure. 
+            // If this is a contiguous tensor input we want to do an async load so that we decrease register pressure.
             // and increase bandwidth on newer architectures
             bool async_loads_requested = false;
             if constexpr (is_tensor_view_v<OpA>) {
@@ -425,15 +425,15 @@ namespace matx
             bool supported = false;
             auto result = combine_capabilities<Cap>(supported, detail::get_operator_capability<Cap>(a_, in));
             MATX_LOG_DEBUG("SUPPORTS_JIT (no cuFFTDx): {}", result);
-            return result;      
-          } 
+            return result;
+          }
           else if constexpr (Cap == OperatorCapability::JIT_TYPE_QUERY) {
             MATX_LOG_DEBUG("JIT_TYPE_QUERY (no cuFFTDx): \"\"");
             return "";
           }
           else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
             MATX_LOG_DEBUG("ALIASED_MEMORY (no cuFFTDx): false");
-            // FFTs with cuFFT cannot have aliased memory errors since they allow the same input and output. Do not 
+            // FFTs with cuFFT cannot have aliased memory errors since they allow the same input and output. Do not
             // pass this property on to the child operators.
             return false;
           }
@@ -450,7 +450,7 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          if constexpr (std::is_same_v<PermDims, no_permute_t>) {
+          if constexpr (cuda::std::is_same_v<PermDims, no_permute_t>) {
             if constexpr (Direction == detail::FFTDirection::FORWARD) {
               fft_impl(cuda::std::get<0>(out), a_, fft_size_, norm_, ex);
             }
@@ -480,7 +480,7 @@ namespace matx
                 ifft_impl(permute(tout, perm_), permute(a_, perm_), fft_size_, norm_, ex);
               }
             }
-          }        
+          }
         }
 
         template <typename ShapeType, typename Executor>
@@ -488,8 +488,8 @@ namespace matx
         {
           if constexpr (is_matx_op<OpA>()) {
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }         
-        }      
+          }
+        }
 
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -498,9 +498,9 @@ namespace matx
             return;
           }
 
-          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
+          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
-          detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);         
+          detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
           prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
         }
@@ -526,7 +526,7 @@ namespace matx
    * Creates a new FFT plan in the cache if none exists, and uses that to execute
    * the 1D FFT. Note that FFTs and IFFTs share the same plans if all dimensions
    * match
-   * Note: fft_size must be unsigned so that the axis overload does not match both 
+   * Note: fft_size must be unsigned so that the axis overload does not match both
    * prototypes with index_t. However, the value of fft_size must still fit into an index_t.
    *
    * @tparam OpA
@@ -574,7 +574,7 @@ namespace matx
    * Creates a new FFT plan in the cache if none exists, and uses that to execute
    * the 1D FFT. Note that FFTs and IFFTs share the same plans if all dimensions
    * match
-   * Note: fft_size must be unsigned so that the axis overload does not match both 
+   * Note: fft_size must be unsigned so that the axis overload does not match both
    * prototypes with index_t. However, the value of fft_size must still fit into an index_t.
    *
    * @tparam OpA
@@ -625,7 +625,7 @@ namespace matx
      const index_t fft_size_ = static_cast<index_t>(fft_size);
      return detail::FFTOp<OpA, detail::no_permute_t, detail::FFTDirection::FORWARD, detail::FFTType::R2C>(a, fft_size_, detail::no_permute_t{}, norm);
    }
- 
+
    /**
     * R2C FFT
     *
@@ -654,7 +654,7 @@ namespace matx
        const index_t fft_size_ = static_cast<index_t>(fft_size);
        return detail::FFTOp<OpA, decltype(perm), detail::FFTDirection::FORWARD, detail::FFTType::R2C>(a, fft_size_, perm, norm);
      }
-   }  
+   }
 
   /**
    * Run a 1D IFFT with a cached plan
@@ -665,8 +665,8 @@ namespace matx
    *
    * @tparam OpA
    *   Input tensor or operator type
-   * 
-   * Note: fft_size must be unsigned so that the axis overload does not match both 
+   *
+   * Note: fft_size must be unsigned so that the axis overload does not match both
    * prototypes with index_t. However, the value of fft_size must still fit into an index_t.
    * @param a
    *   input tensor or operator
@@ -687,7 +687,7 @@ namespace matx
    * Creates a new FFT Iplan in the cache if none exists, and uses that to execute
    * the 1D IFFT. Note that FFTs and IFFTs share the same plans if all dimensions
    * match
-   * Note: fft_size must be unsigned so that the axis overload does not match both 
+   * Note: fft_size must be unsigned so that the axis overload does not match both
    * prototypes with index_t. However, the value of fft_size must still fit into an index_t.
    *
    * @tparam OpA
@@ -721,8 +721,8 @@ namespace matx
    *
    * @tparam OpA
    *   Input tensor or operator type
-   * 
-   * Note: fft_size must be unsigned so that the axis overload does not match both 
+   *
+   * Note: fft_size must be unsigned so that the axis overload does not match both
    * prototypes with index_t. However, the value of fft_size must still fit into an index_t.
    * @param a
    *   input tensor or operator
@@ -736,7 +736,7 @@ namespace matx
      const index_t fft_size_ = static_cast<index_t>(fft_size);
      return detail::FFTOp<OpA, detail::no_permute_t, detail::FFTDirection::BACKWARD, detail::FFTType::C2R>(a, fft_size_, detail::no_permute_t{} , norm);
    }
- 
+
    /**
     * C2R inverse FFT
     *
@@ -764,7 +764,7 @@ namespace matx
        const index_t fft_size_ = static_cast<index_t>(fft_size);
        return detail::FFTOp<OpA, decltype(perm), detail::FFTDirection::BACKWARD, detail::FFTType::C2R>(a, fft_size_, perm, norm);
      }
-   }    
+   }
 
 
   namespace detail {
@@ -776,13 +776,13 @@ namespace matx
         PermDims perm_;
         FFTNorm norm_;
         cuda::std::array<index_t, OpA::Rank()> out_dims_;
-        using ttype = std::conditional_t<is_complex_v<typename OpA::value_type>, 
-                                          typename OpA::value_type, 
+        using ttype = std::conditional_t<is_complex_v<typename OpA::value_type>,
+                                          typename OpA::value_type,
                                           typename scalar_to_complex<typename OpA::value_type>::ctype>;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in fft
-        mutable detail::tensor_impl_t<ttype, OpA::Rank()> tmp_out_; 
+        mutable detail::tensor_impl_t<ttype, OpA::Rank()> tmp_out_;
         mutable ttype *ptr = nullptr;
-        mutable bool prerun_done_ = false;                                                
+        mutable bool prerun_done_ = false;
 #if defined(MATX_EN_MATHDX) && defined(__CUDACC__)
         mutable cuFFTDx2DHelper<typename OpA::value_type> dx_fft2_helper_;
         bool jit_axes_supported_ = true;
@@ -809,7 +809,7 @@ namespace matx
         }
 #endif
 
-        __MATX_INLINE__ std::string str() const { 
+        __MATX_INLINE__ std::string str() const {
           if constexpr (Direction == detail::FFTDirection::FORWARD) {
             return "fft2(" + get_type_str(a_) + ")";
           }
@@ -825,13 +825,13 @@ namespace matx
           }
 
           if constexpr (Type == detail::FFTType::C2C) {
-            if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+            if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
               out_dims_[perm_[0]] = out_dims_[perm_[0]];
               out_dims_[perm_[1]] = out_dims_[perm_[1]];
             }
           }
           else if constexpr (Type == detail::FFTType::R2C) {
-            if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+            if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
               out_dims_[perm_[0]] = out_dims_[perm_[0]] / 2 + 1;
               out_dims_[perm_[1]] = out_dims_[perm_[1]];
             }
@@ -841,7 +841,7 @@ namespace matx
             }
           }
           else {
-            if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+            if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
               out_dims_[perm_[0]] = 2 * (out_dims_[perm_[0]] - 1);
               out_dims_[perm_[1]] = out_dims_[perm_[1]];
             }
@@ -852,7 +852,7 @@ namespace matx
           }
 
 #if defined(MATX_EN_MATHDX) && defined(__CUDACC__)
-          if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+          if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
             for (int32_t i = 0; i < Rank(); i++) {
               if (perm_[static_cast<size_t>(i)] != i) {
                 jit_axes_supported_ = false;
@@ -943,7 +943,7 @@ namespace matx
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return tmp_out_.template operator()<DefaultCapabilities>(indices...);
-        }        
+        }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank() {
           return OpA::Rank();
@@ -965,8 +965,8 @@ namespace matx
 
         template <typename Out, typename Executor>
         void Exec(Out &&out, Executor &&ex) const {
-          if constexpr (std::is_same_v<PermDims, no_permute_t>) {
-            if constexpr (Direction == detail::FFTDirection::FORWARD) { 
+          if constexpr (cuda::std::is_same_v<PermDims, no_permute_t>) {
+            if constexpr (Direction == detail::FFTDirection::FORWARD) {
               fft2_impl(cuda::std::get<0>(out), a_, norm_, ex);
             }
             else {
@@ -1144,8 +1144,8 @@ namespace matx
         {
           if constexpr (is_matx_op<OpA>()) {
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }         
-        }      
+          }
+        }
 
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -1154,9 +1154,9 @@ namespace matx
             return;
           }
 
-          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
+          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
-          detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);          
+          detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
           prerun_done_ = true;
           Exec(cuda::std::make_tuple(tmp_out_), std::forward<Executor>(ex));
@@ -1172,8 +1172,8 @@ namespace matx
           matxFree(ptr);
           ptr = nullptr;
           prerun_done_ = false;
-        }    
-    };    
+        }
+    };
   }
 
 /**
@@ -1215,7 +1215,7 @@ namespace matx
   template<typename OpA>
   __MATX_INLINE__ auto fft2(const OpA &a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD) {
     constexpr auto fft_type = detail::ComplexInType<OpA>();
-    auto perm = detail::getPermuteDims<remove_cvref_t<OpA>::Rank()>(axis);  
+    auto perm = detail::getPermuteDims<remove_cvref_t<OpA>::Rank()>(axis);
     return detail::FFT2Op<OpA, decltype(perm), detail::FFTDirection::FORWARD, fft_type>(a, perm, norm);
   }
 
@@ -1258,9 +1258,9 @@ namespace matx
   template<typename OpA>
   __MATX_INLINE__ auto ifft2(const OpA &a, const int32_t (&axis)[2], FFTNorm norm = FFTNorm::BACKWARD) {
     constexpr auto fft_type = detail::ComplexInType<OpA>();
-    auto perm = detail::getPermuteDims<remove_cvref_t<OpA>::Rank()>(axis);  
+    auto perm = detail::getPermuteDims<remove_cvref_t<OpA>::Rank()>(axis);
     return detail::FFT2Op<OpA, decltype(perm), detail::FFTDirection::BACKWARD, fft_type>(a, perm, norm);
-  }  
+  }
 
 
   /**

--- a/include/matx/operators/find_peaks.h
+++ b/include/matx/operators/find_peaks.h
@@ -58,9 +58,9 @@ namespace detail {
       using find_peaks_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "find_peaks(" + get_type_str(a_) + ")"; }
-      __MATX_INLINE__ FindPeaksOp(const OpA &a, value_type height, 
-                                                value_type threshold) : 
-                                                a_(a), height_(height), threshold_(threshold) { 
+      __MATX_INLINE__ FindPeaksOp(const OpA &a, value_type height,
+                                                value_type threshold) :
+                                                a_(a), height_(height), threshold_(threshold) {
         MATX_LOG_TRACE("{} constructor: height={}, threshold={}", str(), height, threshold);
       }
 
@@ -75,11 +75,11 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(cuda::std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 2 outputs on find_peaks(). ie: (mtie(O, num_found) = find_peaks(A, height, threshold))");     
+        static_assert(cuda::std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 2 outputs on find_peaks(). ie: (mtie(O, num_found) = find_peaks(A, height, threshold))");
         static_assert(remove_cvref_t<decltype(cuda::std::get<1>(out))>::Rank() == 0 &&
-                      std::is_same_v<typename remove_cvref_t<decltype(cuda::std::get<1>(out))>::value_type, int>, 
+                      cuda::std::is_same_v<typename remove_cvref_t<decltype(cuda::std::get<1>(out))>::value_type, int>,
                       "Num elements output must be a scalar integer tensor");
-        static_assert(std::is_same_v<typename remove_cvref_t<decltype(cuda::std::get<0>(out))>::value_type, index_t>, 
+        static_assert(cuda::std::is_same_v<typename remove_cvref_t<decltype(cuda::std::get<0>(out))>::value_type, index_t>,
                       "Peak indices output must be a 1D matx::index_t tensor");
         find_peaks_impl(cuda::std::get<0>(out), cuda::std::get<1>(out), a_, height_, threshold_, ex);
       }
@@ -94,13 +94,13 @@ namespace detail {
       {
         if constexpr (is_matx_op<OpA>()) {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        }          
-      }      
+        }
+      }
 
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
       {
-        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));    
+        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
       }
 
       template <typename ShapeType, typename Executor>
@@ -124,7 +124,7 @@ namespace detail {
  * Compute peak search of input
  *
  * Returns a tensor representing the indices of peaks found in the input operator. The first output parameter holds the indices
- * while the second holds the number of indices/peaks found. The output index tensor must be large enough to hold all of the peaks 
+ * while the second holds the number of indices/peaks found. The output index tensor must be large enough to hold all of the peaks
  * found or the behavior is undefined.
  *
  * @tparam InType

--- a/include/matx/operators/frexp.h
+++ b/include/matx/operators/frexp.h
@@ -144,7 +144,7 @@ namespace detail {
       __MATX_INLINE__ std::string str() const { return "frexp()"; }
       __MATX_INLINE__ FrexpOp(const OpA &a) : a_(a) {
         MATX_LOG_TRACE("{} constructor: rank={}", str(), Rank());
-        static_assert(std::is_floating_point_v<input_type> ||
+        static_assert(cuda::std::is_floating_point_v<input_type> ||
                       is_cuda_complex_v<input_type>, "frexp() must take a floating point input");
 
       };

--- a/include/matx/operators/frexp.h
+++ b/include/matx/operators/frexp.h
@@ -77,7 +77,7 @@ namespace detail {
         for (int i = 0; i < actual_rank; ++i) {
           out_dims_[i] = Size(i);
         }
-        
+
         return cuda::std::make_tuple(
           func_name,
           std::format("template <typename OpA> struct {} {{\n"
@@ -150,12 +150,12 @@ namespace detail {
       };
 
       template <typename CapType, typename... Is>
-      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+      __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
       {
         auto get_scalar = [](const auto &x){
-          [[maybe_unused]] int rexp;        
+          [[maybe_unused]] int rexp;
           if constexpr (is_cuda_complex_v<input_type>) {
-            if constexpr (std::is_same_v<float, typename input_type::value_type>) {
+            if constexpr (cuda::std::is_same_v<float, typename input_type::value_type>) {
               if constexpr (WHICH == 0) { // real fractional
                 const auto frac = cuda::std::frexpf(x.real(), &rexp);
                 return frac;
@@ -187,7 +187,7 @@ namespace detail {
             }
           }
           else {
-            if constexpr (std::is_same_v<float, input_type>) {
+            if constexpr (cuda::std::is_same_v<float, input_type>) {
               [[maybe_unused]] const float frac = cuda::std::frexpf(x, &rexp);
               if constexpr (WHICH == 0) { // fractional
                 return frac;

--- a/include/matx/operators/interleaved.h
+++ b/include/matx/operators/interleaved.h
@@ -55,7 +55,7 @@ namespace matx
         using dynamic_tensor_expr = cuda::std::bool_constant<
           is_dynamic_tensor_v<T1> || is_dynamic_rank_op_v<T1>>;
 
-        using complex_type = std::conditional_t<is_matx_half_v<value_type>,
+        using complex_type = cuda::std::conditional_t<is_matx_half_v<value_type>,
               matxHalfComplex<value_type>,
               cuda::std::complex<value_type>>;
 
@@ -80,7 +80,7 @@ namespace matx
           for (int i = 0; i < actual_rank; ++i) {
             out_dims_[i] = Size(i);
           }
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::format("template <typename T> struct {} {{\n"
@@ -125,10 +125,10 @@ namespace matx
           static_assert(!is_complex_v<extract_value_type_t<T1>>, "Complex interleaved op only works on scalar input types");
           static_assert(Rank() > 0);
         };
- 
+
 
         template <typename CapType, typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
         {
           if constexpr (CapType::ept == ElementsPerThread::ONE) {
             auto real = get_value<DefaultCapabilities>(op_, indices...);
@@ -145,7 +145,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
         {
           return this->operator()<DefaultCapabilities>(indices...);
         }

--- a/include/matx/operators/lu.h
+++ b/include/matx/operators/lu.h
@@ -156,7 +156,7 @@ namespace detail {
           }
           else {
 #if MATX_EN_CPU_SOLVER
-            if constexpr (std::is_same_v<piv_value_type, lapack_int_t>) {
+            if constexpr (cuda::std::is_same_v<piv_value_type, lapack_int_t>) {
               lu_impl(factors_, piv_, a_, std::forward<Executor>(ex));
             }
             else {
@@ -351,7 +351,7 @@ namespace detail {
 
       template <typename Out, typename Executor>
       void Exec(Out &&out, Executor &&ex) const {
-        static_assert(cuda::std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 2 outputs on lu(). ie: (mtie(O, piv) = lu(A))");     
+        static_assert(cuda::std::tuple_size_v<remove_cvref_t<Out>> == 3, "Must use mtie with 2 outputs on lu(). ie: (mtie(O, piv) = lu(A))");
 
         lu_impl(cuda::std::get<0>(out), cuda::std::get<1>(out), state_->Input(), ex);
       }
@@ -390,25 +390,25 @@ namespace detail {
 /**
  * Performs an LU factorization using partial pivoting with row interchanges.
  * The factorization has the form `A = P * L * U`.
- * 
+ *
  * The input and output tensors may be the same tensor, in which case the
  * input is overwritten.
  *
  * If rank > 2, operations are batched.
- * 
+ *
  * @tparam OpA
  *   Data type of input a tensor or operator
- * 
+ *
  * @param a
  *   Input tensor or operator of shape `... x m x n`
- * 
+ *
  * @return
  *   Operator that produces a tensor containing *L* and *U* and another containing the pivot indices.
  *   - **Out** - A tensor of shape `... x m x n` containing both *L* and *U*. *L* can be extracted
  *               from the bottom half (the unit diagonals are not stored in *Out*), and *U* can
  *               be extracted from the top half with the diagonals.
  *   - **Piv** - The tensor of pivot indices with shape `... x min(m, n)`. For
- *               \f$ 0 \leq i < \min(m, n) \f$, row i was interchanged with row 
+ *               \f$ 0 \leq i < \min(m, n) \f$, row i was interchanged with row
  *               \f$ Piv(..., i) - 1 \f$. It must be of type `int64_t` for cuda
  *               `matx::lapack_int_t` for host.
  */

--- a/include/matx/operators/matmul.h
+++ b/include/matx/operators/matmul.h
@@ -61,7 +61,7 @@ namespace matx
         typename detail::base_type_t<OpB> b_;
         float alpha_;
         float beta_;
-        PermDims perm_; 
+        PermDims perm_;
         static constexpr int out_rank = cuda::std::max(OpA::Rank(), OpB::Rank());
         cuda::std::array<index_t, out_rank> out_dims_;
         // This should be tensor_impl_t, but need to work around issues with temp types returned in matmul
@@ -70,7 +70,7 @@ namespace matx
         mutable bool prerun_done_ = false;
 #if defined(MATX_EN_MATHDX) && defined(__CUDACC__)
         mutable cuBLASDxHelper<typename OpA::value_type> dx_gemm_helper_;
-#endif 
+#endif
 
       public:
         using matxop = bool;
@@ -84,7 +84,7 @@ namespace matx
           is_dynamic_tensor_v<OpA> || is_dynamic_rank_op_v<OpA> ||
           is_dynamic_tensor_v<OpB> || is_dynamic_rank_op_v<OpB>>;
 
-        __MATX_INLINE__ std::string str() const { 
+        __MATX_INLINE__ std::string str() const {
             return "matmul(" + get_type_str(a_) + "," + get_type_str(b_) + ")";
         }
 
@@ -97,7 +97,7 @@ namespace matx
         JIT_Storage ToJITStorage() const {
           return JIT_Storage{detail::to_jit_storage(a_), detail::to_jit_storage(b_)};
         }
-#endif           
+#endif
 
 #if defined(MATX_EN_MATHDX) && defined(__CUDACC__)
         __MATX_INLINE__ std::string get_jit_class_name() const {
@@ -148,16 +148,16 @@ namespace matx
                  "  constexpr __MATX_INLINE__ __MATX_DEVICE__ index_t Size(int dim) const\n" +
                  "  {\n" +
                  "    return out_dims_[dim];\n" +
-                 "  }\n" +    
+                 "  }\n" +
                  "};\n")
           );
         }
 #endif
 
-        __MATX_INLINE__ MatMulOp(const OpA &a, const OpB &b, float alpha, float beta, PermDims perm) : 
+        __MATX_INLINE__ MatMulOp(const OpA &a, const OpB &b, float alpha, float beta, PermDims perm) :
               a_(a), b_(b), alpha_(alpha), beta_(beta), perm_(perm) {
           MATX_LOG_TRACE("{} constructor: alpha={}, beta={}", str(), alpha, beta);
-          if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+          if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
             for (int r = 0; r < Rank(); r++) {
               if (r == Rank() - 2) {
                 out_dims_[perm_[r]] = a_.Size(r);
@@ -186,7 +186,7 @@ namespace matx
           // n = cols of output (from B's last dim)
           // k = inner dimension (A's last dim = B's second-to-last dim)
           const int cc = GetComputeCapability();  // Compute capability as __CUDA_ARCH__ digits (e.g., 890 for SM 8.9)
-          
+
           dx_gemm_helper_.set_m(a_.Size(OpA::Rank() - 2));
           dx_gemm_helper_.set_n(b_.Size(OpB::Rank() - 1));
           dx_gemm_helper_.set_k(a_.Size(OpA::Rank() - 1));
@@ -217,7 +217,7 @@ namespace matx
             return combine_capabilities<Cap>(detail::get_operator_capability<Cap>(a_, in_copy), detail::get_operator_capability<Cap>(b_, in_copy));
           }
           else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-#if defined(MATX_EN_MATHDX) && defined(__CUDACC__)            
+#if defined(MATX_EN_MATHDX) && defined(__CUDACC__)
             auto result = ElementsPerThread::ONE;
             MATX_LOG_DEBUG("cuBLASDx ELEMENTS_PER_THREAD: {}", static_cast<int>(result));
             return cuda::std::array<ElementsPerThread, 2>{result, result};
@@ -226,17 +226,17 @@ namespace matx
 #endif
           }
           else if constexpr (Cap == OperatorCapability::DYN_SHM_SIZE) {
-            auto result = combine_capabilities<Cap>(dx_gemm_helper_.GetShmRequired(), 
+            auto result = combine_capabilities<Cap>(dx_gemm_helper_.GetShmRequired(),
                                                     detail::get_operator_capability<Cap>(a_, in),
                                                     detail::get_operator_capability<Cap>(b_, in));
             MATX_LOG_DEBUG("cuBLASDx DYN_SHM_SIZE: {}", result);
             return result;
           }
           else if constexpr (Cap == OperatorCapability::SUPPORTS_JIT) {
-            bool supported = dx_gemm_helper_.template CheckJITSizeAndTypeRequirements<OpA, OpB>() && 
+            bool supported = dx_gemm_helper_.template CheckJITSizeAndTypeRequirements<OpA, OpB>() &&
                              dx_gemm_helper_.IsSupported();
 
-            auto result = combine_capabilities<Cap>(supported, 
+            auto result = combine_capabilities<Cap>(supported,
                                                     detail::get_operator_capability<Cap>(a_, in),
                                                     detail::get_operator_capability<Cap>(b_, in));
             MATX_LOG_DEBUG("cuBLASDx SUPPORTS_JIT: {}", result);
@@ -245,12 +245,12 @@ namespace matx
           else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
             // Get the capability string and add to map
             const auto [key, value] = get_jit_op_str();
-      
+
             // Insert into the map if the key doesn't exist
             if (in.find(key) == in.end()) {
               in[key] = value;
             }
-            
+
             // Also handle child operators
             detail::get_operator_capability<Cap>(a_, in);
             detail::get_operator_capability<Cap>(b_, in);
@@ -263,13 +263,13 @@ namespace matx
             MATX_LOG_DEBUG("cuBLASDx block dim: {} {} {}", block_dims[0], block_dims[1], block_dims[2]);
             // Use the first dimension as the primary block size (similar to FFT)
             const auto my_block = cuda::std::array<int, 2>{block_dims[0], block_dims[0]};
-            return combine_capabilities<Cap>(my_block, 
+            return combine_capabilities<Cap>(my_block,
                                              detail::get_operator_capability<Cap>(a_, in),
                                              detail::get_operator_capability<Cap>(b_, in));
           }
           else if constexpr (Cap == OperatorCapability::GENERATE_LTOIR) {
             auto result = combine_capabilities<Cap>(
-                dx_gemm_helper_.GenerateLTOIR(in.ltoir_symbols), 
+                dx_gemm_helper_.GenerateLTOIR(in.ltoir_symbols),
                 detail::get_operator_capability<Cap>(a_, in),
                 detail::get_operator_capability<Cap>(b_, in));
             MATX_LOG_DEBUG("cuBLASDx GENERATE_LTOIR: {}", result);
@@ -321,13 +321,13 @@ namespace matx
           else if constexpr (Cap == OperatorCapability::GROUPS_PER_BLOCK) {
             // 2D block operators only support one group per block
             const auto my_cap = cuda::std::array<int, 2>{1, 1};
-            return combine_capabilities<Cap>(my_cap, 
+            return combine_capabilities<Cap>(my_cap,
                                              detail::get_operator_capability<Cap>(a_, in),
                                              detail::get_operator_capability<Cap>(b_, in));
           }
           else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
-            return combine_capabilities<Cap>(self_has_cap, 
+            return combine_capabilities<Cap>(self_has_cap,
                                              detail::get_operator_capability<Cap>(a_, in),
                                              detail::get_operator_capability<Cap>(b_, in));
           }
@@ -340,7 +340,7 @@ namespace matx
           }
           else if constexpr (Cap == OperatorCapability::SUPPORTS_JIT) {
             bool supported = false;
-            auto result = combine_capabilities<Cap>(supported, 
+            auto result = combine_capabilities<Cap>(supported,
                                                     detail::get_operator_capability<Cap>(a_, in),
                                                     detail::get_operator_capability<Cap>(b_, in));
             MATX_LOG_DEBUG("SUPPORTS_JIT (no cuBLASDx): {}", result);
@@ -352,13 +352,13 @@ namespace matx
           }
           else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
-            return combine_capabilities<Cap>(self_has_cap, 
+            return combine_capabilities<Cap>(self_has_cap,
                                              detail::get_operator_capability<Cap>(a_, in),
                                              detail::get_operator_capability<Cap>(b_, in));
           }
 #endif
         }
-   
+
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {
           return out_rank;
@@ -384,14 +384,14 @@ namespace matx
           // Perform SpMM or otherwise GEMM.
           static_assert(!is_sparse_tensor_v<OpB>, "sparse rhs not implemented");
           if constexpr (is_sparse_tensor_v<OpA>) {
-            if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+            if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
               sparse_matmul_impl(permute(cuda::std::get<0>(out), perm_), a_, b_, ex, alpha_, beta_);
             }
             else {
               sparse_matmul_impl(cuda::std::get<0>(out), a_, b_, ex, alpha_, beta_);
             }
           }
-          else if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+          else if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
             bool perm_is_identity = true;
             for (int32_t i = 0; i < Rank(); i++) {
               if (perm_[static_cast<size_t>(i)] != i) {
@@ -416,12 +416,12 @@ namespace matx
         {
           if constexpr (is_matx_op<OpA>()) {
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }     
+          }
 
           if constexpr (is_matx_op<OpB>()) {
             b_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }           
-        }      
+          }
+        }
 
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -430,7 +430,7 @@ namespace matx
             return;
           }
 
-          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));  
+          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
@@ -479,8 +479,8 @@ namespace matx
    *   Scalar multiplier to apply to operator A
    * @param beta
    *   Scalar multiplier to apply to operator C on input
-   * 
-   * @return 
+   *
+   * @return
    *   Operator that produces the output tensor C of shape `... x m x n`
    */
   template<typename OpA, typename OpB>
@@ -535,8 +535,8 @@ namespace matx
    *   Scalar multiplier to apply to operator A
    * @param beta
    *   Scalar multiplier to apply to operator C on input
-   * 
-   * @return 
+   *
+   * @return
    *   Operator that produces the output tensor C of shape `... x m x n`
    */
   template<typename OpA, typename OpB>
@@ -553,5 +553,5 @@ namespace matx
     auto in2 = permute(B, perm);
 
     return detail::MatMulOp(in1, in2, alpha, beta, perm);
-  }  
+  }
 }

--- a/include/matx/operators/max.h
+++ b/include/matx/operators/max.h
@@ -183,7 +183,7 @@ namespace detail {
         }
         else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
 #ifdef MATX_EN_JIT
-          static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
+          static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
                         "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type");
           const auto [key, value] = get_jit_op_str();
           if (in.find(key) == in.end()) {

--- a/include/matx/operators/min.h
+++ b/include/matx/operators/min.h
@@ -183,7 +183,7 @@ namespace detail {
         }
         else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
 #ifdef MATX_EN_JIT
-          static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
+          static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
                         "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type");
           const auto [key, value] = get_jit_op_str();
           if (in.find(key) == in.end()) {

--- a/include/matx/operators/norm.h
+++ b/include/matx/operators/norm.h
@@ -47,11 +47,11 @@ namespace matx
         using out_type = typename inner_op_type_t<typename remove_cvref_t<OpA>::value_type>::type;
         typename detail::base_type_t<OpA> a_;
         NormOrder order_;
-        static constexpr int ORank = std::is_same_v<NormType, detail::NormTypeVector> ? OpA::Rank() - 1 : OpA::Rank() - 2;
+        static constexpr int ORank = cuda::std::is_same_v<NormType, detail::NormTypeVector> ? OpA::Rank() - 1 : OpA::Rank() - 2;
         cuda::std::array<index_t, ORank> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
         mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
-        mutable bool prerun_done_ = false; 
+        mutable bool prerun_done_ = false;
 
       public:
         using matxop = bool;
@@ -60,9 +60,9 @@ namespace matx
         using norm_xform_op = bool;
         using matx_inner_op_impl = bool; // Indicates this operator uses matx operators for its implementation
 
-      __MATX_INLINE__ std::string str() const { 
-        if constexpr (std::is_same_v<NormType, detail::NormTypeVector>) {
-          return "vector_norm()"; 
+      __MATX_INLINE__ std::string str() const {
+        if constexpr (cuda::std::is_same_v<NormType, detail::NormTypeVector>) {
+          return "vector_norm()";
         }
         else {
           return "matrix_norm";
@@ -71,7 +71,7 @@ namespace matx
 
       __MATX_INLINE__ NormOp(const OpA &op, NormOrder order) : a_(op), order_(order) {
         MATX_LOG_TRACE("{} constructor: order={}", str(), static_cast<int>(order));
-        if constexpr (std::is_same_v<NormType, detail::NormTypeVector>) {
+        if constexpr (cuda::std::is_same_v<NormType, detail::NormTypeVector>) {
           MATX_ASSERT_STR(order == NormOrder::NONE || order == NormOrder::L1 || order == NormOrder::L2, matxInvalidParameter,
             "Invalid norm order used for vector mode");
         }
@@ -114,7 +114,7 @@ namespace matx
         if constexpr (is_matx_op<OpA>()) {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
         }
-      } 
+      }
 
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -175,7 +175,7 @@ namespace matx
    *
    * @tparam Op Type of input values to evaluate
    * @param op Input values to evaluate
-   * @param dims Dimensions to perform norm over   
+   * @param dims Dimensions to perform norm over
    * @param order Order of norm
    * @return norm operator
    */
@@ -211,7 +211,7 @@ namespace matx
    *
    * @tparam Op Type of input values to evaluate
    * @param op Input values to evaluate
-   * @param dims Dimensions to perform norm over   
+   * @param dims Dimensions to perform norm over
    * @param order Order of norm
    * @return norm operator
    */
@@ -221,5 +221,5 @@ namespace matx
     auto perm = detail::getPermuteDims<Op::Rank()>(dims);
     auto permop = permute(op, perm);
     return detail::NormOp<Op, detail::NormTypeMatrix>(permop, order);
-  }  
+  }
 } // end namespace matx

--- a/include/matx/operators/normalize.h
+++ b/include/matx/operators/normalize.h
@@ -36,7 +36,7 @@
 #include "matx/operators/base_operator.h"
 #include "matx/transforms/normalize.h"
 
-namespace matx 
+namespace matx
 {
   namespace detail
   {
@@ -50,8 +50,8 @@ namespace matx
         float p_ = -1.0f;
         float a_ = 0.0f;
         float b_ = 1.0f;
-        using ttype = std::conditional_t<is_complex_v<typename OpA::value_type>, 
-                                      typename OpA::value_type, 
+        using ttype = cuda::std::conditional_t<is_complex_v<typename OpA::value_type>,
+                                      typename OpA::value_type,
                                       typename scalar_to_complex<typename OpA::value_type>::ctype>;
         mutable ::matx::detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
         mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
@@ -67,7 +67,7 @@ namespace matx
 
       public:
         using matxop = bool;
-        using matx_transform_op = bool; 
+        using matx_transform_op = bool;
         using value_type = typename OpA::value_type;
         using self_type = NormalizeOp<OpA, DIM>;
 

--- a/include/matx/operators/permute.h
+++ b/include/matx/operators/permute.h
@@ -220,7 +220,7 @@ namespace matx
         {
           if constexpr (CapType::ept == ElementsPerThread::ONE) {
             static_assert(sizeof...(Is)==Rank());
-            static_assert((std::is_convertible_v<Is, index_t> && ... ));
+            static_assert((cuda::std::is_convertible_v<Is, index_t> && ... ));
 
             const cuda::std::array<index_t, Rank()> inds{indices...};
             return apply_permuted_<CapType>(cuda::std::forward<Op>(op),

--- a/include/matx/operators/prod.h
+++ b/include/matx/operators/prod.h
@@ -191,7 +191,7 @@ namespace detail {
         }
         else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
 #ifdef MATX_EN_JIT
-          static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
+          static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
                         "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type");
           const auto [key, value] = get_jit_op_str();
           if (in.find(key) == in.end()) {

--- a/include/matx/operators/reduce.h
+++ b/include/matx/operators/reduce.h
@@ -52,7 +52,7 @@ namespace matx
         cuda::std::array<index_t, ORank> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, ORank> tmp_out_;
         mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
-        mutable bool prerun_done_ = false; 
+        mutable bool prerun_done_ = false;
 
       public:
         using matxop = bool;
@@ -60,11 +60,11 @@ namespace matx
         using matx_transform_op = bool;
         using reduce_xform_op = bool;
 
-        __MATX_INLINE__ std::string str() const { 
+        __MATX_INLINE__ std::string str() const {
           return "reduce(" + get_type_str(a_) + ")";
         }
 
-        __MATX_INLINE__ ReduceOp(const OpA &A, PermDims perm, ReductionOp rop, bool init) : 
+        __MATX_INLINE__ ReduceOp(const OpA &A, PermDims perm, ReductionOp rop, bool init) :
               a_(A), perm_(perm), reduction_op_(rop), init_(init) {
           MATX_LOG_TRACE("{} constructor: rop={}, init={}", str(), static_cast<int>(rop), init);
           for (int r = 0; r < ORank; r++) {
@@ -105,7 +105,7 @@ namespace matx
         void Exec(Out &&out, Executor &&ex) const {
           static_assert(is_cuda_executor_v<Executor>, "reduce() only supports the CUDA executor currently");
 
-          if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+          if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
             reduce_impl(cuda::std::get<0>(out), a_, perm_, reduction_op_, ex.getStream(), init_);
           }
           else {
@@ -118,8 +118,8 @@ namespace matx
         {
           if constexpr (is_matx_op<OpA>()) {
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }           
-        }      
+          }
+        }
 
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -128,7 +128,7 @@ namespace matx
             return;
           }
 
-          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));           
+          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
@@ -146,7 +146,7 @@ namespace matx
           matxFree(ptr);
           ptr = nullptr;
           prerun_done_ = false;
-        }               
+        }
     };
   }
 
@@ -163,7 +163,7 @@ namespace matx
  *   Reduction operator type
  *
  * @param in
- *   Input data to compute the reduce 
+ *   Input data to compute the reduce
  * @param op
  *   Reduction operator
  * @param init
@@ -172,8 +172,8 @@ namespace matx
 template <typename InType, typename ReduceOp>
 __MATX_INLINE__ auto reduce(const InType &in, ReduceOp op, bool init = true)
 {
-  return detail::ReduceOp(in, detail::no_permute_t{}, op, init);     
-}  
+  return detail::ReduceOp(in, detail::no_permute_t{}, op, init);
+}
 
 
 
@@ -188,7 +188,7 @@ __MATX_INLINE__ auto reduce(const InType &in, ReduceOp op, bool init = true)
  * anything higher, the reduction is performed across the number of ranks below
  * the input tensor that the output tensor is. For example, if the input tensor
  * is a 4D tensor and the reduction is on a single axis, the reduction is performed
- * across the innermost dimension of the input. 
+ * across the innermost dimension of the input.
  *
  * @tparam InType
  *   Input data type
@@ -198,7 +198,7 @@ __MATX_INLINE__ auto reduce(const InType &in, ReduceOp op, bool init = true)
  *   Reduction operator type
  *
  * @param in
- *   Input data to compute the reduce 
+ *   Input data to compute the reduce
  * @param dims
  *   C-style array containing the dimensions to sum over
  * @param op
@@ -210,7 +210,7 @@ template <typename InType, int D, typename ReduceOp>
 __MATX_INLINE__ auto reduce(const InType &in, const int (&dims)[D], ReduceOp op, bool init = true)
 {
   MATX_NVTX_START("reduce(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
-  
+
   static_assert(D < InType::Rank(), "reduce dimensions must be <= Rank of input");
 
   return detail::ReduceOp(in, detail::to_array(dims), op, init);

--- a/include/matx/operators/remap.h
+++ b/include/matx/operators/remap.h
@@ -157,7 +157,7 @@ namespace matx
         {
           if constexpr (CapType::ept == ElementsPerThread::ONE) {
             static_assert(sizeof...(Is) == Rank());
-            static_assert((std::is_convertible_v<Is, index_t> && ... ));
+            static_assert((cuda::std::is_convertible_v<Is, index_t> && ... ));
 
             cuda::std::array ind{indices...};
 
@@ -307,7 +307,7 @@ namespace matx
 
         __MATX_INLINE__ auto operator=(const self_type &rhs) {
           return set(*this, rhs);
-        }        
+        }
 
         template<typename R>
         __MATX_INLINE__ auto operator=(const R &rhs) {

--- a/include/matx/operators/resample_poly.h
+++ b/include/matx/operators/resample_poly.h
@@ -46,8 +46,8 @@ namespace detail {
   class ResamplePolyOp : public BaseOp<ResamplePolyOp<OpA, FilterType>>
   {
     private:
-      using out_t = std::conditional_t<is_complex_v<typename OpA::value_type>, 
-            typename FilterType::value_type, typename FilterType::value_type>;          
+      using out_t = cuda::std::conditional_t<is_complex_v<typename OpA::value_type>,
+            typename FilterType::value_type, typename FilterType::value_type>;
       typename detail::base_type_t<OpA> a_;
       typename detail::base_type_t<FilterType> f_;
       index_t up_;
@@ -55,19 +55,19 @@ namespace detail {
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<out_t, OpA::Rank()> tmp_out_;
       mutable out_t *ptr = nullptr;
-      mutable bool prerun_done_ = false;       
+      mutable bool prerun_done_ = false;
 
     public:
       using matxop = bool;
       using matx_transform_op = bool;
       using resample_poly_xform_op = bool;
-      using value_type = out_t;            
+      using value_type = out_t;
 
       __MATX_INLINE__ std::string str() const { return "resample_poly(" + get_type_str(a_) + "," + get_type_str(f_) + ")";}
-      __MATX_INLINE__ ResamplePolyOp(const OpA &a, const FilterType &f, index_t up, index_t down) : 
-          a_(a), f_(f), up_(up), down_(down) 
+      __MATX_INLINE__ ResamplePolyOp(const OpA &a, const FilterType &f, index_t up, index_t down) :
+          a_(a), f_(f), up_(up), down_(down)
       {
-        MATX_LOG_TRACE("{} constructor: up={}, down={}", str(), up, down); 
+        MATX_LOG_TRACE("{} constructor: up={}, down={}", str(), up, down);
         const index_t up_len = a_.Size(OpA::Rank() - 1) * up_;
         const index_t b_len = up_len / down_ + ((up_len % down_) ? 1 : 0);
 
@@ -92,7 +92,7 @@ namespace detail {
       template <OperatorCapability Cap, typename InType>
       __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType &in) const {
         auto self_has_cap = capability_attributes<Cap>::default_value;
-        return combine_capabilities<Cap>(self_has_cap, 
+        return combine_capabilities<Cap>(self_has_cap,
                                            detail::get_operator_capability<Cap>(a_, in),
                                            detail::get_operator_capability<Cap>(f_, in));
       }
@@ -100,7 +100,7 @@ namespace detail {
       constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ index_t Size(int dim) const
       {
         return out_dims_[dim];
-      }      
+      }
 
       static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
       {
@@ -127,8 +127,8 @@ namespace detail {
 
         if constexpr (is_matx_op<FilterType>()) {
           f_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        }              
-      } 
+        }
+      }
 
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -137,7 +137,7 @@ namespace detail {
           return;
         }
 
-        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));         
+        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
         if constexpr (is_host_executor_v<Executor>) {
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr,
@@ -160,25 +160,25 @@ namespace detail {
 
         if constexpr (is_matx_op<FilterType>()) {
           f_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        } 
+        }
 
         matxFree(ptr);
         ptr = nullptr;
         prerun_done_ = false;
-      }             
+      }
   };
 }
 
 /**
  * @brief 1D polyphase resampler
- * 
+ *
  * @tparam InType Type of input
  * @tparam FilterType Type of filter
  * @param in Input operator
  * @param f Filter operator
  * @param up Factor by which to upsample
  * @param down Factor by which to downsample
- * 
+ *
  * @returns Operator representing the filtered inputs
  */
 template <typename InType, typename FilterType>

--- a/include/matx/operators/scalar_ops.h
+++ b/include/matx/operators/scalar_ops.h
@@ -110,7 +110,7 @@ namespace detail {
     template <OperatorCapability Cap, typename InType> \
     __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType &in) const { \
       if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) { \
-        static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
+        static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
                       "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type"); \
         const auto [key, value] = get_jit_op_str(); \
         if (in.find(key) == in.end()) { \
@@ -182,7 +182,7 @@ namespace detail {
     template <OperatorCapability Cap, typename InType> \
     __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType &in) const { \
       if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) { \
-        static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
+        static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
                       "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type"); \
         const auto [key, value] = get_jit_op_str(); \
         if (in.find(key) == in.end()) { \
@@ -262,7 +262,7 @@ namespace detail {
     template <OperatorCapability Cap, typename InType> \
     __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType &in) const { \
       if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) { \
-        static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
+        static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
                       "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type"); \
         const auto [key, value] = get_jit_op_str(); \
         if (in.find(key) == in.end()) { \
@@ -336,7 +336,7 @@ namespace detail {
     template <OperatorCapability Cap, typename InType> \
     __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType &in) const { \
       if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) { \
-        static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
+        static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
                       "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type"); \
         const auto [key, value] = get_jit_op_str(); \
         if (in.find(key) == in.end()) { \
@@ -408,7 +408,7 @@ namespace detail {
     template <OperatorCapability Cap, typename InType> \
     __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType &in) const { \
       if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) { \
-        static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
+        static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>, \
                       "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type"); \
         const auto [key, value] = get_jit_op_str(); \
         if (in.find(key) == in.end()) { \

--- a/include/matx/operators/set.h
+++ b/include/matx/operators/set.h
@@ -65,7 +65,7 @@ private:
   template <typename F, typename U>
   static constexpr bool compute()
   {
-    if constexpr (std::is_void_v<F> || std::is_void_v<U> || std::is_same_v<F, U>) {
+    if constexpr (std::is_void_v<F> || std::is_void_v<U> || cuda::std::is_same_v<F, U>) {
       return false;
     }
     else if constexpr (is_vector_v<F>) {
@@ -87,8 +87,8 @@ private:
       return false;
     }
     else {
-      // List initialization will reject narrowing conversions, so we can check if the conversion is narrowing by 
-      // testing if F can be list-initialized into U. We also check that the types are not the same, as some 
+      // List initialization will reject narrowing conversions, so we can check if the conversion is narrowing by
+      // testing if F can be list-initialized into U. We also check that the types are not the same, as some
       // types (e.g. half) have non-narrowing implicit conversions to the same type that are not accepted by list initialization.
       return !requires(F from) { U{from}; };
     }
@@ -272,12 +272,12 @@ public:
       }
       return in_val;
     }
-  } 
-  
+  }
+
 #ifdef MATX_EN_JIT
   struct JIT_Storage {
     mutable typename detail::inner_storage_or_self_t<detail::base_type_t<T>> out_;
-    mutable typename detail::inner_storage_or_self_t<detail::base_type_t<Op>> op_;  
+    mutable typename detail::inner_storage_or_self_t<detail::base_type_t<Op>> op_;
   };
 
   JIT_Storage ToJITStorage() const {
@@ -372,12 +372,12 @@ public:
            "   }\n" +
            "};\n"
     );
-  }      
-#endif  
+  }
+#endif
 
 
   template <typename... Is>
-  __MATX_DEVICE__ __MATX_HOST__ inline decltype(auto) operator()(Is... indices) const noexcept  
+  __MATX_DEVICE__ __MATX_HOST__ inline decltype(auto) operator()(Is... indices) const noexcept
   {
     return (*this).template operator()<DefaultCapabilities>(indices...);
   }
@@ -407,7 +407,7 @@ public:
   template <detail::OperatorCapability Cap, typename InType>
   __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
     if constexpr (Cap == OperatorCapability::JIT_TYPE_QUERY) {
-#ifdef MATX_EN_JIT       
+#ifdef MATX_EN_JIT
       // No need to use combine_capabilities here since we're just returning a string.
       const auto lhs_jit_name = detail::get_operator_capability<Cap>(out_, in);
       const auto rhs_jit_name = detail::get_operator_capability<Cap>(op_, in);
@@ -415,7 +415,7 @@ public:
 #else
       return "";
 #endif
-    }  
+    }
     else if constexpr (Cap == OperatorCapability::JIT_CACHE_KEY) {
 #ifdef MATX_EN_JIT
       auto key = detail::MakeJITCacheKeyForType<set<T, Op>>("JITSetOp");
@@ -442,16 +442,16 @@ public:
 #ifdef MATX_EN_JIT
       // Get the key/value pair from get_jit_op_str()
       const auto [key, value] = get_jit_op_str();
-      
+
       // Insert into the map if the key doesn't exist
       if (in.find(key) == in.end()) {
         in[key] = value;
       }
-      
+
       // Also handle child operators
       detail::get_operator_capability<Cap>(out_, in);
       detail::get_operator_capability<Cap>(op_, in);
-      
+
       // Always return true for now
       return true;
 #else
@@ -460,7 +460,7 @@ public:
         }
         else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
           if constexpr (ContainsBlockReduction<Op>()) {
-            if constexpr (std::is_same_v<remove_cvref_t<InType>, EPTQueryInput>) {
+            if constexpr (cuda::std::is_same_v<remove_cvref_t<InType>, EPTQueryInput>) {
               if (!in.jit) {
                 return cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE,
                                                               ElementsPerThread::ONE};
@@ -490,7 +490,7 @@ public:
         else {
           auto self_has_cap = capability_attributes<Cap>::default_value;
 
-      return combine_capabilities<Cap>(self_has_cap, 
+      return combine_capabilities<Cap>(self_has_cap,
                                       detail::get_operator_capability<Cap>(out_, in),
                                       detail::get_operator_capability<Cap>(op_, in));
     }

--- a/include/matx/operators/set.h
+++ b/include/matx/operators/set.h
@@ -65,7 +65,7 @@ private:
   template <typename F, typename U>
   static constexpr bool compute()
   {
-    if constexpr (std::is_void_v<F> || std::is_void_v<U> || cuda::std::is_same_v<F, U>) {
+    if constexpr (cuda::std::is_void_v<F> || cuda::std::is_void_v<U> || cuda::std::is_same_v<F, U>) {
       return false;
     }
     else if constexpr (is_vector_v<F>) {
@@ -83,7 +83,7 @@ private:
     else if constexpr (is_complex_v<F> && !is_complex_v<U>) {
       return false;
     }
-    else if constexpr (!std::is_assignable_v<U &, F>) {
+    else if constexpr (!cuda::std::is_assignable_v<U &, F>) {
       return false;
     }
     else {

--- a/include/matx/operators/slice.h
+++ b/include/matx/operators/slice.h
@@ -89,7 +89,7 @@ namespace matx
         }
 
         __MATX_INLINE__ std::string get_jit_stride_type_name() const {
-          if constexpr (std::is_same_v<StrideType, NoStride>) {
+          if constexpr (cuda::std::is_same_v<StrideType, NoStride>) {
             return "matx::detail::NoStride";
           }
           else {
@@ -162,7 +162,7 @@ namespace matx
 
             starts_[i] = start;
 
-            if constexpr (!std::is_same_v<NoStride, StrideType>) {
+            if constexpr (!cuda::std::is_same_v<NoStride, StrideType>) {
               strides_[i] = strides[i];
             }
 
@@ -179,7 +179,7 @@ namespace matx
               }
 
               //adjust size by stride
-              if constexpr (!std::is_same_v<NoStride, StrideType>) {
+              if constexpr (!cuda::std::is_same_v<NoStride, StrideType>) {
                 sizes_[d] = (shape_type)std::ceil(static_cast<double>(sizes_[d])/ static_cast<double>(strides_[d]));
               }
 
@@ -197,11 +197,11 @@ namespace matx
             const decltype(strides_) &strides,
             const decltype(dims_) &dims,
             Is... indices)
-        {   
+        {
           if constexpr (CapType::ept == ElementsPerThread::ONE) {
             static_assert(sizeof...(Is)==Rank());
             static_assert((cuda::std::is_convertible_v<Is, index_t> && ... ));
-        
+
             // convert variadic type to tuple so we can read/update
             cuda::std::array<index_t, T::Rank()> ind = starts;
             cuda::std::array<index_t, Rank()> inds{indices...};
@@ -219,8 +219,8 @@ namespace matx
                   }
                 }
               }
-            }       
-                
+            }
+
             return get_value<CapType>(cuda::std::forward<Op>(op), ind);
           } else {
             return Vector<value_type, static_cast<index_t>(CapType::ept)>{};
@@ -263,7 +263,7 @@ namespace matx
           // to the tensor's EPT logic if the input is a tensor
           else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
             const auto my_cap = cuda::std::array<ElementsPerThread, 2>{ElementsPerThread::ONE, ElementsPerThread::ONE};
-            return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));          
+            return combine_capabilities<Cap>(my_cap, detail::get_operator_capability<Cap>(op_, in));
           } else {
             auto self_has_cap = capability_attributes<Cap>::default_value;
             return combine_capabilities<Cap>(self_has_cap, detail::get_operator_capability<Cap>(op_, in));
@@ -271,7 +271,7 @@ namespace matx
         }
 
         template <typename CapType, typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices) const
         {
           return get_impl<CapType>(cuda::std::as_const(op_), starts_, strides_, dims_, indices...);
         }
@@ -292,7 +292,7 @@ namespace matx
         __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ decltype(auto) operator()(Is... indices)
         {
           return this->operator()<DefaultCapabilities>(indices...);
-        }        
+        }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {

--- a/include/matx/operators/softmax.h
+++ b/include/matx/operators/softmax.h
@@ -49,7 +49,7 @@ namespace matx
         cuda::std::array<index_t, OpA::Rank()> out_dims_;
         mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
         mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
-        mutable bool prerun_done_ = false; 
+        mutable bool prerun_done_ = false;
 
       public:
         using matxop = bool;
@@ -57,16 +57,16 @@ namespace matx
         using matx_transform_op = bool;
         using softmax_xform_op = bool;
 
-        __MATX_INLINE__ std::string str() const { 
+        __MATX_INLINE__ std::string str() const {
           return "softmax(" + get_type_str(a_) + ")";
         }
 
-        __MATX_INLINE__ SoftmaxOp(const OpA &A, PermDims perm) : 
+        __MATX_INLINE__ SoftmaxOp(const OpA &A, PermDims perm) :
               a_(A), perm_(perm) {
           MATX_LOG_TRACE("{} constructor: rank={}", str(), Rank());
           for (int r = 0; r < OpA::Rank(); r++) {
             out_dims_[r] = a_.Size(r);
-          }          
+          }
         }
 
         template <typename CapType, typename... Is>
@@ -101,7 +101,7 @@ namespace matx
         void Exec(Out &&out, Executor &&ex) const {
           static_assert(is_cuda_executor_v<Executor>, "softmax() only supports the CUDA executor currently");
 
-          if constexpr (!std::is_same_v<PermDims, no_permute_t>) {
+          if constexpr (!cuda::std::is_same_v<PermDims, no_permute_t>) {
             softmax_impl(cuda::std::get<0>(out), a_, perm_, ex.getStream());
           }
           else {
@@ -114,8 +114,8 @@ namespace matx
         {
           if constexpr (is_matx_op<OpA>()) {
             a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }         
-        }      
+          }
+        }
 
         template <typename ShapeType, typename Executor>
         __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -124,7 +124,7 @@ namespace matx
             return;
           }
 
-          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));          
+          InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
           detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 
@@ -142,7 +142,7 @@ namespace matx
           matxFree(ptr);
           ptr = nullptr;
           prerun_done_ = false;
-        }   
+        }
     };
   }
 
@@ -152,21 +152,21 @@ namespace matx
  * softmax computes the exponential of each value divided by the sum of the exponentials
  * of items in the reduced set. The axes in which to perform the softmax over determine
  * which axes the sum will be computed over, but the input tensor rank and sizes match
- * between input and output. Note that traditional definitions of softmax are simply 
- * exp(x)/sum(exp(x)), but this is not how most libraries are implemented. Instead, x 
+ * between input and output. Note that traditional definitions of softmax are simply
+ * exp(x)/sum(exp(x)), but this is not how most libraries are implemented. Instead, x
  * is biased by a correction factor of max(x).
  *
  * @tparam InType
  *   Input data type
  *
  * @param in
- *   Input data to compute the softmax 
+ *   Input data to compute the softmax
  */
 template <typename InType>
 __MATX_INLINE__ auto softmax(const InType &in)
 {
-  return detail::SoftmaxOp(in, detail::no_permute_t{});     
-}  
+  return detail::SoftmaxOp(in, detail::no_permute_t{});
+}
 
 
 
@@ -176,8 +176,8 @@ __MATX_INLINE__ auto softmax(const InType &in)
  * softmax computes the exponential of each value divided by the sum of the exponentials
  * of items in the reduced set. The axes in which to perform the softmax over determine
  * which axes the sum will be computed over, but the input tensor rank and sizes match
- * between input and output. Note that traditional definitions of softmax are simply 
- * exp(x)/sum(exp(x)), but this is not how most libraries are implemented. Instead, x 
+ * between input and output. Note that traditional definitions of softmax are simply
+ * exp(x)/sum(exp(x)), but this is not how most libraries are implemented. Instead, x
  * is biased by a correction factor of max(x).
  *
  * @tparam InType
@@ -186,7 +186,7 @@ __MATX_INLINE__ auto softmax(const InType &in)
  *   Rank of dimension array
  *
  * @param in
- *   Input data to compute the softmax 
+ *   Input data to compute the softmax
  * @param dims
  *   C-style array containing the dimensions to sum over
  */
@@ -195,11 +195,11 @@ __MATX_INLINE__ auto softmax(const InType &in, const int (&dims)[D])
 {
 #ifdef __CUDACC__
   MATX_NVTX_START("softmax(" + get_type_str(in) + ")", matx::MATX_NVTX_LOG_API)
-  
+
   static_assert(D < InType::Rank(), "softmax dimensions must be <= Rank of input");
 
   return detail::SoftmaxOp(in, detail::to_array(dims));
-#endif  
+#endif
 }
 
 

--- a/include/matx/operators/sort.h
+++ b/include/matx/operators/sort.h
@@ -56,7 +56,7 @@ namespace detail {
       cuda::std::array<index_t, OpA::Rank()> out_dims_;
       mutable detail::tensor_impl_t<typename remove_cvref_t<OpA>::value_type, OpA::Rank()> tmp_out_;
       mutable typename remove_cvref_t<OpA>::value_type *ptr = nullptr;
-      mutable bool prerun_done_ = false; 
+      mutable bool prerun_done_ = false;
       mutable ElementsPerThread current_ept_ = ElementsPerThread::ONE;
       mutable int current_groups_per_block_ = 1;
 
@@ -67,7 +67,7 @@ namespace detail {
       using sort_xform_op = bool;
 
       __MATX_INLINE__ std::string str() const { return "sort()"; }
-      __MATX_INLINE__ SortOp(const OpA &a, SortDirection_t dir) : a_(a), dir_(dir) { 
+      __MATX_INLINE__ SortOp(const OpA &a, SortDirection_t dir) : a_(a), dir_(dir) {
         MATX_LOG_TRACE("{} constructor: rank={}, dir={}", str(), Rank(), static_cast<int>(dir));
         for (int r = 0; r < Rank(); r++) {
           out_dims_[r] = a_.Size(r);
@@ -176,7 +176,7 @@ namespace detail {
       }
 
       template <OperatorCapability Cap, typename InType>
-      __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {      
+      __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
         if constexpr (Cap == OperatorCapability::BLOCK_DIM) {
 #if defined(MATX_EN_JIT) && defined(__CUDACC__)
           const int block_threads = CurrentBlockThreads();
@@ -188,7 +188,7 @@ namespace detail {
         }
         else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
 #ifdef MATX_EN_JIT
-          static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>, 
+          static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
                         "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type");
           const auto [key, value] = get_jit_op_str();
           if (in.find(key) == in.end()) {
@@ -201,7 +201,7 @@ namespace detail {
 #endif
         }
         else if constexpr (Cap == OperatorCapability::ELEMENTS_PER_THREAD) {
-          static_assert(std::is_same_v<remove_cvref_t<InType>, EPTQueryInput>, "ELEMENTS_PER_THREAD capability requires EPTQueryInput as input type");
+          static_assert(cuda::std::is_same_v<remove_cvref_t<InType>, EPTQueryInput>, "ELEMENTS_PER_THREAD capability requires EPTQueryInput as input type");
 #if defined(MATX_EN_JIT) && defined(__CUDACC__)
           if (in.jit) {
             const auto max_ept = static_cast<ElementsPerThread>(MaxJitElementsPerThread());
@@ -219,7 +219,7 @@ namespace detail {
 #else
           supported = false;
 #endif
-          return combine_capabilities<Cap>(supported, detail::get_operator_capability<Cap>(a_, in));      
+          return combine_capabilities<Cap>(supported, detail::get_operator_capability<Cap>(a_, in));
         }
         else if constexpr (Cap == OperatorCapability::SET_ELEMENTS_PER_THREAD) {
 #ifdef MATX_EN_JIT
@@ -306,8 +306,8 @@ namespace detail {
       {
         if constexpr (is_matx_op<OpA>()) {
           a_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-        }          
-      }      
+        }
+      }
 
       template <typename ShapeType, typename Executor>
       __MATX_INLINE__ void PreRun([[maybe_unused]] ShapeType &&shape, Executor &&ex) const noexcept
@@ -316,7 +316,7 @@ namespace detail {
           return;
         }
 
-        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));     
+        InnerPreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
 
         detail::AllocateTempTensor(tmp_out_, std::forward<Executor>(ex), out_dims_, &ptr);
 

--- a/include/matx/operators/sum.h
+++ b/include/matx/operators/sum.h
@@ -65,7 +65,7 @@ namespace detail {
       using sum_xform_op = bool;
       using matx_jit_block_reduction = bool;
       using matx_jit_contains_block_reduction = cuda::std::true_type;
-      static constexpr int InRank = std::remove_reference_t<OpA>::Rank();
+      static constexpr int InRank = cuda::std::remove_reference_t<OpA>::Rank();
       static_assert(ORank < InRank, "SumOp output rank must be less than input rank");
 
       __MATX_INLINE__ std::string str() const { return "sum(" + get_type_str(a_) + ")"; }

--- a/include/matx/operators/sum.h
+++ b/include/matx/operators/sum.h
@@ -191,7 +191,7 @@ namespace detail {
         }
         else if constexpr (Cap == OperatorCapability::JIT_CLASS_QUERY) {
 #ifdef MATX_EN_JIT
-          static_assert(std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
+          static_assert(cuda::std::is_same_v<InType, std::unordered_map<std::string, std::string>>,
                         "JIT_CLASS_QUERY capability requires std::unordered_map<std::string, std::string> as input type");
           const auto [key, value] = get_jit_op_str();
           if (in.find(key) == in.end()) {

--- a/include/matx/operators/toeplitz.h
+++ b/include/matx/operators/toeplitz.h
@@ -79,7 +79,7 @@ namespace matx
           index_t size1 = 0, size2 = 0;
           if constexpr (is_matx_op<T1>()) size1 = op1_.Size(0);
           if constexpr (is_matx_op<T2>()) size2 = op2_.Size(0);
-          
+
           return cuda::std::make_tuple(
             func_name,
             std::format("template <typename T1, typename T2> struct {} {{\n"
@@ -110,7 +110,7 @@ namespace matx
         }
 #endif
 
-      __MATX_INLINE__ std::string str() const { 
+      __MATX_INLINE__ std::string str() const {
         std::string top1;
         if constexpr (is_matx_op<T1>()) {
           top1 = op1_.str();
@@ -125,9 +125,9 @@ namespace matx
         }
         else {
           top2 = "array";
-        }        
+        }
 
-        return "toeplitz(" + top1 + "," + top2 + ")"; 
+        return "toeplitz(" + top1 + "," + top2 + ")";
       }
 
         __MATX_INLINE__ ToeplitzOp(const T1 &op1, const T2 &op2) : op1_(op1), op2_(op2)
@@ -137,13 +137,13 @@ namespace matx
           static_assert(T1::Rank() == 1, "toeplitz() operator input rank must be 1");
         }
 
-        if constexpr (!std::is_same_v<T2, EmptyOp>) {
-          static_assert(std::is_same_v<typename T1::value_type, 
+        if constexpr (!cuda::std::is_same_v<T2, EmptyOp>) {
+          static_assert(cuda::std::is_same_v<typename T1::value_type,
                                        typename T2::value_type>, "Input types to toeplitz() must match");
           if constexpr (is_matx_op<T2>()) {
             static_assert(T2::Rank() == 1, "toeplitz() operator input rank must be 1");
           }
-        }        
+        }
       }
 
         template <typename CapType>
@@ -168,7 +168,7 @@ namespace matx
               else {
                 auto val = op1_[i - j];
                 return val;
-              }          
+              }
             }
           } else {
             return Vector<value_type, static_cast<index_t>(CapType::ept)>{};
@@ -193,7 +193,7 @@ namespace matx
           }
           else if constexpr (Cap == OperatorCapability::SUPPORTS_JIT) {
 #ifdef MATX_EN_JIT
-            return combine_capabilities<Cap>(true, 
+            return combine_capabilities<Cap>(true,
               detail::get_operator_capability<Cap>(op1_, in),
               detail::get_operator_capability<Cap>(op2_, in));
 #else
@@ -223,7 +223,7 @@ namespace matx
             auto op1_cap = detail::get_operator_capability<Cap>(op1_, in);
             auto op2_cap = detail::get_operator_capability<Cap>(op2_, in);
             return combine_capabilities<Cap>(my_cap, op1_cap, op2_cap);
-          } 
+          }
           else if constexpr (Cap == OperatorCapability::ALIASED_MEMORY) {
             auto in_copy = in;
             in_copy.permutes_input_output = true;
@@ -246,7 +246,7 @@ namespace matx
 
           if constexpr (is_matx_op<T2>()) {
             op2_.PreRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          }          
+          }
         }
 
         template <typename ShapeType, typename Executor>
@@ -258,8 +258,8 @@ namespace matx
 
           if constexpr (is_matx_op<T2>()) {
             op2_.PostRun(std::forward<ShapeType>(shape), std::forward<Executor>(ex));
-          } 
-        }          
+          }
+        }
 
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {
@@ -309,7 +309,7 @@ namespace matx
     if constexpr (is_complex_v<T>) {
       cuda::std::array<T, D> r_conj = op;
       cuda::std::transform(r_conj.begin(), r_conj.end(), r_conj.begin(), [](T val){ return _internal_conj(val); } );
-      op2 = r_conj;      
+      op2 = r_conj;
     }
     return detail::ToeplitzOp(op, op2);
   };
@@ -337,7 +337,7 @@ namespace matx
     else {
       return detail::ToeplitzOp(c, c);
     }
-  };  
+  };
 
   /**
    * Toeplitz operator
@@ -362,7 +362,7 @@ namespace matx
   auto __MATX_INLINE__ toeplitz(const T (&c)[D1], const T (&r)[D2])
   {
     const auto cop = detail::to_array(c);
-    const auto rop = detail::to_array(r);    
+    const auto rop = detail::to_array(r);
     return detail::ToeplitzOp(cop, rop);
   };
 
@@ -374,7 +374,7 @@ namespace matx
    * @tparam COp
    *   Operator type of c
    * @tparam ROp
-   *   Operator type of r 
+   *   Operator type of r
    * @param c
    *   First column of the matrix
    * @param r
@@ -384,10 +384,10 @@ namespace matx
    *   New operator of the kronecker product
    */
   template <typename COp, typename ROp>
-    requires (!cuda::std::is_array_v<remove_cvref_t<COp>> && 
+    requires (!cuda::std::is_array_v<remove_cvref_t<COp>> &&
               !cuda::std::is_array_v<remove_cvref_t<ROp>>)
   auto __MATX_INLINE__ toeplitz(const COp &c, const ROp &r)
   {
     return detail::ToeplitzOp<COp, ROp>(c, r);
-  };    
+  };
 } // end namespace matx

--- a/include/matx/operators/updownsample.h
+++ b/include/matx/operators/updownsample.h
@@ -63,7 +63,7 @@ namespace matx
         static __MATX_INLINE__ constexpr __MATX_HOST__ __MATX_DEVICE__ int32_t Rank()
         {
           return T::Rank();
-        }        
+        }
 
         static_assert(Rank() > 0, "UpsampleOp: Rank of operator must be greater than 0.");
 
@@ -118,7 +118,7 @@ namespace matx
                 func_name, dim_, n_, actual_rank, detail::array_to_string(out_dims_, actual_rank))
           );
         }
-#endif 
+#endif
 
         __MATX_INLINE__ std::string str() const { return "upsample(" + op_.str() + ")"; }
 
@@ -127,11 +127,11 @@ namespace matx
         };
 
         template <typename CapType, typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
         {
           if constexpr (CapType::ept == ElementsPerThread::ONE) {
               static_assert(sizeof...(Is)==Rank());
-              static_assert((std::is_convertible_v<Is, index_t> && ... ));
+              static_assert((cuda::std::is_convertible_v<Is, index_t> && ... ));
 
               // convert variadic type to tuple so we can read/update
               cuda::std::array<index_t, Rank()> ind{indices...};
@@ -147,7 +147,7 @@ namespace matx
         }
 
         template <typename... Is>
-        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const 
+        __MATX_INLINE__ __MATX_DEVICE__ __MATX_HOST__ auto operator()(Is... indices) const
         {
           return this->operator()<DefaultCapabilities>(indices...);
         }
@@ -230,13 +230,13 @@ namespace matx
 
         ~UpsampleOp() = default;
         UpsampleOp(const UpsampleOp &rhs) = default;
-        
+
         __MATX_INLINE__ auto operator=(const self_type &rhs) {
           return set(*this, rhs);
         }
 
-        template<typename R> __MATX_INLINE__ auto operator=(const R &rhs) { 
-          return set(*this, rhs); 
+        template<typename R> __MATX_INLINE__ auto operator=(const R &rhs) {
+          return set(*this, rhs);
         }
     };
   }

--- a/include/matx/streaming/channelize_poly_stream.h
+++ b/include/matx/streaming/channelize_poly_stream.h
@@ -234,7 +234,7 @@ public:
   index_t feed(const InOp &new_samples, OutTensor &out)
   {
     static_assert(InOp::Rank() == 1, "ChannelizePolyStream::feed expects a 1D segment");
-    static_assert(std::is_same_v<typename InOp::value_type, InType>,
+    static_assert(cuda::std::is_same_v<typename InOp::value_type, InType>,
         "ChannelizePolyStream::feed: input operator value_type must match the stream's "
         "InType (wrap the input in an explicit cast operator to convert)");
     static_assert(OutTensor::Rank() == 2, "ChannelizePolyStream::feed expects a 2D [blocks, M] output");

--- a/include/matx/streaming/conv1d_stream.h
+++ b/include/matx/streaming/conv1d_stream.h
@@ -244,7 +244,7 @@ public:
   index_t feed(const InOp &new_samples, OutTensor &out)
   {
     static_assert(InOp::Rank() == 1, "Conv1DStream::feed expects a 1D segment");
-    static_assert(std::is_same_v<typename InOp::value_type, InType>,
+    static_assert(cuda::std::is_same_v<typename InOp::value_type, InType>,
         "Conv1DStream::feed: input operator value_type must match the stream's "
         "InType (wrap the input in an explicit cast operator to convert)");
     static_assert(OutTensor::Rank() == 1, "Conv1DStream::feed expects a 1D output");

--- a/include/matx/streaming/resample_poly_stream.h
+++ b/include/matx/streaming/resample_poly_stream.h
@@ -226,7 +226,7 @@ public:
   index_t feed(const InOp &new_samples, OutTensor &out)
   {
     static_assert(InOp::Rank() == 1, "ResamplePolyStream::feed expects a 1D segment");
-    static_assert(std::is_same_v<typename InOp::value_type, InType>,
+    static_assert(cuda::std::is_same_v<typename InOp::value_type, InType>,
         "ResamplePolyStream::feed: input operator value_type must match the stream's "
         "InType (wrap the input in an explicit cast operator to convert)");
     static_assert(OutTensor::Rank() == 1, "ResamplePolyStream::feed expects 1D output");

--- a/include/matx/transforms/ambgfun.h
+++ b/include/matx/transforms/ambgfun.h
@@ -111,7 +111,7 @@ public:
             detail::get_operator_capability<Cap>(ynorm_, in),
             detail::get_operator_capability<Cap>(out_, in));
     }
-  }     
+  }
 };
 
 template <class O, class I1>
@@ -144,7 +144,7 @@ public:
   __MATX_DEVICE__ inline void operator()(index_t idx)
   {
     return this->template operator()<DefaultCapabilities>(idx);
-  } 
+  }
 
   template <OperatorCapability Cap, typename InType>
   __MATX_INLINE__ __MATX_HOST__ auto get_capability([[maybe_unused]] InType& in) const {
@@ -160,7 +160,7 @@ public:
             detail::get_operator_capability<Cap>(out_, in),
             detail::get_operator_capability<Cap>(x_, in));
     }
-  }       
+  }
 
   constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) const noexcept
   {
@@ -214,7 +214,7 @@ public:
             detail::get_operator_capability<Cap>(out_, in),
             detail::get_operator_capability<Cap>(x_, in));
     }
-  }           
+  }
 
   constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ auto Size(int dim) const noexcept
   {
@@ -233,7 +233,7 @@ void ambgfun_impl(AMFTensor &amf, XTensor &x,
                      [[maybe_unused]] float cut_val, cudaStream_t stream = 0)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
-  
+
   constexpr int RANK = XTensor::Rank();
   using T1 = typename XTensor::value_type;
 
@@ -250,7 +250,7 @@ void ambgfun_impl(AMFTensor &amf, XTensor &x,
 
   auto y_normdiv_v = x_normdiv_v.View();
 
-  if constexpr (!std::is_same_v<YTensor, EmptyY>) {
+  if constexpr (!cuda::std::is_same_v<YTensor, EmptyY>) {
     ry.Reset(y.Data(), y.Shape());
     y_normdiv_v.Shallow(make_tensor<T1>(y_normdiv_v.Shape(), MATX_ASYNC_DEVICE_MEMORY, stream));
     auto y_norm_v = make_tensor<float>({}, MATX_ASYNC_DEVICE_MEMORY, stream);
@@ -265,7 +265,7 @@ void ambgfun_impl(AMFTensor &amf, XTensor &x,
   index_t xlen = x_normdiv_v.Size(RANK - 1);
 
   if (cut == ::matx::AMBGFUN_CUT_TYPE_2D) {
-          
+
     auto new_ynorm_v = make_tensor<T1>({len_seq - 1, xlen}, MATX_ASYNC_DEVICE_MEMORY, stream);
 
     newYNorm(new_ynorm_v, x_normdiv_v, y_normdiv_v).run(stream);

--- a/include/matx/transforms/channelize_poly.h
+++ b/include/matx/transforms/channelize_poly.h
@@ -712,7 +712,7 @@ inline void UnpackDFT(DataType inout, cudaStream_t stream)
  * constituent channels, each corresponding to a band of the input signal bandwidth. Supports both
  * maximally decimated (critically sampled, decimation_factor == num_channels) and oversampled
  * (decimation_factor < num_channels) cases, including rational oversampling ratios.
- * 
+ *
  * @tparam OutType Type of output
  * @tparam InType Type of input
  * @tparam FilterType Type of filter
@@ -742,9 +742,9 @@ inline void channelize_poly_impl(OutType out, const InType &in, const FilterType
                    index_t num_channels, index_t decimation_factor, cudaStream_t stream = 0,
                    index_t out_elem_offset = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  using OutputOp = std::remove_cv_t<std::remove_reference_t<OutType>>;
-  using InputOp = std::remove_cv_t<std::remove_reference_t<InType>>;
-  using FilterOp = std::remove_cv_t<std::remove_reference_t<FilterType>>;
+  using OutputOp = cuda::std::remove_cv_t<cuda::std::remove_reference_t<OutType>>;
+  using InputOp = cuda::std::remove_cv_t<cuda::std::remove_reference_t<InType>>;
+  using FilterOp = cuda::std::remove_cv_t<cuda::std::remove_reference_t<FilterType>>;
   using input_t = typename InputOp::value_type;
   using filter_t = typename FilterOp::value_type;
   using output_t = typename OutputOp::value_type;
@@ -908,9 +908,9 @@ inline void channelize_poly_impl(OutType out, const InType &in, const FilterType
                    [[maybe_unused]] const HostExecutor<MODE> &exec,
                    index_t out_elem_offset = 0) {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-  using OutputOp = std::remove_cv_t<std::remove_reference_t<OutType>>;
-  using InputOp = std::remove_cv_t<std::remove_reference_t<InType>>;
-  using FilterOp = std::remove_cv_t<std::remove_reference_t<FilterType>>;
+  using OutputOp = cuda::std::remove_cv_t<cuda::std::remove_reference_t<OutType>>;
+  using InputOp = cuda::std::remove_cv_t<cuda::std::remove_reference_t<InType>>;
+  using FilterOp = cuda::std::remove_cv_t<cuda::std::remove_reference_t<FilterType>>;
   using input_t = typename InputOp::value_type;
   using filter_t = typename FilterOp::value_type;
   using output_t = typename OutputOp::value_type;

--- a/include/matx/transforms/chol/chol_cuda.h
+++ b/include/matx/transforms/chol/chol_cuda.h
@@ -101,7 +101,7 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "Cholesky solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
 
     params = GetCholParams(a, uplo, exec);
 
@@ -128,7 +128,7 @@ public:
     params.n = a.Size(RANK - 1);
     params.A = a.Data();
     params.uplo = uplo;
-    params.stream = exec.getStream();    
+    params.stream = exec.getStream();
     params.dtype = TypeToInt<T1>();
 
     return params;
@@ -170,7 +170,7 @@ public:
 
     std::vector<int> h_info(this->batch_a_ptrs.size());
     cudaMemcpyAsync(h_info.data(), this->d_info, sizeof(int) * this->batch_a_ptrs.size(), cudaMemcpyDeviceToHost, stream);
-    
+
     // This will block. Figure this out later
     cudaStreamSynchronize(stream);
 
@@ -179,7 +179,7 @@ public:
         MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
           ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xpotrf").c_str());
       } else {
-        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
           (std::to_string(info) + "-th leading minor is not positive definite in cuSolver Xpotrf").c_str());
       }
     }
@@ -206,8 +206,8 @@ private:
 struct DnCholCUDAParamsKeyHash {
   std::size_t operator()(const DnCholCUDAParams_t &k) const noexcept
   {
-    return  (std::hash<uint64_t>()(k.n)) + 
-            (std::hash<uint64_t>()(k.batch_size)) + 
+    return  (std::hash<uint64_t>()(k.n)) +
+            (std::hash<uint64_t>()(k.batch_size)) +
             (std::hash<uint64_t>()((uint64_t)(k.stream)));
   }
 };
@@ -220,8 +220,8 @@ struct DnCholCUDAParamsKeyEq {
   bool operator()(const DnCholCUDAParams_t &l, const DnCholCUDAParams_t &t) const
       noexcept
   {
-    return  l.n == t.n && 
-            l.batch_size == t.batch_size && 
+    return  l.n == t.n &&
+            l.batch_size == t.batch_size &&
             l.dtype == t.dtype &&
             l.stream == t.stream;
   }
@@ -262,7 +262,7 @@ void chol_impl(OutputTensor &&out, const ATensor &a,
           SolverFillMode uplo = SolverFillMode::UPPER)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-    
+
   using OutputTensor_t = remove_cvref_t<OutputTensor>;
   using T1 = typename OutputTensor_t::value_type;
   constexpr int RANK = ATensor::Rank();
@@ -286,7 +286,7 @@ void chol_impl(OutputTensor &&out, const ATensor &a,
   T1 *out_ptr = nullptr;
   detail::tensor_impl_t<T1, RANK> tmp_out;
   const bool allContiguous = a_new.IsContiguous() && out.IsContiguous();
-  
+
   if (allContiguous) {
     make_tensor(tmp_out, out.Data(), out.Shape());
     (out = a_new).run(exec);

--- a/include/matx/transforms/chol/chol_lapack.h
+++ b/include/matx/transforms/chol/chol_lapack.h
@@ -100,7 +100,7 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "Cholesky solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
 
     params = GetCholParams(a, uplo);
   }
@@ -148,7 +148,7 @@ public:
         MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
           ("Parameter " + std::to_string(-info) + " had an illegal value in LAPACK potrf").c_str());
       } else {
-        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
           (std::to_string(info) + "-th leading minor is not positive definite in LAPACK potrf").c_str());
       }
     }
@@ -167,17 +167,17 @@ private:
   void potrf_dispatch(const char* uplo, const lapack_int_t* n, T1* a,
                       const lapack_int_t* lda, lapack_int_t* info)
   {
-    if constexpr (std::is_same_v<T1, float>) {
+    if constexpr (cuda::std::is_same_v<T1, float>) {
       LAPACK_CALL(spotrf)(uplo, n, a, lda, info);
-    } else if constexpr (std::is_same_v<T1, double>) {
+    } else if constexpr (cuda::std::is_same_v<T1, double>) {
       LAPACK_CALL(dpotrf)(uplo, n, a, lda, info);
-    } else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+    } else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
       LAPACK_CALL(cpotrf)(uplo, n, a, lda, info);
-    } else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+    } else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
       LAPACK_CALL(zpotrf)(uplo, n, a, lda, info);
     }
   }
-  
+
   DnCholHostParams_t params;
 };
 
@@ -195,7 +195,7 @@ private:
  * from only the matrix A. The input and output parameters may be the same
  * tensor. In that case, the input is destroyed and the output is stored
  * in-place. Input must be a positive-definite Hermitian or real symmetric matrix.
- * 
+ *
  * No caching as LAPACK allocation/setup is not needed.
  *
  * @tparam T1
@@ -222,7 +222,7 @@ void chol_impl([[maybe_unused]] OutputTensor &&out,
   MATX_ASSERT_STR(MATX_EN_CPU_SOLVER, matxInvalidExecutor,
     "Trying to run a host Solver executor but host Solver support is not configured");
 #if MATX_EN_CPU_SOLVER
-    
+
   using OutputTensor_t = remove_cvref_t<OutputTensor>;
   using T1 = typename OutputTensor_t::value_type;
   constexpr int RANK = ATensor::Rank();

--- a/include/matx/transforms/conv.h
+++ b/include/matx/transforms/conv.h
@@ -198,7 +198,7 @@ inline void matxDirectConv1DInternal(OutputType &o, const InType &i,
   size_t signal_shm = sizeof(strip_input_t) * (CONV1D_ELEMENTS_PER_BLOCK + filter_len);
 
   // align filter size to signal size
-  size_t align = std::alignment_of_v<InType>;
+  size_t align = cuda::std::alignment_of_v<InType>;
   filter_shm = (filter_shm + align - 1) / align * align;
 
   size_t shmsize = filter_shm + signal_shm;

--- a/include/matx/transforms/convert/dense2sparse_cusparse.h
+++ b/include/matx/transforms/convert/dense2sparse_cusparse.h
@@ -294,13 +294,13 @@ void dense2sparse_impl(OutputTensorType &o, const InputTensorType &A,
 
   // Restrictions.
   static_assert(RANKA == RANKO, "tensors must have same rank");
-  static_assert(std::is_same_v<TA, TO>, "tensors must have the same data type");
-  static_assert(std::is_same_v<TO, int8_t> ||
-                    std::is_same_v<TO, matx::matxFp16> ||
-                    std::is_same_v<TO, matx::matxBf16> ||
-                    std::is_same_v<TO, float> || std::is_same_v<TO, double> ||
-                    std::is_same_v<TO, cuda::std::complex<float>> ||
-                    std::is_same_v<TO, cuda::std::complex<double>>,
+  static_assert(cuda::std::is_same_v<TA, TO>, "tensors must have the same data type");
+  static_assert(cuda::std::is_same_v<TO, int8_t> ||
+                    cuda::std::is_same_v<TO, matx::matxFp16> ||
+                    cuda::std::is_same_v<TO, matx::matxBf16> ||
+                    cuda::std::is_same_v<TO, float> || cuda::std::is_same_v<TO, double> ||
+                    cuda::std::is_same_v<TO, cuda::std::complex<float>> ||
+                    cuda::std::is_same_v<TO, cuda::std::complex<double>>,
                 "unsupported data type");
   MATX_ASSERT(a.Stride(RANKA - 1) == 1, matxInvalidParameter);
 

--- a/include/matx/transforms/convert/sparse2dense_cusparse.h
+++ b/include/matx/transforms/convert/sparse2dense_cusparse.h
@@ -241,13 +241,13 @@ void sparse2dense_impl(OutputTensorType &O, const InputTensorType &a,
 
   // Restrictions.
   static_assert(RANKA == RANKO, "tensors must have same rank");
-  static_assert(std::is_same_v<TA, TO>, "tensors must have the same data type");
-  static_assert(std::is_same_v<TO, int8_t> ||
-                    std::is_same_v<TO, matx::matxFp16> ||
-                    std::is_same_v<TO, matx::matxBf16> ||
-                    std::is_same_v<TO, float> || std::is_same_v<TO, double> ||
-                    std::is_same_v<TO, cuda::std::complex<float>> ||
-                    std::is_same_v<TO, cuda::std::complex<double>>,
+  static_assert(cuda::std::is_same_v<TA, TO>, "tensors must have the same data type");
+  static_assert(cuda::std::is_same_v<TO, int8_t> ||
+                    cuda::std::is_same_v<TO, matx::matxFp16> ||
+                    cuda::std::is_same_v<TO, matx::matxBf16> ||
+                    cuda::std::is_same_v<TO, float> || cuda::std::is_same_v<TO, double> ||
+                    cuda::std::is_same_v<TO, cuda::std::complex<float>> ||
+                    cuda::std::is_same_v<TO, cuda::std::complex<double>>,
                 "unsupported data type");
 
   // cuSPARSE sparse-to-dense conversion requires unit innermost stride.

--- a/include/matx/transforms/convert/sparse2sparse_cusparse.h
+++ b/include/matx/transforms/convert/sparse2sparse_cusparse.h
@@ -186,7 +186,7 @@ struct Sparse2SparseParamsKeyEq {
     return l.dtype == t.dtype && l.ptype == t.ptype && l.ctype == t.ctype &&
            l.stream == t.stream && l.nse == t.nse && l.m == t.m && l.n == t.n &&
            l.ptrO1 == t.ptrO1 && l.ptrA0 == t.ptrA0 && l.ptrA1 == t.ptrA1 &&
-           l.ptrA2 == t.ptrA2 && l.ptrA3 == t.ptrA3 && 
+           l.ptrA2 == t.ptrA2 && l.ptrA3 == t.ptrA3 &&
            l.format_hash_in == t.format_hash_in && l.format_hash_out == t.format_hash_out;
   }
 };
@@ -214,10 +214,10 @@ void sparse2sparse_impl(OutputTensorType &o, const InputTensorType &a,
 
   // Restrictions.
   static_assert(RANKA == 2 && RANKO == 2, "tensors must have rank-2");
-  static_assert(std::is_same_v<TA, TO>, "tensors must have the same data type");
-  static_assert(std::is_same_v<typename atype::crd_type, int32_t> &&
-                    std::is_same_v<typename otype::pos_type, int32_t> &&
-                    std::is_same_v<typename otype::crd_type, int32_t>,
+  static_assert(cuda::std::is_same_v<TA, TO>, "tensors must have the same data type");
+  static_assert(cuda::std::is_same_v<typename atype::crd_type, int32_t> &&
+                    cuda::std::is_same_v<typename otype::pos_type, int32_t> &&
+                    cuda::std::is_same_v<typename otype::crd_type, int32_t>,
                 "unsupported index type");
 
   // Get parameters required by these tensors (for caching).

--- a/include/matx/transforms/cub.h
+++ b/include/matx/transforms/cub.h
@@ -2759,7 +2759,7 @@ void hist_impl(OutputTensor &a_out, const InputOperator &a,
           int num_levels,
           const cudaStream_t stream = 0)
 {
-  static_assert(std::is_same_v<typename OutputTensor::value_type, int>, "Output histogram operator must use int type");
+  static_assert(cuda::std::is_same_v<typename OutputTensor::value_type, int>, "Output histogram operator must use int type");
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
   const cudaExecutor exec{stream};

--- a/include/matx/transforms/cub.h
+++ b/include/matx/transforms/cub.h
@@ -100,7 +100,7 @@ struct SortParams_t {
 template <typename Op, typename I>
 struct ReduceParams_t {
   Op reduce_op;
-  std::decay_t<I> init;
+  cuda::std::decay_t<I> init;
 };
 
 template <typename SelectOp, typename CountTensor>

--- a/include/matx/transforms/det.h
+++ b/include/matx/transforms/det.h
@@ -78,7 +78,7 @@ void det_impl(OutputTensor &out, const InputTensor &a,
   static_assert(OutputTensor::Rank() == InputTensor::Rank() - 2, "Output tensor rank must be 2 less than input for det()");
   constexpr int RANK = InputTensor::Rank();
   using value_type = typename OutputTensor::value_type;
-  using piv_value_type = std::conditional_t<is_cuda_executor_v<Executor>, int64_t, lapack_int_t>;
+  using piv_value_type = cuda::std::conditional_t<is_cuda_executor_v<Executor>, int64_t, lapack_int_t>;
 
   // Get parameters required by these tensors
   cuda::std::array<index_t, RANK - 1> s;
@@ -111,7 +111,7 @@ void det_impl(OutputTensor &out, const InputTensor &a,
   pIdxShape[RANK-2] = matxKeepDim;
   auto idx = range<0, 1, piv_value_type>({piv_len}, 1, 1);  // piv has 1-based indexing
   auto piv_idx = clone(idx, pIdxShape);
-  
+
   // Calculate number of swaps for each matrix in the batch
   auto swap_count = sum(as_type<piv_value_type>(piv != piv_idx), {RANK-2});
 

--- a/include/matx/transforms/eig/eig_cuda.h
+++ b/include/matx/transforms/eig/eig_cuda.h
@@ -111,17 +111,17 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "Eigen solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and output types must match");
     MATX_STATIC_ASSERT_STR(!is_complex_v<T2>, matxInvalidType, "W type must be real");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<typename inner_op_type_t<T1>::type, T2>), matxInvalidType, "Out and W inner types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<typename inner_op_type_t<T1>::type, T2>), matxInvalidType, "Out and W inner types must match");
 
     params = GetEigParams(w, a, jobz, uplo, exec);
     this->GetWorkspaceSize();
-#if CUSOLVER_VERSION > 11701 || (CUSOLVER_VERSION == 11701 && CUSOLVER_VER_BUILD >= 2)    
+#if CUSOLVER_VERSION > 11701 || (CUSOLVER_VERSION == 11701 && CUSOLVER_VER_BUILD >= 2)
     this->AllocateWorkspace(params.batch_size, true, exec);
-#else    
+#else
     this->AllocateWorkspace(params.batch_size, false, exec);
-#endif    
+#endif
   }
 
   void GetWorkspaceSize() override
@@ -129,19 +129,19 @@ public:
 #if CUSOLVER_VERSION > 11701 || (CUSOLVER_VERSION == 11701 && CUSOLVER_VER_BUILD >=2)
     // Use vector mode for a larger workspace size that works for both modes
     [[maybe_unused]] cusolverStatus_t ret = cusolverDnXsyevBatched_bufferSize(
-                    this->handle, this->dn_params, CUSOLVER_EIG_MODE_VECTOR, 
+                    this->handle, this->dn_params, CUSOLVER_EIG_MODE_VECTOR,
                     params.uplo, params.n, MatXTypeToCudaType<T1>(), params.A,
                     params.n, MatXTypeToCudaType<T2>(), params.W,
                     MatXTypeToCudaType<T1>(), &this->dspace,
                     &this->hspace, params.batch_size);
 #else
     [[maybe_unused]] cusolverStatus_t ret = cusolverDnXsyevd_bufferSize(
-                    this->handle, this->dn_params, CUSOLVER_EIG_MODE_VECTOR, 
+                    this->handle, this->dn_params, CUSOLVER_EIG_MODE_VECTOR,
                     params.uplo, params.n, MatXTypeToCudaType<T1>(), params.A,
                     params.n, MatXTypeToCudaType<T2>(), params.W,
                     MatXTypeToCudaType<T1>(), &this->dspace,
                     &this->hspace);
-#endif                    
+#endif
 
     MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
   }
@@ -159,7 +159,7 @@ public:
     params.W = w.Data();
     params.jobz = jobz;
     params.uplo = uplo;
-    params.exec = exec;    
+    params.exec = exec;
 
     params.dtype = TypeToInt<T1>();
 
@@ -191,7 +191,7 @@ public:
     const auto stream = exec.getStream();
     cusolverDnSetStream(this->handle, stream);
 
-#if CUSOLVER_VERSION > 11701 || ( CUSOLVER_VERSION == 11701 && CUSOLVER_VER_BUILD >=2)   
+#if CUSOLVER_VERSION > 11701 || ( CUSOLVER_VERSION == 11701 && CUSOLVER_VER_BUILD >=2)
     [[maybe_unused]] auto ret = cusolverDnXsyevBatched(
         this->handle, this->dn_params, jobz, uplo, params.n, MatXTypeToCudaType<T1>(),
         out.Data(), params.n, MatXTypeToCudaType<T2>(), w.Data(),
@@ -207,8 +207,8 @@ public:
     cudaMemcpyAsync(h_info.data(), this->d_info, sizeof(int) * params.batch_size, cudaMemcpyDeviceToHost, stream);
 #else
     SetBatchPointers<BatchType::MATRIX>(out, this->batch_a_ptrs);
-    SetBatchPointers<BatchType::VECTOR>(w, this->batch_w_ptrs); 
-    
+    SetBatchPointers<BatchType::VECTOR>(w, this->batch_w_ptrs);
+
     // Older cuSolver versions do not support batching with cusolverDnXsyevd
     for (size_t i = 0; i < this->batch_a_ptrs.size(); i++) {
       [[maybe_unused]] auto ret = cusolverDnXsyevd(
@@ -225,7 +225,7 @@ public:
 
     std::vector<int> h_info(this->batch_a_ptrs.size());
     cudaMemcpyAsync(h_info.data(), this->d_info, sizeof(int) * this->batch_a_ptrs.size(), cudaMemcpyDeviceToHost, stream);
-#endif        
+#endif
 
     // This will block. Figure this out later
     cudaStreamSynchronize(stream);
@@ -235,7 +235,7 @@ public:
         MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
           ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xsyevd").c_str());
       } else {
-        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
             (std::to_string(info) + " off-diagonal elements of an intermediate tridiagonal form did not converge to zero in cuSolver Xsyevd").c_str());
       }
     }
@@ -338,7 +338,7 @@ void eig_impl(OutputTensor &&out, WTensor &&w,
   matxAlloc(reinterpret_cast<void **>(&tp), a_new.Bytes(), MATX_ASYNC_DEVICE_MEMORY,
               exec.getStream());
   auto tv = TransposeCopy(tp, a_new, exec);
-  
+
   cusolverEigMode_t jobz_cusolver = (jobz == EigenMode::VECTOR) ? CUSOLVER_EIG_MODE_VECTOR : CUSOLVER_EIG_MODE_NOVECTOR;
   cublasFillMode_t uplo_cusolver = (uplo == SolverFillMode::UPPER) ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER;
 

--- a/include/matx/transforms/eig/eig_lapack.h
+++ b/include/matx/transforms/eig/eig_lapack.h
@@ -109,9 +109,9 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "Eigen solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and output types must match");
     MATX_STATIC_ASSERT_STR(!is_complex_v<T2>, matxInvalidType, "W type must be real");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<typename inner_op_type_t<T1>::type, T2>), matxInvalidType, "Out and W inner types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<typename inner_op_type_t<T1>::type, T2>), matxInvalidType, "Out and W inner types must match");
 
     params = GetEigParams(w, a, jobz, uplo);
     this->GetWorkspaceSize();
@@ -126,10 +126,10 @@ public:
     // Due to a LAPACK bug which gives incorrect workspace size calculations for single-precision
     // routines at large matrix sizes from to float-to-int conversions, should use double-precision
     // for the query. Only an issue in routines which may need O(n^2) memory.
-    using WorkQuery = std::conditional_t<std::is_same_v<T1, float>, double,
-                      std::conditional_t<std::is_same_v<T1, cuda::std::complex<float>>,
+    using WorkQuery = std::conditional_t<cuda::std::is_same_v<T1, float>, double,
+                      std::conditional_t<cuda::std::is_same_v<T1, cuda::std::complex<float>>,
                                         cuda::std::complex<double>, T1>>;
-    using RworkQuery = std::conditional_t<std::is_same_v<T2, float>, double, T2>;
+    using RworkQuery = std::conditional_t<cuda::std::is_same_v<T2, float>, double, T2>;
     WorkQuery work_query;
     RworkQuery rwork_query;
     lapack_int_t iwork_query;
@@ -232,13 +232,13 @@ private:
   {
     // TODO: remove warning suppression once syevd is optimized in NVPL LAPACK
 MATX_IGNORE_WARNING_PUSH_GCC("-Wdeprecated-declarations")
-    if constexpr (std::is_same_v<AType, float>) {
+    if constexpr (cuda::std::is_same_v<AType, float>) {
       LAPACK_CALL(ssyevd)(jobz, uplo, n, a, lda, w, work_in, lwork_in, iwork_in, liwork_in, info);
-    } else if constexpr (std::is_same_v<AType, double>) {
+    } else if constexpr (cuda::std::is_same_v<AType, double>) {
       LAPACK_CALL(dsyevd)(jobz, uplo, n, a, lda, w, work_in, lwork_in, iwork_in, liwork_in, info);
-    } else if constexpr (std::is_same_v<AType, cuda::std::complex<float>>) {
+    } else if constexpr (cuda::std::is_same_v<AType, cuda::std::complex<float>>) {
       LAPACK_CALL(cheevd)(jobz, uplo, n, a, lda, w, work_in, lwork_in, rwork_in, lrwork_in, iwork_in, liwork_in, info);
-    } else if constexpr (std::is_same_v<AType, cuda::std::complex<double>>) {
+    } else if constexpr (cuda::std::is_same_v<AType, cuda::std::complex<double>>) {
       LAPACK_CALL(zheevd)(jobz, uplo, n, a, lda, w, work_in, lwork_in, rwork_in, lrwork_in, iwork_in, liwork_in, info);
     }
 MATX_IGNORE_WARNING_POP_GCC

--- a/include/matx/transforms/eig/eig_lapack.h
+++ b/include/matx/transforms/eig/eig_lapack.h
@@ -126,10 +126,10 @@ public:
     // Due to a LAPACK bug which gives incorrect workspace size calculations for single-precision
     // routines at large matrix sizes from to float-to-int conversions, should use double-precision
     // for the query. Only an issue in routines which may need O(n^2) memory.
-    using WorkQuery = std::conditional_t<cuda::std::is_same_v<T1, float>, double,
-                      std::conditional_t<cuda::std::is_same_v<T1, cuda::std::complex<float>>,
+    using WorkQuery = cuda::std::conditional_t<cuda::std::is_same_v<T1, float>, double,
+                      cuda::std::conditional_t<cuda::std::is_same_v<T1, cuda::std::complex<float>>,
                                         cuda::std::complex<double>, T1>>;
-    using RworkQuery = std::conditional_t<cuda::std::is_same_v<T2, float>, double, T2>;
+    using RworkQuery = cuda::std::conditional_t<cuda::std::is_same_v<T2, float>, double, T2>;
     WorkQuery work_query;
     RworkQuery rwork_query;
     lapack_int_t iwork_query;

--- a/include/matx/transforms/einsum.h
+++ b/include/matx/transforms/einsum.h
@@ -508,13 +508,14 @@ public:
     // to tensor rank. Therefore, ellipsis tokens are validated with EllipsisRank()
 
     i = 0;
-    [[maybe_unused]] auto check_rank = [&](const std::string &tok, int32_t rank) {
+    auto check_rank = [&](const std::string &tok, int32_t rank) {
       bool ok =
         tok.find("...") != std::string::npos ||
         tok.length() == static_cast<size_t>(rank);
         i++;
         return ok;
     };
+    (void)check_rank;
 
     MATX_ASSERT_STR(
     (check_rank(tokens[i], tensors.Rank()) && ...),

--- a/include/matx/transforms/einsum.h
+++ b/include/matx/transforms/einsum.h
@@ -83,7 +83,7 @@ __MATX_INLINE__ auto getEinsumSupportedTensor( const Op &in, cudaStream_t stream
       return true;
     }
   };
-  
+
   return GetSupportedTensor(in, support_func, MATX_ASYNC_DEVICE_MEMORY, stream);
 }
 
@@ -309,7 +309,7 @@ public:
 
   /**
    * @brief Splits a string on "," into a vector of substrings
-   * 
+   *
    * @param str string to split
    * @param out vector to append each comma-separated substring to
    */
@@ -330,7 +330,7 @@ public:
 
   /**
    * @brief Infers the output subscript for implicit mode einsum without "->"
-   * 
+   *
    * If any input token contains a broadcast ellipsis ("..."), it represents
    * the other remaining dimensions
    */
@@ -345,7 +345,7 @@ public:
       has_ellipsis = has_ellipsis || (epos != std::string::npos);
 
       for (size_t pos = 0; pos < tok.size(); pos++){
-        if (epos != std::string::npos 
+        if (epos != std::string::npos
         && pos >= epos
         && pos < epos +3){
           continue;
@@ -355,14 +355,14 @@ public:
     }
 
     std::string implicit_out = has_ellipsis ? "..." : "";
-    
+
     for (int32_t c=0; c< 256; c++){
       if (counts[c]==1){
         implicit_out.push_back(static_cast<char>(c));
       }
     }
     return implicit_out;
- 
+
   }
 
   /**
@@ -371,7 +371,7 @@ public:
    * Supports both explicit mode, where subscripts contain "->", and
    * implicit mode (no "->"), where the output subscript is inferred using NumPy's
    * implicit-output rule. See InferImplicitOutput().
-   * 
+   *
    * @param str einsum string
    * @param out tokenized vector
    * @return true if tokenized successfully, or false otherwise
@@ -392,7 +392,7 @@ public:
     }
 
     SplitOnCommas(str.substr(0, iout), out);
-    
+
     // Nothing after the output separator -> indicates this is a 0D output
     out.push_back(str.substr(iout + 2));
 
@@ -416,10 +416,10 @@ public:
     }
   return pos;
 }
- 
+
 /**
  * @brief Returns how many tensor dimensions are represented by "..."
- * 
+ *
  * @param token subscript token for one einsum operand
  * @param rank number of dimensions in that operand's tensor
  * @return number of dimensions "..." represents for this operand
@@ -433,9 +433,9 @@ public:
     if (epos == std::string::npos){
       return 0;
     }
-    
-  
-    auto ellipsis_rank = rank - static_cast<int32_t>(token.length() - 3); 
+
+
+    auto ellipsis_rank = rank - static_cast<int32_t>(token.length() - 3);
     MATX_ASSERT_STR(ellipsis_rank >=0,
       matxInvalidDim,
       "einsum operand rank is too small for the explicit subscripts given alongside \"...\""
@@ -487,7 +487,7 @@ public:
         modes_out.push_back(static_cast<int32_t>(c));
       }
     }
-  
+
   static EinsumParams_t<InT...> GetEinsumParams(OutputTensor &out, const std::string &subscripts, const InT&... tensors)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
@@ -508,7 +508,7 @@ public:
     // to tensor rank. Therefore, ellipsis tokens are validated with EllipsisRank()
 
     i = 0;
-    auto check_rank = [&](const std::string &tok, int32_t rank) {
+    [[maybe_unused]] auto check_rank = [&](const std::string &tok, int32_t rank) {
       bool ok =
         tok.find("...") != std::string::npos ||
         tok.length() == static_cast<size_t>(rank);
@@ -520,7 +520,7 @@ public:
     (check_rank(tokens[i], tensors.Rank()) && ...),
     matxInvalidDim,
     "Tensor rank must match number of einsum subscripts");
-    
+
     i = 0;
     int32_t max_ellipsis_rank = 0;
 
@@ -535,11 +535,11 @@ public:
     // Ellipsis-covered batch dimensions must match exactly across every operand
     // cuTensorNet requires tensors share the same modeID to have identical dimension
     // size. Therefore, MatX does not support NumPy-style size-1 broadcasting for
-    // "..." batch dimensions. 
-    
+    // "..." batch dimensions.
+
     if (max_ellipsis_rank > 0) {
       std::vector<int64_t> ellipsis_sizes(max_ellipsis_rank, -1);
-      
+
       i = 0;
       auto check_ellipsis_sizes = [&](const auto &t, const std::string &tok) {
         auto epos = FindEllipsis(tok);
@@ -573,7 +573,7 @@ public:
     };
     (expand_modes(tokens[i], tensors.Rank(), params.modes_[i]), ...);
     ExpandTokenModes(tokens[sizeof...(InT)], out.Rank(), params.modes_[sizeof...(InT)]); // output tensor
-  
+
 
     auto set_sizes = [](auto &t, std::vector<int64_t> &sizes) {
       for (int32_t s = 0; s < t.Rank(); s++) {
@@ -777,9 +777,9 @@ namespace cutensor {
       detail::cutensor::EinsumParamsKeyEq<decltype(detail::cutensor::getEinsumSupportedTensor(tensors, stream))...>
     >;
 
-    detail::assign_tuple_tensors<0, cudaStream_t>(stream, in_t, tensors...); 
+    detail::assign_tuple_tensors<0, cudaStream_t>(stream, in_t, tensors...);
 
-    using cache_val_type = matx::detail::cutensor::matxEinsumHandle_t<decltype(out_n), 
+    using cache_val_type = matx::detail::cutensor::matxEinsumHandle_t<decltype(out_n),
             decltype(detail::cutensor::getEinsumSupportedTensor(tensors, stream))...>;
 
     // Get parameters required by these tensors
@@ -788,7 +788,7 @@ namespace cutensor {
             return cache_val_type::GetEinsumParams(out_n, subscripts, args...);
         },
         in_t
-    );    
+    );
 
     params.stream = stream;
 

--- a/include/matx/transforms/fft/fft_common.h
+++ b/include/matx/transforms/fft/fft_common.h
@@ -35,14 +35,14 @@
 namespace matx {
 
 namespace detail {
-    
+
   template <typename OutputTensor, typename InputTensor, typename Executor>
   __MATX_INLINE__ auto  GetFFTInputView([[maybe_unused]] OutputTensor &o,
                       const InputTensor &i, index_t fft_size,
                       [[maybe_unused]] const Executor &exec)
   {
     MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
-    
+
     using index_type = typename OutputTensor::shape_type;
     using T1    = typename OutputTensor::value_type;
     using T2    = typename InputTensor::value_type;
@@ -58,28 +58,28 @@ namespace detail {
 
     // Auto-detect FFT size
     if (fft_size == 0) {
-      act_fft_size = o.Lsize();   
+      act_fft_size = o.Lsize();
 
       // If R2C transform, set length of FFT appropriately
-      if constexpr ((std::is_same_v<T2, float> &&
-                    std::is_same_v<T1, cuda::std::complex<float>>) ||
-                    (std::is_same_v<T2, double> &&
-                    std::is_same_v<T1, cuda::std::complex<double>>) ||
-                    (std::is_same_v<T2, matxBf16> &&
-                    std::is_same_v<T1, matxBf16Complex>) ||
-                    (std::is_same_v<T2, matxFp16> &&
-                    std::is_same_v<T1, matxFp16Complex>)) { // R2C
+      if constexpr ((cuda::std::is_same_v<T2, float> &&
+                    cuda::std::is_same_v<T1, cuda::std::complex<float>>) ||
+                    (cuda::std::is_same_v<T2, double> &&
+                    cuda::std::is_same_v<T1, cuda::std::complex<double>>) ||
+                    (cuda::std::is_same_v<T2, matxBf16> &&
+                    cuda::std::is_same_v<T1, matxBf16Complex>) ||
+                    (cuda::std::is_same_v<T2, matxFp16> &&
+                    cuda::std::is_same_v<T1, matxFp16Complex>)) { // R2C
         nom_fft_size = in_size;
         act_fft_size = in_size;
       }
-      else if constexpr ((std::is_same_v<T1, float> &&
-                          std::is_same_v<T2, cuda::std::complex<float>>) ||
-                        (std::is_same_v<T1, double> &&
-                          std::is_same_v<T2, cuda::std::complex<double>>) ||
-                        (std::is_same_v<T1, matxBf16> &&
-                          std::is_same_v<T2, matxBf16Complex>) ||
-                        (std::is_same_v<T1, matxFp16> &&
-                          std::is_same_v<T2, matxFp16Complex>)) { // C2R
+      else if constexpr ((cuda::std::is_same_v<T1, float> &&
+                          cuda::std::is_same_v<T2, cuda::std::complex<float>>) ||
+                        (cuda::std::is_same_v<T1, double> &&
+                          cuda::std::is_same_v<T2, cuda::std::complex<double>>) ||
+                        (cuda::std::is_same_v<T1, matxBf16> &&
+                          cuda::std::is_same_v<T2, matxBf16Complex>) ||
+                        (cuda::std::is_same_v<T1, matxFp16> &&
+                          cuda::std::is_same_v<T2, matxFp16Complex>)) { // C2R
         nom_fft_size = (in_size - 1) * 2;
         act_fft_size = (o.Lsize() / 2) + 1;
       }
@@ -131,13 +131,13 @@ namespace detail {
 
           (i_new = static_cast<promote_half_t<T2>>(0)).run(exec);
           matx::copy(i_pad_part_v, i, exec);
-          return i_new;        
+          return i_new;
         }
       }
     }
 
     return i;
-  }  
+  }
 
   template <typename InType>
   constexpr __MATX_INLINE__ FFTType ComplexInType()
@@ -159,14 +159,14 @@ namespace detail {
 
     // Deduce plan type from view types
     // Check if input is complex and output is real -> C2R
-    if constexpr ((std::is_same_v<T1, cuda::std::complex<float>> && std::is_same_v<T2, float>) ||
-                  (std::is_same_v<T1, cuda::std::complex<double>> && std::is_same_v<T2, double>) ||
+    if constexpr ((cuda::std::is_same_v<T1, cuda::std::complex<float>> && cuda::std::is_same_v<T2, float>) ||
+                  (cuda::std::is_same_v<T1, cuda::std::complex<double>> && cuda::std::is_same_v<T2, double>) ||
                   (is_complex_half_v<T1> && (is_half_v<T2> || is_matx_half_v<T2>))) {
       return FFTType::R2C;
     }
-    // Check if input is real and output is complex -> R2C  
-    else if constexpr ((std::is_same_v<T1, float> && std::is_same_v<T2, cuda::std::complex<float>>) ||
-                       (std::is_same_v<T1, double> && std::is_same_v<T2, cuda::std::complex<double>>) ||
+    // Check if input is real and output is complex -> R2C
+    else if constexpr ((cuda::std::is_same_v<T1, float> && cuda::std::is_same_v<T2, cuda::std::complex<float>>) ||
+                       (cuda::std::is_same_v<T1, double> && cuda::std::is_same_v<T2, cuda::std::complex<double>>) ||
                        ((is_half_v<T1> || is_matx_half_v<T1>) && is_complex_half_v<T2>)) {
       return FFTType::C2R;
     }

--- a/include/matx/transforms/fft/fft_cuda.h
+++ b/include/matx/transforms/fft/fft_cuda.h
@@ -74,7 +74,7 @@
       std::cout << #a ": " << "(" << tmp << " != " << expected << "): " << fft_str << "\n";\
       MATX_THROW(matxCufftError, "");  \
     }                                  \
-  }  
+  }
 
 namespace matx {
 
@@ -211,9 +211,9 @@ public:
                         : i.Size(RANK - 1);
 
       if (i.IsContiguous() && o.IsContiguous()) {
-        // Previously we used cudaMemGetInfo to get free memory to determine batch size. This can be very slow, 
-        // and for small FFTs this call can create extra latency. For now we'll just assume the user knows what 
-        // they're doing and not try to batch FFTs that are too small        
+        // Previously we used cudaMemGetInfo to get free memory to determine batch size. This can be very slow,
+        // and for small FFTs this call can create extra latency. For now we'll just assume the user knows what
+        // they're doing and not try to batch FFTs that are too small
         const auto shape = i.Shape();
         params.batch = std::accumulate(std::begin(shape), std::end(shape) - 1, static_cast<index_t>(1), std::multiplies<index_t>());
         params.batch_dims = i.Rank() - 1;
@@ -328,7 +328,7 @@ protected:
   cufftHandle plan_;
   FftCUDAParams_t params_;
   void *workspace_;
-  size_t workspaceSize;  
+  size_t workspaceSize;
   int fftrank_ = 0;
   std::mutex mutex_;
 };
@@ -400,7 +400,7 @@ matxCUDAFFTPlan1D_t(OutTensorType &o, const InTensorType &i)
     }
   }
   else {
-    if (!is_complex_v<T2> || !is_complex_v<T1> || !std::is_same_v<T1, T2>) {
+    if (!is_complex_v<T2> || !is_complex_v<T1> || !cuda::std::is_same_v<T1, T2>) {
       MATX_THROW(matxInvalidType, "FFT types inconsistent with C2C transform");
     }
     if (this->params_.n[0] != o.Size(InTensorType::Rank()-1) ||
@@ -527,7 +527,7 @@ public:
                   matxInvalidType);
     }
     else {
-      MATX_ASSERT((std::is_same_v<T1, T2>), matxInvalidType);
+      MATX_ASSERT((cuda::std::is_same_v<T1, T2>), matxInvalidType);
       MATX_ASSERT(is_complex_v<T2> && is_complex_v<T1>, matxInvalidType);
       MATX_ASSERT(o.Size(RANK-2) * o.Size(RANK-1) == i.Size(RANK-2) * i.Size(RANK-1),
                   matxInvalidSize);
@@ -541,7 +541,7 @@ public:
 
     // We allocate our own workspace
     cufftSetAutoAllocation(this->plan_, false);
-        
+
     [[maybe_unused]] cufftResult error;
     error = cufftXtGetSizeMany(this->plan_, 2, this->params_.n, this->params_.inembed,
                        this->params_.istride, this->params_.idist,
@@ -549,7 +549,7 @@ public:
                        this->params_.ostride, this->params_.odist,
                        this->params_.output_type, this->params_.batch,
                        &this->workspaceSize, this->params_.exec_type);
-    MATX_CUFFT_ASSERT_STR_EXP(error, CUFFT_SUCCESS);                       
+    MATX_CUFFT_ASSERT_STR_EXP(error, CUFFT_SUCCESS);
 
     error = cufftXtMakePlanMany(
         this->plan_, 2, this->params_.n, this->params_.inembed,
@@ -650,7 +650,7 @@ __MATX_INLINE__ auto getCufft1DSupportedTensor( const Op &in, cudaStream_t strea
   const auto support_func = []() {
     return true;
   };
-  
+
   return GetSupportedTensor(in, support_func, MATX_ASYNC_DEVICE_MEMORY, stream);
 }
 
@@ -672,7 +672,7 @@ __MATX_INLINE__ auto getCufft2DSupportedTensor( const Op &in, cudaStream_t strea
       return true;
     }
   };
-  
+
   return GetSupportedTensor(in, support_func, MATX_ASYNC_DEVICE_MEMORY, stream);
 }
 

--- a/include/matx/transforms/fft/fft_fftw.h
+++ b/include/matx/transforms/fft/fft_fftw.h
@@ -316,7 +316,7 @@ private:
 template<typename OutTensorType, typename InTensorType> class matxFFTWPlan_t {
 public:
   using out_value_type = typename OutTensorType::value_type;
-  using plan_type = std::conditional_t<is_fp32_inner_type_v<out_value_type>, fftwf_plan, fftw_plan>;
+  using plan_type = cuda::std::conditional_t<is_fp32_inner_type_v<out_value_type>, fftwf_plan, fftw_plan>;
 
   template <ThreadsMode MODE>
   matxFFTWPlan_t(OutTensorType &o,

--- a/include/matx/transforms/fft/fft_fftw.h
+++ b/include/matx/transforms/fft/fft_fftw.h
@@ -150,7 +150,7 @@ struct FftFFTWParams_t {
     }
 
     params.is_fp32 = is_fp32_inner_type_v<typename OutTensorType::value_type>;
-    if constexpr (std::is_same_v<typename OutTensorType::value_type,
+    if constexpr (cuda::std::is_same_v<typename OutTensorType::value_type,
                                 typename InTensorType::value_type>) {
       params.in_place = o.Data() == i.Data();
     } else {
@@ -177,7 +177,7 @@ struct FftFFTWParams_t {
         }
       }
       else {
-        if (!is_complex_v<T2> || !is_complex_v<T1> || !std::is_same_v<T1, T2>) {
+        if (!is_complex_v<T2> || !is_complex_v<T1> || !cuda::std::is_same_v<T1, T2>) {
           MATX_THROW(matxInvalidType, "FFT types inconsistent with C2C transform");
         }
         if (params.n[0] != o.Size(OutTensorType::Rank()-1) ||
@@ -200,7 +200,7 @@ struct FftFFTWParams_t {
                     matxInvalidType);
       }
       else {
-        MATX_ASSERT((std::is_same_v<T1, T2>), matxInvalidType);
+        MATX_ASSERT((cuda::std::is_same_v<T1, T2>), matxInvalidType);
         MATX_ASSERT(is_complex_v<T2> && is_complex_v<T1>, matxInvalidType);
         MATX_ASSERT(o.Size(RANK-2) * o.Size(RANK-1) == i.Size(RANK-2) * i.Size(RANK-1),
                     matxInvalidSize);
@@ -377,9 +377,9 @@ public:
     else {
       FFTWPlanManager::InitFFTW();
       fftw_plan_with_nthreads(exec.GetNumThreads());
-      if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::C2C && 
-                    std::is_same_v<typename InTensorType::value_type, cuda::std::complex<double>> &&
-                    std::is_same_v<typename OutTensorType::value_type, cuda::std::complex<double>>) {
+      if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::C2C &&
+                    cuda::std::is_same_v<typename InTensorType::value_type, cuda::std::complex<double>> &&
+                    cuda::std::is_same_v<typename OutTensorType::value_type, cuda::std::complex<double>>) {
         plan_  = fftw_plan_many_dft( params_.fft_rank,
                                     params_.n,
                                     params_.batch,
@@ -394,9 +394,9 @@ public:
                                     fft_dir,
                                     FFTW_ESTIMATE);
       }
-      else if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::C2R && 
-                         std::is_same_v<typename InTensorType::value_type, cuda::std::complex<double>> &&
-                         std::is_same_v<typename OutTensorType::value_type, double>) {
+      else if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::C2R &&
+                         cuda::std::is_same_v<typename InTensorType::value_type, cuda::std::complex<double>> &&
+                         cuda::std::is_same_v<typename OutTensorType::value_type, double>) {
         plan_  = fftw_plan_many_dft_c2r( params_.fft_rank,
                                     params_.n,
                                     params_.batch,
@@ -410,9 +410,9 @@ public:
                                     params_.odist,
                                     FFTW_ESTIMATE);
       }
-      else if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::R2C && 
-                         std::is_same_v<typename InTensorType::value_type, double> &&
-                         std::is_same_v<typename OutTensorType::value_type, cuda::std::complex<double>>) {
+      else if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::R2C &&
+                         cuda::std::is_same_v<typename InTensorType::value_type, double> &&
+                         cuda::std::is_same_v<typename OutTensorType::value_type, cuda::std::complex<double>>) {
         plan_  = fftw_plan_many_dft_r2c( params_.fft_rank,
                                     params_.n,
                                     params_.batch,
@@ -474,23 +474,23 @@ public:
       }
     }
     else {
-      if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::C2C && 
-                    std::is_same_v<typename InTensorType::value_type, cuda::std::complex<double>> &&
-                    std::is_same_v<typename OutTensorType::value_type, cuda::std::complex<double>>) {
+      if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::C2C &&
+                    cuda::std::is_same_v<typename InTensorType::value_type, cuda::std::complex<double>> &&
+                    cuda::std::is_same_v<typename OutTensorType::value_type, cuda::std::complex<double>>) {
         fftw_execute_dft(plan_,
                           reinterpret_cast<fftw_complex*>(in),
                           reinterpret_cast<fftw_complex*>(out));
       }
-      else if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::C2R && 
-                         std::is_same_v<typename InTensorType::value_type, cuda::std::complex<double>> &&
-                         std::is_same_v<typename OutTensorType::value_type, double>) {
+      else if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::C2R &&
+                         cuda::std::is_same_v<typename InTensorType::value_type, cuda::std::complex<double>> &&
+                         cuda::std::is_same_v<typename OutTensorType::value_type, double>) {
         fftw_execute_dft_c2r(plan_,
                           reinterpret_cast<fftw_complex*>(in),
                           out);
       }
-      else if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::R2C && 
-                         std::is_same_v<typename InTensorType::value_type, double> &&
-                         std::is_same_v<typename OutTensorType::value_type, cuda::std::complex<double>>) {
+      else if constexpr (DeduceFFTTransformType<OutTensorType, InTensorType>() == FFTType::R2C &&
+                         cuda::std::is_same_v<typename InTensorType::value_type, double> &&
+                         cuda::std::is_same_v<typename OutTensorType::value_type, cuda::std::complex<double>>) {
         fftw_execute_dft_r2c(plan_,
                           in,
                           reinterpret_cast<fftw_complex*>(out));

--- a/include/matx/transforms/filter.h
+++ b/include/matx/transforms/filter.h
@@ -228,7 +228,7 @@ private:
         // There are an implicit num_recursive columns prior to
         // the actual coefficients beginning that are needed for computation
         FilterType res;
-        if constexpr (std::is_same_v<FilterType, COMPLEX_TYPE>) {
+        if constexpr (cuda::std::is_same_v<FilterType, COMPLEX_TYPE>) {
           res.x = 0;
           res.y = 0;
         }
@@ -240,7 +240,7 @@ private:
           int offs = col - k - 1;
           if (offs < 0) {
             // We're in the implicit coefficients
-            if constexpr (std::is_same_v<FilterType, COMPLEX_TYPE>) {
+            if constexpr (cuda::std::is_same_v<FilterType, COMPLEX_TYPE>) {
               res = (static_cast<int>(row) + 1 == -offs)
                         ? cuCaddf(res, coeffs[k])
                         : res;
@@ -250,7 +250,7 @@ private:
             }
           }
           else {
-            if constexpr (std::is_same_v<FilterType, COMPLEX_TYPE>) {
+            if constexpr (cuda::std::is_same_v<FilterType, COMPLEX_TYPE>) {
               res = cuCaddf(
                   res, cuCmulf(coeffs[k], out[row * CORR_COLS + col - k - 1]));
             }

--- a/include/matx/transforms/inverse.h
+++ b/include/matx/transforms/inverse.h
@@ -124,11 +124,11 @@ public:
         backend = MatInverseLUBackend::cuSolverGetRfRs;
       }
       else {
-        backend = (a.Size(TensorTypeA::Rank()-1) <= BATCHED_SINGLE_CALL_INV_THRESHOLD) ? 
-                          MatInverseLUBackend::cuBLASMatInv : 
+        backend = (a.Size(TensorTypeA::Rank()-1) <= BATCHED_SINGLE_CALL_INV_THRESHOLD) ?
+                          MatInverseLUBackend::cuBLASMatInv :
                           MatInverseLUBackend::cuBLASGetRf;
       }
-            
+
       const bool use_input_workbuf = UseInputWorkBuffer(a);
       // The cuBLAS getr*Batched LU decomposition functions overwrite the input, so
       // we use a temporary buffer to store the inputs.
@@ -156,22 +156,22 @@ public:
             &dspace,
             &hspace);
 
-        MATX_ASSERT_STR_EXP(solver_ret, CUSOLVER_STATUS_SUCCESS, matxSolverError, "Error in cusolverDnXgetrf_bufferSize");            
+        MATX_ASSERT_STR_EXP(solver_ret, CUSOLVER_STATUS_SUCCESS, matxSolverError, "Error in cusolverDnXgetrf_bufferSize");
 
         if (hspace > 0) {
           matxAlloc(&h_workspace, hspace, MATX_HOST_MEMORY);
-        }  
+        }
 
         if (dspace > 0) {
           matxAlloc(&d_workspace, dspace, MATX_DEVICE_MEMORY);
         }
 
-        // cuSolver uses a 64-bit pivot, so allocate a large size vs 
+        // cuSolver uses a 64-bit pivot, so allocate a large size vs
         matxAlloc((void **)&d_pivot,
                   a.Size(RANK - 1) * sizeof(int64_t),
                   MATX_ASYNC_DEVICE_MEMORY, stream);
-      }  
-      else if ( backend == MatInverseLUBackend::cuBLASGetRf || 
+      }
+      else if ( backend == MatInverseLUBackend::cuBLASGetRf ||
                 backend == MatInverseLUBackend::cuBLASMatInv) {
         // cuBLAS requires a list of pointers to each matrix. Construct that list
         // here as our batch dims
@@ -179,7 +179,7 @@ public:
         std::vector<T1 *> out_pointers;
 
         ret = cublasCreate(&cublas_handle);
-        MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxInverseError);      
+        MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxInverseError);
 
         if constexpr (RANK == 2) {
           if (use_input_workbuf) {
@@ -228,14 +228,14 @@ public:
           // The single function inverse calls do not save the pivots
           matxAlloc((void **)&d_pivot,
                     a.Size(RANK - 1) * in_pointers.size() * sizeof(*d_info),
-                    MATX_ASYNC_DEVICE_MEMORY, stream);                 
+                    MATX_ASYNC_DEVICE_MEMORY, stream);
         }
 
         cudaMemcpyAsync(d_A_array, in_pointers.data(),
                         in_pointers.size() * sizeof(T1 *), cudaMemcpyHostToDevice, stream);
         cudaMemcpyAsync(d_A_inv_array, out_pointers.data(),
-                        out_pointers.size() * sizeof(T1 *), cudaMemcpyHostToDevice, stream);   
-      }   
+                        out_pointers.size() * sizeof(T1 *), cudaMemcpyHostToDevice, stream);
+      }
 
       matxAlloc((void **)&d_info, params.batch_size * sizeof(*d_info),
                 MATX_ASYNC_DEVICE_MEMORY, stream);
@@ -253,8 +253,8 @@ public:
     if constexpr (!is_tensor_view_v<TensorTypeA>) {
       return true;
     } else {
-      return  backend == MatInverseLUBackend::cuBLASGetRf || 
-              backend == MatInverseLUBackend::cuSolverGetRfRs || 
+      return  backend == MatInverseLUBackend::cuBLASGetRf ||
+              backend == MatInverseLUBackend::cuSolverGetRfRs ||
               !a.IsContiguous();
     }
   }
@@ -306,11 +306,11 @@ public:
     else if (backend == MatInverseLUBackend::cuSolverGetRfRs) {
       cusolverDnDestroy(cusolver_handle);
       if (d_workspace) matxFree(d_workspace, cudaStreamDefault);
-      if (h_workspace) matxFree(h_workspace, cudaStreamDefault); 
+      if (h_workspace) matxFree(h_workspace, cudaStreamDefault);
     }
 
     if (d_info) { matxFree(d_info, cudaStreamDefault); d_info = nullptr; }
-    if (h_info) { matxFree(h_info); h_info = nullptr; }    
+    if (h_info) { matxFree(h_info); h_info = nullptr; }
   }
 
   /**
@@ -345,24 +345,24 @@ public:
 
     if constexpr (ALGO == MAT_INVERSE_ALGO_LU) {
       if (backend == MatInverseLUBackend::cuBLASGetRf) {
-        if constexpr (std::is_same_v<T1, float>) {
+        if constexpr (cuda::std::is_same_v<T1, float>) {
           ret =
               cublasSgetrfBatched(cublas_handle, static_cast<int>(params.n), d_A_array, static_cast<int>(params.n), d_pivot,
                                   d_info, static_cast<int>(params.batch_size));
         }
-        else if constexpr (std::is_same_v<T1, double>) {
+        else if constexpr (cuda::std::is_same_v<T1, double>) {
           ret =
               cublasDgetrfBatched(cublas_handle, static_cast<int>(params.n), d_A_array, static_cast<int>(params.n), d_pivot,
                                   d_info, static_cast<int>(params.batch_size));
         }
-        else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+        else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
           ret =
               cublasCgetrfBatched(cublas_handle, static_cast<int>(params.n),
                                   reinterpret_cast<cuComplex *const *>(d_A_array),
                                   static_cast<int>(params.n), d_pivot, d_info,
                                   static_cast<int>(params.batch_size));
         }
-        else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+        else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
           ret = cublasZgetrfBatched(
               cublas_handle, static_cast<int>(params.n),
               reinterpret_cast<cuDoubleComplex *const *>(d_A_array),
@@ -373,19 +373,19 @@ public:
         MATX_ASSERT(ret == CUBLAS_STATUS_SUCCESS, matxLUError);
 
         // Perform LU factorization
-        if constexpr (std::is_same_v<T1, float>) {
+        if constexpr (cuda::std::is_same_v<T1, float>) {
           ret = cublasSgetriBatched(cublas_handle, static_cast<int>(params.n), d_A_array,
                                     static_cast<int>(params.n), d_pivot,
                                     d_A_inv_array, static_cast<int>(params.n),
                                     d_info, static_cast<int>(params.batch_size));
         }
-        else if constexpr (std::is_same_v<T1, double>) {
+        else if constexpr (cuda::std::is_same_v<T1, double>) {
           ret = cublasDgetriBatched(cublas_handle, static_cast<int>(params.n), d_A_array,
                                     static_cast<int>(params.n), d_pivot,
                                     d_A_inv_array, static_cast<int>(params.n),
                                     d_info, static_cast<int>(params.batch_size));
         }
-        else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+        else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
           ret = cublasCgetriBatched(
               cublas_handle, static_cast<int>(params.n),
               reinterpret_cast<cuComplex *const *>(d_A_array),
@@ -394,7 +394,7 @@ public:
               static_cast<int>(params.n), d_info,
               static_cast<int>(params.batch_size));
         }
-        else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+        else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
           ret = cublasZgetriBatched(
               cublas_handle, static_cast<int>(params.n),
               reinterpret_cast<cuDoubleComplex *const *>(d_A_array),
@@ -412,24 +412,24 @@ public:
           if (h_info[i] != 0) {
             MATX_THROW(matxLUError, "inverse failed");
           }
-        }         
-      } 
+        }
+      }
       else if (backend == MatInverseLUBackend::cuBLASMatInv) {
         // For linear systems of size <= BATCHED_SINGLE_CALL_INV_THRESHOLD, we can use the more
         // efficient single call inverse functions.
-        if constexpr (std::is_same_v<T1, float>) {
+        if constexpr (cuda::std::is_same_v<T1, float>) {
           ret = cublasSmatinvBatched(cublas_handle, static_cast<int>(params.n), d_A_array,
                                     static_cast<int>(params.n),
                                     d_A_inv_array, static_cast<int>(params.n),
                                     d_info, static_cast<int>(params.batch_size));
         }
-        else if constexpr (std::is_same_v<T1, double>) {
+        else if constexpr (cuda::std::is_same_v<T1, double>) {
           ret = cublasDmatinvBatched(cublas_handle, static_cast<int>(params.n), d_A_array,
                                     static_cast<int>(params.n),
                                     d_A_inv_array, static_cast<int>(params.n),
                                     d_info, static_cast<int>(params.batch_size));
         }
-        else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+        else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
           ret = cublasCmatinvBatched(cublas_handle, static_cast<int>(params.n),
                                     reinterpret_cast<cuComplex *const *>(d_A_array),
                                     static_cast<int>(params.n),
@@ -437,7 +437,7 @@ public:
                                     static_cast<int>(params.n),
                                     d_info, static_cast<int>(params.batch_size));
         }
-        else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+        else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
           ret = cublasZmatinvBatched(cublas_handle, static_cast<int>(params.n),
                                     reinterpret_cast<cuDoubleComplex *const *>(d_A_array),
                                     static_cast<int>(params.n),
@@ -453,14 +453,14 @@ public:
           if (h_info[i] != 0) {
             MATX_THROW(matxLUError, "inverse failed");
           }
-        }         
+        }
       }
       else if (backend == MatInverseLUBackend::cuSolverGetRfRs) {
         MATX_ASSERT_STR(params.batch_size == 1, matxInvalidParameter, "cuSolverGetRfRs backend only used for single batches");
 
         // cuSolver has a bug that requires this workspace to be zeroed each time
         cudaMemsetAsync(d_workspace, 0, this->dspace, stream);
-        
+
         [[maybe_unused]] cusolverStatus_t solver_ret;
         solver_ret = cusolverDnXgetrf(
             cusolver_handle,
@@ -475,8 +475,8 @@ public:
             d_workspace,
             dspace,
             h_workspace,
-            hspace, 
-            d_info);            
+            hspace,
+            d_info);
         MATX_ASSERT_STR_EXP(solver_ret, CUSOLVER_STATUS_SUCCESS, matxSolverError, "Error in cusolverDnXgetrf");
 
         cudaMemcpyAsync(h_info, d_info, sizeof(int) * params.batch_size, cudaMemcpyDeviceToHost, stream);
@@ -503,9 +503,9 @@ public:
             MatXTypeToCudaType<typename TensorTypeA::value_type>(),
             a_inv.Data(),
             static_cast<int64_t>(params.n),
-            d_info);          
-            
-          MATX_ASSERT_STR_EXP(solver_ret, CUSOLVER_STATUS_SUCCESS, matxSolverError, "Error in cusolverDnXgetrs");          
+            d_info);
+
+          MATX_ASSERT_STR_EXP(solver_ret, CUSOLVER_STATUS_SUCCESS, matxSolverError, "Error in cusolverDnXgetrs");
       }
       else {
         MATX_THROW(matxInvalidParameter, "Invalid LU backend for inv()");
@@ -524,7 +524,7 @@ private:
   size_t hspace = 0;
   size_t dspace = 0;
   void *d_workspace = nullptr;
-  void *h_workspace = nullptr;  
+  void *h_workspace = nullptr;
   matx::tensor_t<typename TensorTypeA::value_type, TensorTypeA::Rank()> d_B;
 
   InverseParams_t params;

--- a/include/matx/transforms/lu/lu_cuda.h
+++ b/include/matx/transforms/lu/lu_cuda.h
@@ -104,8 +104,8 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "LU solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T2, int64_t>), matxInavlidType, "Pivot tensor type must be int64_t");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T2, int64_t>), matxInavlidType, "Pivot tensor type must be int64_t");
 
     params = GetLUParams(piv, a, exec);
     this->GetWorkspaceSize();
@@ -187,7 +187,7 @@ public:
         MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
           ("Parameter " + std::to_string(-info) + " had an illegal value in cuSolver Xgetrf").c_str());
       } else {
-        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
           ("U is singular: U(" + std::to_string(info) + "," + std::to_string(info) + ") = 0 in cuSolver Xgetrf").c_str());
       }
     }
@@ -265,7 +265,7 @@ void lu_impl(OutputTensor &&out, PivotTensor &&piv,
         const ATensor &a, const cudaExecutor &exec)
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
-    
+
   using T1 = typename remove_cvref_t<OutputTensor>::value_type;
 
   auto piv_new = OpToTensor(piv, exec);

--- a/include/matx/transforms/lu/lu_lapack.h
+++ b/include/matx/transforms/lu/lu_lapack.h
@@ -102,8 +102,8 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "LU solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T2, lapack_int_t>), matxInavlidType,
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T2, lapack_int_t>), matxInavlidType,
                             "Pivot tensor type must match the LAPACK host library integer type");
 
     params = GetLUParams(piv, a);
@@ -155,7 +155,7 @@ public:
         MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
           ("Parameter " + std::to_string(-info) + " had an illegal value in LAPACK getrf").c_str());
       } else {
-        MATX_ASSERT_STR_EXP(info, 0, matxSolverError, 
+        MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
           ("U is singular: U(" + std::to_string(info) + "," + std::to_string(info) + ") = 0 in LAPACK getrf").c_str());
       }
     }
@@ -174,13 +174,13 @@ private:
   void getrf_dispatch(const lapack_int_t* m, const lapack_int_t* n, T1* a,
                       const lapack_int_t* lda, lapack_int_t* piv, lapack_int_t* info)
   {
-    if constexpr (std::is_same_v<T1, float>) {
+    if constexpr (cuda::std::is_same_v<T1, float>) {
       LAPACK_CALL(sgetrf)(m, n, a, lda, piv, info);
-    } else if constexpr (std::is_same_v<T1, double>) {
+    } else if constexpr (cuda::std::is_same_v<T1, double>) {
       LAPACK_CALL(dgetrf)(m, n, a, lda, piv, info);
-    } else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+    } else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
       LAPACK_CALL(cgetrf)(m, n, a, lda, piv, info);
-    } else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+    } else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
       LAPACK_CALL(zgetrf)(m, n, a, lda, piv, info);
     }
   }
@@ -202,7 +202,7 @@ private:
  * library by deducing all parameters needed to perform an LU decomposition from
  * only the matrix A. The input and output parameters may be the same tensor. In
  * that case, the input is destroyed and the output is stored in-place.
- * 
+ *
  * No caching as LAPACK allocation/setup is not needed.
  *
  * @tparam T1

--- a/include/matx/transforms/matmul/matmul_cblas.h
+++ b/include/matx/transforms/matmul/matmul_cblas.h
@@ -71,16 +71,16 @@ namespace detail {
 template <typename OpA, typename OpB, typename OpC>
 constexpr bool CompatibleGemmCBLASTypes() {
   // All 3 should be the same type
-  if constexpr (!std::is_same_v<typename OpA::value_type, typename OpB::value_type> ||
-                !std::is_same_v<typename OpB::value_type, typename OpC::value_type>) {
+  if constexpr (!cuda::std::is_same_v<typename OpA::value_type, typename OpB::value_type> ||
+                !cuda::std::is_same_v<typename OpB::value_type, typename OpC::value_type>) {
     return false;
   }
 
   // List of accepted types when A/B/C match
-  return std::is_same_v<typename OpA::value_type, float> ||
-         std::is_same_v<typename OpA::value_type, double> ||
-         std::is_same_v<typename OpA::value_type, cuda::std::complex<float>> ||
-         std::is_same_v<typename OpA::value_type, cuda::std::complex<double>>;
+  return cuda::std::is_same_v<typename OpA::value_type, float> ||
+         cuda::std::is_same_v<typename OpA::value_type, double> ||
+         cuda::std::is_same_v<typename OpA::value_type, cuda::std::complex<float>> ||
+         cuda::std::is_same_v<typename OpA::value_type, cuda::std::complex<double>>;
 }
 
 #if MATX_EN_CPU_MATMUL
@@ -263,13 +263,13 @@ __MATX_INLINE__ void matmul_exec(TensorTypeC &c,
 
   value_type salpha;
   value_type sbeta;
-  if constexpr (std::is_same_v<value_type, cuda::std::complex<float>> ||
-                std::is_same_v<value_type, cuda::std::complex<double>>) {
+  if constexpr (cuda::std::is_same_v<value_type, cuda::std::complex<float>> ||
+                cuda::std::is_same_v<value_type, cuda::std::complex<double>>) {
     salpha = {alpha, 0};
     sbeta = {beta, 0};
   }
-  else if constexpr (std::is_same_v<value_type, float> ||
-                     std::is_same_v<value_type, double>) {
+  else if constexpr (cuda::std::is_same_v<value_type, float> ||
+                     cuda::std::is_same_v<value_type, double>) {
     salpha = alpha;;
     sbeta = beta;
   }
@@ -280,25 +280,25 @@ __MATX_INLINE__ void matmul_exec(TensorTypeC &c,
     auto b_ptr = b.Data();
     auto c_ptr = c.Data();
 
-    if constexpr (std::is_same_v<value_type, float>) {
+    if constexpr (cuda::std::is_same_v<value_type, float>) {
       cblas_sgemm_batch_strided(CblasRowMajor, params.opA, params.opB,
                                 params.m, params.n, params.k, salpha,
                                 a_ptr, params.lda, params.astride,
                                 b_ptr, params.ldb, params.bstride, sbeta,
                                 c_ptr, params.ldc, params.cstride, params.batch);
-    } else if constexpr (std::is_same_v<value_type, double>) {
+    } else if constexpr (cuda::std::is_same_v<value_type, double>) {
       cblas_dgemm_batch_strided(CblasRowMajor, params.opA, params.opB,
                                 params.m, params.n, params.k, salpha,
                                 a_ptr, params.lda, params.astride,
                                 b_ptr, params.ldb, params.bstride, sbeta,
                                 c_ptr, params.ldc, params.cstride, params.batch);
-    } else if constexpr (std::is_same_v<value_type, cuda::std::complex<float>>) {
+    } else if constexpr (cuda::std::is_same_v<value_type, cuda::std::complex<float>>) {
       cblas_cgemm_batch_strided(CblasRowMajor, params.opA, params.opB,
                                 params.m, params.n, params.k, (void *)&salpha,
                                 (void *)a_ptr, params.lda, params.astride,
                                 (void *)b_ptr, params.ldb, params.bstride, (void *)&sbeta,
                                 (void *)c_ptr, params.ldc, params.cstride, params.batch);
-    } else if constexpr (std::is_same_v<value_type, cuda::std::complex<double>>) {
+    } else if constexpr (cuda::std::is_same_v<value_type, cuda::std::complex<double>>) {
       cblas_zgemm_batch_strided(CblasRowMajor, params.opA, params.opB,
                                 params.m, params.n, params.k, (void *)&salpha,
                                 (void *)a_ptr, params.lda, params.astride,
@@ -313,25 +313,25 @@ __MATX_INLINE__ void matmul_exec(TensorTypeC &c,
       auto bp = cuda::std::apply([&b](auto... param) { return b.GetPointer(param...); }, b_idx);
       auto cp = cuda::std::apply([&c](auto... param) { return c.GetPointer(param...); }, c_idx);
 
-      if constexpr (std::is_same_v<value_type, float>) {
+      if constexpr (cuda::std::is_same_v<value_type, float>) {
         cblas_sgemm_batch_strided(CblasRowMajor, params.opA, params.opB,
                                   params.m, params.n, params.k, salpha,
                                   ap, params.lda, params.astride,
                                   bp, params.ldb, params.bstride, sbeta,
                                   cp, params.ldc, params.cstride, params.batch);
-      } else if constexpr (std::is_same_v<value_type, double>) {
+      } else if constexpr (cuda::std::is_same_v<value_type, double>) {
         cblas_dgemm_batch_strided(CblasRowMajor, params.opA, params.opB,
                                   params.m, params.n, params.k, salpha,
                                   ap, params.lda, params.astride,
                                   bp, params.ldb, params.bstride, sbeta,
                                   cp, params.ldc, params.cstride, params.batch);
-      } else if constexpr (std::is_same_v<value_type, cuda::std::complex<float>>) {
+      } else if constexpr (cuda::std::is_same_v<value_type, cuda::std::complex<float>>) {
         cblas_cgemm_batch_strided(CblasRowMajor, params.opA, params.opB,
                                   params.m, params.n, params.k, (void *)&salpha,
                                   (void *)ap, params.lda, params.astride,
                                   (void *)bp, params.ldb, params.bstride, (void *)&sbeta,
                                   (void *)cp, params.ldc, params.cstride, params.batch);
-      } else if constexpr (std::is_same_v<value_type, cuda::std::complex<double>>) {
+      } else if constexpr (cuda::std::is_same_v<value_type, cuda::std::complex<double>>) {
         cblas_zgemm_batch_strided(CblasRowMajor, params.opA, params.opB,
                                   params.m, params.n, params.k, (void *)&salpha,
                                   (void *)ap, params.lda, params.astride,
@@ -362,25 +362,25 @@ __MATX_INLINE__ void matmul_exec(TensorTypeC &c,
     auto bp = cuda::std::apply([&b](auto... param) { return b.GetPointer(param...); }, b_idx);
     auto cp = cuda::std::apply([&c](auto... param) { return c.GetPointer(param...); }, c_idx);
 
-    if constexpr (std::is_same_v<value_type, float>) {
+    if constexpr (cuda::std::is_same_v<value_type, float>) {
       cblas_sgemm(CblasRowMajor, params.opA, params.opB,
                   params.m, params.n, params.k, salpha,
                   ap, params.lda,
                   bp, params.ldb, sbeta,
                   cp, params.ldc);
-    } else if constexpr (std::is_same_v<value_type, double>) {
+    } else if constexpr (cuda::std::is_same_v<value_type, double>) {
       cblas_dgemm(CblasRowMajor, params.opA, params.opB,
                   params.m, params.n, params.k, salpha,
                   ap, params.lda,
                   bp, params.ldb, sbeta,
                   cp, params.ldc);
-    } else if constexpr (std::is_same_v<value_type, cuda::std::complex<float>>) {
+    } else if constexpr (cuda::std::is_same_v<value_type, cuda::std::complex<float>>) {
       cblas_cgemm(CblasRowMajor, params.opA, params.opB,
                   params.m, params.n, params.k, (void *)&salpha,
                   (const void **)ap, params.lda,
                   (const void **)bp, params.ldb, (void *)&sbeta,
                   (void **)cp, params.ldc);
-    } else if constexpr (std::is_same_v<value_type, cuda::std::complex<double>>) {
+    } else if constexpr (cuda::std::is_same_v<value_type, cuda::std::complex<double>>) {
       cblas_zgemm(CblasRowMajor, params.opA, params.opB,
                   params.m, params.n, params.k, (void *)&salpha,
                   (const void **)ap, params.lda,

--- a/include/matx/transforms/matmul/matmul_cublasdx.h
+++ b/include/matx/transforms/matmul/matmul_cublasdx.h
@@ -65,7 +65,7 @@ namespace matx {
   int max_size = 0;
 
   // Real, half or bfloat16
-  if constexpr (std::is_same_v<T, matxFp16> || std::is_same_v<T, matxBf16>) {
+  if constexpr (cuda::std::is_same_v<T, matxFp16> || cuda::std::is_same_v<T, matxBf16>) {
     if (compute_capability == 700 || compute_capability == 720) max_size = 128;
     else if (compute_capability == 750) max_size = 104;
     else if (compute_capability == 800 || compute_capability == 870) max_size = 166;
@@ -73,7 +73,7 @@ namespace matx {
       else if (compute_capability == 900 || compute_capability == 1000 || compute_capability == 1010 || compute_capability == 1030 || compute_capability == 1100) max_size = 196;
   }
     // Real, float OR Complex, half/bf16
-  else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, matxFp16Complex> || std::is_same_v<T, cuda::std::complex<matxBf16>>) {
+  else if constexpr (cuda::std::is_same_v<T, float> || cuda::std::is_same_v<T, matxFp16Complex> || cuda::std::is_same_v<T, cuda::std::complex<matxBf16>>) {
     if (compute_capability == 700 || compute_capability == 720) max_size = 90;
     else if (compute_capability == 750) max_size = 73;
     else if (compute_capability == 800 || compute_capability == 870) max_size = 117;
@@ -81,7 +81,7 @@ namespace matx {
       else if (compute_capability == 900 || compute_capability == 1000 || compute_capability == 1010 || compute_capability == 1030 || compute_capability == 1100) max_size = 139;
   }
   // Real, double OR Complex, float
-  else if constexpr (std::is_same_v<T, double> || std::is_same_v<T, cuda::std::complex<float>>) {
+  else if constexpr (cuda::std::is_same_v<T, double> || cuda::std::is_same_v<T, cuda::std::complex<float>>) {
     if (compute_capability == 700 || compute_capability == 720) max_size = 64;
     else if (compute_capability == 750) max_size = 52;
     else if (compute_capability == 800 || compute_capability == 870) max_size = 83;
@@ -89,7 +89,7 @@ namespace matx {
       else if (compute_capability == 900 || compute_capability == 1000 || compute_capability == 1010 || compute_capability == 1030 || compute_capability == 1100) max_size = 98;
   }
   // Complex, double
-  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
     if (compute_capability == 700 || compute_capability == 720) max_size = 45;
     else if (compute_capability == 750) max_size = 36;
     else if (compute_capability == 800 || compute_capability == 870) max_size = 58;
@@ -163,20 +163,20 @@ namespace matx {
 
         // Set precision for A, B, C matrices (all same precision for now)
         commondxPrecision precision;
-        if constexpr (std::is_same_v<InputType, matxFp16> || std::is_same_v<InputType, matxFp16Complex>) {
+        if constexpr (cuda::std::is_same_v<InputType, matxFp16> || cuda::std::is_same_v<InputType, matxFp16Complex>) {
           precision = COMMONDX_PRECISION_F16;
-        } else if constexpr (std::is_same_v<InputType, matxBf16> || std::is_same_v<InputType, cuda::std::complex<matxBf16>>) {
+        } else if constexpr (cuda::std::is_same_v<InputType, matxBf16> || cuda::std::is_same_v<InputType, cuda::std::complex<matxBf16>>) {
           precision = COMMONDX_PRECISION_BF16;
-        } else if constexpr (std::is_same_v<InputType, float> || std::is_same_v<InputType, cuda::std::complex<float>>) {
+        } else if constexpr (cuda::std::is_same_v<InputType, float> || cuda::std::is_same_v<InputType, cuda::std::complex<float>>) {
           precision = COMMONDX_PRECISION_F32;
-        } else if constexpr (std::is_same_v<InputType, double> || std::is_same_v<InputType, cuda::std::complex<double>>) {
+        } else if constexpr (cuda::std::is_same_v<InputType, double> || cuda::std::is_same_v<InputType, cuda::std::complex<double>>) {
           precision = COMMONDX_PRECISION_F64;
         } else {
           MATX_THROW(matxInvalidParameter, "Unsupported input type for cuBLASDx");
         }
 
-        long long int precisions[3] = {static_cast<long long int>(precision), 
-                                       static_cast<long long int>(precision), 
+        long long int precisions[3] = {static_cast<long long int>(precision),
+                                       static_cast<long long int>(precision),
                                        static_cast<long long int>(precision)};
         LIBCUBLASDX_CHECK(cublasdxSetOperatorInt64s(h_, CUBLASDX_OPERATOR_PRECISION, 3, precisions));
 
@@ -188,8 +188,8 @@ namespace matx {
         LIBCUBLASDX_CHECK(cublasdxSetOperatorInt64(h_, CUBLASDX_OPERATOR_SM, cc_));
 
         // Set arrangement - row major for all matrices (MatX default)
-        long long int arrangements[3] = {CUBLASDX_ARRANGEMENT_ROW_MAJOR, 
-                                         CUBLASDX_ARRANGEMENT_ROW_MAJOR, 
+        long long int arrangements[3] = {CUBLASDX_ARRANGEMENT_ROW_MAJOR,
+                                         CUBLASDX_ARRANGEMENT_ROW_MAJOR,
                                          CUBLASDX_ARRANGEMENT_ROW_MAJOR};
         LIBCUBLASDX_CHECK(cublasdxSetOperatorInt64s(h_, CUBLASDX_OPERATOR_ARRANGEMENT, 3, arrangements));
 
@@ -209,13 +209,13 @@ namespace matx {
         symbol_name += std::to_string(cc_);
 
         // Add precision identifier
-        if constexpr (std::is_same_v<InputType, matxFp16> || std::is_same_v<InputType, matxFp16Complex>) {
+        if constexpr (cuda::std::is_same_v<InputType, matxFp16> || cuda::std::is_same_v<InputType, matxFp16Complex>) {
           symbol_name += "_F16";
-        } else if constexpr (std::is_same_v<InputType, matxBf16> || std::is_same_v<InputType, cuda::std::complex<matxBf16>>) {
+        } else if constexpr (cuda::std::is_same_v<InputType, matxBf16> || cuda::std::is_same_v<InputType, cuda::std::complex<matxBf16>>) {
           symbol_name += "_BF16";
-        } else if constexpr (std::is_same_v<InputType, float> || std::is_same_v<InputType, cuda::std::complex<float>>) {
+        } else if constexpr (cuda::std::is_same_v<InputType, float> || cuda::std::is_same_v<InputType, cuda::std::complex<float>>) {
           symbol_name += "_F32";
-        } else if constexpr (std::is_same_v<InputType, double> || std::is_same_v<InputType, cuda::std::complex<double>>) {
+        } else if constexpr (cuda::std::is_same_v<InputType, double> || cuda::std::is_same_v<InputType, cuda::std::complex<double>>) {
           symbol_name += "_F64";
         }
 
@@ -226,7 +226,7 @@ namespace matx {
 #else
         symbol_name += "_CUDAUNKNOWN";
 #endif
-        
+
         return symbol_name;
       }
 
@@ -247,13 +247,13 @@ namespace matx {
 
         // For now, only support float and double (and their complex variants)
         // Half and bf16 support can be added later
-        if constexpr (std::is_same_v<InputType, float> || 
-                      std::is_same_v<InputType, double> ||
-                      std::is_same_v<InputType, cuda::std::complex<float>> ||
-                      std::is_same_v<InputType, cuda::std::complex<double>>) {
+        if constexpr (cuda::std::is_same_v<InputType, float> ||
+                      cuda::std::is_same_v<InputType, double> ||
+                      cuda::std::is_same_v<InputType, cuda::std::complex<float>> ||
+                      cuda::std::is_same_v<InputType, cuda::std::complex<double>>) {
           return true;
         }
-        
+
         return false;
       }
 
@@ -261,20 +261,20 @@ namespace matx {
       bool CheckJITSizeAndTypeRequirements() const {
         using OpAType = typename OpA::value_type;
         using OpBType = typename OpB::value_type;
-        
+
         // A and B must have same type
-        if constexpr (!std::is_same_v<OpAType, OpBType>) {
+        if constexpr (!cuda::std::is_same_v<OpAType, OpBType>) {
           return false;
         }
-        
+
         // Check supported types for JIT
-        if constexpr (!(std::is_same_v<OpAType, float> || 
-                        std::is_same_v<OpAType, double> ||
-                        std::is_same_v<OpAType, cuda::std::complex<float>> ||
-                        std::is_same_v<OpAType, cuda::std::complex<double>>)) {
+        if constexpr (!(cuda::std::is_same_v<OpAType, float> ||
+                        cuda::std::is_same_v<OpAType, double> ||
+                        cuda::std::is_same_v<OpAType, cuda::std::complex<float>> ||
+                        cuda::std::is_same_v<OpAType, cuda::std::complex<double>>)) {
           return false;
         }
-        
+
         // Check size constraints
         return IscuBLASDxSupported<OpAType>(m_, n_, k_, cc_);
       }
@@ -287,7 +287,7 @@ namespace matx {
 
         // Total shared memory requirement
         size_t total_shm = a_size + b_size + c_size;
-        
+
         MATX_LOG_DEBUG("cuBLASDx shared memory: A={}, B={}, C={}, Total={}", a_size, b_size, c_size, total_shm);
         return static_cast<int>(total_shm);
       }
@@ -299,11 +299,11 @@ namespace matx {
         LIBCUBLASDX_CHECK(
             cublasdxGetTraitInt64s(handle, CUBLASDX_TRAIT_SUGGESTED_BLOCK_DIM, 3, block_dim.data()));
         MATX_LOG_DEBUG("cuBLASDx suggested block dim: {} {} {}", block_dim[0], block_dim[1], block_dim[2]);
-        
+
         cublasdxDestroyDescriptor(handle);
-        
-        return cuda::std::array<int, 3>{static_cast<int>(block_dim[0]), 
-                                         static_cast<int>(block_dim[1]), 
+
+        return cuda::std::array<int, 3>{static_cast<int>(block_dim[0]),
+                                         static_cast<int>(block_dim[1]),
                                          static_cast<int>(block_dim[2])};
       }
 
@@ -314,18 +314,18 @@ namespace matx {
         LIBCUBLASDX_CHECK(
             cublasdxGetTraitInt64s(handle, CUBLASDX_TRAIT_SUGGESTED_LEADING_DIMENSION, 3, ld.data()));
         MATX_LOG_DEBUG("cuBLASDx suggested leading dimensions: {} {} {}", ld[0], ld[1], ld[2]);
-        
+
         cublasdxDestroyDescriptor(handle);
-        
-        return cuda::std::array<int, 3>{static_cast<int>(ld[0]), 
-                                         static_cast<int>(ld[1]), 
+
+        return cuda::std::array<int, 3>{static_cast<int>(ld[0]),
+                                         static_cast<int>(ld[1]),
                                          static_cast<int>(ld[2])};
       }
 
       bool GenerateLTOIR(std::set<std::string> &ltoir_symbols) {
         LTOIRData ltoir;
         const auto symbol_name = std::string(GEMM_DX_FUNC_PREFIX) + "_" + GetSymbolName();
-        ltoir_symbols.insert(symbol_name);        
+        ltoir_symbols.insert(symbol_name);
 
         if (detail::GetCache().GetLTOIRCachedBytes(symbol_name) != nullptr) {
           MATX_LOG_DEBUG("cuBLASDx LTOIR found in cache with size {}", detail::GetCache().GetLTOIRCachedBytes(symbol_name)->length);
@@ -334,7 +334,7 @@ namespace matx {
 
         auto handle = GeneratePlan();
 
-        LIBCUBLASDX_CHECK(cublasdxSetOptionStr(handle, COMMONDX_OPTION_SYMBOL_NAME, symbol_name.c_str())); 
+        LIBCUBLASDX_CHECK(cublasdxSetOptionStr(handle, COMMONDX_OPTION_SYMBOL_NAME, symbol_name.c_str()));
 
         commondxCode code;
         LIBCUBLASDX_CHECK(commondxCreateCode(&code));
@@ -348,22 +348,22 @@ namespace matx {
 
         LIBCUBLASDX_CHECK(commondxGetCodeLTOIR(code, ltoir.length, ltoir.data));
 
-        MATX_LOG_DEBUG("cuBLASDx Function {}", symbol_name);        
+        MATX_LOG_DEBUG("cuBLASDx Function {}", symbol_name);
         MATX_LOG_DEBUG("cuBLASDx LTOIR size {}", ltoir.length);
-        
+
         if (!detail::GetCache().StoreLTOIRCachedBytes(symbol_name, ltoir.data, ltoir.length)) {
           free(ltoir.data);
           MATX_LOG_ERROR("Failed to store cuBLASDx LTOIR cached bytes for: {}", symbol_name);
           return false;
         }
-        
+
         // CRITICAL: Set to nullptr after transferring ownership to cache to prevent double-free
         ltoir.data = nullptr;
         ltoir.length = 0;
-        
+
         LIBCUBLASDX_CHECK(commondxDestroyCode(code));
         LIBCUBLASDX_CHECK(cublasdxDestroyDescriptor(handle));
-    
+
         return true;
       }
 
@@ -372,11 +372,11 @@ namespace matx {
           using value_type = )";
         result += detail::type_to_string<InputType>();
         result += R"(;
-          
+
           // cuBLASDx requires block-level cooperation, so all threads in the block
           // must participate in loading data and executing the GEMM
           extern __shared__ __align__(16) char smem[];
-          
+
           // Partition shared memory for A, B, C matrices
           constexpr size_t a_size = )";
         result += std::to_string(static_cast<int>(m_ * k_));
@@ -385,11 +385,11 @@ namespace matx {
         result += std::to_string(static_cast<int>(k_ * n_));
 
         result += R"( * sizeof(value_type);
-          
+
           value_type* smem_a = reinterpret_cast<value_type*>(smem);
           value_type* smem_b = reinterpret_cast<value_type*>(smem + a_size);
           value_type* smem_c = reinterpret_cast<value_type*>(smem + a_size + b_size);
-          
+
           // Cooperatively load A and B from global to shared memory using operator()
           // Batch indices are already preset in the operators, so we only need 2D matrix indices
           const int tid = threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.x * blockDim.y;
@@ -405,7 +405,7 @@ namespace matx {
             const index_t col = i % a_cols;
             smem_a[row * a_cols + col] = a_.template operator()<CapType>(row, col);
           }
-          
+
           // Load B matrix (k x n) - each thread loads multiple elements strided by total_threads
           constexpr index_t b_cols = )";
         result += std::to_string(static_cast<int>(n_));
@@ -417,23 +417,23 @@ namespace matx {
             const index_t col = i % b_cols;
             smem_b[row * b_cols + col] = b_.template operator()<CapType>(row, col);
           }
-          
+
           __syncthreads();
-          
+
           // Call the cuBLASDx generated GEMM function
           // Signature: void func(value_type* alpha, value_type* a, value_type* b, value_type* beta, value_type* c)
         )";
         using literal_type = cuda::std::conditional_t<
-            std::is_same_v<InputType, double> || std::is_same_v<InputType, cuda::std::complex<double>>,
+            cuda::std::is_same_v<InputType, double> || cuda::std::is_same_v<InputType, cuda::std::complex<double>>,
             double,
             float>;
         result += "value_type alpha_val = static_cast<value_type>(" + FormatScalarLiteral(static_cast<literal_type>(alpha)) + ");\n";
         result += "value_type beta_val = static_cast<value_type>(" + FormatScalarLiteral(static_cast<literal_type>(beta)) + ");\n";
         result += gemm_func_name;
         result += R"((&alpha_val, smem_a, smem_b, &beta_val, smem_c);
-          
+
           __syncthreads();
-          
+
           // Each thread returns its portion of the result
           // For vectorized execution, return a Vector; for scalar, return scalar
           static_assert(CapType::ept == ElementsPerThread::ONE, "cuBLASDx only supports ONE elements per thread");
@@ -463,7 +463,7 @@ namespace matx {
 
   // Stub implementation when MathDx is not enabled
   template <typename T>
-  __MATX_INLINE__ bool IscuBLASDxSupported([[maybe_unused]] index_t m, [[maybe_unused]] index_t n, 
+  __MATX_INLINE__ bool IscuBLASDxSupported([[maybe_unused]] index_t m, [[maybe_unused]] index_t n,
                                            [[maybe_unused]] index_t k, [[maybe_unused]] int compute_capability)
   {
     return false;

--- a/include/matx/transforms/matmul/matmul_cuda.h
+++ b/include/matx/transforms/matmul/matmul_cuda.h
@@ -1015,13 +1015,13 @@ private:
     if constexpr (RANK == 2) {
       if constexpr (PROV == PROVIDER_TYPE_CUTLASS) {
 #ifdef MATX_ENABLE_CUTLASS
-        using CutlassAOrder = std::conditional_t<OrderA == MEM_ORDER_ROW_MAJOR,
+        using CutlassAOrder = cuda::std::conditional_t<OrderA == MEM_ORDER_ROW_MAJOR,
                                                  cutlass::layout::RowMajor,
                                                  cutlass::layout::ColumnMajor>;
-        using CutlassBOrder = std::conditional_t<OrderB == MEM_ORDER_ROW_MAJOR,
+        using CutlassBOrder = cuda::std::conditional_t<OrderB == MEM_ORDER_ROW_MAJOR,
                                                  cutlass::layout::RowMajor,
                                                  cutlass::layout::ColumnMajor>;
-        using CutlassCOrder = std::conditional_t<OrderC == MEM_ORDER_ROW_MAJOR,
+        using CutlassCOrder = cuda::std::conditional_t<OrderC == MEM_ORDER_ROW_MAJOR,
                                                  cutlass::layout::RowMajor,
                                                  cutlass::layout::ColumnMajor>;
         using CutlassGemm =
@@ -1059,13 +1059,13 @@ private:
     else {
       static_assert(RANK > 2);
 #ifdef MATX_ENABLE_CUTLASS
-      using CutlassAOrder = std::conditional_t<OrderA == MEM_ORDER_ROW_MAJOR,
+      using CutlassAOrder = cuda::std::conditional_t<OrderA == MEM_ORDER_ROW_MAJOR,
                                                cutlass::layout::RowMajor,
                                                cutlass::layout::ColumnMajor>;
-      using CutlassBOrder = std::conditional_t<OrderB == MEM_ORDER_ROW_MAJOR,
+      using CutlassBOrder = cuda::std::conditional_t<OrderB == MEM_ORDER_ROW_MAJOR,
                                                cutlass::layout::RowMajor,
                                                cutlass::layout::ColumnMajor>;
-      using CutlassCOrder = std::conditional_t<OrderC == MEM_ORDER_ROW_MAJOR,
+      using CutlassCOrder = cuda::std::conditional_t<OrderC == MEM_ORDER_ROW_MAJOR,
                                                cutlass::layout::RowMajor,
                                                cutlass::layout::ColumnMajor>;
       using CutlassGemm = cutlass::gemm::device::GemmBatched<

--- a/include/matx/transforms/matmul/matmul_cuda.h
+++ b/include/matx/transforms/matmul/matmul_cuda.h
@@ -79,37 +79,37 @@ typedef enum {
 
 template <typename OpA, typename OpB, typename OpC, MatMulCUDAProvider_t PROV = PROVIDER_TYPE_CUBLASLT>
 constexpr bool CompatibleGemmCUDATypes() {
-  if constexpr (!std::is_same_v<typename OpA::value_type, typename OpB::value_type> &&
-                !std::is_same_v<typename OpB::value_type, typename OpC::value_type> &&
-                !std::is_same_v<typename OpA::value_type, typename OpC::value_type>) {
+  if constexpr (!cuda::std::is_same_v<typename OpA::value_type, typename OpB::value_type> &&
+                !cuda::std::is_same_v<typename OpB::value_type, typename OpC::value_type> &&
+                !cuda::std::is_same_v<typename OpA::value_type, typename OpC::value_type>) {
     return false;
   }
 
   if constexpr (PROV == PROVIDER_TYPE_CUBLASLT) {
-    if constexpr (std::is_same_v<typename OpA::value_type, typename OpB::value_type> &&
-                  std::is_same_v<typename OpB::value_type, typename OpC::value_type>) {
+    if constexpr (cuda::std::is_same_v<typename OpA::value_type, typename OpB::value_type> &&
+                  cuda::std::is_same_v<typename OpB::value_type, typename OpC::value_type>) {
       // List of accepted types when A/B/C match
-      return  std::is_same_v<typename OpA::value_type, matxFp16> ||
-              std::is_same_v<typename OpA::value_type, matxBf16> ||
-              std::is_same_v<typename OpA::value_type, float> ||
-              std::is_same_v<typename OpA::value_type, double> ||
-              std::is_same_v<typename OpA::value_type, cuda::std::complex<float>> ||
-              std::is_same_v<typename OpA::value_type, cuda::std::complex<double>> ||
-              std::is_same_v<typename OpA::value_type, int8_t> ||
-              std::is_same_v<typename OpA::value_type, matxFp16Complex> ||
-              std::is_same_v<typename OpA::value_type, matxBf16Complex> ||
-              std::is_same_v<typename OpA::value_type, matxFp16ComplexPlanar> ||
-              std::is_same_v<typename OpA::value_type, matxBf16ComplexPlanar>;
+      return  cuda::std::is_same_v<typename OpA::value_type, matxFp16> ||
+              cuda::std::is_same_v<typename OpA::value_type, matxBf16> ||
+              cuda::std::is_same_v<typename OpA::value_type, float> ||
+              cuda::std::is_same_v<typename OpA::value_type, double> ||
+              cuda::std::is_same_v<typename OpA::value_type, cuda::std::complex<float>> ||
+              cuda::std::is_same_v<typename OpA::value_type, cuda::std::complex<double>> ||
+              cuda::std::is_same_v<typename OpA::value_type, int8_t> ||
+              cuda::std::is_same_v<typename OpA::value_type, matxFp16Complex> ||
+              cuda::std::is_same_v<typename OpA::value_type, matxBf16Complex> ||
+              cuda::std::is_same_v<typename OpA::value_type, matxFp16ComplexPlanar> ||
+              cuda::std::is_same_v<typename OpA::value_type, matxBf16ComplexPlanar>;
 
     }
     // Accumulator type different from A/B
-    else if constexpr (  std::is_same_v<typename OpA::value_type, typename OpB::value_type> &&
-                        !std::is_same_v<typename OpB::value_type, typename OpC::value_type>) {
-      return (std::is_same_v<typename OpA::value_type, int8_t> && std::is_same_v<typename OpC::value_type, int32_t>) ||
-              (std::is_same_v<typename OpA::value_type, int8_t> && std::is_same_v<typename OpC::value_type, float>) ||
-              (std::is_same_v<typename OpA::value_type, matxBf16> && std::is_same_v<typename OpC::value_type, float>) ||
-              (std::is_same_v<typename OpA::value_type, matxFp16> && std::is_same_v<typename OpC::value_type, float>) ||
-              (std::is_same_v<typename OpA::value_type, int8_t> && std::is_same_v<typename OpC::value_type, float>);
+    else if constexpr (  cuda::std::is_same_v<typename OpA::value_type, typename OpB::value_type> &&
+                        !cuda::std::is_same_v<typename OpB::value_type, typename OpC::value_type>) {
+      return (cuda::std::is_same_v<typename OpA::value_type, int8_t> && cuda::std::is_same_v<typename OpC::value_type, int32_t>) ||
+              (cuda::std::is_same_v<typename OpA::value_type, int8_t> && cuda::std::is_same_v<typename OpC::value_type, float>) ||
+              (cuda::std::is_same_v<typename OpA::value_type, matxBf16> && cuda::std::is_same_v<typename OpC::value_type, float>) ||
+              (cuda::std::is_same_v<typename OpA::value_type, matxFp16> && cuda::std::is_same_v<typename OpC::value_type, float>) ||
+              (cuda::std::is_same_v<typename OpA::value_type, int8_t> && cuda::std::is_same_v<typename OpC::value_type, float>);
     }
   }
 
@@ -305,27 +305,27 @@ public:
                            [[maybe_unused]] float const beta)
   {
     // For now we don't give much flexibility on compute type/alpha
-    if constexpr (std::is_same_v<InputType, cuda::std::complex<float>> ||
+    if constexpr (cuda::std::is_same_v<InputType, cuda::std::complex<float>> ||
                   is_complex_half_v<InputType>) {
       cuComplex *calpha = reinterpret_cast<cuComplex *>(palpha);
       cuComplex *cbeta = reinterpret_cast<cuComplex *>(pbeta);
       *calpha = {alpha, 0};
       *cbeta = {beta, 0};
     }
-    else if constexpr (std::is_same_v<InputType, cuda::std::complex<double>>) {
+    else if constexpr (cuda::std::is_same_v<InputType, cuda::std::complex<double>>) {
       cuDoubleComplex *dalpha = reinterpret_cast<cuDoubleComplex *>(palpha);
       cuDoubleComplex *dbeta = reinterpret_cast<cuDoubleComplex *>(pbeta);
       *dalpha = {alpha, 0};
       *dbeta = {beta, 0};
     }
-    else if constexpr (std::is_same_v<InputType, double>) {
+    else if constexpr (cuda::std::is_same_v<InputType, double>) {
       double *dalpha = reinterpret_cast<double *>(palpha);
       double *dbeta = reinterpret_cast<double *>(pbeta);
       *dalpha = alpha;
       *dbeta = beta;
     }
     else if constexpr (is_matx_half_v<InputType> ||
-                       std::is_same_v<InputType, float>) {
+                       cuda::std::is_same_v<InputType, float>) {
       float *talpha = reinterpret_cast<float *>(palpha);
       float *tbeta = reinterpret_cast<float *>(pbeta);
       *talpha = alpha;
@@ -676,14 +676,14 @@ private:
 
     // Update this later when we're more flexible on compute type
     int32_t scaleType;
-    if constexpr (std::is_same_v<T1, float> || is_matx_half_v<T1>) {
+    if constexpr (cuda::std::is_same_v<T1, float> || is_matx_half_v<T1>) {
       scaleType = CUDA_R_32F;
     }
     else if constexpr (is_complex_half_v<T1> ||
-                       std::is_same_v<T1, cuda::std::complex<float>>) {
+                       cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
       scaleType = CUDA_C_32F;
     }
-    else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+    else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
       scaleType = CUDA_C_64F;
     }
     else {
@@ -959,20 +959,20 @@ private:
       memset(&salpha, 0, sizeof(salpha));
       memset(&sbeta, 0, sizeof(sbeta));
 
-      if constexpr (std::is_same_v<T1, cuda::std::complex<float>> ||
+      if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>> ||
                     is_complex_half_v<T1>) {
         salpha.cf32[0] = alpha;
         sbeta.cf32[0] = beta;
       }
-      else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+      else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
         salpha.cf64[0] = alpha;
         sbeta.cf64[0] = beta;
       }
-      else if constexpr (std::is_same_v<T1, float> || is_matx_half_v<T1>) {
+      else if constexpr (cuda::std::is_same_v<T1, float> || is_matx_half_v<T1>) {
         salpha.f32 = alpha;
         sbeta.f32 = beta;
       }
-      else if constexpr (std::is_same_v<T1, double>) {
+      else if constexpr (cuda::std::is_same_v<T1, double>) {
         salpha.f64 = alpha;
         sbeta.f64 = beta;
       }
@@ -988,7 +988,7 @@ private:
       }
       else {
         // When rank exceeds threshold, we loop over the outer dimensions where each iteration
-        // of cublasLtMatMul processes the innermost 'threshold' number of dimensions        
+        // of cublasLtMatMul processes the innermost 'threshold' number of dimensions
         for (size_t iter = 0; iter < total_iter; iter++) {
           // Get pointers into A/B/C for this round
           auto ap = cuda::std::apply([&a_adj](auto... param) { return a_adj.GetPointer(param...); }, a_idx);
@@ -1304,7 +1304,7 @@ __MATX_INLINE__ void WithMatmulOperand(const Op &op, cudaStream_t stream,
   using OpType = remove_cvref_t<Op>;
   constexpr bool can_use_metadata_op =
       PROV == PROVIDER_TYPE_CUBLASLT &&
-      std::is_same_v<typename OpType::value_type, ValueType> &&
+      cuda::std::is_same_v<typename OpType::value_type, ValueType> &&
       CanUseCublasLtConjTransposeOp<ValueType>();
 
   if constexpr (can_use_metadata_op && is_hermitian_trans_op_v<OpType>) {

--- a/include/matx/transforms/matmul/matmul_cusparse.h
+++ b/include/matx/transforms/matmul/matmul_cusparse.h
@@ -94,12 +94,12 @@ public:
     params_ = GetGemmParams(c, a, b, stream, alpha, beta);
 
     // Properly typed alpha, beta.
-    if constexpr (std::is_same_v<TCOMP, cuda::std::complex<float>> ||
-                  std::is_same_v<TCOMP, cuda::std::complex<double>>) {
+    if constexpr (cuda::std::is_same_v<TCOMP, cuda::std::complex<float>> ||
+                  cuda::std::is_same_v<TCOMP, cuda::std::complex<double>>) {
       salpha_ = {alpha, 0};
       sbeta_ = {beta, 0};
-    } else if constexpr (std::is_same_v<TCOMP, float> ||
-                         std::is_same_v<TCOMP, double>) {
+    } else if constexpr (cuda::std::is_same_v<TCOMP, float> ||
+                         cuda::std::is_same_v<TCOMP, double>) {
       salpha_ = alpha;
       sbeta_ = beta;
     } else {
@@ -298,13 +298,13 @@ void sparse_matmul_impl(TensorTypeC &C, const TensorTypeA &a,
   // Restrictions.
   static_assert(RANKA == 2 && RANKB == 2 && RANKC == 2,
                 "tensors must have rank-2");
-  static_assert(std::is_same_v<TC, TA> && std::is_same_v<TC, TB>,
+  static_assert(cuda::std::is_same_v<TC, TA> && cuda::std::is_same_v<TC, TB>,
                 "tensors must have the same data type");
-  static_assert(std::is_same_v<TC, matx::matxFp16> ||
-                    std::is_same_v<TC, matx::matxBf16> ||
-                    std::is_same_v<TC, float> || std::is_same_v<TC, double> ||
-                    std::is_same_v<TC, cuda::std::complex<float>> ||
-                    std::is_same_v<TC, cuda::std::complex<double>>,
+  static_assert(cuda::std::is_same_v<TC, matx::matxFp16> ||
+                    cuda::std::is_same_v<TC, matx::matxBf16> ||
+                    cuda::std::is_same_v<TC, float> || cuda::std::is_same_v<TC, double> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<float>> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<double>>,
                 "unsupported data type");
   MATX_ASSERT(a.Size(RANKA - 1) == b.Size(RANKB - 2) &&
                   c.Size(RANKC - 1) == b.Size(RANKB - 1) &&

--- a/include/matx/transforms/matmul/matmul_cusparse.h
+++ b/include/matx/transforms/matmul/matmul_cusparse.h
@@ -80,7 +80,7 @@ public:
   using TC = typename TensorTypeC::value_type;
 
   // Mixed-precision compute type.
-  using TCOMP = std::conditional_t<is_matx_half_v<TC>, float, TC>;
+  using TCOMP = cuda::std::conditional_t<is_matx_half_v<TC>, float, TC>;
 
   /**
    * Construct a sparse GEMM handle

--- a/include/matx/transforms/matmul/matvec_cusparse.h
+++ b/include/matx/transforms/matmul/matvec_cusparse.h
@@ -91,12 +91,12 @@ public:
     params_ = GetSpMVParams(c, a, b, stream, alpha, beta);
 
     // Properly typed alpha, beta.
-    if constexpr (std::is_same_v<TCOMP, cuda::std::complex<float>> ||
-                  std::is_same_v<TCOMP, cuda::std::complex<double>>) {
+    if constexpr (cuda::std::is_same_v<TCOMP, cuda::std::complex<float>> ||
+                  cuda::std::is_same_v<TCOMP, cuda::std::complex<double>>) {
       salpha_ = {alpha, 0};
       sbeta_ = {beta, 0};
-    } else if constexpr (std::is_same_v<TCOMP, float> ||
-                         std::is_same_v<TCOMP, double>) {
+    } else if constexpr (cuda::std::is_same_v<TCOMP, float> ||
+                         cuda::std::is_same_v<TCOMP, double>) {
       salpha_ = alpha;
       sbeta_ = beta;
     } else {
@@ -290,13 +290,13 @@ void sparse_matvec_impl(TensorTypeC &C, const TensorTypeA &a,
   // Restrictions.
   static_assert(RANKA == 2 && RANKB == 1 && RANKC == 1,
                 "tensors must have SpMV rank");
-  static_assert(std::is_same_v<TC, TA> && std::is_same_v<TC, TB>,
+  static_assert(cuda::std::is_same_v<TC, TA> && cuda::std::is_same_v<TC, TB>,
                 "tensors must have the same data type");
-  static_assert(std::is_same_v<TC, matx::matxFp16> ||
-                    std::is_same_v<TC, matx::matxBf16> ||
-                    std::is_same_v<TC, float> || std::is_same_v<TC, double> ||
-                    std::is_same_v<TC, cuda::std::complex<float>> ||
-                    std::is_same_v<TC, cuda::std::complex<double>>,
+  static_assert(cuda::std::is_same_v<TC, matx::matxFp16> ||
+                    cuda::std::is_same_v<TC, matx::matxBf16> ||
+                    cuda::std::is_same_v<TC, float> || cuda::std::is_same_v<TC, double> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<float>> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<double>>,
                 "unsupported data type");
   MATX_ASSERT(a.Size(RANKA - 1) == b.Size(RANKB - 1) &&
                   a.Size(RANKA - 2) == c.Size(RANKC - 1),

--- a/include/matx/transforms/matmul/matvec_cusparse.h
+++ b/include/matx/transforms/matmul/matvec_cusparse.h
@@ -79,7 +79,7 @@ public:
   using TC = typename TensorTypeC::value_type;
 
   // Mixed-precision compute type.
-  using TCOMP = std::conditional_t<is_matx_half_v<TC>, float, TC>;
+  using TCOMP = cuda::std::conditional_t<is_matx_half_v<TC>, float, TC>;
 
   /**
    * Construct a SpMV handle

--- a/include/matx/transforms/norm.h
+++ b/include/matx/transforms/norm.h
@@ -63,21 +63,21 @@ __MATX_INLINE__ void norm_impl(OutputOp out, const InputOp &in,
 {
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
 
-  if constexpr (std::is_same_v<NormType, detail::NormTypeVector>) {
+  if constexpr (cuda::std::is_same_v<NormType, detail::NormTypeVector>) {
     if (order == NormOrder::NONE || order == NormOrder::L2) {
       // This is really just:
       // (out = sqrt(sum(abs2(in), {InputOp::Rank() - 1}))).run(exec);
       // But we need to force the output rank here to avoid a no-op permute using the {} syntax on sum
       auto tOp = abs2(in);
       auto sumOp = sum<decltype(tOp), 1>(tOp);
-      (out = sqrt(sumOp)).run(exec);      
+      (out = sqrt(sumOp)).run(exec);
     }
     else if (order == NormOrder::L1) {
       // This is really just:
       // (out = sum(abs(in), {InputOp::Rank() - 1})).run(exec);
-      // But we need to force the output rank here to avoid a no-op permute using the {} syntax on sum      
+      // But we need to force the output rank here to avoid a no-op permute using the {} syntax on sum
       auto tOp = abs(in);
-      (out = sum<decltype(tOp), 1>(tOp)).run(exec);      
+      (out = sum<decltype(tOp), 1>(tOp)).run(exec);
     }
     else {
       MATX_ASSERT_STR(false, matxInvalidParameter, "Invalid order type for vector norm");
@@ -89,7 +89,7 @@ __MATX_INLINE__ void norm_impl(OutputOp out, const InputOp &in,
       // Same as (out = sqrt(sum(abs2(in), {InputOp::Rank() - 2, InputOp::Rank() - 1}))).run(exec);
       auto tOp = abs2(in);
       auto sumOp = sum<decltype(tOp), 2>(tOp);
-      (out = sqrt(sumOp)).run(exec);      
+      (out = sqrt(sumOp)).run(exec);
     }
     else if (order == NormOrder::L1) {
       // See comment above

--- a/include/matx/transforms/pinv.h
+++ b/include/matx/transforms/pinv.h
@@ -81,14 +81,14 @@ void pinv_impl(OutputTensor &out,
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_API)
   MATX_ASSERT_STR(!(is_host_executor_v<Executor> && !MATX_EN_CPU_SOLVER), matxInvalidExecutor,
     "Trying to run a host Solver executor but host Solver support is not configured");
-  
+
   using T1 = typename InputTensor::value_type;
   using inner_type = typename inner_op_type_t<T1>::type;
   constexpr int RANK = InputTensor::Rank();
 
   MATX_STATIC_ASSERT_STR(OutputTensor::Rank() == InputTensor::Rank(), matxInvalidDim, "Output and input tensors must have same rank for pinv()");
   MATX_STATIC_ASSERT_STR(RANK >= 2, matxInvalidDim, "Input/Output tensor must be rank 2 or higher");
-  MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutputTensor::value_type>), matxInavlidType, "A and Out types must match");
+  MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutputTensor::value_type>), matxInavlidType, "A and Out types must match");
 
   const index_t m = a.Size(RANK-2); // rows
   const index_t n = a.Size(RANK-1); // cols
@@ -101,11 +101,11 @@ void pinv_impl(OutputTensor &out,
 
   MATX_ASSERT_STR((out.Size(RANK-1) == m) && (out.Size(RANK-2) == n), matxInvalidSize,
       "Out must be ... x n x m for A ... x m x n");
-  
-  /* 
+
+  /*
     Need to perform pinv = V * S^-1 * U^H where svd(A) = U * S * V^H.
     Alternatively, can run svd(A^H) to get V, S, U^H
-  */ 
+  */
 
   // Allocate v, s, ut
   auto aShape = a.Shape();
@@ -157,7 +157,7 @@ void pinv_impl(OutputTensor &out,
   // Need to explicitly run before inverting s since the mask needs to be created
   // based on original singular values.
   (s_mask = s > cutoff_add_axis).run(exec);
-  
+
   // IF required to avoid nans when singular value is 0
   (IF(s != inner_type(0), s = inner_type(1) / s)).run(exec);
   (s *= s_mask).run(exec);
@@ -168,7 +168,7 @@ void pinv_impl(OutputTensor &out,
   dShape[RANK-2] = n;
   auto d = clone<RANK>(s, dShape);
   (v = v * d).run(exec);
-  
+
   // (V * S-1) * UT
   matmul_impl(out, v, ut, exec);
 }

--- a/include/matx/transforms/pwelch.h
+++ b/include/matx/transforms/pwelch.h
@@ -55,7 +55,7 @@ namespace matx
       index_t batches = x_with_overlaps.Shape()[0];
       auto X_with_overlaps = make_tensor<cuda::std::complex<typename PxxType::value_type>>({batches,static_cast<index_t>(nfft)},MATX_ASYNC_DEVICE_MEMORY,stream);
 
-      if constexpr (std::is_same_v<wType, std::nullopt_t>) {
+      if constexpr (cuda::std::is_same_v<wType, std::nullopt_t>) {
         (X_with_overlaps = fft(x_with_overlaps,nfft)).run(stream);
       }
       else {

--- a/include/matx/transforms/qr/qr_cuda.h
+++ b/include/matx/transforms/qr/qr_cuda.h
@@ -117,26 +117,26 @@ namespace detail {
       (R = A).run(stream);
 
       // we will slice X directly from R.
-      cuda::std::array<index_t, RANK> xSliceB, xSliceE;   
+      cuda::std::array<index_t, RANK> xSliceB, xSliceE;
       xSliceB.fill(0); xSliceE.fill(matxEnd);
       xSliceE[RANK-1] = matxDropDim; // drop last dim to make a vector
 
 
       // v is of size m x 1.  Instead of allocating additional memory we will just reuse a row of Qin
-      cuda::std::array<index_t, RANK> vSliceB, vSliceE;   
+      cuda::std::array<index_t, RANK> vSliceB, vSliceE;
       vSliceB.fill(0); vSliceE.fill(matxEnd);
       // select a single row of Q to alias as v
-      vSliceE[RANK-2] = matxDropDim; 
+      vSliceE[RANK-2] = matxDropDim;
       auto v = slice<RANK-1>(Qin, vSliceB, vSliceE);
-      auto xz = v; // alias 
+      auto xz = v; // alias
 
 
       // N is of size 1.  Instead of allocating additional memory we will just reuse an entry of Qin
-      cuda::std::array<index_t, RANK> nSliceB, nSliceE;   
+      cuda::std::array<index_t, RANK> nSliceB, nSliceE;
       nSliceB.fill(0); nSliceE.fill(matxEnd);
       // select a single row of Q to alias as v
-      nSliceE[RANK-2] = matxDropDim; 
-      nSliceE[RANK-1] = matxDropDim; 
+      nSliceE[RANK-2] = matxDropDim;
+      nSliceE[RANK-1] = matxDropDim;
 
       auto N = slice<RANK-2>(wwt, nSliceB, nSliceE);
 
@@ -147,9 +147,9 @@ namespace detail {
       auto nc = clone<RANK-1>(N,ncShape);
 
       // aliasing some memory here to share storage and provide clarity in the code below
-      auto s = N; // alias 
+      auto s = N; // alias
       auto sc = nc; // alias
-      auto w = v; // alias 
+      auto w = v; // alias
 
       for(int i = 0 ; i < k ; i++) {
 
@@ -160,11 +160,11 @@ namespace detail {
         // operator which zeros out values above current index in matrix
         (xz = as_type<typename inner_op_type_t<ATypeS>::type >(index(x.Rank()-1) >= i) * x).run(stream);
 
-        // compute L2 norm without sqrt. 
+        // compute L2 norm without sqrt.
         (N = sum(abs2(xz))).run(stream);
         //(N = sqrt(N)).run(stream);  // sqrt folded into next op
 
-        (v = xz + as_type<typename inner_op_type_t<ATypeS>::type >(index(v.Rank()-1) == i) * sign(xz) * sqrt(nc)).run(stream); 
+        (v = xz + as_type<typename inner_op_type_t<ATypeS>::type >(index(v.Rank()-1) == i) * sign(xz) * sqrt(nc)).run(stream);
 
         auto r = x;  // alias column of R happens to be the same as x
 
@@ -173,7 +173,7 @@ namespace detail {
 
         // IFELSE to avoid nans when dividing by zero
         using v_type = typename decltype(v)::value_type;
-        (IFELSE(sc != v_type(0), 
+        (IFELSE(sc != v_type(0),
                 w = (v / sqrt(sc)),
                 w = v_type(0))).run(stream);
 
@@ -186,7 +186,7 @@ namespace detail {
 
         (wwt = outer(w, conj(w))).run(stream);
 
-        (Qin = Q).run(stream);  // save input 
+        (Qin = Q).run(stream);  // save input
         matmul_impl(Q, Qin, wwt, exec, -2, 1);
 
       }
@@ -294,8 +294,8 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "QR solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, T2>), matxInavlidType, "A and Tau types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, T2>), matxInavlidType, "A and Tau types must match");
 
     params = GetQRParams(tau, a, exec);
     this->GetWorkspaceSize();
@@ -549,9 +549,9 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "QR solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename RTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, T2>), matxInavlidType, "A and Tau types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename RTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, T2>), matxInavlidType, "A and Tau types must match");
 
     params = GetQRParams(tau, a, exec);
     this->GetWorkspaceSize();
@@ -632,7 +632,7 @@ public:
 
       MATX_ASSERT(ret == CUSOLVER_STATUS_SUCCESS, matxSolverError);
 
-      
+
     }
 
     std::vector<int> h_info(this->batch_a_ptrs.size());
@@ -649,19 +649,19 @@ public:
     // at this point, R is stored in the upper triangular part of out
     // so copy it out into memory assigned by user.
     // Per the cuSolver documentation (quoted):
-    // The matrix R is overwritten in upper triangular part of A, 
+    // The matrix R is overwritten in upper triangular part of A,
     // including diagonal elements
-    cuda::std::array<index_t, RANK> rSliceB, rSliceE;   
+    cuda::std::array<index_t, RANK> rSliceB, rSliceE;
     rSliceB.fill(0); rSliceE.fill(matxEnd);
     rSliceE[RANK-2] = matxDropDim;
-    rSliceE[RANK-1] = params.n; // taking upper triangular portion of out    
+    rSliceE[RANK-1] = params.n; // taking upper triangular portion of out
 
     for (int i = 0; i < std::min(params.m, params.n); i++){
       rSliceB[RANK-2] = i;
       (slice<RANK-1>(out_r, rSliceB, rSliceE) = as_type<typename OutTensor_t::value_type>(index(RANK-2) >= i)*slice<RANK-1>(out, rSliceB, rSliceE)).run(exec);
     }
 
-    // Intentionally looping AGAIN, so we can reuse h_info and d_info without 
+    // Intentionally looping AGAIN, so we can reuse h_info and d_info without
     // having to copy to host with each iteration of the loop
     for (size_t i = 0; i < this->batch_a_ptrs.size(); i++) {
       [[maybe_unused]] auto ret = orgqr_dispatch(
@@ -693,40 +693,40 @@ public:
   ~matxDnEconQRCUDAPlan_t() {}
 
 private:
-  
+
   cusolverStatus_t orgqr_bufferSize_dispatch(
     int64_t m64, int64_t n64, int64_t k64,
     void* A, int64_t lda64,
     void* tau,
     int* lwork){
-    
+
     int m = static_cast<int>(m64);
     int n = static_cast<int>(n64);
     int k = static_cast<int>(k64);
     int lda = static_cast<int>(lda64);
 
-    if constexpr (std::is_same_v<T1, float>) {
-      return cusolverDnSorgqr_bufferSize(handle, m, n, k, 
-              reinterpret_cast<T1*>(A), lda, 
-              reinterpret_cast<T1*>(tau), 
+    if constexpr (cuda::std::is_same_v<T1, float>) {
+      return cusolverDnSorgqr_bufferSize(handle, m, n, k,
+              reinterpret_cast<T1*>(A), lda,
+              reinterpret_cast<T1*>(tau),
               lwork);
-    } 
-    else if constexpr (std::is_same_v<T1, double>) {
-      return cusolverDnDorgqr_bufferSize(handle, m, n, k, 
-        reinterpret_cast<T1*>(A), lda, 
-        reinterpret_cast<T1*>(tau), 
+    }
+    else if constexpr (cuda::std::is_same_v<T1, double>) {
+      return cusolverDnDorgqr_bufferSize(handle, m, n, k,
+        reinterpret_cast<T1*>(A), lda,
+        reinterpret_cast<T1*>(tau),
               lwork);
-    } 
-    else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
-      return cusolverDnCungqr_bufferSize(handle, m, n, k, 
-              reinterpret_cast<cuComplex*>(A), lda, 
-              reinterpret_cast<cuComplex*>(tau), 
+    }
+    else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
+      return cusolverDnCungqr_bufferSize(handle, m, n, k,
+              reinterpret_cast<cuComplex*>(A), lda,
+              reinterpret_cast<cuComplex*>(tau),
               lwork);
-    } 
-    else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
-      return cusolverDnZungqr_bufferSize(handle, m, n, k, 
-        reinterpret_cast<cuDoubleComplex*>(A), lda, 
-        reinterpret_cast<cuDoubleComplex*>(tau), 
+    }
+    else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
+      return cusolverDnZungqr_bufferSize(handle, m, n, k,
+        reinterpret_cast<cuDoubleComplex*>(A), lda,
+        reinterpret_cast<cuDoubleComplex*>(tau),
               lwork);
     }
     else{
@@ -750,28 +750,28 @@ private:
     int lda = static_cast<int>(lda64);
     int lwork = static_cast<int>(lwork64);
 
-    if constexpr (std::is_same_v<T1, float>) {
-      return cusolverDnSorgqr(handle, m, n, k, 
-              reinterpret_cast<T1*>(A), lda, 
-              reinterpret_cast<T1*>(tau), 
+    if constexpr (cuda::std::is_same_v<T1, float>) {
+      return cusolverDnSorgqr(handle, m, n, k,
+              reinterpret_cast<T1*>(A), lda,
+              reinterpret_cast<T1*>(tau),
               reinterpret_cast<T1*>(work), lwork, info);
-    } 
-    else if constexpr (std::is_same_v<T1, double>) {
-      return cusolverDnDorgqr(handle, m, n, k, 
-              reinterpret_cast<T1*>(A), lda, 
-              reinterpret_cast<T1*>(tau), 
+    }
+    else if constexpr (cuda::std::is_same_v<T1, double>) {
+      return cusolverDnDorgqr(handle, m, n, k,
+              reinterpret_cast<T1*>(A), lda,
+              reinterpret_cast<T1*>(tau),
               reinterpret_cast<T1*>(work), lwork, info);
-    } 
-    else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
-      return cusolverDnCungqr(handle, m, n, k, 
-              reinterpret_cast<cuComplex*>(A), lda, 
-              reinterpret_cast<cuComplex*>(tau), 
+    }
+    else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
+      return cusolverDnCungqr(handle, m, n, k,
+              reinterpret_cast<cuComplex*>(A), lda,
+              reinterpret_cast<cuComplex*>(tau),
               reinterpret_cast<cuComplex*>(work), lwork, info);
-    } 
-    else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
-      return cusolverDnZungqr(handle, m, n, k, 
-              reinterpret_cast<cuDoubleComplex*>(A), lda, 
-              reinterpret_cast<cuDoubleComplex*>(tau), 
+    }
+    else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
+      return cusolverDnZungqr(handle, m, n, k,
+              reinterpret_cast<cuDoubleComplex*>(A), lda,
+              reinterpret_cast<cuDoubleComplex*>(tau),
               reinterpret_cast<cuDoubleComplex*>(work), lwork, info);
     }
     else{
@@ -828,7 +828,7 @@ void qr_econ_impl(OutTensor &&out, RTensor &&out_r,
 
   auto tau_new = make_tensor<T1>(tau_shape);
   auto a_new = OpToTensor(a, exec);
-  
+
   if(!is_matx_transform_op<ATensor>() && !a_new.isSameView(a)) {
     (a_new = a).run(exec);
   }
@@ -866,7 +866,7 @@ void qr_econ_impl(OutTensor &&out, RTensor &&out_r,
 
   /* Temporary WAR
    * Copy and free async buffer for transpose */
-  cuda::std::array<index_t, RANK> rSliceB, rSliceE;   
+  cuda::std::array<index_t, RANK> rSliceB, rSliceE;
   rSliceB.fill(0); rSliceE.fill(matxEnd);
   rSliceE[RANK-2] = params.m;
   rSliceE[RANK-1] = std::min(params.m, params.n);

--- a/include/matx/transforms/qr/qr_lapack.h
+++ b/include/matx/transforms/qr/qr_lapack.h
@@ -106,8 +106,8 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "QR solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, T2>), matxInavlidType, "A and Tau types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, typename OutTensor_t::value_type>), matxInavlidType, "Input and Output types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, T2>), matxInavlidType, "A and Tau types must match");
 
     params = GetQRParams(tau, a);
     this->GetWorkspaceSize();
@@ -125,7 +125,7 @@ public:
                     &work_query, &this->lwork, &info);
       MATX_ASSERT_STR_EXP(info, 0, matxSolverError,
         ("Parameter " + std::to_string(-info) + " had an illegal value in LAPACK geqrf workspace query").c_str());
-    
+
     // the real part of the first elem of work holds the optimal lwork
     if constexpr (is_complex_v<T1>) {
       this->lwork = static_cast<lapack_int_t>(work_query.real());
@@ -196,17 +196,17 @@ private:
                       const lapack_int_t* lda, T1* tau, T1* work_in,
                       const lapack_int_t* lwork_in, lapack_int_t* info)
   {
-    if constexpr (std::is_same_v<T1, float>) {
+    if constexpr (cuda::std::is_same_v<T1, float>) {
       LAPACK_CALL(sgeqrf)(m, n, a, lda, tau, work_in, lwork_in, info);
-    } else if constexpr (std::is_same_v<T1, double>) {
+    } else if constexpr (cuda::std::is_same_v<T1, double>) {
       LAPACK_CALL(dgeqrf)(m, n, a, lda, tau, work_in, lwork_in, info);
-    } else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+    } else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
       LAPACK_CALL(cgeqrf)(m, n, a, lda, tau, work_in, lwork_in, info);
-    } else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+    } else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
       LAPACK_CALL(zgeqrf)(m, n, a, lda, tau, work_in, lwork_in, info);
     }
   }
-  
+
   std::vector<T2 *> batch_tau_ptrs;
   DnQRHostParams_t params;
 };
@@ -273,7 +273,7 @@ void qr_solver_impl([[maybe_unused]] OutTensor &&out,
   MATX_ASSERT_STR(MATX_EN_CPU_SOLVER, matxInvalidExecutor,
     "Trying to run a host Solver executor but host Solver support is not configured");
 #if MATX_EN_CPU_SOLVER
-  
+
   using T1 = typename remove_cvref_t<OutTensor>::value_type;
 
   auto tau_new = OpToTensor(tau, exec);

--- a/include/matx/transforms/reduce.h
+++ b/include/matx/transforms/reduce.h
@@ -75,11 +75,11 @@ namespace detail {
 
 #ifdef __CUDACC__
 template <typename T> constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T maxVal() {
-  if constexpr (std::is_same_v<convert_matx_type_t<T>, __half>) {
+  if constexpr (cuda::std::is_same_v<convert_matx_type_t<T>, __half>) {
     constexpr HalfBits tmp{0x7BFF};
     return tmp.h;
   }
-  if constexpr (std::is_same_v<convert_matx_type_t<T>, __nv_bfloat16>) {
+  if constexpr (cuda::std::is_same_v<convert_matx_type_t<T>, __nv_bfloat16>) {
     constexpr HalfBits tmp{0x7F7F};
     return tmp.b;
   }
@@ -89,11 +89,11 @@ template <typename T> constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T 
 }
 
 template <typename T> constexpr __MATX_INLINE__ __MATX_HOST__ __MATX_DEVICE__ T minVal() {
-  if constexpr (std::is_same_v<convert_matx_type_t<T>, __half>) {
+  if constexpr (cuda::std::is_same_v<convert_matx_type_t<T>, __half>) {
     constexpr HalfBits tmp{0x0400};
     return tmp.h;
   }
-  if constexpr (std::is_same_v<convert_matx_type_t<T>, __nv_bfloat16>) {
+  if constexpr (cuda::std::is_same_v<convert_matx_type_t<T>, __nv_bfloat16>) {
     constexpr HalfBits tmp{0x0080};
     return tmp.b;
   }

--- a/include/matx/transforms/resample_poly.h
+++ b/include/matx/transforms/resample_poly.h
@@ -73,7 +73,7 @@ inline void matxResamplePoly1DInternal(OutType &o, const InType &i,
 {
 #ifdef __CUDACC__
   MATX_NVTX_START("", matx::MATX_NVTX_LOG_INTERNAL)
-  
+
   using filter_t = typename FilterType::value_type;
   using output_t = typename OutType::value_type;
   using shape_type = typename OutType::shape_type;
@@ -112,7 +112,7 @@ inline void matxResamplePoly1DInternal(OutType &o, const InType &i,
   } kernel = ResampleKernel::ElemBlock;
 
   // The WarpCentric kernel currently uses cg::reduce(), which requires trivially-copyable types.
-  if constexpr (std::is_trivially_copyable_v<output_t>) {
+  if constexpr (cuda::std::is_trivially_copyable_v<output_t>) {
     // There are a couple cases where a warp-centric resampler tends to be faster:
     // 1. When we have a small number of output points, handling one or a few points per warp is an effective
     // way to achieve higher occupancy.
@@ -180,7 +180,7 @@ inline void matxResamplePoly1DInternal(OutType &o, const InType &i,
     } else {
       // We only select the WarpCentric kernel for trivially copyable types, but we need this
       // constexpr if to avoid instantiating the kernel with inappropriate types.
-      if constexpr (std::is_trivially_copyable_v<output_t>) {
+      if constexpr (cuda::std::is_trivially_copyable_v<output_t>) {
         const size_t filter_sz_bytes = (filter_len % 2 == 0) ? sizeof(filter_t)*(filter_len+1) : sizeof(filter_t)*filter_len;
         const size_t smemBytes = (filter_sz_bytes <= MATX_RESAMPLE_POLY_MAX_SMEM_BYTES) ? filter_sz_bytes : 0;
         static_assert(THREADS % WARP_SIZE == 0);
@@ -286,7 +286,7 @@ inline void matxResamplePoly1DInternal(OutType &o, const InType &i,
 
 /**
  * @brief 1D polyphase resampler
- * 
+ *
  * @tparam OutType Type of output
  * @tparam InType Type of input
  * @tparam FilterType Type of filter

--- a/include/matx/transforms/solve/solve_common.h
+++ b/include/matx/transforms/solve/solve_common.h
@@ -78,10 +78,10 @@ private:
 
 template <typename T>
 inline constexpr bool is_dense_solve_supported_type_v =
-    std::is_same_v<T, float> ||
-    std::is_same_v<T, double> ||
-    std::is_same_v<T, cuda::std::complex<float>> ||
-    std::is_same_v<T, cuda::std::complex<double>>;
+    cuda::std::is_same_v<T, float> ||
+    cuda::std::is_same_v<T, double> ||
+    cuda::std::is_same_v<T, cuda::std::complex<float>> ||
+    cuda::std::is_same_v<T, cuda::std::complex<double>>;
 
 template <typename ATensor, typename BTensor>
 static constexpr bool IsDenseSolveVectorRHS()
@@ -108,9 +108,9 @@ __MATX_INLINE__ void ValidateDenseSolve([[maybe_unused]] OutputTensor &&out,
                 "Dense solve B must have rank A.Rank() or A.Rank() - 1");
   static_assert(ORANK == BRANK,
                 "Dense solve output rank must match B rank");
-  static_assert(std::is_same_v<T, typename BTensor_t::value_type>,
+  static_assert(cuda::std::is_same_v<T, typename BTensor_t::value_type>,
                 "Dense solve A and B value types must match");
-  static_assert(std::is_same_v<T, typename OutTensor_t::value_type>,
+  static_assert(cuda::std::is_same_v<T, typename OutTensor_t::value_type>,
                 "Dense solve output value type must match A and B");
   static_assert(is_dense_solve_supported_type_v<T>,
                 "Dense solve supports float, double, complex<float>, and complex<double>");

--- a/include/matx/transforms/solve/solve_cuda.h
+++ b/include/matx/transforms/solve/solve_cuda.h
@@ -60,18 +60,18 @@ __MATX_INLINE__ cublasStatus_t DenseSolveGetrfBatched(cublasHandle_t handle,
                                                       int *info,
                                                       int batch_size)
 {
-  if constexpr (std::is_same_v<T, float>) {
+  if constexpr (cuda::std::is_same_v<T, float>) {
     return cublasSgetrfBatched(handle, n, a_array, lda, piv, info, batch_size);
   }
-  else if constexpr (std::is_same_v<T, double>) {
+  else if constexpr (cuda::std::is_same_v<T, double>) {
     return cublasDgetrfBatched(handle, n, a_array, lda, piv, info, batch_size);
   }
-  else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
     return cublasCgetrfBatched(handle, n,
                                reinterpret_cast<cuComplex *const *>(a_array),
                                lda, piv, info, batch_size);
   }
-  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
     return cublasZgetrfBatched(handle, n,
                                reinterpret_cast<cuDoubleComplex *const *>(a_array),
                                lda, piv, info, batch_size);
@@ -93,21 +93,21 @@ __MATX_INLINE__ cublasStatus_t DenseSolveGetrsBatched(cublasHandle_t handle,
                                                       int *info,
                                                       int batch_size)
 {
-  if constexpr (std::is_same_v<T, float>) {
+  if constexpr (cuda::std::is_same_v<T, float>) {
     return cublasSgetrsBatched(handle, CUBLAS_OP_N, n, nrhs, a_array, lda,
                                piv, b_array, ldb, info, batch_size);
   }
-  else if constexpr (std::is_same_v<T, double>) {
+  else if constexpr (cuda::std::is_same_v<T, double>) {
     return cublasDgetrsBatched(handle, CUBLAS_OP_N, n, nrhs, a_array, lda,
                                piv, b_array, ldb, info, batch_size);
   }
-  else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
     return cublasCgetrsBatched(
         handle, CUBLAS_OP_N, n, nrhs,
         reinterpret_cast<const cuComplex *const *>(a_array), lda, piv,
         reinterpret_cast<cuComplex *const *>(b_array), ldb, info, batch_size);
   }
-  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
     return cublasZgetrsBatched(
         handle, CUBLAS_OP_N, n, nrhs,
         reinterpret_cast<const cuDoubleComplex *const *>(a_array), lda, piv,

--- a/include/matx/transforms/solve/solve_cudss.h
+++ b/include/matx/transforms/solve/solve_cudss.h
@@ -263,11 +263,11 @@ void sparse_solve_impl(TensorTypeC &C, const TensorTypeA &a,
   // Restrictions.
   static_assert(RANKA == 2 && RANKB == 2 && RANKC == 2,
                 "tensors must have rank-2");
-  static_assert(std::is_same_v<TC, TA> && std::is_same_v<TC, TB>,
+  static_assert(cuda::std::is_same_v<TC, TA> && cuda::std::is_same_v<TC, TB>,
                 "tensors must have the same data type");
-  static_assert(std::is_same_v<TC, float> || std::is_same_v<TC, double> ||
-                    std::is_same_v<TC, cuda::std::complex<float>> ||
-                    std::is_same_v<TC, cuda::std::complex<double>>,
+  static_assert(cuda::std::is_same_v<TC, float> || cuda::std::is_same_v<TC, double> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<float>> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<double>>,
                 "unsupported data type");
   MATX_ASSERT( // Note: B,C transposed!
       a.Size(RANKA - 1) == b.Size(RANKB - 1) &&
@@ -276,8 +276,8 @@ void sparse_solve_impl(TensorTypeC &C, const TensorTypeA &a,
       matxInvalidSize);
   MATX_ASSERT(b.Stride(RANKB - 1) == 1 && c.Stride(RANKC - 1) == 1,
               matxInvalidParameter);
-  static_assert(std::is_same_v<typename atype::pos_type, int32_t> &&
-                    std::is_same_v<typename atype::crd_type, int32_t>,
+  static_assert(cuda::std::is_same_v<typename atype::pos_type, int32_t> &&
+                    cuda::std::is_same_v<typename atype::crd_type, int32_t>,
                 "unsupported index type");
 
   // Get parameters required by these tensors (for caching).

--- a/include/matx/transforms/solve/solve_cusparse.h
+++ b/include/matx/transforms/solve/solve_cusparse.h
@@ -212,9 +212,9 @@ void sparse_dia_solve_impl(TensorTypeC &C, const TensorTypeA &a,
   [[maybe_unused]] const index_t numD = a.crdSize(0);
   // TODO: we should also check that offsets = {-1,0,1} (host and device)?
   MATX_ASSERT(numD == 3, matxInvalidParameter);
-  using T = std::conditional_t<
+  using T = cuda::std::conditional_t<
       cuda::std::is_same_v<TA, cuda::std::complex<double>>, cuDoubleComplex,
-      std::conditional_t<cuda::std::is_same_v<TA, cuda::std::complex<float>>,
+      cuda::std::conditional_t<cuda::std::is_same_v<TA, cuda::std::complex<float>>,
                          cuFloatComplex, TA>>;
   T *AD = reinterpret_cast<T *>(a.Data());
   T *BD = reinterpret_cast<T *>(b.Data());
@@ -281,9 +281,9 @@ void sparse_batched_dia_solve_impl(TensorTypeC &C, const TensorTypeA &a,
   [[maybe_unused]] const index_t numD = a.crdSize(0);
   // TODO: we should also check that offsets = {-1,0,1} (host and device)?
   MATX_ASSERT(numD == 3, matxInvalidParameter);
-  using T = std::conditional_t<
+  using T = cuda::std::conditional_t<
       cuda::std::is_same_v<TA, cuda::std::complex<double>>, cuDoubleComplex,
-      std::conditional_t<cuda::std::is_same_v<TA, cuda::std::complex<float>>,
+      cuda::std::conditional_t<cuda::std::is_same_v<TA, cuda::std::complex<float>>,
                          cuFloatComplex, TA>>;
   T *AD = reinterpret_cast<T *>(a.Data());
   T *BD = reinterpret_cast<T *>(b.Data());

--- a/include/matx/transforms/solve/solve_cusparse.h
+++ b/include/matx/transforms/solve/solve_cusparse.h
@@ -59,16 +59,16 @@ inline void SolveTridiagonalSystem(int m, int n, VAL *dl, VAL *dm, VAL *du,
   size_t workspaceSize = 0;
   void *workspace = nullptr;
 
-  if constexpr (std::is_same_v<VAL, float>) {
+  if constexpr (cuda::std::is_same_v<VAL, float>) {
     ret = cusparseSgtsv2_bufferSizeExt(handle, m, n, dl, dm, du, x, /*ldb*/ m,
                                        &workspaceSize);
-  } else if constexpr (std::is_same_v<VAL, double>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, double>) {
     ret = cusparseDgtsv2_bufferSizeExt(handle, m, n, dl, dm, du, x, /*ldb*/ m,
                                        &workspaceSize);
-  } else if constexpr (std::is_same_v<VAL, cuFloatComplex>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, cuFloatComplex>) {
     ret = cusparseCgtsv2_bufferSizeExt(handle, m, n, dl, dm, du, x, /*ldb*/ m,
                                        &workspaceSize);
-  } else if constexpr (std::is_same_v<VAL, cuDoubleComplex>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, cuDoubleComplex>) {
     ret = cusparseZgtsv2_bufferSizeExt(handle, m, n, dl, dm, du, x, /*ldb*/ m,
                                        &workspaceSize);
   } else {
@@ -78,13 +78,13 @@ inline void SolveTridiagonalSystem(int m, int n, VAL *dl, VAL *dm, VAL *du,
 
   matxAlloc((void **)&workspace, workspaceSize, MATX_DEVICE_MEMORY, stream);
 
-  if constexpr (std::is_same_v<VAL, float>) {
+  if constexpr (cuda::std::is_same_v<VAL, float>) {
     ret = cusparseSgtsv2(handle, m, n, dl, dm, du, x, /*ldb*/ m, workspace);
-  } else if constexpr (std::is_same_v<VAL, double>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, double>) {
     ret = cusparseDgtsv2(handle, m, n, dl, dm, du, x, /*ldb*/ m, workspace);
-  } else if constexpr (std::is_same_v<VAL, cuFloatComplex>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, cuFloatComplex>) {
     ret = cusparseCgtsv2(handle, m, n, dl, dm, du, x, /*ldb*/ m, workspace);
-  } else if constexpr (std::is_same_v<VAL, cuDoubleComplex>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, cuDoubleComplex>) {
     ret = cusparseZgtsv2(handle, m, n, dl, dm, du, x, /*ldb*/ m, workspace);
   }
   MATX_ASSERT(ret == CUSPARSE_STATUS_SUCCESS, matxSolverError);
@@ -107,16 +107,16 @@ inline void SolveBatchedTridiagonalSystem(int m, int b, VAL *dl, VAL *dm,
   size_t workspaceSize = 0;
   void *workspace = nullptr;
 
-  if constexpr (std::is_same_v<VAL, float>) {
+  if constexpr (cuda::std::is_same_v<VAL, float>) {
     ret = cusparseSgtsv2StridedBatch_bufferSizeExt(handle, m, dl, dm, du, x, b,
                                                    m, &workspaceSize);
-  } else if constexpr (std::is_same_v<VAL, double>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, double>) {
     ret = cusparseDgtsv2StridedBatch_bufferSizeExt(handle, m, dl, dm, du, x, b,
                                                    m, &workspaceSize);
-  } else if constexpr (std::is_same_v<VAL, cuFloatComplex>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, cuFloatComplex>) {
     ret = cusparseCgtsv2StridedBatch_bufferSizeExt(handle, m, dl, dm, du, x, b,
                                                    m, &workspaceSize);
-  } else if constexpr (std::is_same_v<VAL, cuDoubleComplex>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, cuDoubleComplex>) {
     ret = cusparseZgtsv2StridedBatch_bufferSizeExt(handle, m, dl, dm, du, x, b,
                                                    m, &workspaceSize);
   } else {
@@ -126,13 +126,13 @@ inline void SolveBatchedTridiagonalSystem(int m, int b, VAL *dl, VAL *dm,
 
   matxAlloc((void **)&workspace, workspaceSize, MATX_DEVICE_MEMORY, stream);
 
-  if constexpr (std::is_same_v<VAL, float>) {
+  if constexpr (cuda::std::is_same_v<VAL, float>) {
     ret = cusparseSgtsv2StridedBatch(handle, m, dl, dm, du, x, b, m, workspace);
-  } else if constexpr (std::is_same_v<VAL, double>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, double>) {
     ret = cusparseDgtsv2StridedBatch(handle, m, dl, dm, du, x, b, m, workspace);
-  } else if constexpr (std::is_same_v<VAL, cuFloatComplex>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, cuFloatComplex>) {
     ret = cusparseCgtsv2StridedBatch(handle, m, dl, dm, du, x, b, m, workspace);
-  } else if constexpr (std::is_same_v<VAL, cuDoubleComplex>) {
+  } else if constexpr (cuda::std::is_same_v<VAL, cuDoubleComplex>) {
     ret = cusparseZgtsv2StridedBatch(handle, m, dl, dm, du, x, b, m, workspace);
   }
   MATX_ASSERT(ret == CUSPARSE_STATUS_SUCCESS, matxSolverError);
@@ -188,11 +188,11 @@ void sparse_dia_solve_impl(TensorTypeC &C, const TensorTypeA &a,
                 "Tridiagonal solve requires I-index DIAG");
   static_assert(RANKA == 2 && RANKB == 2 && RANKC == 2,
                 "tensors must have rank-2");
-  static_assert(std::is_same_v<TC, TA> && std::is_same_v<TC, TB>,
+  static_assert(cuda::std::is_same_v<TC, TA> && cuda::std::is_same_v<TC, TB>,
                 "tensors must have the same data type");
-  static_assert(std::is_same_v<TC, float> || std::is_same_v<TC, double> ||
-                    std::is_same_v<TC, cuda::std::complex<float>> ||
-                    std::is_same_v<TC, cuda::std::complex<double>>,
+  static_assert(cuda::std::is_same_v<TC, float> || cuda::std::is_same_v<TC, double> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<float>> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<double>>,
                 "unsupported data type");
   MATX_ASSERT(                                  // Note: B,C transposed!
       a.Size(RANKA - 1) == a.Size(RANKA - 2) && // square
@@ -213,8 +213,8 @@ void sparse_dia_solve_impl(TensorTypeC &C, const TensorTypeA &a,
   // TODO: we should also check that offsets = {-1,0,1} (host and device)?
   MATX_ASSERT(numD == 3, matxInvalidParameter);
   using T = std::conditional_t<
-      std::is_same_v<TA, cuda::std::complex<double>>, cuDoubleComplex,
-      std::conditional_t<std::is_same_v<TA, cuda::std::complex<float>>,
+      cuda::std::is_same_v<TA, cuda::std::complex<double>>, cuDoubleComplex,
+      std::conditional_t<cuda::std::is_same_v<TA, cuda::std::complex<float>>,
                          cuFloatComplex, TA>>;
   T *AD = reinterpret_cast<T *>(a.Data());
   T *BD = reinterpret_cast<T *>(b.Data());
@@ -259,11 +259,11 @@ void sparse_batched_dia_solve_impl(TensorTypeC &C, const TensorTypeA &a,
                 "Tridiagonal solve requires I-index DIAG");
   static_assert(RANKA == 3 && RANKB == 1 && RANKC == 1,
                 "tensors must define batched system");
-  static_assert(std::is_same_v<TC, TA> && std::is_same_v<TC, TB>,
+  static_assert(cuda::std::is_same_v<TC, TA> && cuda::std::is_same_v<TC, TB>,
                 "tensors must have the same data type");
-  static_assert(std::is_same_v<TC, float> || std::is_same_v<TC, double> ||
-                    std::is_same_v<TC, cuda::std::complex<float>> ||
-                    std::is_same_v<TC, cuda::std::complex<double>>,
+  static_assert(cuda::std::is_same_v<TC, float> || cuda::std::is_same_v<TC, double> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<float>> ||
+                    cuda::std::is_same_v<TC, cuda::std::complex<double>>,
                 "unsupported data type");
   MATX_ASSERT(a.Size(RANKA - 1) == a.Size(RANKA - 2) && // square after batch
                   a.Size(RANKA - 3) * a.Size(RANKA - 2) == b.Size(RANKB - 1) &&
@@ -282,8 +282,8 @@ void sparse_batched_dia_solve_impl(TensorTypeC &C, const TensorTypeA &a,
   // TODO: we should also check that offsets = {-1,0,1} (host and device)?
   MATX_ASSERT(numD == 3, matxInvalidParameter);
   using T = std::conditional_t<
-      std::is_same_v<TA, cuda::std::complex<double>>, cuDoubleComplex,
-      std::conditional_t<std::is_same_v<TA, cuda::std::complex<float>>,
+      cuda::std::is_same_v<TA, cuda::std::complex<double>>, cuDoubleComplex,
+      std::conditional_t<cuda::std::is_same_v<TA, cuda::std::complex<float>>,
                          cuFloatComplex, TA>>;
   T *AD = reinterpret_cast<T *>(a.Data());
   T *BD = reinterpret_cast<T *>(b.Data());

--- a/include/matx/transforms/solve/solve_lapack.h
+++ b/include/matx/transforms/solve/solve_lapack.h
@@ -56,16 +56,16 @@ __MATX_INLINE__ void DenseSolveGesvDispatch(lapack_int_t *n,
                                             lapack_int_t *ldb,
                                             lapack_int_t *info)
 {
-  if constexpr (std::is_same_v<T, float>) {
+  if constexpr (cuda::std::is_same_v<T, float>) {
     LAPACK_CALL(sgesv)(n, nrhs, a, lda, piv, b, ldb, info);
   }
-  else if constexpr (std::is_same_v<T, double>) {
+  else if constexpr (cuda::std::is_same_v<T, double>) {
     LAPACK_CALL(dgesv)(n, nrhs, a, lda, piv, b, ldb, info);
   }
-  else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
     LAPACK_CALL(cgesv)(n, nrhs, a, lda, piv, b, ldb, info);
   }
-  else if constexpr (std::is_same_v<T, cuda::std::complex<double>>) {
+  else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>) {
     LAPACK_CALL(zgesv)(n, nrhs, a, lda, piv, b, ldb, info);
   }
 }

--- a/include/matx/transforms/svd/svd_cuda.h
+++ b/include/matx/transforms/svd/svd_cuda.h
@@ -640,10 +640,10 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "SVD solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, T2>), matxInavlidType, "A and U types must match");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, T4>), matxInavlidType, "A and VT types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, T2>), matxInavlidType, "A and U types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, T4>), matxInavlidType, "A and VT types must match");
     MATX_STATIC_ASSERT_STR(!is_complex_v<T3>, matxInvalidType, "S type must be real");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<typename inner_op_type_t<T1>::type, T3>), matxInvalidType, "A and S inner types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<typename inner_op_type_t<T1>::type, T3>), matxInvalidType, "A and S inner types must match");
 
     params        = GetSVDParams(u, s, vt, a, jobz, exec);
     params.method = method;
@@ -681,7 +681,7 @@ public:
       int i_dspace = 0;
       const cusolverEigMode_t eig_mode = params.jobz == 'N' ? CUSOLVER_EIG_MODE_NOVECTOR : CUSOLVER_EIG_MODE_VECTOR;
 
-      if constexpr (std::is_same_v<float, T1>) {
+      if constexpr (cuda::std::is_same_v<float, T1>) {
         ret = cusolverDnSgesvdjBatched_bufferSize(
                 this->handle, eig_mode, static_cast<int>(params.m), static_cast<int>(params.n),
                 reinterpret_cast<const float *>(params.A), static_cast<int>(params.m),
@@ -689,7 +689,7 @@ public:
                 reinterpret_cast<const float *>(params.VT), static_cast<int>(params.n),
                 &i_dspace, batch_params, static_cast<int>(params.batch_size));
       }
-      else if constexpr (std::is_same_v<double, T1>) {
+      else if constexpr (cuda::std::is_same_v<double, T1>) {
         ret = cusolverDnDgesvdjBatched_bufferSize(
                 this->handle, eig_mode, static_cast<int>(params.m), static_cast<int>(params.n),
                 reinterpret_cast<const double *>(params.A), static_cast<int>(params.m),
@@ -697,7 +697,7 @@ public:
                 static_cast<int>(params.m), reinterpret_cast<const double *>(params.VT), static_cast<int>(params.n),
                 &i_dspace, batch_params, static_cast<int>(params.batch_size));
       }
-      else if constexpr (std::is_same_v<cuda::std::complex<float>, T1>) {
+      else if constexpr (cuda::std::is_same_v<cuda::std::complex<float>, T1>) {
         ret = cusolverDnCgesvdjBatched_bufferSize(
                 this->handle, eig_mode, static_cast<int>(params.m), static_cast<int>(params.n),
                 reinterpret_cast<const cuComplex *>(params.A), static_cast<int>(params.m),
@@ -705,7 +705,7 @@ public:
                 static_cast<int>(params.m), reinterpret_cast<const cuComplex *>(params.VT), static_cast<int>(params.n),
                 &i_dspace, batch_params, static_cast<int>(params.batch_size));
       }
-      else if constexpr (std::is_same_v<cuda::std::complex<double>, T1>) {
+      else if constexpr (cuda::std::is_same_v<cuda::std::complex<double>, T1>) {
         ret = cusolverDnZgesvdjBatched_bufferSize(
                 this->handle, eig_mode, static_cast<int>(params.m), static_cast<int>(params.n),
                 reinterpret_cast<const cuDoubleComplex *>(params.A), static_cast<int>(params.m),
@@ -805,7 +805,7 @@ public:
     }
     else if (params.method == SVDMethod::GESVDJ_BATCHED) {
       const cusolverEigMode_t eig_mode = jobz == 'N' ? CUSOLVER_EIG_MODE_NOVECTOR : CUSOLVER_EIG_MODE_VECTOR;
-      if constexpr (std::is_same_v<float, T1>) {
+      if constexpr (cuda::std::is_same_v<float, T1>) {
         ret = cusolverDnSgesvdjBatched(
                 this->handle, eig_mode, static_cast<int>(params.m), static_cast<int>(params.n),
                 reinterpret_cast<float *>(params.A), static_cast<int>(params.m),
@@ -814,7 +814,7 @@ public:
                 reinterpret_cast<float *>(this->d_workspace), static_cast<int>(this->dspace),
                 this->d_info, batch_params, static_cast<int>(params.batch_size));
       }
-      else if constexpr (std::is_same_v<double, T1>) {
+      else if constexpr (cuda::std::is_same_v<double, T1>) {
         ret = cusolverDnDgesvdjBatched(
                 this->handle, eig_mode, static_cast<int>(params.m), static_cast<int>(params.n),
                 reinterpret_cast<double *>(params.A), static_cast<int>(params.m),
@@ -823,7 +823,7 @@ public:
                 reinterpret_cast<double *>(this->d_workspace), static_cast<int>(this->dspace),
                 this->d_info, batch_params, static_cast<int>(params.batch_size));
       }
-      else if constexpr (std::is_same_v<cuda::std::complex<float>, T1>) {
+      else if constexpr (cuda::std::is_same_v<cuda::std::complex<float>, T1>) {
         ret = cusolverDnCgesvdjBatched(
                 this->handle, eig_mode, static_cast<int>(params.m), static_cast<int>(params.n),
                 reinterpret_cast<cuComplex *>(params.A), static_cast<int>(params.m),
@@ -832,7 +832,7 @@ public:
                 reinterpret_cast<cuComplex *>(this->d_workspace), static_cast<int>(this->dspace),
                 this->d_info, batch_params, static_cast<int>(params.batch_size));
       }
-      else if constexpr (std::is_same_v<cuda::std::complex<double>, T1>) {
+      else if constexpr (cuda::std::is_same_v<cuda::std::complex<double>, T1>) {
         ret = cusolverDnZgesvdjBatched(
                 this->handle, eig_mode, static_cast<int>(params.m), static_cast<int>(params.n),
                 reinterpret_cast<cuDoubleComplex *>(params.A), static_cast<int>(params.m),

--- a/include/matx/transforms/svd/svd_lapack.h
+++ b/include/matx/transforms/svd/svd_lapack.h
@@ -127,10 +127,10 @@ public:
 
     // Type checks
     MATX_STATIC_ASSERT_STR(!is_half_v<T1>, matxInvalidType, "SVD solver does not support half precision");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, T2>), matxInavlidType, "A and U types must match");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<T1, T4>), matxInavlidType, "A and VT types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, T2>), matxInavlidType, "A and U types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<T1, T4>), matxInavlidType, "A and VT types must match");
     MATX_STATIC_ASSERT_STR(!is_complex_v<T3>, matxInvalidType, "S type must be real");
-    MATX_STATIC_ASSERT_STR((std::is_same_v<typename inner_op_type_t<T1>::type, T3>), matxInvalidType, "A and S inner types must match");
+    MATX_STATIC_ASSERT_STR((cuda::std::is_same_v<typename inner_op_type_t<T1>::type, T3>), matxInvalidType, "A and S inner types must match");
 
     params = GetSVDParams(u, s, vt, a, jobz, algo);
     this->GetWorkspaceSize();
@@ -168,10 +168,10 @@ public:
       // Due to a LAPACK bug which gives incorrect workspace size calculations for single-precision
       // routines at large matrix sizes from to float-to-int conversions, should use double-precision
       // for the query. Only an issue in routines which may need O(n^2) memory.
-      using WorkQuery = std::conditional_t<std::is_same_v<T1, float>, double,
-                          std::conditional_t<std::is_same_v<T1, cuda::std::complex<float>>,
+      using WorkQuery = std::conditional_t<cuda::std::is_same_v<T1, float>, double,
+                          std::conditional_t<cuda::std::is_same_v<T1, cuda::std::complex<float>>,
                                             cuda::std::complex<double>, T1>>;
-      using RworkQuery = std::conditional_t<std::is_same_v<T3, float>, double, T3>;
+      using RworkQuery = std::conditional_t<cuda::std::is_same_v<T3, float>, double, T3>;
       WorkQuery work_query;
 
       gesdd_dispatch<WorkQuery, RworkQuery>("A", &params.m, &params.n, nullptr, &params.m, nullptr,
@@ -309,13 +309,13 @@ private:
   {
     // TODO: remove warning suppression once gesvd is optimized in NVPL LAPACK
 MATX_IGNORE_WARNING_PUSH_GCC("-Wdeprecated-declarations")
-    if constexpr (std::is_same_v<T1, float>) {
+    if constexpr (cuda::std::is_same_v<T1, float>) {
       LAPACK_CALL(sgesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, info);
-    } else if constexpr (std::is_same_v<T1, double>) {
+    } else if constexpr (cuda::std::is_same_v<T1, double>) {
       LAPACK_CALL(dgesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, info);
-    } else if constexpr (std::is_same_v<T1, cuda::std::complex<float>>) {
+    } else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<float>>) {
       LAPACK_CALL(cgesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, rwork_in, info);
-    } else if constexpr (std::is_same_v<T1, cuda::std::complex<double>>) {
+    } else if constexpr (cuda::std::is_same_v<T1, cuda::std::complex<double>>) {
       LAPACK_CALL(zgesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, rwork_in, info);
     }
 MATX_IGNORE_WARNING_POP_GCC
@@ -330,13 +330,13 @@ MATX_IGNORE_WARNING_POP_GCC
                       T *vt, const lapack_int_t *ldvt, T *work_in, const lapack_int_t *lwork_in,
                       [[maybe_unused]] S *rwork_in, lapack_int_t *iwork_in, lapack_int_t *info)
   {
-    if constexpr (std::is_same_v<T, float>) {
+    if constexpr (cuda::std::is_same_v<T, float>) {
       LAPACK_CALL(sgesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, iwork_in, info);
-    } else if constexpr (std::is_same_v<T, double>) {
+    } else if constexpr (cuda::std::is_same_v<T, double>) {
       LAPACK_CALL(dgesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, iwork_in, info);
-    } else if constexpr (std::is_same_v<T, cuda::std::complex<float>>) {
+    } else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<float>>) {
       LAPACK_CALL(cgesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, rwork_in, iwork_in, info);
-    } else if constexpr (std::is_same_v<T, cuda::std::complex<double>>)  {
+    } else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<double>>)  {
       LAPACK_CALL(zgesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work_in, lwork_in, rwork_in, iwork_in, info);
     }
   }

--- a/include/matx/transforms/svd/svd_lapack.h
+++ b/include/matx/transforms/svd/svd_lapack.h
@@ -168,10 +168,10 @@ public:
       // Due to a LAPACK bug which gives incorrect workspace size calculations for single-precision
       // routines at large matrix sizes from to float-to-int conversions, should use double-precision
       // for the query. Only an issue in routines which may need O(n^2) memory.
-      using WorkQuery = std::conditional_t<cuda::std::is_same_v<T1, float>, double,
-                          std::conditional_t<cuda::std::is_same_v<T1, cuda::std::complex<float>>,
+      using WorkQuery = cuda::std::conditional_t<cuda::std::is_same_v<T1, float>, double,
+                          cuda::std::conditional_t<cuda::std::is_same_v<T1, cuda::std::complex<float>>,
                                             cuda::std::complex<double>, T1>>;
-      using RworkQuery = std::conditional_t<cuda::std::is_same_v<T3, float>, double, T3>;
+      using RworkQuery = cuda::std::conditional_t<cuda::std::is_same_v<T3, float>, double, T3>;
       WorkQuery work_query;
 
       gesdd_dispatch<WorkQuery, RworkQuery>("A", &params.m, &params.n, nullptr, &params.m, nullptr,

--- a/test/00_operators/GeneratorTests.cu
+++ b/test/00_operators/GeneratorTests.cu
@@ -93,7 +93,7 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Windows)
   MATX_ENTER_HANDLER();
 
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
   ExecType exec{};
 
   auto pb = std::make_unique<detail::MatXPybind>();
@@ -134,13 +134,13 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Windows)
   MATX_TEST_ASSERT_COMPARE(pb, ov, "flattop", 0.01);
 
 
-  MATX_EXIT_HANDLER();  
+  MATX_EXIT_HANDLER();
 }
 
 TYPED_TEST(BasicGeneratorTestsAll, Diag)
 {
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
   ExecType exec{};
 
   MATX_ENTER_HANDLER();
@@ -203,7 +203,7 @@ TYPED_TEST(BasicGeneratorTestsAll, Diag)
       for (int i = 0; i < tdk.Size(0); i++) {
         MATX_ASSERT_EQ(tdk(i), tc(i + 6, i));
       }
-    }    
+    }
 
     {
       auto wide = make_tensor<TestType>({3, 5});
@@ -236,7 +236,7 @@ TYPED_TEST(BasicGeneratorTestsAll, Diag)
 
     // Test with a nested transform. Restrict to floating point types for
     // the convolution
-    if constexpr (std::is_same_v<TestType,float> || std::is_same_v<TestType,double>)
+    if constexpr (cuda::std::is_same_v<TestType,float> || cuda::std::is_same_v<TestType,double>)
     {
       auto delta = make_tensor<TestType>({1});
       delta(0) = static_cast<TestType>(1.0);
@@ -262,8 +262,8 @@ TYPED_TEST(BasicGeneratorTestsFloat, Alternate)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
-  ExecType exec{};  
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
 
   // example-begin alternate-gen-test-1
   auto td = make_tensor<TestType>({10});
@@ -285,7 +285,7 @@ TEST(OperatorTests, Kron)
 {
   MATX_ENTER_HANDLER();
 
-  cudaExecutor exec{};    
+  cudaExecutor exec{};
   using dtype = int;
   auto pb = std::make_unique<detail::MatXPybind>();
   pb->InitTVGenerator<dtype>("00_operators", "kron_operator", {});
@@ -305,10 +305,10 @@ TEST(OperatorTests, Kron)
   tensor_t<dtype, 2> ov2({4, 6});
   av.SetVals({{1, 2, 3}, {4, 5, 6}});
 
-  // example-begin ones-gen-test-2 
+  // example-begin ones-gen-test-2
   // Explicit shape specified in ones()
   (ov2 = kron(av, ones({2, 2}))).run(exec);
-  // example-end ones-gen-test-2  
+  // example-end ones-gen-test-2
   exec.sync();
   MATX_TEST_ASSERT_COMPARE(pb, ov2, "rect", 0);
 
@@ -318,8 +318,8 @@ TEST(OperatorTests, Kron)
 TEST(OperatorTests, MeshGrid)
 {
   MATX_ENTER_HANDLER();
-  
-  cudaExecutor exec{};  
+
+  cudaExecutor exec{};
   using dtype = int;
   auto pb = std::make_unique<detail::MatXPybind>();
   constexpr dtype xd = 3;
@@ -351,7 +351,7 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, FFTFreq)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
   ExecType exec{};
 
   auto pb = std::make_unique<detail::MatXPybind>();
@@ -378,7 +378,7 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, FFTFreq)
   (t1 = fftfreq(t1.Size(0), 0.5)).run(exec);
   // example-end fftfreq-gen-test-2
   exec.sync();
-  MATX_TEST_ASSERT_COMPARE(pb, t1, "F3", 0.1);  
+  MATX_TEST_ASSERT_COMPARE(pb, t1, "F3", 0.1);
 
   MATX_EXIT_HANDLER();
 }
@@ -388,9 +388,9 @@ TYPED_TEST(BasicGeneratorTestsAll, Zeros)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
-  ExecType exec{};    
-  // example-begin zeros-gen-test-1    
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
+  // example-begin zeros-gen-test-1
   index_t count = 100;
 
   cuda::std::array<index_t, 1> s({count});
@@ -416,15 +416,15 @@ TYPED_TEST(BasicGeneratorTestsAll, Ones)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
-  ExecType exec{};    
-  // example-begin ones-gen-test-1    
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
+  // example-begin ones-gen-test-1
   index_t count = 100;
   cuda::std::array<index_t, 1> s({count});
   auto t1 = make_tensor<TestType>(s);
 
   (t1 = ones<TestType>()).run(exec);
-  // example-end ones-gen-test-1    
+  // example-end ones-gen-test-1
   exec.sync();
 
   for (index_t i = 0; i < count; i++) {
@@ -484,7 +484,7 @@ TYPED_TEST(BasicGeneratorTestsAll, FillNoShape)
   const TestType value = static_cast<TestType>(11);
   // Shapeless fill() broadcasts as a scalar across `src`. The result's
   // shape comes from `src`, so fill needs no shape of its own.
-  if constexpr (std::is_same_v<TestType, bool>) {
+  if constexpr (cuda::std::is_same_v<TestType, bool>) {
     (t1 = src || fill<TestType>(value)).run(exec);
   }
   else {
@@ -931,8 +931,8 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Range)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
-  ExecType exec{};   
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
 
   // example-begin range-gen-test-1
   index_t count = 100;
@@ -940,7 +940,7 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Range)
 
   // Generate a sequence of 100 numbers starting at 1 and spaced by 1
   (t1 = range<0>(t1.Shape(), static_cast<TestType>(1), static_cast<TestType>(1))).run(exec);
-  // example-end range-gen-test-1  
+  // example-end range-gen-test-1
   exec.sync();
 
   TestType one = 1;
@@ -991,15 +991,15 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
-  ExecType exec{};   
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
 
   {
     // example-begin linspace-gen-test-1
     index_t count = 100;
     auto t1 = make_tensor<TestType>({count});
 
-    // Create a set of linearly-spaced numbers starting at 1, ending at 100, and 
+    // Create a set of linearly-spaced numbers starting at 1, ending at 100, and
     // with `count` points in between
     (t1 = linspace((TestType)1, (TestType)100, count)).run(exec);
     // example-end linspace-gen-test-1
@@ -1048,7 +1048,7 @@ TYPED_TEST(BasicGeneratorTestsNumericNonComplex, Linspace)
         EXPECT_TRUE(MatXUtils::MatXTypeCompare(ls(row, col), expected));
       }
     }
-  }    
+  }
 
   {
     index_t count = 100;
@@ -1160,8 +1160,8 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplex, Logspace)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
-  ExecType exec{};   
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
 
   // example-begin logspace-gen-test-1
   index_t count = 20;
@@ -1244,8 +1244,8 @@ TYPED_TEST(BasicGeneratorTestsNumeric, Eye)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
-  ExecType exec{};   
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
 
   // example-begin eye-gen-test-1
   index_t count = 10;
@@ -1308,8 +1308,8 @@ TYPED_TEST(BasicGeneratorTestsNumeric, Diag)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
-  ExecType exec{};     
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
   index_t count = 10;
   TestType c = GenerateData<TestType>();
 
@@ -1371,17 +1371,17 @@ TYPED_TEST(BasicGeneratorTestsFloatNonComplexNonHalf, Chirp)
 {
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
-  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;  
-  ExecType exec{};   
-    
+  using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
+  ExecType exec{};
+
   index_t count = 1500;
   TestType end = 10;
   TestType f0 = -200;
   TestType f1 = 300;
-  
+
   auto pb = std::make_unique<detail::MatXPybind>();
   pb->template InitAndRunTVGenerator<TestType>(
-      "01_signal", "chirp", "run", {count, static_cast<index_t>(end), static_cast<index_t>(f0), static_cast<index_t>(f1)});  
+      "01_signal", "chirp", "run", {count, static_cast<index_t>(end), static_cast<index_t>(f0), static_cast<index_t>(f1)});
 
   // example-begin chirp-gen-test-1
   auto t1 = make_tensor<TestType>({count});

--- a/test/00_operators/ReductionTests.cu
+++ b/test/00_operators/ReductionTests.cu
@@ -505,7 +505,7 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, PermutedReduce)
     }
   }
 
-  if constexpr (std::is_same_v<TestType, bool>)
+  if constexpr (cuda::std::is_same_v<TestType, bool>)
   {
     // example-begin any-test-2
     // Reduce a 4D tensor into a 2D tensor by collapsing the inner two dimensions. Both
@@ -523,7 +523,7 @@ TYPED_TEST(ReductionTestsFloatNonComplexNonHalfAllExecs, PermutedReduce)
     }
   }
 
-  if constexpr (std::is_same_v<TestType, bool>)
+  if constexpr (cuda::std::is_same_v<TestType, bool>)
   {
     // example-begin all-test-2
     // Reduce a 4D tensor into a 2D tensor by collapsing the inner two dimensions. Both

--- a/test/00_operators/abs2_test.cu
+++ b/test/00_operators/abs2_test.cu
@@ -38,7 +38,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Abs2)
     x() = static_cast<TestType>(2);
     (y = abs2(x)).run(exec);
     exec.sync();
-    if constexpr (std::is_integral_v<inner_type>) {
+    if constexpr (cuda::std::is_integral_v<inner_type>) {
       ASSERT_EQ(y(), static_cast<inner_type>(4));
     }
     else {
@@ -64,7 +64,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Abs2)
       for (int j = 0; j < 3; j++) {
         for (int k = 0; k < 3; k++) {
           TestType v = static_cast<TestType>(i*9 + j*3 + k);
-          if constexpr (std::is_integral_v<inner_type>) {
+          if constexpr (cuda::std::is_integral_v<inner_type>) {
             ASSERT_EQ(y3(i,j,k), static_cast<inner_type>(v*v));
           }
           else {

--- a/test/00_operators/abs2_test.cu
+++ b/test/00_operators/abs2_test.cu
@@ -15,8 +15,8 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Abs2)
 
   ExecType exec{};
 
-  if constexpr (std::is_same_v<TestType, cuda::std::complex<float>> &&
-    std::is_same_v<ExecType,cudaExecutor>) {
+  if constexpr (cuda::std::is_same_v<TestType, cuda::std::complex<float>> &&
+    cuda::std::is_same_v<ExecType,cudaExecutor>) {
     // example-begin abs2-test-1
     auto x = make_tensor<cuda::std::complex<float>>({});
     auto y = make_tensor<float>({});
@@ -69,7 +69,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Abs2)
           }
           else {
             ASSERT_NEAR(y3(i,j,k), static_cast<inner_type>(v*v), 1.0e-6);
-          }          
+          }
         }
       }
     }

--- a/test/00_operators/at_test.cu
+++ b/test/00_operators/at_test.cu
@@ -23,7 +23,7 @@ TYPED_TEST(OperatorTestsNumericNonComplexAllExecs, AtOp)
   t1.SetVals({10, 20, 30, 40, 50, 60, 70, 80, 90, 100});
   (t2 = t1).run(exec);
 
-  // Select the fourth element from `t1` as part of the execution. Value should match 
+  // Select the fourth element from `t1` as part of the execution. Value should match
   // `t1(3)` after execution
   (t0 = at(t1, 3)).run(exec);
   // example-end at-test-1
@@ -34,9 +34,9 @@ TYPED_TEST(OperatorTestsNumericNonComplexAllExecs, AtOp)
   (t0 = at(t2, 1, 4)).run(exec);
   exec.sync();
 
-  ASSERT_EQ(t0(), t2(1, 4));  
+  ASSERT_EQ(t0(), t2(1, 4));
 
-  if constexpr (is_cuda_non_jit_executor_v<ExecType> && (std::is_same_v<TestType, float> || std::is_same_v<TestType, double>)) {
+  if constexpr (is_cuda_non_jit_executor_v<ExecType> && (cuda::std::is_same_v<TestType, float> || cuda::std::is_same_v<TestType, double>)) {
     using ComplexType = detail::complex_from_scalar_t<TestType>;
     auto c0 = make_tensor<ComplexType>({});
     (c0 = at(fft(t1), 0)).run(exec);
@@ -49,4 +49,4 @@ TYPED_TEST(OperatorTestsNumericNonComplexAllExecs, AtOp)
   }
 
   MATX_EXIT_HANDLER();
-} 
+}

--- a/test/00_operators/collapse_test.cu
+++ b/test/00_operators/collapse_test.cu
@@ -12,7 +12,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, CollapseOp)
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
   using inner_type = typename inner_op_type_t<TestType>::type;
 
-  ExecType exec{}; 
+  ExecType exec{};
 
   int N = 10;
   int M = 12;
@@ -32,7 +32,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, CollapseOp)
 
   { // rcollapse 2
     auto tov = make_tensor<TestType>({N,M*K});
-  
+
     // example-begin rcollapse-test-1
     // Collapse two right-most dimensions together
     auto op = rcollapse<2>(tiv);
@@ -54,10 +54,10 @@ TYPED_TEST(OperatorTestsNumericAllExecs, CollapseOp)
       }
     }
   }
-  
+
   { // lcollapse 12
     auto tov = make_tensor<TestType>({N*M,K});
-  
+
     // example-begin lcollapse-test-1
     // Collapse two left-most dimensions together
     auto op = lcollapse<2>(tiv);
@@ -66,8 +66,8 @@ TYPED_TEST(OperatorTestsNumericAllExecs, CollapseOp)
     EXPECT_TRUE(op.Rank() == 2);
     EXPECT_TRUE(op.Size(0) == N*M);
     EXPECT_TRUE(op.Size(1) == K);
-    
-    
+
+
     (tov = (TestType)0).run(exec);
     (tov = op).run(exec);
     exec.sync();
@@ -80,10 +80,10 @@ TYPED_TEST(OperatorTestsNumericAllExecs, CollapseOp)
       }
     }
   }
-  
+
   { // rcollapse 3
     auto tov = make_tensor<TestType>({N*M*K});
-  
+
     auto op = rcollapse<3>(tiv);
 
     EXPECT_TRUE(op.Rank() == 1);
@@ -102,9 +102,9 @@ TYPED_TEST(OperatorTestsNumericAllExecs, CollapseOp)
     }
   }
 
-  { // lcollapse 3 
+  { // lcollapse 3
     auto tov = make_tensor<TestType>({N*M*K});
-  
+
     auto op = lcollapse<3>(tiv);
 
     EXPECT_TRUE(op.Rank() == 1);
@@ -123,7 +123,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, CollapseOp)
     }
   }
 
-  if constexpr (is_cuda_non_jit_executor<ExecType> && (std::is_same_v<TestType, float> || std::is_same_v<TestType, double>))
+  if constexpr (is_cuda_non_jit_executor<ExecType> && (cuda::std::is_same_v<TestType, float> || cuda::std::is_same_v<TestType, double>))
   { // rcollapse with nested transform operator
     auto tov = make_tensor<TestType>({N,M*K});
     auto delta = make_tensor<TestType>({1,1});
@@ -148,7 +148,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, CollapseOp)
     }
   }
 
-  if constexpr (is_cuda_non_jit_executor<ExecType> && (std::is_same_v<TestType, float> || std::is_same_v<TestType, double>))
+  if constexpr (is_cuda_non_jit_executor<ExecType> && (cuda::std::is_same_v<TestType, float> || cuda::std::is_same_v<TestType, double>))
   { // lcollapse with nested transform operator
     auto tov = make_tensor<TestType>({N*M,K});
     auto delta = make_tensor<TestType>({1,1});
@@ -173,4 +173,4 @@ TYPED_TEST(OperatorTestsNumericAllExecs, CollapseOp)
     }
   }
   MATX_EXIT_HANDLER();
-} 
+}

--- a/test/00_operators/concat_test.cu
+++ b/test/00_operators/concat_test.cu
@@ -14,7 +14,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Concatenate)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
-  ExecType exec{}; 
+  ExecType exec{};
   index_t i, j;
 
   // example-begin concat-test-1
@@ -40,7 +40,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Concatenate)
   }
 
   // Test contcat with nested transforms
-  if constexpr (is_cuda_non_jit_executor<ExecType> && (std::is_same_v<TestType, float> || std::is_same_v<TestType, double>)) {
+  if constexpr (is_cuda_non_jit_executor<ExecType> && (cuda::std::is_same_v<TestType, float> || cuda::std::is_same_v<TestType, double>)) {
     auto delta = make_tensor<TestType>({1});
     delta.SetVals({static_cast<TestType>(1)});
 
@@ -64,8 +64,8 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Concatenate)
   auto t22 = make_tensor<TestType>({3, 4});
   auto t23 = make_tensor<TestType>({4, 3});
 
-  auto t2o1 = make_tensor<TestType>({7,4});  
-  auto t2o2 = make_tensor<TestType>({4,7});  
+  auto t2o1 = make_tensor<TestType>({7,4});
+  auto t2o2 = make_tensor<TestType>({4,7});
   t21.SetVals({{1,2,3,4},
                {2,3,4,5},
                {3,4,5,6},
@@ -92,9 +92,9 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Concatenate)
     }
   }
 
-  (t2o2 = concat(1, t21, t23)).run(exec); 
+  (t2o2 = concat(1, t21, t23)).run(exec);
   exec.sync();
-  
+
   for (j = 0; j < t21.Size(1) + t23.Size(1); j++) {
     for (i = 0; i < t21.Size(0); i++) {
       if (j < t21.Size(1)) {
@@ -104,9 +104,9 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Concatenate)
         ASSERT_EQ(t23(i, j - t21.Size(1)), t2o2(i,j));
       }
     }
-  }  
+  }
 
-  auto t1o1 = make_tensor<TestType>({30});  
+  auto t1o1 = make_tensor<TestType>({30});
 
   // Concatenating 3 tensors
   (t1o1 = concat(0, t11, t11, t11)).run(exec);
@@ -123,13 +123,13 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Concatenate)
     auto b = matx::make_tensor<float>({10});
     auto c = matx::make_tensor<float>({10});
     auto d = matx::make_tensor<float>({10});
-    
+
     auto result = matx::make_tensor<float>({40});
     a.SetVals({1,2,3,4,5,6,7,8,9,10});
     b.SetVals({11,12,13,14,15,16,17,18,19,20});
     c.SetVals({21,22,23,24,25,26,27,28,29,30});
     d.SetVals({31,32,33,34,35,36,37,38,39,40});
-    
+
     auto tempConcat1 = matx::concat(0, a, b);
     auto tempConcat2 = matx::concat(0, c, d);
     (result = matx::concat(0, tempConcat1, tempConcat2 )).run(exec);
@@ -137,8 +137,8 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, Concatenate)
     exec.sync();
     for (int cnt = 0; cnt < result.Size(0); cnt++) {
       ASSERT_EQ(result(cnt), cnt + 1);
-    }    
-  }  
-  
+    }
+  }
+
   MATX_EXIT_HANDLER();
 }

--- a/test/00_operators/corrmap_test.cu
+++ b/test/00_operators/corrmap_test.cu
@@ -208,11 +208,11 @@ void for_each_mode(F &&fn) {
 template <typename InnerT>
 constexpr double tolerance_for()
 {
-  if constexpr (std::is_same_v<InnerT, matxBf16>) {
+  if constexpr (cuda::std::is_same_v<InnerT, matxBf16>) {
     return 3.0e-2;
-  } else if constexpr (std::is_same_v<InnerT, matxFp16>) {
+  } else if constexpr (cuda::std::is_same_v<InnerT, matxFp16>) {
     return 5.0e-3;
-  } else if constexpr (std::is_same_v<InnerT, float>) {
+  } else if constexpr (cuda::std::is_same_v<InnerT, float>) {
     return 5.0e-5;
   } else {
     return 1.0e-12; // double
@@ -224,11 +224,11 @@ constexpr double tolerance_for()
 template <typename InnerT>
 constexpr double tolerance_magnitude_for()
 {
-  if constexpr (std::is_same_v<InnerT, matxBf16>) {
+  if constexpr (cuda::std::is_same_v<InnerT, matxBf16>) {
     return 2.0e-2;
-  } else if constexpr (std::is_same_v<InnerT, matxFp16>) {
+  } else if constexpr (cuda::std::is_same_v<InnerT, matxFp16>) {
     return 2.0e-3;
-  } else if constexpr (std::is_same_v<InnerT, float>) {
+  } else if constexpr (cuda::std::is_same_v<InnerT, float>) {
     return 1.0e-6;
   } else {
     return 1.0e-14; // double
@@ -239,11 +239,11 @@ constexpr double tolerance_magnitude_for()
 template <typename InnerT>
 constexpr double tolerance_zncc_affine_for()
 {
-  if constexpr (std::is_same_v<InnerT, matxBf16>) {
+  if constexpr (cuda::std::is_same_v<InnerT, matxBf16>) {
     return 5.0e-2;
-  } else if constexpr (std::is_same_v<InnerT, matxFp16>) {
+  } else if constexpr (cuda::std::is_same_v<InnerT, matxFp16>) {
     return 5.0e-3;
-  } else if constexpr (std::is_same_v<InnerT, float>) {
+  } else if constexpr (cuda::std::is_same_v<InnerT, float>) {
     return 5.0e-6;
   } else {
     return 1.0e-12; // double

--- a/test/00_operators/filter_test.cu
+++ b/test/00_operators/filter_test.cu
@@ -53,7 +53,7 @@ void RunIIRRegressionCase(cudaExecutor &exec, index_t batches, index_t num_sampl
   (out = filter(in, h_rec, h_nonrec)).run(exec);
   exec.sync();
 
-  const double tol = std::is_same_v<TestType, float> ? 1.0e-2 : 1.0e-8;
+  const double tol = cuda::std::is_same_v<TestType, float> ? 1.0e-2 : 1.0e-8;
   for (index_t b = 0; b < batches; b++) {
     for (index_t i = 0; i < num_samples; i++) {
       ASSERT_NEAR(static_cast<double>(out(b, i)),
@@ -68,7 +68,7 @@ TYPED_TEST(FilterTestsFloatNonComplexNonHalfCUDA, IIRNonMultipleOfChunkSize)
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
-  static_assert(std::is_same_v<ExecType, cudaExecutor>);
+  static_assert(cuda::std::is_same_v<ExecType, cudaExecutor>);
 
   ExecType exec{};
   constexpr index_t kRecursiveChunkSize = 1024 * 8;

--- a/test/00_operators/frexp_test.cu
+++ b/test/00_operators/frexp_test.cu
@@ -12,7 +12,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, Frexp)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
-  ExecType exec{}; 
+  ExecType exec{};
 
   // example-begin frexp-test-1
   // Input data
@@ -35,28 +35,28 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecs, Frexp)
   MATX_IGNORE_WARNING_POP_MSVC
   // example-end frexp-test-1
 
-  static_assert(std::is_same_v<typename decltype(ofrac)::value_type,
+  static_assert(cuda::std::is_same_v<typename decltype(ofrac)::value_type,
                                TestType>);
-  static_assert(std::is_same_v<typename decltype(oint)::value_type, int>);
+  static_assert(cuda::std::is_same_v<typename decltype(oint)::value_type, int>);
   (toexp_parity = oint & 1).run(exec);
 
   exec.sync();
 
-  int texp;  
+  int texp;
   for (int i = 0; i < tiv0.Size(0); i++) {
-    if constexpr (std::is_same_v<TypeParam, float>) {
+    if constexpr (cuda::std::is_same_v<TypeParam, float>) {
       float tfrac = cuda::std::frexpf(tiv0(i), &texp);
-      ASSERT_EQ(tfrac, tofrac(i)); 
-      ASSERT_EQ(texp,  toint(i)); 
+      ASSERT_EQ(tfrac, tofrac(i));
+      ASSERT_EQ(texp,  toint(i));
       ASSERT_EQ(texp & 1, toexp_parity(i));
     }
     else {
       double tfrac = cuda::std::frexp(tiv0(i), &texp);
-      ASSERT_EQ(tfrac, tofrac(i)); 
-      ASSERT_EQ(texp,  toint(i));   
+      ASSERT_EQ(tfrac, tofrac(i));
+      ASSERT_EQ(texp,  toint(i));
       ASSERT_EQ(texp & 1, toexp_parity(i));
     }
   }
 
   MATX_EXIT_HANDLER();
-} 
+}

--- a/test/00_operators/frexpc_test.cu
+++ b/test/00_operators/frexpc_test.cu
@@ -13,7 +13,7 @@ TYPED_TEST(OperatorTestsComplexNonHalfTypesAllExecs, Frexpc)
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
   using InnerType = typename TestType::value_type;
 
-  ExecType exec{}; 
+  ExecType exec{};
 
   // example-begin frexpc-test-1
   // Input data
@@ -42,36 +42,36 @@ TYPED_TEST(OperatorTestsComplexNonHalfTypesAllExecs, Frexpc)
   (toint_imag = oint_imag).run(exec);
   // example-end frexpc-test-1
 
-  static_assert(std::is_same_v<typename decltype(ofrac_real)::value_type,
+  static_assert(cuda::std::is_same_v<typename decltype(ofrac_real)::value_type,
                                InnerType>);
-  static_assert(std::is_same_v<typename decltype(oint_real)::value_type, int>);
-  static_assert(std::is_same_v<typename decltype(ofrac_imag)::value_type,
+  static_assert(cuda::std::is_same_v<typename decltype(oint_real)::value_type, int>);
+  static_assert(cuda::std::is_same_v<typename decltype(ofrac_imag)::value_type,
                                InnerType>);
-  static_assert(std::is_same_v<typename decltype(oint_imag)::value_type, int>);
+  static_assert(cuda::std::is_same_v<typename decltype(oint_imag)::value_type, int>);
   (tofrac_real_scaled = ofrac_real * InnerType{2}).run(exec);
 
   exec.sync();
-  int texp_real, texp_imag;  
+  int texp_real, texp_imag;
   for (int i = 0; i < tiv0.Size(0); i++) {
-    if constexpr (std::is_same_v<TypeParam, cuda::std::complex<float>>) {
+    if constexpr (cuda::std::is_same_v<TypeParam, cuda::std::complex<float>>) {
       float tfrac_real = cuda::std::frexpf(tiv0(i).real(), &texp_real);
       float tfrac_imag = cuda::std::frexpf(tiv0(i).imag(), &texp_imag);
-      ASSERT_EQ(tfrac_real, tofrac_real(i)); 
-      ASSERT_EQ(texp_real,  toint_real(i)); 
-      ASSERT_EQ(tfrac_imag, tofrac_imag(i)); 
+      ASSERT_EQ(tfrac_real, tofrac_real(i));
+      ASSERT_EQ(texp_real,  toint_real(i));
+      ASSERT_EQ(tfrac_imag, tofrac_imag(i));
       ASSERT_EQ(texp_imag,  toint_imag(i));
       ASSERT_EQ(tfrac_real * 2.0f, tofrac_real_scaled(i));
     }
     else {
       double tfrac_real = cuda::std::frexp(tiv0(i).real(), &texp_real);
       double tfrac_imag = cuda::std::frexp(tiv0(i).imag(), &texp_imag);
-      ASSERT_EQ(tfrac_real, tofrac_real(i)); 
-      ASSERT_EQ(texp_real,  toint_real(i)); 
-      ASSERT_EQ(tfrac_imag, tofrac_imag(i)); 
+      ASSERT_EQ(tfrac_real, tofrac_real(i));
+      ASSERT_EQ(texp_real,  toint_real(i));
+      ASSERT_EQ(tfrac_imag, tofrac_imag(i));
       ASSERT_EQ(texp_imag,  toint_imag(i));
       ASSERT_EQ(tfrac_real * 2.0, tofrac_real_scaled(i));
     }
   }
 
   MATX_EXIT_HANDLER();
-} 
+}

--- a/test/00_operators/isnaninf_test.cu
+++ b/test/00_operators/isnaninf_test.cu
@@ -12,48 +12,48 @@ TYPED_TEST(OperatorTestsFloatNonComplexAllExecs, IsNanInf)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
-  ExecType exec{};    
+  ExecType exec{};
 
   auto nan = make_tensor<TestType>({});
-  using conversionType = typename matx::detail::value_promote_t<TestType>;  
-  if constexpr(matx::is_complex_v<TestType>) {    
+  using conversionType = typename matx::detail::value_promote_t<TestType>;
+  if constexpr(matx::is_complex_v<TestType>) {
     nan() = TestType(std::numeric_limits<conversionType>::quiet_NaN());
   } else {
     nan() = std::numeric_limits<conversionType>::quiet_NaN();
   }
   auto tob = make_tensor<bool>({});
   // example-begin nan-test-1
-  (tob = matx::isnan(nan)).run(exec); 
+  (tob = matx::isnan(nan)).run(exec);
   // example-end nan-test-1
   exec.sync();
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tob(), std::is_floating_point_v<conversionType> ? true : false));
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tob(), cuda::std::is_floating_point_v<conversionType> ? true : false));
 
   auto notnanorinf = make_tensor<TestType>({});
-  if constexpr(matx::is_complex_v<TestType>) {    
+  if constexpr(matx::is_complex_v<TestType>) {
     notnanorinf() = TestType(0);
   } else {
     notnanorinf() = 0;
-  }  
+  }
   (tob = matx::isnan(notnanorinf)).run(exec);
   exec.sync();
   EXPECT_TRUE(MatXUtils::MatXTypeCompare(tob(), false));
 
   auto inf = make_tensor<TestType>({});
-  if constexpr(matx::is_complex_v<TestType>) {    
+  if constexpr(matx::is_complex_v<TestType>) {
     inf() = TestType(std::numeric_limits<conversionType>::infinity());
   } else {
     inf() = std::numeric_limits<conversionType>::infinity();
-  }  
+  }
   // example-begin inf-test-1
-  (tob = matx::isinf(inf)).run(exec); 
+  (tob = matx::isinf(inf)).run(exec);
   // example-end inf-test-1
-  exec.sync(); 
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tob(), std::is_floating_point_v<conversionType> ? true : false));
+  exec.sync();
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tob(), cuda::std::is_floating_point_v<conversionType> ? true : false));
 
   (tob = matx::isinf(notnanorinf)).run(exec);
   exec.sync();
-  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tob(), false));  
+  EXPECT_TRUE(MatXUtils::MatXTypeCompare(tob(), false));
 
 
   MATX_EXIT_HANDLER();
-} 
+}

--- a/test/00_operators/sar_bulk_mocomp_test.cu
+++ b/test/00_operators/sar_bulk_mocomp_test.cu
@@ -166,7 +166,7 @@ void RunRank2ReferenceCase(ExecType &exec, index_t num_samples, int sgn) {
   // example-end sar-bulk-mocomp-1
   exec.sync();
 
-  const double tolerance = std::is_same_v<RangeType, float> ? 2.0e-5 : 1.0e-12;
+  const double tolerance = cuda::std::is_same_v<RangeType, float> ? 2.0e-5 : 1.0e-12;
   for (index_t pulse = 0; pulse < num_pulses; ++pulse) {
     for (index_t sample = 0; sample < num_samples; ++sample) {
       const auto expected = ExpectedCorrection(
@@ -264,7 +264,7 @@ TYPED_TEST(SarBulkMocompTests, TransformBackedRangeOffset) {
       .run(exec);
   exec.sync();
 
-  const double tolerance = std::is_same_v<RangeType, float> ? 2.0e-5 : 1.0e-12;
+  const double tolerance = cuda::std::is_same_v<RangeType, float> ? 2.0e-5 : 1.0e-12;
   for (index_t pulse = 0; pulse < pulses; ++pulse) {
     RangeType range_offset = static_cast<RangeType>(0);
     for (index_t term = 0; term < range_terms; ++term) {
@@ -331,7 +331,7 @@ TYPED_TEST(SarBulkMocompTests, BatchedReferenceChangeAndComposition) {
       .run(exec);
   exec.sync();
 
-  const double tolerance = std::is_same_v<RangeType, float> ? 3.0e-5 : 2.0e-12;
+  const double tolerance = cuda::std::is_same_v<RangeType, float> ? 3.0e-5 : 2.0e-12;
   for (index_t batch = 0; batch < batches; ++batch) {
     for (index_t pulse = 0; pulse < pulses; ++pulse) {
       for (index_t sample = 0; sample < samples; ++sample) {

--- a/test/00_operators/transpose_test.cu
+++ b/test/00_operators/transpose_test.cu
@@ -13,7 +13,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Transpose3D)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
-  ExecType exec{};     
+  ExecType exec{};
 
   index_t num_rows = 5998;
   index_t num_cols = 64;
@@ -30,7 +30,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, Transpose3D)
   (t3t = transpose_matrix(t3)).run(exec);
   exec.sync();
 
-  if constexpr (std::is_same_v<ExecType,cudaExecutor>) {
+  if constexpr (cuda::std::is_same_v<ExecType,cudaExecutor>) {
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
   }
 
@@ -74,7 +74,7 @@ TYPED_TEST(OperatorTestsNumericAllExecs, TransposeVsTransposeMatrix)
   (t3tm = transpose_matrix(t3)).run(exec);
 
   exec.sync();
-  if constexpr (std::is_same_v<ExecType,cudaExecutor>) {
+  if constexpr (cuda::std::is_same_v<ExecType,cudaExecutor>) {
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
   }
 
@@ -100,7 +100,7 @@ TYPED_TEST(OperatorTestsComplexTypesAllExecs, HermitianTranspose)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
-  ExecType exec{};   
+  ExecType exec{};
   index_t count0 = 100;
   index_t count1 = 200;
   tensor_t<TestType, 2> t2({count0, count1});

--- a/test/00_operators/zipvec_test.cu
+++ b/test/00_operators/zipvec_test.cu
@@ -24,7 +24,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecsWithoutJIT, ZipVecOp)
     ASSERT_EQ(t(0).x, static_cast<TestType>(2));
   }
 
-  if constexpr (std::is_same_v<TestType, float>)
+  if constexpr (cuda::std::is_same_v<TestType, float>)
   { // 2D example for documentation
     // example-begin zipvec-test-1
     auto v = linspace<float>(0.25f, 1.0f, 4);
@@ -116,7 +116,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecsWithoutJIT, ZipVecOp)
       (t3 = zipvec(t, t2)).run(exec);
       exec.sync();
       ASSERT_EQ(t3(0).x, static_cast<float>(1));
-      ASSERT_EQ(t3(0).y, static_cast<float>(1));  
+      ASSERT_EQ(t3(0).y, static_cast<float>(1));
     }
     {
       // float can be converted to double without narrowing
@@ -126,7 +126,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecsWithoutJIT, ZipVecOp)
       (t3 = zipvec(t, t2)).run(exec);
       exec.sync();
       ASSERT_EQ(t3(0).x, static_cast<double>(1));
-      ASSERT_EQ(t3(0).y, static_cast<double>(1));  
+      ASSERT_EQ(t3(0).y, static_cast<double>(1));
     }
     {
       // int can be converted to double without narrowing
@@ -136,7 +136,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecsWithoutJIT, ZipVecOp)
       (t3 = zipvec(t, t2)).run(exec);
       exec.sync();
       ASSERT_EQ(t3(0).x, static_cast<double>(1));
-      ASSERT_EQ(t3(0).y, static_cast<double>(1));  
+      ASSERT_EQ(t3(0).y, static_cast<double>(1));
     }
     // Note that some narrowing conversions like int -> float are currently allowed.
     // This is because std::common_type_t<int, float> is float, and the zipvec operator
@@ -144,4 +144,4 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecsWithoutJIT, ZipVecOp)
   }
 
   MATX_EXIT_HANDLER();
-} 
+}

--- a/test/00_operators/zipvec_test.cu
+++ b/test/00_operators/zipvec_test.cu
@@ -139,7 +139,7 @@ TYPED_TEST(OperatorTestsFloatNonComplexNonHalfAllExecsWithoutJIT, ZipVecOp)
       ASSERT_EQ(t3(0).y, static_cast<double>(1));
     }
     // Note that some narrowing conversions like int -> float are currently allowed.
-    // This is because std::common_type_t<int, float> is float, and the zipvec operator
+    // This is because cuda::std::common_type_t<int, float> is float, and the zipvec operator
     // uses std::common_type for its value_type.
   }
 

--- a/test/00_solver/LU.cu
+++ b/test/00_solver/LU.cu
@@ -43,7 +43,7 @@ constexpr int n = 50;
 template <typename T> class LUSolverTest : public ::testing::Test {
 protected:
   using GTestType = cuda::std::tuple_element_t<0, T>;
-  using GExecType = cuda::std::tuple_element_t<1, T>;   
+  using GExecType = cuda::std::tuple_element_t<1, T>;
   void SetUp() override
   {
     if constexpr (!detail::CheckSolverSupport<GExecType>()) {
@@ -435,7 +435,7 @@ TYPED_TEST(LUSolverTestFloatTypes, LUBasic)
   MATX_ENTER_HANDLER();
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
-  using piv_value_type = std::conditional_t<is_cuda_executor_v<ExecType>, int64_t, lapack_int_t>;
+  using piv_value_type = cuda::std::conditional_t<is_cuda_executor_v<ExecType>, int64_t, lapack_int_t>;
 
   auto Av = make_tensor<TestType>({m, n});
   auto PivV = make_tensor<piv_value_type>({std::min(m, n)});
@@ -476,7 +476,7 @@ TYPED_TEST(LUSolverTestFloatTypes, LUBasicBatched)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
-  using piv_value_type = std::conditional_t<is_cuda_executor_v<ExecType>, int64_t, lapack_int_t>;
+  using piv_value_type = cuda::std::conditional_t<is_cuda_executor_v<ExecType>, int64_t, lapack_int_t>;
   constexpr int batches = 10;
 
   auto Av = make_tensor<TestType>({batches, m, n});
@@ -518,7 +518,7 @@ TYPED_TEST(LUSolverTestFloatTypes, ProjectionAPI)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
   using value_type = typename inner_op_type_t<TestType>::type;
-  using piv_value_type = std::conditional_t<is_cuda_executor_v<ExecType>, int64_t, lapack_int_t>;
+  using piv_value_type = cuda::std::conditional_t<is_cuda_executor_v<ExecType>, int64_t, lapack_int_t>;
 
   constexpr index_t rows = 8;
   constexpr index_t cols = 5;

--- a/test/00_sparse/Dia.cu
+++ b/test/00_sparse/Dia.cu
@@ -67,7 +67,7 @@ template <typename T, typename IDX> static auto makeDIA() {
   D(10) = static_cast<T>(1);
   D(11) = static_cast<T>(1);
   // FIX DL/DU ///////////////
-  if constexpr (std::is_same_v<IDX, experimental::DIA_INDEX_I>) {
+  if constexpr (cuda::std::is_same_v<IDX, experimental::DIA_INDEX_I>) {
     D(0) = static_cast<T>(0);
     D(11) = static_cast<T>(0);
   } else {

--- a/test/00_tensor/DistributedTensorTests.cu
+++ b/test/00_tensor/DistributedTensorTests.cu
@@ -78,10 +78,10 @@ concept CanAssignRegularToDistributed = requires(
 static_assert(!CanAssignRegularToDistributed<
               distributed_tensor_t<float, 1, block_distribution_t<1>>,
               tensor_t<float, 1>>);
-static_assert(!std::is_constructible_v<
+static_assert(!cuda::std::is_constructible_v<
               local_fragment_t<float, 1>, tensor_t<double, 1>, size_t,
               distributed_endpoint_t, std::shared_ptr<void>>);
-static_assert(!std::is_constructible_v<
+static_assert(!cuda::std::is_constructible_v<
               local_fragment_t<float, 1>, tensor_t<float, 2>, size_t,
               distributed_endpoint_t, std::shared_ptr<void>>);
 

--- a/test/00_tensor/TensorCreationTests.cu
+++ b/test/00_tensor/TensorCreationTests.cu
@@ -438,7 +438,7 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorDescriptor)
 
 TEST(TensorCreationTests, CArrayDescriptorConstructors)
 {
-  static_assert(std::is_default_constructible_v<DefaultDescriptor<0>>);
+  static_assert(cuda::std::is_default_constructible_v<DefaultDescriptor<0>>);
 
   index_t shape[2] = {2, 3};
   index_t strides[2] = {3, 1};

--- a/test/00_tensor/TensorCreationTests.cu
+++ b/test/00_tensor/TensorCreationTests.cu
@@ -40,7 +40,7 @@ using namespace matx;
 
 template <typename T> struct TensorCreationTestsData {
   using GTestType = cuda::std::tuple_element_t<0, T>;
-  using GExecType = cuda::std::tuple_element_t<1, T>;     
+  using GExecType = cuda::std::tuple_element_t<1, T>;
   tensor_t<GTestType, 0> t0{{}};
   tensor_t<GTestType, 1> t1{{10}};
   tensor_t<GTestType, 2> t2{{20, 10}};
@@ -97,7 +97,7 @@ TYPED_TEST(TensorCreationTestsAll, MakeShape)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
 
-  ExecType exec{};  
+  ExecType exec{};
   auto mt2 = make_tensor<TestType>({2, 2});
   ASSERT_EQ(mt2.Size(0), 2);
   ASSERT_EQ(mt2.Size(1), 2);
@@ -114,7 +114,7 @@ TYPED_TEST(TensorCreationTestsAll, MakeShape)
   ASSERT_EQ(mt4.Size(0), 10);
   ASSERT_EQ(mt4.Size(1), 5);
   ASSERT_EQ(mt4.Size(2), 4);
-  ASSERT_EQ(mt4.Size(3), 3);  
+  ASSERT_EQ(mt4.Size(3), 3);
 }
 
 TYPED_TEST(TensorCreationTestsAll, MakeStaticShape)
@@ -308,7 +308,7 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic)
 
   (a = ones<TestType>()).run(exec);
   (b = ones<TestType>()).run(exec);
-  if constexpr (std::is_same_v<TestType, bool>) {
+  if constexpr (cuda::std::is_same_v<TestType, bool>) {
     (c = a || b).run(exec);
   }
   else {
@@ -316,7 +316,7 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic)
   }
   exec.sync();
 
-  const TestType expected = std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
+  const TestType expected = cuda::std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
   for (index_t i = 0; i < 4; i++) {
     ASSERT_EQ(c(i), expected);
   }
@@ -334,7 +334,7 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic2D)
 
   (a = ones<TestType>()).run(exec);
   (b = ones<TestType>()).run(exec);
-  if constexpr (std::is_same_v<TestType, bool>) {
+  if constexpr (cuda::std::is_same_v<TestType, bool>) {
     (c = a || b).run(exec);
   }
   else {
@@ -342,7 +342,7 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic2D)
   }
   exec.sync();
 
-  const TestType expected = std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
+  const TestType expected = cuda::std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
   for (index_t i = 0; i < 3; i++) {
     for (index_t j = 0; j < 4; j++) {
       ASSERT_EQ(c(i, j), expected);
@@ -362,7 +362,7 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic3D)
 
   (a = ones<TestType>()).run(exec);
   (b = ones<TestType>()).run(exec);
-  if constexpr (std::is_same_v<TestType, bool>) {
+  if constexpr (cuda::std::is_same_v<TestType, bool>) {
     (c = a || b).run(exec);
   }
   else {
@@ -370,7 +370,7 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic3D)
   }
   exec.sync();
 
-  const TestType expected = std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
+  const TestType expected = cuda::std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
   for (index_t i = 0; i < 2; i++) {
     for (index_t j = 0; j < 3; j++) {
       for (index_t k = 0; k < 4; k++) {
@@ -392,7 +392,7 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic4D)
 
   (a = ones<TestType>()).run(exec);
   (b = ones<TestType>()).run(exec);
-  if constexpr (std::is_same_v<TestType, bool>) {
+  if constexpr (cuda::std::is_same_v<TestType, bool>) {
     (c = a || b).run(exec);
   }
   else {
@@ -400,7 +400,7 @@ TYPED_TEST(TensorCreationTestsAll, StaticTensorArithmetic4D)
   }
   exec.sync();
 
-  const TestType expected = std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
+  const TestType expected = cuda::std::is_same_v<TestType, bool> ? TestType(true) : TestType(2);
   for (index_t i = 0; i < 2; i++) {
     for (index_t j = 0; j < 3; j++) {
       for (index_t k = 0; k < 4; k++) {

--- a/test/00_transform/ChannelizePoly.cu
+++ b/test/00_transform/ChannelizePoly.cu
@@ -54,7 +54,7 @@ protected:
 
     if constexpr (is_complex_half_v<GTestType> || is_matx_half_v<GTestType>) {
       thresh = 1.0e-1;
-    } else if constexpr (std::is_same_v<GTestType, double>) {
+    } else if constexpr (cuda::std::is_same_v<GTestType, double>) {
       thresh = 1.0e-12;
     } else {
       // Revisit this tolerance. We should likely use a relative tolerance
@@ -353,7 +353,7 @@ TYPED_TEST(ChannelizePolyTestNonHalfFloatTypes, Simple)
     // example-end channelize_poly-test-1
 
     this->exec.sync();
-    MATX_TEST_ASSERT_COMPARE(this->pb, b, "b_random", this->thresh);    
+    MATX_TEST_ASSERT_COMPARE(this->pb, b, "b_random", this->thresh);
 
     // Now test with a multiplicative operator on the input. The channelizer is linear,
     // so we can inverse-scale the output to compare against the golden outputs.
@@ -711,7 +711,7 @@ TYPED_TEST(ChannelizePolyTestNonHalfFloatTypes, Batched)
 
     this->exec.sync();
 
-    MATX_TEST_ASSERT_COMPARE(this->pb, b, "b_random", this->thresh);    
+    MATX_TEST_ASSERT_COMPARE(this->pb, b, "b_random", this->thresh);
 
     // Now test with a multiplicative operator on the input. The channelizer is linear,
     // so we can inverse-scale the output to compare against the golden outputs.
@@ -1091,7 +1091,7 @@ TYPED_TEST(ChannelizePolyTestDoubleType, Harris2003)
 
   for (auto chan = 0; chan < num_channels; chan++) {
     for (auto k = 0; k < b_elem_per_channel; k++) {
-      ComplexType gold { output[chan*b_elem_per_channel+k] };      
+      ComplexType gold { output[chan*b_elem_per_channel+k] };
       ComplexType test { b(k,chan) };
       ASSERT_NEAR(test.real(), gold.real(), this->thresh);
       ASSERT_NEAR(test.imag(), gold.imag(), this->thresh);

--- a/test/00_transform/Copy.cu
+++ b/test/00_transform/Copy.cu
@@ -56,7 +56,7 @@ TYPED_TEST(CopyTestsAll, CopyOutParam)
 
   const int SZ = 5;
   TestType DEFAULT, TEST_VAL;
-  if constexpr (std::is_same_v<TestType, bool>) {
+  if constexpr (cuda::std::is_same_v<TestType, bool>) {
     DEFAULT = true;
     TEST_VAL = false;
   } else {
@@ -126,7 +126,7 @@ TYPED_TEST(CopyTestsAll, CopyOutParam)
     ASSERT_EQ(out(0), DEFAULT);
   }
 
-  if constexpr (std::is_same_v<ExecType,cudaExecutor>) {
+  if constexpr (cuda::std::is_same_v<ExecType,cudaExecutor>) {
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
   }
 
@@ -144,7 +144,7 @@ TYPED_TEST(CopyTestsAll, CopyReturn)
 
   const int SZ = 5;
   TestType DEFAULT, TEST_VAL;
-  if constexpr (std::is_same_v<TestType, bool>) {
+  if constexpr (cuda::std::is_same_v<TestType, bool>) {
     DEFAULT = true;
     TEST_VAL = false;
   } else {
@@ -211,7 +211,7 @@ TYPED_TEST(CopyTestsAll, CopyReturn)
     ASSERT_EQ(out(0), DEFAULT);
   }
 
-  if constexpr (std::is_same_v<ExecType,cudaExecutor>) {
+  if constexpr (cuda::std::is_same_v<ExecType,cudaExecutor>) {
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
   }
 

--- a/test/00_transform/ResamplePoly.cu
+++ b/test/00_transform/ResamplePoly.cu
@@ -142,7 +142,7 @@ void AssertNearResampleValue(const T &actual, const T &expected, double thresh)
 template <typename T>
 class ResamplePolyTest : public ::testing::Test {
   using GTestType = cuda::std::tuple_element_t<0, T>;
-  using GExecType = cuda::std::tuple_element_t<1, T>;  
+  using GExecType = cuda::std::tuple_element_t<1, T>;
 
 protected:
   void SetUp() override
@@ -152,7 +152,7 @@ protected:
 
     if constexpr (is_complex_half_v<GTestType> || is_matx_half_v<GTestType>) {
       thresh = 1.0e-1;
-    } else if constexpr (std::is_same_v<GTestType, double>) {
+    } else if constexpr (cuda::std::is_same_v<GTestType, double>) {
       thresh = 1.0e-10;
     } else {
       // Revisit this tolerance. We should likely use a relative tolerance
@@ -319,7 +319,7 @@ TYPED_TEST(ResamplePolyTestNonHalfFloatTypes, SimpleOddLength)
     { 3501, 62501, 384, 3125 },
     // Filter shorter than upsampling factor
     { 137103, 137, 384, 3125 },
-    { 137104, 137, 384, 3125 },    
+    { 137104, 137, 384, 3125 },
     // Upsampling only (down=1)
     { 7173, 173, 7, 1 },
     // Downsampling only (up=1)
@@ -351,7 +351,7 @@ TYPED_TEST(ResamplePolyTestNonHalfFloatTypes, SimpleOddLength)
 
     this->exec.sync();
 
-    MATX_TEST_ASSERT_COMPARE(this->pb, b, "b_random", this->thresh);    
+    MATX_TEST_ASSERT_COMPARE(this->pb, b, "b_random", this->thresh);
 
     // Now test with a multiplicative operator on the input. The resampler is linear,
     // so we can inverse-scale the output to compare against the golden outputs.
@@ -413,7 +413,7 @@ TYPED_TEST(ResamplePolyTestNonHalfFloatTypes, SimpleEvenLength)
 
     this->exec.sync();
 
-    MATX_TEST_ASSERT_COMPARE(this->pb, b, "b_random", this->thresh);    
+    MATX_TEST_ASSERT_COMPARE(this->pb, b, "b_random", this->thresh);
 
     // Now test with a multiplicative operator on the input. The resampler is linear,
     // so we can inverse-scale the output to compare against the golden outputs.
@@ -552,7 +552,7 @@ TYPED_TEST(ResamplePolyTestNonHalfFloatTypes, Batched)
     [[maybe_unused]] const index_t b_len = up_len / down + ((up_len % down) ? 1 : 0);
     this->pb->template InitAndRunTVGenerator<TestType>(
       "00_transforms", "resample_poly_operators", "resample", {a_len, f_len, up, down});
-   
+
     const int nA = 16;
     const int nB = 37;
     const int nC = 55;

--- a/test/00_transform/SarBp.cu
+++ b/test/00_transform/SarBp.cu
@@ -53,7 +53,7 @@ protected:
 
     if constexpr (is_complex_half_v<GTestType> || is_matx_half_v<GTestType>) {
       thresh = 1.0e-1;
-    } else if constexpr (std::is_same_v<GTestType, double>) {
+    } else if constexpr (cuda::std::is_same_v<GTestType, double>) {
       thresh = 1.0e-12;
     } else {
       // Revisit this tolerance. We should likely use a relative tolerance
@@ -90,7 +90,7 @@ TYPED_TEST(SarBpTestNonComplexNonHalfFloatTypes, NonMixedTypes)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
   using complex_t = cuda::std::complex<TestType>;
-  using apc_t = std::conditional_t<std::is_same_v<TestType, double>, double3, float3>;
+  using apc_t = std::conditional_t<cuda::std::is_same_v<TestType, double>, double3, float3>;
 
   const index_t num_range_bins = 128;
   const index_t num_pulses = 128;
@@ -108,9 +108,9 @@ TYPED_TEST(SarBpTestNonComplexNonHalfFloatTypes, NonMixedTypes)
   auto pix_coords_xclone = matx::clone<2>(pix_coords_x, {image_height, matx::matxKeepDim});
   auto voxel_locations = matx::zipvec(
     pix_coords_xclone, pix_coords_yclone, matx::zeros<TestType>({image_height, image_width}));
-  
+
   auto range_profiles = matx::ones<complex_t>({num_pulses, num_range_bins});
-  auto range_to_mcp = matx::make_tensor<TestType>({num_pulses});  
+  auto range_to_mcp = matx::make_tensor<TestType>({num_pulses});
   auto platform_positions = matx::make_tensor<apc_t>({num_pulses});
   auto image = matx::make_tensor<complex_t>({image_height, image_width});
   const TestType plat_dx = (max_x - min_x) / num_pulses;
@@ -123,7 +123,7 @@ TYPED_TEST(SarBpTestNonComplexNonHalfFloatTypes, NonMixedTypes)
   }
 
   SarBpParams params;
-  if constexpr (std::is_same_v<TestType, double>) {
+  if constexpr (cuda::std::is_same_v<TestType, double>) {
     params.compute_type = SarBpComputeType::Double;
   } else {
     params.compute_type = SarBpComputeType::Float;
@@ -150,7 +150,7 @@ TYPED_TEST(SarBpTestDoubleType, MixedPrecision)
   using complex_t = cuda::std::complex<float>;
   using loose_compute_t = float;
   using strict_compute_t = double;
-  using apc_t = double3;  
+  using apc_t = double3;
 
   const index_t num_range_bins = 128;
   const index_t num_pulses = 128;
@@ -168,9 +168,9 @@ TYPED_TEST(SarBpTestDoubleType, MixedPrecision)
   auto pix_coords_xclone = matx::clone<2>(pix_coords_x, {image_height, matx::matxKeepDim});
   auto voxel_locations = matx::zipvec(
     pix_coords_xclone, pix_coords_yclone, matx::zeros<loose_compute_t>({image_height, image_width}));
-  
+
   auto range_profiles = matx::ones<complex_t>({num_pulses, num_range_bins});
-  auto range_to_mcp = matx::make_tensor<strict_compute_t>({num_pulses});  
+  auto range_to_mcp = matx::make_tensor<strict_compute_t>({num_pulses});
   auto platform_positions = matx::make_tensor<apc_t>({num_pulses});
   auto image = matx::make_tensor<complex_t>({image_height, image_width});
   const strict_compute_t plat_dx = (max_x - min_x) / num_pulses;
@@ -442,7 +442,7 @@ TYPED_TEST(SarBpTestDoubleType, PointTarget)
 
   for (matx::index_t i = 0; i < num_pulses; i++) {
     h_antenna_phase_centers[i] = double3{
-      plat_x_min + 
+      plat_x_min +
       plat_dx * static_cast<double>(i),
       plat_y,
       plat_z
@@ -908,7 +908,7 @@ TYPED_TEST(SarBpTestNonComplexNonHalfFloatTypes, RangeToMcpOperatorInput)
 
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using complex_t = cuda::std::complex<TestType>;
-  using apc_t = std::conditional_t<std::is_same_v<TestType, double>, double3, float3>;
+  using apc_t = std::conditional_t<cuda::std::is_same_v<TestType, double>, double3, float3>;
 
   const index_t num_range_bins = 64;
   const index_t num_pulses = 64;
@@ -938,7 +938,7 @@ TYPED_TEST(SarBpTestNonComplexNonHalfFloatTypes, RangeToMcpOperatorInput)
   }
 
   SarBpParams params;
-  if constexpr (std::is_same_v<TestType, double>) {
+  if constexpr (cuda::std::is_same_v<TestType, double>) {
     params.compute_type = SarBpComputeType::Double;
   } else {
     params.compute_type = SarBpComputeType::Float;

--- a/test/00_transform/SarBp.cu
+++ b/test/00_transform/SarBp.cu
@@ -90,7 +90,7 @@ TYPED_TEST(SarBpTestNonComplexNonHalfFloatTypes, NonMixedTypes)
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using ExecType = cuda::std::tuple_element_t<1, TypeParam>;
   using complex_t = cuda::std::complex<TestType>;
-  using apc_t = std::conditional_t<cuda::std::is_same_v<TestType, double>, double3, float3>;
+  using apc_t = cuda::std::conditional_t<cuda::std::is_same_v<TestType, double>, double3, float3>;
 
   const index_t num_range_bins = 128;
   const index_t num_pulses = 128;
@@ -908,7 +908,7 @@ TYPED_TEST(SarBpTestNonComplexNonHalfFloatTypes, RangeToMcpOperatorInput)
 
   using TestType = cuda::std::tuple_element_t<0, TypeParam>;
   using complex_t = cuda::std::complex<TestType>;
-  using apc_t = std::conditional_t<cuda::std::is_same_v<TestType, double>, double3, float3>;
+  using apc_t = cuda::std::conditional_t<cuda::std::is_same_v<TestType, double>, double3, float3>;
 
   const index_t num_range_bins = 64;
   const index_t num_pulses = 64;


### PR DESCRIPTION
CCCL provides all standard C++ type traits.

However, we are a bit more aggressive with compile time optimizations because we can rely on C++17 as the minimal standard mode.

So rather than going through type instantiations we almost exclusively rely on inline variables and type aliases 