### PR TITLE
Fix/emit managed device type dl pack

### DIFF
--- a/include/matx/core/error.h
+++ b/include/matx/core/error.h
@@ -265,6 +265,19 @@ namespace matx
     MATX_CUDA_CHECK(e);                \
   }
 
+// Macro for checking CUDA driver API (CUresult) errors
+#define MATX_CUDA_DRIVER_CHECK(e)                                          \
+  do {                                                                     \
+    const CUresult e_ = (e);                                               \
+    if (e_ != CUDA_SUCCESS)                                                \
+    {                                                                      \
+      const char *err_str = nullptr;                                       \
+      cuGetErrorString(e_, &err_str);                                      \
+      MATX_LOG_ERROR("{}:{} CUDA Driver Error: {} ({})", __FILE__, __LINE__, err_str != nullptr ? err_str : "unknown", static_cast<int>(e_)); \
+      MATX_THROW(matx::matxCudaError, err_str != nullptr ? err_str : "unknown"); \
+    }                                                                      \
+  } while (0)
+
 // This macro asserts compatible dimensions of current class to an operator.
 #define MATX_ASSERT_COMPATIBLE_OP_SIZES(op)                          \
   if constexpr (Rank() > 0) {                                        \

--- a/include/matx/core/print.h
+++ b/include/matx/core/print.h
@@ -600,11 +600,10 @@ namespace matx {
           CUmemorytype mtype;
           void *data[] = {&mtype};
           CUpointer_attribute attrs[] = {CU_POINTER_ATTRIBUTE_MEMORY_TYPE};
-          [[maybe_unused]] auto ret = cuPointerGetAttributes(1,
+          MATX_CUDA_DRIVER_CHECK(cuPointerGetAttributes(1,
                                             &attrs[0],
                                             data,
-                                            reinterpret_cast<CUdeviceptr>(op.Data()));
-          MATX_ASSERT_STR_EXP(ret, CUDA_SUCCESS, matxCudaError, "Failed to get memory type");
+                                            reinterpret_cast<CUdeviceptr>(op.Data())));
           MATX_ASSERT_STR(mtype == CU_MEMORYTYPE_HOST || mtype == 0 || mtype == CU_MEMORYTYPE_DEVICE,
             matxNotSupported, "Invalid memory type for printing");
 

--- a/include/matx/core/tensor.h
+++ b/include/matx/core/tensor.h
@@ -1508,11 +1508,6 @@ MATX_LOOP_UNROLL
 
     auto *mt = new ManagedType;
     DLTensor *t = &mt->dl_tensor;
-    CUpointer_attribute attr[] = {CU_POINTER_ATTRIBUTE_MEMORY_TYPE, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, CU_POINTER_ATTRIBUTE_IS_MANAGED};
-    CUmemorytype mem_type;
-    int dev_ord;
-    int is_managed;
-    void *data[3]       = {&mem_type, &dev_ord, &is_managed};
 
     // DLPack carries mutability via flags (versioned API), not via pointer type.
     // Preserve const-export semantics by marking versioned tensors read-only below.
@@ -1521,20 +1516,30 @@ MATX_LOOP_UNROLL
 
     // Determine where this memory resides
     // Pass in the base pointer, not a potentially offset pointer
-    // returned by this->Data()
     void *data_ptr = const_cast<void *>(static_cast<const void *>(this->GetStorage().data()));
     auto kind = GetPointerKind(data_ptr);
-    [[maybe_unused]] auto mem_res = cuPointerGetAttributes(sizeof(attr)/sizeof(attr[0]), attr, data, reinterpret_cast<CUdeviceptr>(data_ptr));
-    MATX_ASSERT_STR_EXP(mem_res, CUDA_SUCCESS, matxCudaError, "Error returned from cuPointerGetAttributes");
+    auto cu_ptr = reinterpret_cast<CUdeviceptr>(data_ptr);
+
     if (kind == MATX_INVALID_MEMORY) {
       // GetStorage().data() is only guaranteed to be the true allocation base
       // for storage that still shares its owning tensor's buffer (e.g. Slice()/
       // Permute()). A view with its own non-owning storage at an offset/
       // reinterpreted address (e.g. RealView()/ImagView()) lands here instead,
       // so classify it from the driver's own record of that address.
-      // CU_POINTER_ATTRIBUTE_MEMORY_TYPE alone can't tell managed memory from
-      // pinned host memory, so check CU_POINTER_ATTRIBUTE_IS_MANAGED too.
-      if (mem_type == CU_MEMORYTYPE_DEVICE || is_managed) {
+      // Managed memory is reported separately from plain device memory since
+      // DLPack defines a distinct kDLCUDAManaged device type for it.
+      CUpointer_attribute attr[] = {CU_POINTER_ATTRIBUTE_MEMORY_TYPE, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, CU_POINTER_ATTRIBUTE_IS_MANAGED};
+      CUmemorytype mem_type;
+      int dev_ord;
+      int is_managed;
+      void *data[3] = {&mem_type, &dev_ord, &is_managed};
+      MATX_CUDA_DRIVER_CHECK(cuPointerGetAttributes(sizeof(attr)/sizeof(attr[0]), attr, data, cu_ptr));
+
+      if (is_managed) {
+        t->device.device_type = kDLCUDAManaged;
+        t->device.device_id = dev_ord;
+      }
+      else if (mem_type == CU_MEMORYTYPE_DEVICE) {
         t->device.device_type = kDLCUDA;
         t->device.device_id = dev_ord;
       }
@@ -1546,26 +1551,36 @@ MATX_LOOP_UNROLL
         t->device.device_type = kDLCPU;
       }
     }
+    else if (kind == MATX_HOST_MALLOC_MEMORY) {
+      // Plain malloc'd memory has no device ordinal to query
+      t->device.device_type = kDLCPU;
+    }
     else {
-      // We have a record of this pointer and can map it from the record
+      // We have a record of this pointer's memory space; only the device
+      // ordinal still needs to come from the driver
+      CUpointer_attribute attr = CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL;
+      int dev_ord;
+      void *data = &dev_ord;
+      MATX_CUDA_DRIVER_CHECK(cuPointerGetAttributes(1, &attr, &data, cu_ptr));
+
       switch (kind) {
         case MATX_MANAGED_MEMORY:
+          // DLPack defines a distinct device type for cudaMallocManaged
+          // memory rather than folding it into plain device memory.
+          t->device.device_type = kDLCUDAManaged;
+          break;
         case MATX_DEVICE_MEMORY:
         case MATX_ASYNC_DEVICE_MEMORY:
           t->device.device_type = kDLCUDA;
-          t->device.device_id = dev_ord;
           break;
         case MATX_HOST_MEMORY:
           t->device.device_type = kDLCUDAHost;
-          t->device.device_id = dev_ord;
-          break;
-        case MATX_HOST_MALLOC_MEMORY:
-          t->device.device_type = kDLCPU;
           break;
         default:
           MATX_ASSERT_STR(false, matxCudaError, "Cannot determine kind of memory");
           break;
       }
+      t->device.device_id = dev_ord;
     }
 
     t->ndim         = RANK;

--- a/test/00_tensor/DLPackTests.cu
+++ b/test/00_tensor/DLPackTests.cu
@@ -508,6 +508,54 @@ TEST(DLPackFallbackTests, ExportImportedManagedMemory)
   MATX_EXIT_HANDLER();
 }
 
+// ToDlPackImpl() must still classify ordinary, unregistered CPU memory as
+// kDLCPU via the same cuPointerGetAttributes fallback used for managed
+// memory.
+TEST(DLPackFallbackTests, ExportUnregisteredHostMemory)
+{
+  MATX_ENTER_HANDLER();
+
+  // Plain new[]'d memory: never touched by cudaMallocHost, cudaHostRegister,
+  // or any other CUDA API, so CUDA has no record of it at all.
+  auto *raw = new float[8];
+
+  auto *dl = new DLManagedTensor{};
+  auto *shape = new int64_t[1]{8};
+  auto *strides = new int64_t[1]{1};
+  dl->dl_tensor.data = raw;
+  dl->dl_tensor.device.device_type = kDLCPU;
+  dl->dl_tensor.device.device_id = 0;
+  dl->dl_tensor.ndim = 1;
+  dl->dl_tensor.dtype = detail::TypeToDLPackType<float>();
+  dl->dl_tensor.shape = shape;
+  dl->dl_tensor.strides = strides;
+  dl->dl_tensor.byte_offset = 0;
+  dl->manager_ctx = raw;
+  dl->deleter = [](DLManagedTensor *mt) {
+    delete[] static_cast<float *>(mt->manager_ctx);
+    delete[] mt->dl_tensor.shape;
+    delete[] mt->dl_tensor.strides;
+    delete mt;
+  };
+
+  tensor_t<float, 1> t;
+  make_tensor(t, dl);
+
+  // Confirm this import indeed lands in the fallback path this test targets,
+  // rather than the allocator-map exact-match path
+  ASSERT_EQ(GetPointerKind(t.GetStorage().data()), MATX_INVALID_MEMORY);
+
+  auto *dl_out = t.ToDlPack();
+  ASSERT_EQ(dl_out->dl_tensor.device.device_type, kDLCPU);
+  dl_out->deleter(dl_out);
+
+  auto *dlv_out = t.ToDlPackVersioned();
+  ASSERT_EQ(dlv_out->dl_tensor.device.device_type, kDLCPU);
+  dlv_out->deleter(dlv_out);
+
+  MATX_EXIT_HANDLER();
+}
+
 TYPED_TEST(DLPackTestsFloatNonComplex, ExportVersionedConstTensorSetsReadOnlyFlag)
 {
   MATX_ENTER_HANDLER();

--- a/test/00_tensor/DLPackTests.cu
+++ b/test/00_tensor/DLPackTests.cu
@@ -264,7 +264,18 @@ void ForEachExportableMemorySpace(CheckFunc &&check)
     // Assert that explicitly so a future allocator change can't silently
     // produce a wrong expectation below
     ASSERT_TRUE(kind == MATX_MANAGED_MEMORY || kind == MATX_HOST_MEMORY);
-    ASSERT_NO_FATAL_FAILURE(check(t, kind == MATX_HOST_MEMORY ? kDLCUDAHost : kDLCUDA));
+    ASSERT_NO_FATAL_FAILURE(check(t, kind == MATX_HOST_MEMORY ? kDLCUDAHost : kDLCUDAManaged));
+  }
+
+  {
+    // Explicit request for managed memory. Same Jetson caveat as the default
+    // case above: the allocator silently downgrades to host pinned memory on
+    // devices without concurrent managed access, so derive the expectation
+    // from what was actually allocated rather than assuming kDLCUDAManaged
+    auto t = make_tensor<TestType>({5, 10, 20}, MATX_MANAGED_MEMORY);
+    auto kind = GetPointerKind(t.GetStorage().data());
+    ASSERT_TRUE(kind == MATX_MANAGED_MEMORY || kind == MATX_HOST_MEMORY);
+    ASSERT_NO_FATAL_FAILURE(check(t, kind == MATX_HOST_MEMORY ? kDLCUDAHost : kDLCUDAManaged));
   }
 
   {
@@ -439,6 +450,60 @@ TYPED_TEST(DLPackTestsComplex, ExportRealImagViewOfOffsetSlice)
   };
 
   ASSERT_NO_FATAL_FAILURE(ForEachExportableMemorySpace<TestType>(check_real_imag_view));
+
+  MATX_EXIT_HANDLER();
+}
+
+// ToDlPackImpl() must classify genuine CUDA managed memory as kDLCUDAManaged,
+// not plain kDLCUDA, since DLPack defines a distinct device type for it.
+//
+// Memory allocated directly with cudaMallocManaged() (bypassing matx's own
+// allocator) is never entered into matx's allocation map, so GetPointerKind()
+// always misses on it and ToDlPackImpl() must classify it via the
+// cuPointerGetAttributes fallback. This is also the only way to exercise a
+// genuinely managed allocation on a device where cudaDevAttrConcurrentManagedAccess
+// == 0 (e.g. Jetson), since matx's own allocator silently downgrades
+// MATX_MANAGED_MEMORY requests to host-pinned memory on such devices.
+TEST(DLPackFallbackTests, ExportImportedManagedMemory)
+{
+  MATX_ENTER_HANDLER();
+
+  float *raw = nullptr;
+  ASSERT_EQ(cudaMallocManaged(&raw, 8 * sizeof(float)), cudaSuccess);
+
+  auto *dl = new DLManagedTensor{};
+  auto *shape = new int64_t[1]{8};
+  auto *strides = new int64_t[1]{1};
+  dl->dl_tensor.data = raw;
+  dl->dl_tensor.device.device_type = kDLCUDAManaged;
+  dl->dl_tensor.device.device_id = 0;
+  dl->dl_tensor.ndim = 1;
+  dl->dl_tensor.dtype = detail::TypeToDLPackType<float>();
+  dl->dl_tensor.shape = shape;
+  dl->dl_tensor.strides = strides;
+  dl->dl_tensor.byte_offset = 0;
+  dl->manager_ctx = raw;
+  dl->deleter = [](DLManagedTensor *mt) {
+    cudaFree(mt->manager_ctx);
+    delete[] mt->dl_tensor.shape;
+    delete[] mt->dl_tensor.strides;
+    delete mt;
+  };
+
+  tensor_t<float, 1> t;
+  make_tensor(t, dl);
+
+  // Confirm this import indeed lands in the fallback path this test targets,
+  // rather than the allocator-map exact-match path
+  ASSERT_EQ(GetPointerKind(t.GetStorage().data()), MATX_INVALID_MEMORY);
+
+  auto *dl_out = t.ToDlPack();
+  ASSERT_EQ(dl_out->dl_tensor.device.device_type, kDLCUDAManaged);
+  dl_out->deleter(dl_out);
+
+  auto *dlv_out = t.ToDlPackVersioned();
+  ASSERT_EQ(dlv_out->dl_tensor.device.device_type, kDLCUDAManaged);
+  dlv_out->deleter(dlv_out);
 
   MATX_EXIT_HANDLER();
 }


### PR DESCRIPTION
**Description**

Fixes Issue #1234 and introduces a new driver error check macro.

ToDlPackImpl() classified cudaMallocManaged memory as plain kDLCUDA
instead of the kDLCUDAManaged device type DLPack defines for it.

- Report managed memory (both allocator-tracked and pointers
  classified via the driver's IS_MANAGED attribute) as kDLCUDAManaged
- Add MATX_CUDA_DRIVER_CHECK, an unconditional check for CUresult from
  CUDA driver API calls (MATX_CUDA_CHECK is typed for cudaError_t;
  MATX_ASSERT_STR_EXP compiles away in release builds)
- Apply it to the two cuPointerGetAttributes calls in ToDlPackImpl(),
  and to print.h's identical call
- Add regression tests covering both the allocator-tracked path and
  memory imported from outside matx's allocator

**Testing**
- test_00_tensor_DLPackTests: 89/89 pass
- test_00_io_PrintTests: 18/18 pass
- Confirmed the new fallback test fails against pre-fix code and
  passes after

Why print.h is in this PR: it wasn't part of the original scope but it makes the exact same cuPointerGetAttributes call